### PR TITLE
Don't crash when adding a parameter to the end of an extension method

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -2818,5 +2818,36 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        [WorkItem(48042, "https://github.com/dotnet/roslyn/issues/48042")]
+        public async Task TestNamedArgOnExtensionMethod()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+namespace r
+{
+    static class AbcExtensions
+    {
+        public static Abc Act(this Abc state, bool p = true) => state;
+    }
+    class Abc {
+        void Test()
+            => new Abc().Act([|param3|]: 123);
+    }
+}",
+@"
+namespace r
+{
+    static class AbcExtensions
+    {
+        public static Abc Act(this Abc state, bool p = true, int param3 = 0) => state;
+    }
+    class Abc {
+        void Test()
+            => new Abc().Act(param3: 123);
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/AddParameter/AddParameterService.cs
+++ b/src/Features/Core/Portable/AddParameter/AddParameterService.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
                             ConflictAnnotation.Create(FeaturesResources.Related_method_signatures_found_in_metadata_will_not_be_updated));
                     }
 
-                    if (method.MethodKind == MethodKind.ReducedExtension)
+                    if (method.MethodKind == MethodKind.ReducedExtension && insertionIndex < existingParameters.Count)
                     {
                         insertionIndex++;
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/48042