### PR TITLE
Make VB commit-on-paste non-blocking.

### DIFF
--- a/docs/compilers/CSharp/CommandLine.md
+++ b/docs/compilers/CSharp/CommandLine.md
@@ -41,7 +41,7 @@
 | **ERRORS AND WARNINGS**
 | `/warnaserror`{`+`&#124;`-`} | Report all warnings as errors
 | `/warnaserror`{`+`&#124;`-`}`:`*warn list* | Report specific warnings as errors
-| `/warn`:*n* | Set warning level (0-4) (Short form: `/w`)
+| `/warn`:*n* | Set warning level (non-negative integer) (Short form: `/w`)
 | `/nowarn`:*warn list* | Disable specific warning messages
 | `/ruleset`:*file* | Specify a ruleset file that disables specific diagnostics.
 | `/errorlog`:*file* | Specify a file to log all compiler and analyzer diagnostics.

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -193,7 +193,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                                 dirtyRegion,
                                 _dirtyState.BaseSnapshot,
                                 tree,
-                                info.SpanToFormat.Snapshot.TextBuffer.CurrentSnapshot,
                                 blocking,
                                 cancellationToken).ConfigureAwait(False)
                         End Using

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitViewManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitViewManager.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 
                     Dim beforeCommitVersion = buffer.CurrentSnapshot.Version
                     Dim subjectBufferCaretPosition = MapDownToPoint(e.OldPosition)
-                    commitBufferManager.CommitDirty(isExplicitFormat:=False, cancellationToken:=cancellationToken)
+                    commitBufferManager.CommitDirty(isExplicitFormat:=False, cancellationToken)
 
                     If buffer.CurrentSnapshot.Version Is beforeCommitVersion Then
                         transaction.Cancel()
@@ -119,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 action:=
                 Sub(waitContext)
                     For Each buffer In _view.BufferGraph.GetTextBuffers(Function(b) b.ContentType.IsOfType(ContentTypeNames.VisualBasicContentType))
-                        _commitBufferManagerFactory.CreateForBuffer(buffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=waitContext.CancellationToken)
+                        _commitBufferManagerFactory.CreateForBuffer(buffer).CommitDirty(isExplicitFormat:=False, waitContext.CancellationToken)
                     Next
                 End Sub)
         End Sub

--- a/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
@@ -8,11 +8,14 @@ Imports Microsoft.VisualStudio.Text
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
     Friend Interface ICommitFormatter
         ''' <summary>
-        ''' Commits a region by formatting and case correcting it. It is assumed that an
-        ''' ITextUndoTransaction is open the underlying text buffer, as multiple edits may be done
-        ''' by this function. Further, if the operation is cancelled, the buffer may be left in a
-        ''' partially committed state that must be rolled back by the transaction.
+        ''' Commits a region by formatting and case correcting it. It is assumed that an ITextUndoTransaction is open
+        ''' the underlying text buffer, as multiple edits may be done by this function. Further, if the operation is
+        ''' cancelled, the buffer may be left in a partially committed state that must be rolled back by the
+        ''' transaction.
         ''' </summary>
+        ''' <remarks>
+        ''' This method must be called when on the UI thread as it examines the current state of the <see cref="ITextBuffer"/>.
+        ''' </remarks>
         Function CommitRegionAsync(
             spanToFormat As SnapshotSpan,
             isExplicitFormat As Boolean,
@@ -20,7 +23,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             dirtyRegion As SnapshotSpan,
             baseSnapshot As ITextSnapshot,
             baseTree As SyntaxTree,
-            currentSnapshot As ITextSnapshot,
             blocking As Boolean,
             cancellationToken As CancellationToken) As Task
     End Interface

--- a/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
@@ -13,13 +13,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
         ''' by this function. Further, if the operation is cancelled, the buffer may be left in a
         ''' partially committed state that must be rolled back by the transaction.
         ''' </summary>
-        Sub CommitRegion(
+        Function CommitRegionAsync(
             spanToFormat As SnapshotSpan,
             isExplicitFormat As Boolean,
             useSemantics As Boolean,
             dirtyRegion As SnapshotSpan,
             baseSnapshot As ITextSnapshot,
             baseTree As SyntaxTree,
-            cancellationToken As CancellationToken)
+            currentSnapshot As ITextSnapshot,
+            cancellationToken As CancellationToken) As Task
     End Interface
 End Namespace

--- a/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
@@ -21,6 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             baseSnapshot As ITextSnapshot,
             baseTree As SyntaxTree,
             currentSnapshot As ITextSnapshot,
