### PR TITLE
Add CodeStyle layer to SourceBuild

### DIFF
--- a/src/CodeStyle/Directory.Build.props
+++ b/src/CodeStyle/Directory.Build.props
@@ -1,8 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-
     <!-- https://github.com/dotnet/roslyn/issues/46984 -->
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>


### PR DESCRIPTION
SourceBuild includes the CodeStyle packages today, but doesn't actually build them from source. As CodeStyle doesn't bring any new dependencies, it's very straightforward to just unexclude them from SourceBuild and everything just works. /cc @dseefeld
