### PR TITLE
Revert "Add semantic classification for records"

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
@@ -71,8 +71,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return _constructor; }
         }
 
-        internal override bool IsRecord => false;
-
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved)
         {
             return _interfaces;

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
@@ -140,7 +140,5 @@ namespace Microsoft.CodeAnalysis.CSharp
         bool ISynthesizedMethodBodyImplementationSymbol.HasMethodBodyDependency => true;
 
         IMethodSymbolInternal ISynthesizedMethodBodyImplementationSymbol.Method => _topLevelMethod;
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
@@ -59,7 +59,5 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => ContainingAssembly.GetSpecialType(SpecialType.System_Object);
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
@@ -36,8 +36,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { throw ExceptionUtilities.Unreachable; }
         }
 
-        internal override bool IsRecord => false;
-
         bool ISynthesizedMethodBodyImplementationSymbol.HasMethodBodyDependency
         {
             get { return true; }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.SymbolDisplay;
+using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -564,8 +565,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             switch (symbol.TypeKind)
             {
-                case TypeKind.Class when symbol.IsRecord:
-                    return SymbolDisplayPartKind.RecordName;
                 case TypeKind.Submission:
                 case TypeKind.Module:
                 case TypeKind.Class:
@@ -662,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     switch (symbol.TypeKind)
                     {
-                        case TypeKind.Class when symbol.IsRecord:
+                        case TypeKind.Class when FindValidCloneMethod(symbol) is object:
                             AddKeyword(SyntaxKind.RecordKeyword);
                             AddSpace();
                             break;
@@ -706,6 +705,66 @@ namespace Microsoft.CodeAnalysis.CSharp
                             break;
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Copy of <see cref="SynthesizedRecordClone.FindValidCloneMethod(TypeSymbol, ref HashSet{DiagnosticInfo}?)"/>
+        /// </summary>
+        private static IMethodSymbol FindValidCloneMethod(ITypeSymbol containingType)
+        {
+            if (containingType.SpecialType == SpecialType.System_Object)
+            {
+                return null;
+            }
+
+            IMethodSymbol candidate = null;
+
+            foreach (var member in containingType.GetMembers(WellKnownMemberNames.CloneMethodName))
+            {
+                if (member is IMethodSymbol
+                    {
+                        DeclaredAccessibility: Accessibility.Public,
+                        IsStatic: false,
+                        Parameters: { Length: 0 },
+                        Arity: 0
+                    } method)
+                {
+                    if (candidate is object)
+                    {
+                        // An ambiguity case, can come from metadata, treat as an error for simplicity.
+                        return null;
+                    }
+
+                    candidate = method;
+                }
+            }
+
+            if (candidate is null ||
+                !(containingType.IsSealed || candidate.IsOverride || candidate.IsVirtual || candidate.IsAbstract) ||
+                !isEqualToOrDerivedFrom(
+                    containingType,
+                    candidate.ReturnType))
+            {
+                return null;
+            }
+
+            return candidate;
+
+            static bool isEqualToOrDerivedFrom(ITypeSymbol one, ITypeSymbol other)
+            {
+                do
+                {
+                    if (one.Equals(other, SymbolEqualityComparer.IgnoreAll))
+                    {
+                        return true;
+                    }
+
+                    one = one.BaseType;
+                }
+                while (one != null);
+
+                return false;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -71,7 +71,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case SymbolDisplayPartKind.AliasName:
                 case SymbolDisplayPartKind.ClassName:
-                case SymbolDisplayPartKind.RecordName:
                 case SymbolDisplayPartKind.StructName:
                 case SymbolDisplayPartKind.InterfaceName:
                 case SymbolDisplayPartKind.EnumName:

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -328,8 +328,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
 
-            internal override bool IsRecord => false;
-
             internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null)
             {
                 Debug.Assert(isValueTypeOverrideOpt == null);

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -439,8 +440,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
             internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
-
-            internal override bool IsRecord => false;
 
             internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -482,8 +482,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return new PublicModel.ArrayTypeSymbol(this, nullableAnnotation);
         }
 
-        internal override bool IsRecord => false;
-
         /// <summary>
         /// Represents SZARRAY - zero-based one-dimensional array 
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -244,7 +245,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.DynamicTypeSymbol(this, nullableAnnotation);
         }
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -4,6 +4,9 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Roslyn.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -542,8 +543,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.ErrorTypeSymbol(this, nullableAnnotation);
         }
-
-        internal override bool IsRecord => false;
     }
 
     internal abstract class SubstitutedErrorTypeSymbol : ErrorTypeSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -212,7 +212,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                    && modifierType.Name.StartsWith("CallConv", StringComparison.Ordinal)
                    && modifierType.IsCompilerServicesTopLevelType();
         }
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -556,15 +556,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override bool IsRecord
-        {
-            get
-            {
-                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                return SynthesizedRecordClone.FindValidCloneMethod(this, ref useSiteDiagnostics) != null;
-            }
-        }
-
         public override Accessibility DeclaredAccessibility
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -160,8 +160,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => _underlyingType;
 
