### PR TITLE
Use a short delay instead of Task.Yield

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
                     // switch to the thread pool for the continuations since the yield will only let operations at the
                     // same or higher priority to execute prior to the continuation.
                     var continueOnCapturedContext = eventProcessingAction is object;
-                    await Task.Yield().ConfigureAwait(continueOnCapturedContext);
+                    await Task.Delay(smallTimeout).ConfigureAwait(continueOnCapturedContext);
 
                     if (startTime.Elapsed > timeout && timeout != Timeout.InfiniteTimeSpan)
                     {


### PR DESCRIPTION
This attempts to avoid CPU overhead during tests that may impact the ability to complete work.