### PR TITLE
 Further optimize FindValidCloneMethod

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
@@ -72,6 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved)
         {

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureEnvironment.cs
@@ -142,5 +142,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         IMethodSymbolInternal ISynthesizedMethodBodyImplementationSymbol.Method => _topLevelMethod;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorStateMachine.cs
@@ -61,5 +61,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => ContainingAssembly.GetSpecialType(SpecialType.System_Object);
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DynamicSiteContainer.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         bool ISynthesizedMethodBodyImplementationSymbol.HasMethodBodyDependency
         {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -347,6 +347,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return this.TypeDescriptor.GetHashCode();
             }
+
+            internal override bool HasPossibleWellKnownCloneMethod() => false;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -507,6 +507,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                         WellKnownMember.System_Diagnostics_DebuggerDisplayAttribute__Type,
                                         new TypedConstant(Manager.System_String, TypedConstantKind.Primitive, "<Anonymous Type>"))));
             }
+
+            internal override bool HasPossibleWellKnownCloneMethod() => false;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -543,8 +543,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return new PublicModel.ErrorTypeSymbol(this, nullableAnnotation);
         }
 
-        internal override bool IsRecord => false;
-        internal override bool HasPossibleWellKnownCloneMethod() => false;
+        internal sealed override bool IsRecord => false;
+        internal sealed override bool HasPossibleWellKnownCloneMethod() => false;
     }
 
     internal abstract class SubstitutedErrorTypeSymbol : ErrorTypeSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -544,6 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 
     internal abstract class SubstitutedErrorTypeSymbol : ErrorTypeSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -1419,7 +1419,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return m;
         }
 
-        internal override bool HasPossibleWellKnownCloneMethod()
+        internal sealed override bool HasPossibleWellKnownCloneMethod()
             => MemberNames.Contains(WellKnownMemberNames.CloneMethodName);
 
         internal override FieldSymbol FixedElementField

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -560,16 +560,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                // First, do a check to see if there are even any members named <Clone>$. If we have to actually find the clone
-                // method, it can be expensive, because we have to load all the members. MemberNames just loads the strings, which
-                // is much cheaper.
-                if (!MemberNames.Contains(WellKnownMemberNames.CloneMethodName))
-                {
-                    return false;
-                }
-
-                // There exists a member named <Clone>$. We still need to check to see if it's actually a valid clone method, but
-                // there's no getting around that now.
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 return SynthesizedRecordClone.FindValidCloneMethod(this, ref useSiteDiagnostics) != null;
             }
@@ -1428,6 +1418,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             return m;
         }
