### PR TITLE
Do not offer inline variable with target-typed new expressions

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -5426,5 +5426,62 @@ namespace Whatever
     </Project>
 </Workspace>");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(1237182, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1237182")]
+        public async Task TestMissingWithTargetTypedNewExpression()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    int M()
+    {
+        Random [||]r = new();
+        return r.Next();
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, new TestParameters(parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp9)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(1237182, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1237182")]
+        public async Task TestMissingWithParenthesizedTargetTypedNewExpression()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    int M()
+    {
+        Random [||]r = (new());
+        return r.Next();
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, new TestParameters(parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp9)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(1237182, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1237182")]
+        public async Task TestMissingWithCastTargetTypedNewExpression()
+        {
+            var code = @"
+using System;
+
+class C
+{
+    int M()
+    {
+        Random [||]r = (Random)new();
+        return r.Next();
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, new TestParameters(parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp9)));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -65,7 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
 
             if (variableDeclarator.Initializer == null ||
                 variableDeclarator.Initializer.Value.IsMissing ||
-                variableDeclarator.Initializer.Value.IsKind(SyntaxKind.StackAllocArrayCreationExpression))
+                variableDeclarator.Initializer.Value.IsKind(SyntaxKind.StackAllocArrayCreationExpression) ||
+                variableDeclarator.Initializer.Value.DescendantNodesAndSelf().Any(n => n.IsKind(SyntaxKind.ImplicitObjectCreationExpression)))
             {
                 return;
             }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1237182/

Target-typed new expressions cannot be inlined, so we should not offer it as a code action to the user.