-        internal override bool IsRecord => false;
-
         internal override bool Equals(TypeSymbol? other, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverrideOpt = null)
         {
             if (other is null)

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -308,7 +308,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.PointerTypeSymbol(this, nullableAnnotation);
         }
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
@@ -171,7 +170,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
         bool ITypeSymbol.IsRefLikeType => UnderlyingTypeSymbol.IsRefLikeType;
 
         bool ITypeSymbol.IsReadOnly => UnderlyingTypeSymbol.IsReadOnly;
-
-        bool ITypeSymbol.IsRecord => UnderlyingTypeSymbol.IsRecord;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -375,7 +375,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
-
-        internal override bool IsRecord => _underlyingType.IsRecord;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -238,7 +238,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override bool AreLocalsZeroed
             => throw ExceptionUtilities.Unreachable;
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -800,7 +800,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsRecord
+        internal bool IsRecord
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -397,7 +397,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
-
-        internal override bool IsRecord => _underlyingType.IsRecord;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
@@ -142,6 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        // Note: this method was replicated in SymbolDisplayVisitor.FindValidCloneMethod
         internal static MethodSymbol? FindValidCloneMethod(TypeSymbol containingType, ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
         {
             if (containingType.IsObjectType())

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -88,8 +88,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { throw ExceptionUtilities.Unreachable; }
         }
 
-        internal override bool IsRecord => false;
-
         private sealed class DelegateConstructor : SynthesizedInstanceConstructor
         {
             private readonly ImmutableArray<ParameterSymbol> _parameters;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -199,8 +199,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
-
-        internal override bool IsRecord => false;
     }
 
     internal sealed class SynthesizedEmbeddedAttributeConstructorSymbol : SynthesizedInstanceConstructor

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNativeIntegerAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNativeIntegerAttributeSymbol.cs
@@ -61,8 +61,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
-        internal override bool IsRecord => false;
-
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {
             return new AttributeUsageInfo(

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableAttributeSymbol.cs
@@ -65,8 +65,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
-        internal override bool IsRecord => false;
-
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {
             return new AttributeUsageInfo(

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableContextAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableContextAttributeSymbol.cs
@@ -49,8 +49,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
-        internal override bool IsRecord => false;
-
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {
             return new AttributeUsageInfo(

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullablePublicOnlyAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullablePublicOnlyAttributeSymbol.cs
@@ -49,8 +49,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
-        internal override bool IsRecord => false;
-
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {
             return new AttributeUsageInfo(AttributeTargets.Module, allowMultiple: false, inherited: false);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -688,7 +688,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(nullableAnnotation != DefaultNullableAnnotation);
             return new PublicModel.TypeParameterSymbol(this, nullableAnnotation);
         }
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -12,6 +12,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
@@ -2254,7 +2257,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return GetITypeSymbol(DefaultNullableAnnotation);
         }
-
-        internal abstract bool IsRecord { get; }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -2778,9 +2778,7 @@ abstract sealed record C1;
             Assert.True(clone.ContainingType.IsSealed);
             Assert.True(clone.ContainingType.IsAbstract);
 
-            var namedTypeSymbol = comp.GlobalNamespace.GetTypeMember("C1");
-            Assert.True(namedTypeSymbol.IsRecord);
-            Assert.Equal("record C1", namedTypeSymbol
+            Assert.Equal("record C1", comp.GlobalNamespace.GetTypeMember("C1")
                 .ToDisplayString(SymbolDisplayFormat.TestFormat.AddKindOptions(SymbolDisplayKindOptions.IncludeTypeKeyword)));
         }
 
@@ -2809,9 +2807,7 @@ sealed abstract record C1;
             Assert.True(clone.ContainingType.IsSealed);
             Assert.True(clone.ContainingType.IsAbstract);
 
-            var namedTypeSymbol = comp.GlobalNamespace.GetTypeMember("C1");
-            Assert.True(namedTypeSymbol.IsRecord);
-            Assert.Equal("record C1", namedTypeSymbol
+            Assert.Equal("record C1", comp.GlobalNamespace.GetTypeMember("C1")
                 .ToDisplayString(SymbolDisplayFormat.TestFormat.AddKindOptions(SymbolDisplayKindOptions.IncludeTypeKeyword)));
         }
 
@@ -2868,9 +2864,7 @@ sealed abstract record C2 : C1;
             Assert.True(clone.ContainingType.IsSealed);
             Assert.True(clone.ContainingType.IsAbstract);
 
-            var namedTypeSymbol = comp.GlobalNamespace.GetTypeMember("C1");
-            Assert.True(namedTypeSymbol.IsRecord);
-            Assert.Equal("record C1", namedTypeSymbol
+            Assert.Equal("record C1", comp.GlobalNamespace.GetTypeMember("C1")
                 .ToDisplayString(SymbolDisplayFormat.TestFormat.AddKindOptions(SymbolDisplayKindOptions.IncludeTypeKeyword)));
         }
 
@@ -7621,7 +7615,6 @@ record C(int X, string Y)
             var withExpr = root.DescendantNodes().OfType<WithExpressionSyntax>().Single();
             var typeInfo = model.GetTypeInfo(withExpr);
             var c = comp.GlobalNamespace.GetTypeMember("C");
-            Assert.True(c.IsRecord);
             Assert.True(c.ISymbol.Equals(typeInfo.Type));
 
             var x = c.GetMembers("X").Single();
@@ -24335,7 +24328,7 @@ record R : I, Base;
         }
 
         [Fact]
-        public void RecordLoadedInVisualBasicDisplaysAsClass()
+        public void RecordLoadedInVisualBasicDisplaysAsRecord()
         {
             var src = @"
 public record A;
@@ -24343,8 +24336,7 @@ public record A;
             var compRef = CreateCompilation(src).EmitToImageReference();
             var vbComp = CreateVisualBasicCompilation("", referencedAssemblies: new[] { compRef });
             var symbol = vbComp.GlobalNamespace.GetTypeMember("A");
-            Assert.False(symbol.IsRecord);
-            Assert.Equal("class A",
+            Assert.Equal("record A",
                 SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.TestFormat.AddKindOptions(SymbolDisplayKindOptions.IncludeTypeKeyword)));
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5,9 +5,11 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -38,53 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 format,
                 "A",
                 SymbolDisplayPartKind.ClassName);
-        }
-
-        [Fact, WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")]
-        public void TestRecordNameOnlySimple()
-        {
-            var text = "record A {}";
-
-            Func<NamespaceSymbol, Symbol> findSymbol = global =>
-                global.GetTypeMembers("A", 0).Single();
-
-            var format = new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly);
-
-            TestSymbolDescription(
-                text,
-                findSymbol,
-                format,
-                "A",
-                SymbolDisplayPartKind.RecordName);
-        }
-
-        [Fact, WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")]
-        public void TestRecordNameOnlyComplex()
-        {
-            var text = @"
-namespace N1 {
-    namespace N2.N3 {
-        record R1 {
-            record R2 {} } } }
-";
-
-            Func<NamespaceSymbol, Symbol> findSymbol = global =>
-                global.GetNestedNamespace("N1").
-                GetNestedNamespace("N2").
-                GetNestedNamespace("N3").
-                GetTypeMembers("R1").Single().
-                GetTypeMembers("R2").Single();
-
-            var format = new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly);
-
-            TestSymbolDescription(
-                text,
-                findSymbol,
-                format,
-                "R2",
-                SymbolDisplayPartKind.RecordName);
         }
 
         [Fact]
@@ -7650,7 +7605,7 @@ record Person(string First, string Last);
                 "record Person",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.RecordName);
+                SymbolDisplayPartKind.ClassName);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -323,7 +323,5 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
-
-        internal override bool IsRecord => false;
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
-Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
-Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayPartKind.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayPartKind.cs
@@ -78,13 +78,11 @@ namespace Microsoft.CodeAnalysis
         ExtensionMethodName = 29,
         /// <summary>The name of a field or local constant.</summary>
         ConstantName = 30,
-        /// <summary>The name of a record.</summary>
-        RecordName = 31,
     }
 
     internal static class InternalSymbolDisplayPartKind
     {
-        private const SymbolDisplayPartKind @base = SymbolDisplayPartKind.RecordName + 1;
+        private const SymbolDisplayPartKind @base = SymbolDisplayPartKind.ConstantName + 1;
         public const SymbolDisplayPartKind Arity = @base + 0;
         public const SymbolDisplayPartKind Other = @base + 1;
     }
@@ -93,7 +91,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal static bool IsValid(this SymbolDisplayPartKind value)
         {
-            return (value >= SymbolDisplayPartKind.AliasName && value <= SymbolDisplayPartKind.RecordName) ||
+            return (value >= SymbolDisplayPartKind.AliasName && value <= SymbolDisplayPartKind.ConstantName) ||
                 (value >= InternalSymbolDisplayPartKind.Arity && value <= InternalSymbolDisplayPartKind.Other);
         }
     }

