### PR TITLE
Use .Any extension of ImmutableArray(Of Symbol)

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -1393,13 +1393,7 @@ _Default:
         End Sub
 
         Private Shared Function UnwrapAliases(symbols As ImmutableArray(Of Symbol)) As ImmutableArray(Of Symbol)
-            Dim anyAliases As Boolean = False
-
-            For Each sym In symbols
-                If sym.Kind = SymbolKind.Alias Then
-                    anyAliases = True
-                End If
-            Next
+            Dim anyAliases As Boolean = symbols.Any(Function(sym) sym.Kind = SymbolKind.Alias)
 
             If Not anyAliases Then
                 Return symbols


### PR DESCRIPTION
Removes the explicit For Each loop and replace with a call to the extension method `.Any` on the `ImmutableArray(Of Symbol)`