+
+        internal override bool HasPossibleWellKnownCloneMethod()
+            => MemberNames.Contains(WellKnownMemberNames.CloneMethodName);
 
         internal override FieldSymbol FixedElementField
         {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -511,6 +511,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// no members with this name, returns an empty ImmutableArray. Never returns null.</returns>
         public abstract override ImmutableArray<Symbol> GetMembers(string name);
 
+        /// <summary>
+        /// A lightweight check for whether this type has a possible clone method. This is less costly than GetMembers,
+        /// particularly for PE symbols, and can be used as a cheap heuristic for whether to fully search through all
+        /// members of this type for a valid clone method.
+        /// </summary>
+        internal abstract bool HasPossibleWellKnownCloneMethod();
+
         internal virtual ImmutableArray<Symbol> GetSimpleNonTypeMembers(string name)
         {
             return GetMembers(name);

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -160,7 +160,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => _underlyingType;
 
-        internal override bool IsRecord => false;
+        internal sealed override bool IsRecord => false;
+        internal sealed override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal override bool Equals(TypeSymbol? other, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool>? isValueTypeOverrideOpt = null)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -376,6 +376,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
 
-        internal override bool IsRecord => _underlyingType.IsRecord;
+        internal sealed override bool IsRecord => _underlyingType.IsRecord;
+        internal sealed override bool HasPossibleWellKnownCloneMethod() => _underlyingType.HasPossibleWellKnownCloneMethod();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -240,5 +240,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             => throw ExceptionUtilities.Unreachable;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1249,6 +1249,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<Symbol>.Empty;
         }
 
+
+        internal override bool HasPossibleWellKnownCloneMethod()
+            // For source symbols, there can only be a valid clone method if this is a record, which is a
+            // simple syntax check. This will need to change when we generalize cloning, but it's a good
+            // heuristic for now.
+            => IsRecord;
+
         internal override ImmutableArray<Symbol> GetSimpleNonTypeMembers(string name)
         {
             if (_lazyMembersDictionary != null || declaration.MemberNames.Contains(name))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1249,11 +1249,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ImmutableArray<Symbol>.Empty;
         }
 
-
+        /// <remarks>
+        /// For source symbols, there can only be a valid clone method if this is a record, which is a
+        /// simple syntax check. This will need to change when we generalize cloning, but it's a good
+        /// heuristic for now.
+        /// </remarks>
         internal override bool HasPossibleWellKnownCloneMethod()
-            // For source symbols, there can only be a valid clone method if this is a record, which is a
-            // simple syntax check. This will need to change when we generalize cloning, but it's a good
-            // heuristic for now.
             => IsRecord;
 
         internal override ImmutableArray<Symbol> GetSimpleNonTypeMembers(string name)

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -398,6 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
 
-        internal override bool IsRecord => _underlyingType.IsRecord;
+        internal sealed override bool IsRecord => _underlyingType.IsRecord;
+        internal sealed override bool HasPossibleWellKnownCloneMethod() => _underlyingType.HasPossibleWellKnownCloneMethod();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordClone.cs
@@ -144,7 +144,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static MethodSymbol? FindValidCloneMethod(TypeSymbol containingType, ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
         {
-            if (containingType.IsObjectType())
+            if (containingType.IsObjectType() || containingType is not NamedTypeSymbol containingNamedType)
+            {
+                return null;
+            }
+
+            // If this symbol is from metadata, getting all members can cause us to realize a lot of structures that we otherwise
+            // don't have to. Optimize for the common case here of there not being a method named <Clone>$. If there is a method
+            // with that name, it's most likely the one we're interested in, and we can't get around loading everything to find it.
+            if (!containingNamedType.HasPossibleWellKnownCloneMethod())
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -221,7 +221,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
-
-        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -221,5 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
+
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -89,6 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         private sealed class DelegateConstructor : SynthesizedInstanceConstructor
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -179,6 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 
     /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -179,7 +179,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
-        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 
     /// <summary>
@@ -202,6 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 
     internal sealed class SynthesizedEmbeddedAttributeConstructorSymbol : SynthesizedInstanceConstructor

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNativeIntegerAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNativeIntegerAttributeSymbol.cs
@@ -62,6 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableAttributeSymbol.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableContextAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullableContextAttributeSymbol.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullablePublicOnlyAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNullablePublicOnlyAttributeSymbol.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         internal override AttributeUsageInfo GetAttributeUsageInfo()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -256,5 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return _underlyingType.GetGuidString(out guidString);
         }
+
+        internal override bool HasPossibleWellKnownCloneMethod() => _underlyingType.HasPossibleWellKnownCloneMethod();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -256,7 +256,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return _underlyingType.GetGuidString(out guidString);
         }
-
-        internal override bool HasPossibleWellKnownCloneMethod() => _underlyingType.HasPossibleWellKnownCloneMethod();
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -325,5 +325,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -349,6 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;
 
         internal override bool IsRecord => false;
+        internal override bool HasPossibleWellKnownCloneMethod() => false;
 
         [Conditional("DEBUG")]
         internal static void VerifyTypeParameters(Symbol container, ImmutableArray<TypeParameterSymbol> typeParameters)


### PR DESCRIPTION
#48935 optimizes one path that hits FindValidCloneMethod, but there are others that could do with the same fast-path optimization. In order to accomplish that, I introduced a new HasPossibleCloneMethod on NamedTypeSymbol, that returns whether the type _could_ have a method on it that is a valid clone method. For source types, this is a quick syntax check to see if it's a record. For metadata types, it's a check on just the member names for something with the right name. This should prevent us from unnecessarily loading all method signatures from metadata whenever we check for a clone method