--- a/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -127,11 +127,6 @@ namespace Microsoft.CodeAnalysis
         bool IsReadOnly { get; }
 
         /// <summary>
-        /// True if the type is a record.
-        /// </summary>
-        bool IsRecord { get; }
-
-        /// <summary>
         /// Converts an <c>ITypeSymbol</c> and a nullable flow state to a string representation.
         /// </summary>
         /// <param name="topLevelNullability">The top-level nullability to use for formatting.</param>

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -592,13 +592,6 @@ Done:
             End Get
         End Property
 
-        Private ReadOnly Property ITypeSymbol_IsRecord As Boolean Implements ITypeSymbol.IsRecord
-            Get
-                ' VB does not have records
-                Return False
-            End Get
-        End Property
-
         Private Function ITypeSymbol_ToDisplayString(topLevelNullability As NullableFlowState, Optional format As SymbolDisplayFormat = Nothing) As String Implements ITypeSymbol.ToDisplayString
             Return ToDisplayString(format)
         End Function

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -198,24 +198,6 @@ class C
 
         [Theory]
         [CombinatorialData]
-        [WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")]
-        public async Task DynamicAsRecordName(TestHost testHost)
-        {
-            await TestAsync(
-@"record dynamic
-{
-}
-
-class C
-{
-    dynamic d;
-}",
-                testHost,
-                Record("dynamic"));
-        }
-
-        [Theory]
-        [CombinatorialData]
         public async Task DynamicAsClassNameAndLocalVariableName(TestHost testHost)
         {
             await TestAsync(
@@ -4410,38 +4392,6 @@ class X
             Keyword("nameof"),
             Static("Method"),
             Method("Method"));
-        }
-
-        [Theory]
-        [CombinatorialData]
-        [WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")]
-        public async Task BasicRecordClassification(TestHost testHost)
-        {
-            await TestAsync(
-@"record R
-{
-    R r;
-
-    R() { }
-}",
-                testHost,
-                Record("R"));
-        }
-
-        [Theory]
-        [CombinatorialData]
-        [WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")]
-        public async Task ParameterizedRecordClassification(TestHost testHost)
-        {
-            await TestAsync(
-@"record R(int X, int Y);
-
-class C
-{
-    R r;
-}",
-                testHost,
-                Record("R"));
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
+++ b/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
@@ -185,25 +185,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             }
         }
         #endregion
-        #region User Types - Records
-        [Export(typeof(EditorFormatDefinition))]
-        [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.RecordName)]
-        [Name(ClassificationTypeNames.RecordName)]
-        [Order(After = PredefinedClassificationTypeNames.Identifier)]
-        [Order(After = PredefinedClassificationTypeNames.Keyword)]
-        [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [UserVisible(true)]
-        [ExcludeFromCodeCoverage]
-        private class UserTypeRecordsFormatDefinition : ClassificationFormatDefinition
-        {
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public UserTypeRecordsFormatDefinition()
-            {
-                this.DisplayName = EditorFeaturesResources.User_Types_Records;
-            }
-        }
-        #endregion
         #region User Types - Delegates
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.DelegateName)]

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -945,7 +945,4 @@ Do you want to proceed?</value>
   <data name="Error_creating_instance_of_CodeFixProvider" xml:space="preserve">
     <value>Error creating instance of CodeFixProvider</value>
   </data>