+            blocking As Boolean,
             cancellationToken As CancellationToken) As Task
     End Interface
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -133,7 +133,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                     dirtyRegion As SnapshotSpan,
                     baseSnapshot As ITextSnapshot,
                     baseTree As SyntaxTree,
-                    currentSnapshot As ITextSnapshot,
                     blocking As Boolean,
                     cancellationToken As CancellationToken) As Task Implements ICommitFormatter.CommitRegionAsync
                 GotCommit = True
@@ -151,8 +150,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                     _testWorkspace.GetService(Of IIndentationManagerService),
                     _testWorkspace.ExportProvider.GetExportedValue(Of IThreadingContext))
                 Return realCommitFormatter.CommitRegionAsync(
-                    spanToFormat, isExplicitFormat, useSemantics, dirtyRegion, baseSnapshot, baseTree,
-                    currentSnapshot, blocking, cancellationToken)
+                    spanToFormat, isExplicitFormat, useSemantics, dirtyRegion, baseSnapshot, baseTree, blocking, cancellationToken)
             End Function
         End Class
     End Class

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute_Names.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute_Names.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public const string CallHierarchy = nameof(CallHierarchy);
         public const string Classification = nameof(Classification);
         public const string CodeModel = nameof(CodeModel);
+        public const string Commit = nameof(Commit);
         public const string CompletionSet = nameof(CompletionSet);
         public const string DiagnosticService = nameof(DiagnosticService);
         public const string EncapsulateField = nameof(EncapsulateField);


### PR DESCRIPTION
Opening up this PR to start a discussion on this topic (and about commit in general).  The PR shows a general approach we could follow here, but has some end user impact that could be concerning or desirable depending on your POV.

tests are not included yet, but would be if we want to go ahead with this.

The main difference here is that paste (and ideally other commit gestures in the future), are kicked off asynchronously and thus allow the user to start editing/etc. immediately after the gesture happens.  If the user does make any further edits we cancel the work.  Otherwise, once the work completes it attempts to apply itself to the workspace.  This will fail silently in the case that other changes have been made, which i feel is a net positive.

This also has the interesting effect of changing how undo works here.  Prior to this change, vb commit gestures create an entire transaction around the entire operation.  For example, if you paste today, VB will paste and commit htat section in one transaction.  That means if you undo, you go back to the state prior to the paste entirely.  Because the commit portion is now asynchronous you can observe two state changes to the buffer.  If you paste *and* it changes things like capitalization, you will have two entries in your undo stack.  This is also arguably a positive as it fits the general roslyn model of "first undo command will undo our 'smarts' and the second undo will undo the original text change that kicked everything off".  However, this could also be a pretty large change to the VB muscle memory model since people may now be surprised that hitting undo won't be enough to get rid of a paste that had commit changes happen to it.

One thing we might want to consider here would be non-modal UI to help the user know what's going on (which would also apply to 'add imports on paste').  i.e. while this async work was in flight, we might want something in the status-bar saying things like "performing pretty listing in background".  that way users could know this was happening, and when it was done, if they wanted to wait for it.  Without that, they'd really have no idea beyond just pausing a while and seeing if anythign changed.

--

Sam has proposed an alternative formalization which i quite like.  The general idea is to think of pretty-listing as something that asynchronously is trying to fixup the 'dirty sections' of a file.  We proactively kick off the work to do this pretty-listing (in an non-blocking fashion) when certain events happen (like typing, moving, pasting, etc.).  However, this work is cancellable when new events comes in and should not be blocking.  We then limit the blocking to work to explicit actions on the user side, like 'saving' or 'explicit format'.  

In essence, instead of having: dirty, blocking fixup, dirty, blocking fixup, etc.   we instead have:

1. dirty
2. try to fixup
3. new changes come in.  cancel fixup, grow dirty section
4. repeat the above until we finally get enough time to fixup, or we get an explicit save/format

I think this model would work quite nice and would meet the goals of being non-blocking for the user for normal typing, while still ensuring they get to a fixed point where the code is prettified.  

The main challenge here is in how crufty and ancient this code is.  Trying to manipulate it myself, i found it the current code extremely baroque and not factored very clearly.  I would be more amenable to a major rewrite here with some core components tasked with very explicit responsibilities.  For example, i would expect to have a cancellable queue that could easily have new work attached to it, while safely passing mutating data to it, and ensuring the right interactions with the BG thread (for computing results) and the UI thread (for applying them).  It would also completely abstract out the language specific processing, instead of having that interwoven all throughout the components today.

In this world, we could even envision C# adopting this sort of thing (in an opt-in/out).  Where we would have the same sort of dirty-tracking, and some C#-specific cleanup applied at some point in the future.  For example, we could envision being non-blocking, and only formatting much later.  

