### PR TITLE
[LSP] Return minimal edits for code actions when possible

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -181,7 +181,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
                     IEnumerable<TextChange> textChanges;
 
-                    // Normal documents use a special method to get their text changes which avoids dirtying the entire file unless necessary.
+                    // Normal documents have a unique method for calculating minimal text edits. If we used the standard 'GetTextChanges'
+                    // method instead, we would get a change that spans the entire document, which we ideally want to avoid.
                     if (newTextDoc is Document newDoc && oldTextDoc is Document oldDoc)
                     {
                         textChanges = await newDoc.GetTextChangesAsync(oldDoc, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -59,13 +59,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     .SelectMany(p => p.GetChangedDocuments(onlyGetDocumentsWithTextChanges: true))
                     .GroupBy(docId => renamedSolution.GetRequiredDocument(docId).FilePath, StringComparer.OrdinalIgnoreCase).Select(group => group.First());
 
+                var textDiffService = renamedSolution.Workspace.Services.GetRequiredService<IDocumentTextDifferencingService>();
                 using var _ = ArrayBuilder<TextDocumentEdit>.GetInstance(out var documentEdits);
                 foreach (var docId in changedDocuments)
                 {
                     var oldDoc = oldSolution.GetRequiredDocument(docId);
                     var newDoc = renamedSolution.GetRequiredDocument(docId);
 
-                    var textChanges = await newDoc.GetTextChangesAsync(oldDoc, cancellationToken).ConfigureAwait(false);
+                    var textChanges = await textDiffService.GetTextChangesAsync(oldDoc, newDoc, cancellationToken).ConfigureAwait(false);
                     var oldText = await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(false);
                     var textDocumentEdit = new TextDocumentEdit
                     {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1223716/

Normal documents have a `GetTextChangesAsync` method, which is much more efficient than the previously used `TextDocument.GetTextChanges` method as it returns minimal edits instead of dirtying the entire file.