-  <data name="User_Types_Records" xml:space="preserve">
-    <value>User Types - Records</value>
-  </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/Classification/ClassificationTypeDefinitions.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/ClassificationTypeDefinitions.cs
@@ -52,12 +52,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)]
         internal readonly ClassificationTypeDefinition UserTypeClassesTypeDefinition;
         #endregion
-        #region User Types - Records
-        [Export]
-        [Name(ClassificationTypeNames.RecordName)]
-        [BaseDefinition(ClassificationTypeNames.ClassName)]
-        internal readonly ClassificationTypeDefinition UserTypeRecordsTypeDefinition;
-        #endregion
         #region User Types - Delegates 
         [Export]
         [Name(ClassificationTypeNames.DelegateName)]

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Uživatelské typy – rozhraní</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Uživatelské typy – struktury</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Benutzertypen - Schnittstellen</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Benutzertypen - Strukturen</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Tipos de usuario: interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Tipos de usuario: estructuras</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Types d'utilisateurs - Interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Types d'utilisateurs - Structures</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Tipi utente - Interfacce</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Tipi utente - Strutture</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -257,11 +257,6 @@
         <target state="translated">ユーザー タイプ - インターフェイス</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">ユーザー タイプ - 構造体</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -257,11 +257,6 @@
         <target state="translated">사용자 형식 - 인터페이스</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">사용자 형식 - 구조</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Typy użytkownika — interfejsy</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Typy użytkownika — struktury</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Tipos de Usuário - Interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Tipos de Usuário - Estruturas</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Пользовательские типы — интерфейсы</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Пользовательские типы — структуры</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -257,11 +257,6 @@
         <target state="translated">Kullanıcı Türleri - Arabirimler</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">Kullanıcı Türleri - Yapılar</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -257,11 +257,6 @@
         <target state="translated">用户类型 - 接口</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">用户类型 - 结构</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -257,11 +257,6 @@
         <target state="translated">使用者類型 - 介面</target>
         <note />
       </trans-unit>
