### PR TITLE
Optimize IsRecord for non-record fast paths

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -560,6 +560,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
+                // First, do a check to see if there are even any members named <Clone>$. If we have to actually find the clone
+                // method, it can be expensive, because we have to load all the members. MemberNames just loads the strings, which
+                // is much cheaper.
+                if (!MemberNames.Contains(WellKnownMemberNames.CloneMethodName))
+                {
+                    return false;
+                }
+
+                // There exists a member named <Clone>$. We still need to check to see if it's actually a valid clone method, but
+                // there's no getting around that now.
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 return SynthesizedRecordClone.FindValidCloneMethod(this, ref useSiteDiagnostics) != null;
             }


### PR DESCRIPTION
We noticed some perf regressions when SymbolDisplayVisitor was calling IsRecord for a lot of types. This attempts to reduce the memory impact by having PEMethodSymbol.IsRecord first check to see if any member is named `<Clone>$`, and not loading the full signatures of all members.