-      <trans-unit id="User_Types_Records">
-        <source>User Types - Records</source>
-        <target state="new">User Types - Records</target>
-        <note />
-      </trans-unit>
       <trans-unit id="User_Types_Structures">
         <source>User Types - Structures</source>
         <target state="translated">使用者類型 - 結構</target>

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Notification
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.UnitTests

--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
@@ -1110,53 +1110,5 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             ToolTipAssert.EqualContent(expected, container)
         End Function
-
-        <WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
-        <WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")>
-        Public Async Function QuickInfoForRecords() As Task
-            Dim workspace =
-                <Workspace>
-                    <Project Language="C#" CommonReferences="true">
-                        <Document>
-                            public sealed record TestRecord(int X, int Y) { }
-
-                            class C
-                            {
-                                void M()
-                                {
-                                    var x = new Test$$Record(1, 2);
-                                }
-                            }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-            Dim intellisenseQuickInfo = Await GetQuickInfoItemAsync(workspace, LanguageNames.CSharp)
-            Assert.NotNull(intellisenseQuickInfo)
-
-            Dim container = Assert.IsType(Of ContainerElement)(intellisenseQuickInfo.Item)
-
-            Dim expected = New ContainerElement(
-                ContainerElementStyle.Stacked Or ContainerElementStyle.VerticalPadding,
-                New ContainerElement(
-                    ContainerElementStyle.Wrapped,
-                    New ImageElement(New ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.MethodPublic)),
-                    New ClassifiedTextElement(
-                        New ClassifiedTextRun(ClassificationTypeNames.RecordName, "TestRecord", navigationAction:=Sub() Return, "TestRecord"),
-                        New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "."),
-                        New ClassifiedTextRun(ClassificationTypeNames.RecordName, "TestRecord", navigationAction:=Sub() Return, "TestRecord.TestRecord(int X, int Y)"),
-                        New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "("),
-                        New ClassifiedTextRun(ClassificationTypeNames.Keyword, "int", navigationAction:=Sub() Return, "int"),
-                        New ClassifiedTextRun(ClassificationTypeNames.WhiteSpace, " "),
-                        New ClassifiedTextRun(ClassificationTypeNames.ParameterName, "X", navigationAction:=Sub() Return, "int X"),
-                        New ClassifiedTextRun(ClassificationTypeNames.Punctuation, ","),
-                        New ClassifiedTextRun(ClassificationTypeNames.WhiteSpace, " "),
-                        New ClassifiedTextRun(ClassificationTypeNames.Keyword, "int", navigationAction:=Sub() Return, "int"),
-                        New ClassifiedTextRun(ClassificationTypeNames.WhiteSpace, " "),
-                        New ClassifiedTextRun(ClassificationTypeNames.ParameterName, "Y", navigationAction:=Sub() Return, "int Y"),
-                        New ClassifiedTextRun(ClassificationTypeNames.Punctuation, ")"))))
-
-            ToolTipAssert.EqualContent(expected, container)
-        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/TestUtilities/Classification/FormattedClassifications.cs
+++ b/src/EditorFeatures/TestUtilities/Classification/FormattedClassifications.cs
@@ -31,10 +31,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             => New(text, ClassificationTypeNames.ClassName);
 
         [DebuggerStepThrough]
-        public static FormattedClassification Record(string text)
-            => New(text, ClassificationTypeNames.RecordName);
-
-        [DebuggerStepThrough]
         public static FormattedClassification Delegate(string text)
             => New(text, ClassificationTypeNames.DelegateName);
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -348,8 +348,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
 
-        internal override bool IsRecord => false;
-
         [Conditional("DEBUG")]
         internal static void VerifyTypeParameters(Symbol container, ImmutableArray<TypeParameterSymbol> typeParameters)
         {

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -290,7 +290,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
                             switch (parts[index + 1].Kind)
                             {
                                 case SymbolDisplayPartKind.ClassName:
-                                case SymbolDisplayPartKind.RecordName:
                                 case SymbolDisplayPartKind.DelegateName:
                                 case SymbolDisplayPartKind.EnumName:
                                 case SymbolDisplayPartKind.ErrorTypeName:
@@ -310,7 +309,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
                         }
 
                         previousWasClass = part.Kind == SymbolDisplayPartKind.ClassName ||
-                                           part.Kind == SymbolDisplayPartKind.RecordName ||
                                            part.Kind == SymbolDisplayPartKind.InterfaceName ||
                                            part.Kind == SymbolDisplayPartKind.StructName;
                     }

--- a/src/Features/Core/Portable/Common/SymbolDisplayPartKindTags.cs
+++ b/src/Features/Core/Portable/Common/SymbolDisplayPartKindTags.cs
@@ -42,7 +42,6 @@ namespace Microsoft.CodeAnalysis
                 SymbolDisplayPartKind.EnumMemberName => TextTags.EnumMember,
                 SymbolDisplayPartKind.ExtensionMethodName => TextTags.ExtensionMethod,
                 SymbolDisplayPartKind.ConstantName => TextTags.Constant,
-                SymbolDisplayPartKind.RecordName => TextTags.Record,
                 _ => string.Empty,
             };
     }

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -226,9 +226,6 @@ namespace Microsoft.CodeAnalysis
                 case TextTags.Text:
                     return ClassificationTypeNames.Text;
 
-                case TextTags.Record:
-                    return ClassificationTypeNames.RecordName;
-
                 default:
                     throw ExceptionUtilities.UnexpectedValue(taggedTextTag);
             }

--- a/src/Features/Core/Portable/Common/TextTags.cs
+++ b/src/Features/Core/Portable/Common/TextTags.cs
@@ -43,7 +43,6 @@ namespace Microsoft.CodeAnalysis
         public const string EnumMember = nameof(EnumMember);
         public const string ExtensionMethod = nameof(ExtensionMethod);
         public const string Constant = nameof(Constant);
-        public const string Record = nameof(Record);
 
         /// <summary>
         /// Indicates the start of a text container. The elements after <see cref="ContainerStart"/> through (but not

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -140,8 +140,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public bool IsReadOnly => _symbol.IsReadOnly;
 
-            public bool IsRecord => _symbol.IsRecord;
-
             public bool IsNativeIntegerType => _symbol.IsNativeIntegerType;
 
             public INamedTypeSymbol NativeIntegerUnderlyingType => _symbol.NativeIntegerUnderlyingType;

--- a/src/Features/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-const Microsoft.CodeAnalysis.TextTags.Record = "Record" -> string
+

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             ClassificationTypeNames.MethodName,
             ClassificationTypeNames.ModuleName,
             ClassificationTypeNames.OperatorOverloaded,
-            ClassificationTypeNames.RecordName,
 
             // Preprocessor
             ClassificationTypeNames.PreprocessorKeyword,

--- a/src/VisualStudio/CSharp/Impl/ChangeSignature/CSharpChangeSignatureViewModelFactoryService.cs
+++ b/src/VisualStudio/CSharp/Impl/ChangeSignature/CSharpChangeSignatureViewModelFactoryService.cs
@@ -30,8 +30,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ChangeSignature
         {
             var parts = new List<SymbolDisplayPart>();
 
-            // TO-DO: We need to add proper colorization for added parameters:
-            // https://github.com/dotnet/roslyn/issues/47986
             var isPredefinedType = SyntaxFactory.ParseExpression(addedParameterViewModel.Type).Kind() == SyntaxKind.PredefinedType;
             var typePartKind = isPredefinedType ? SymbolDisplayPartKind.Keyword : SymbolDisplayPartKind.ClassName;
 

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2017.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2017.xml
@@ -63,8 +63,6 @@
             </Color>
             <Color Name="label name">
             </Color>
-            <Color Name="record name">
-            </Color>
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
                 <Foreground Type="CT_RAW" Source="FF686868" />
@@ -219,8 +217,6 @@
             <Color Name="namespace name">
             </Color>
             <Color Name="label name">
-            </Color>
-            <Color Name="record name">
             </Color>
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
@@ -377,8 +373,6 @@
             </Color>
             <Color Name="label name">
             </Color>
-            <Color Name="record name">
-            </Color>"
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
                 <Foreground Type="CT_RAW" Source="FF504848" />
@@ -534,8 +528,6 @@
             </Color>
             <Color Name="label name">
             </Color>
-            <Color Name="record name">
-            </Color>"
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FF3E3E3E" />
                 <Foreground Type="CT_RAW" Source="FFA9A8A7" />
@@ -703,9 +695,6 @@
                 <Foreground Type="CT_SYSCOLOR" Source="00000008" />
             </Color>
             <Color Name="label name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="record name">
                 <Foreground Type="CT_SYSCOLOR" Source="00000008" />
             </Color>
             <Color Name="inline hints">

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2019.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2019.xml
@@ -69,8 +69,6 @@
             </Color>
             <Color Name="label name">
             </Color>
-            <Color Name="record name">
-            </Color>
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
                 <Foreground Type="CT_RAW" Source="FF686868" />
@@ -231,8 +229,6 @@
             <Color Name="namespace name">
             </Color>
             <Color Name="label name">
-            </Color>
-            <Color Name="record name">
             </Color>
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
@@ -395,8 +391,6 @@
             </Color>
             <Color Name="label name">
             </Color>
-            <Color Name="record name">
-            </Color>
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FFE6E6FA" />
                 <Foreground Type="CT_RAW" Source="FF504848" />
@@ -557,8 +551,6 @@
             <Color Name="namespace name">
             </Color>
             <Color Name="label name">
-            </Color>
-            <Color Name="record name">
             </Color>
             <Color Name="inline hints">
                 <Background Type="CT_RAW" Source="FF3E3E3E" />
@@ -727,9 +719,6 @@
                 <Foreground Type="CT_SYSCOLOR" Source="00000008" />
             </Color>
             <Color Name="label name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="record name">
                 <Foreground Type="CT_SYSCOLOR" Source="00000008" />
             </Color>
             <Color Name="inline parameter name hints">

--- a/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
+++ b/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
@@ -98,7 +98,6 @@ namespace Microsoft.VisualStudio.LanguageServices
             UpdateForegroundColor(ClassificationTypeNames.Punctuation, sourceFormatMap, targetFormatMap);
 
             UpdateForegroundColor(ClassificationTypeNames.ClassName, sourceFormatMap, targetFormatMap);
-            UpdateForegroundColor(ClassificationTypeNames.RecordName, sourceFormatMap, targetFormatMap);
             UpdateForegroundColor(ClassificationTypeNames.StructName, sourceFormatMap, targetFormatMap);
             UpdateForegroundColor(ClassificationTypeNames.InterfaceName, sourceFormatMap, targetFormatMap);
             UpdateForegroundColor(ClassificationTypeNames.DelegateName, sourceFormatMap, targetFormatMap);

--- a/src/VisualStudio/VisualBasic/Impl/ChangeSignature/VisualBasicChangeSignatureViewModelFactoryService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ChangeSignature/VisualBasicChangeSignatureViewModelFactoryService.vb
@@ -25,8 +25,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ChangeSignature
             parts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "As"))
             parts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "))
 
-            ' TO-DO We need to add proper colorization for added parameters: 
-            ' https://github.com/dotnet/roslyn/issues/47986
             Dim isPredefinedType = SyntaxFactory.ParseExpression(addedParameterViewModel.Type).Kind() = SyntaxKind.PredefinedType
             Dim typePartKind = If(isPredefinedType, SymbolDisplayPartKind.Keyword, SymbolDisplayPartKind.ClassName)
 

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -203,11 +203,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             }
             else if (token.Parent is ConstructorDeclarationSyntax constructorDeclaration && constructorDeclaration.Identifier == token)
             {
-                return GetClassificationTypeForConstructorOrDestructorParent(constructorDeclaration.Parent!);
+                return constructorDeclaration.IsParentKind(SyntaxKind.ClassDeclaration)
+                    ? ClassificationTypeNames.ClassName
+                    : ClassificationTypeNames.StructName;
             }
             else if (token.Parent is DestructorDeclarationSyntax destructorDeclaration && destructorDeclaration.Identifier == token)
             {
-                return GetClassificationTypeForConstructorOrDestructorParent(destructorDeclaration.Parent!);
+                return destructorDeclaration.IsParentKind(SyntaxKind.ClassDeclaration)
+                    ? ClassificationTypeNames.ClassName
+                    : ClassificationTypeNames.StructName;
             }
             else if (token.Parent is LocalFunctionStatementSyntax localFunctionStatement && localFunctionStatement.Identifier == token)
             {
@@ -295,15 +299,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             }
         }
 
-        private static string? GetClassificationTypeForConstructorOrDestructorParent(SyntaxNode parentNode)
-            => parentNode.Kind() switch
-            {
-                SyntaxKind.ClassDeclaration => ClassificationTypeNames.ClassName,
-                SyntaxKind.RecordDeclaration => ClassificationTypeNames.RecordName,
-                SyntaxKind.StructDeclaration => ClassificationTypeNames.StructName,
-                _ => null
-            };
-
         private static bool IsNamespaceName(IdentifierNameSyntax identifierSyntax)
         {
             var parent = identifierSyntax.Parent;
@@ -353,7 +348,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 SyntaxKind.EnumDeclaration => ClassificationTypeNames.EnumName,
                 SyntaxKind.StructDeclaration => ClassificationTypeNames.StructName,
                 SyntaxKind.InterfaceDeclaration => ClassificationTypeNames.InterfaceName,
-                SyntaxKind.RecordDeclaration => ClassificationTypeNames.RecordName,
                 _ => null,
             };
 

--- a/src/Workspaces/Core/Portable/Classification/ClassificationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassificationExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Classification
         public static string? GetClassification(this ITypeSymbol type)
             => type.TypeKind switch
             {
-                TypeKind.Class => type.IsRecord ? ClassificationTypeNames.RecordName : ClassificationTypeNames.ClassName,
+                TypeKind.Class => ClassificationTypeNames.ClassName,
                 TypeKind.Module => ClassificationTypeNames.ModuleName,
                 TypeKind.Struct => ClassificationTypeNames.StructName,
                 TypeKind.Interface => ClassificationTypeNames.InterfaceName,

--- a/src/Workspaces/Core/Portable/Classification/ClassificationTypeNames.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassificationTypeNames.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Classification
         public const string StringEscapeCharacter = "string - escape character";
 
         public const string ClassName = "class name";
-        public const string RecordName = "record name";
         public const string DelegateName = "delegate name";
         public const string EnumName = "enum name";
         public const string InterfaceName = "interface name";

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -115,7 +115,6 @@ namespace Microsoft.CodeAnalysis.Classification
                 ClassificationTypeNames.Operator => SymbolDisplayPartKind.Operator,
                 ClassificationTypeNames.Punctuation => SymbolDisplayPartKind.Punctuation,
                 ClassificationTypeNames.ClassName => SymbolDisplayPartKind.ClassName,
-                ClassificationTypeNames.RecordName => SymbolDisplayPartKind.RecordName,
                 ClassificationTypeNames.StructName => SymbolDisplayPartKind.StructName,
                 ClassificationTypeNames.InterfaceName => SymbolDisplayPartKind.InterfaceName,
                 ClassificationTypeNames.DelegateName => SymbolDisplayPartKind.DelegateName,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -78,8 +78,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         bool ITypeSymbol.IsReadOnly => Modifiers.IsReadOnly;
 
-        bool ITypeSymbol.IsRecord => throw new System.NotImplementedException();
-
         public NullableAnnotation NullableAnnotation { get; }
 
         public ITypeSymbol WithNullableAnnotation(NullableAnnotation nullableAnnotation)

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-const Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.RecordName = "record name" -> string
 Microsoft.CodeAnalysis.Editing.DeclarationKind.Record = 29 -> Microsoft.CodeAnalysis.Editing.DeclarationKind


### PR DESCRIPTION
Reverts dotnet/roslyn#47960

We believe this PR has caused an RPS regression in a XAML scenario. https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/283694?view=discussion

Please note that this revert is not a rejection of the change being reverted. It just means that this change is blocking insertion into VS right now. We are happy to take this change back into a release branch once necessary modification and validation has been done to fix or seek exception for the RPS regression.

FYI @allisonchou