### PR TITLE
Use private protected setters in compilation options.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -522,7 +522,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return this;
             }
 
-            return new CSharpCompilationOptions(this) { CurrentLocalTime_internal_protected_set = value };
+            return new CSharpCompilationOptions(this) { CurrentLocalTime = value };
         }
 
         internal CSharpCompilationOptions WithDebugPlusMode(bool debugPlusMode)
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return this;
             }
 
-            return new CSharpCompilationOptions(this) { DebugPlusMode_internal_protected_set = debugPlusMode };
+            return new CSharpCompilationOptions(this) { DebugPlusMode = debugPlusMode };
         }
 
         public new CSharpCompilationOptions WithMetadataImportOptions(MetadataImportOptions value)
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return this;
             }
 
-            return new CSharpCompilationOptions(this) { ReferencesSupersedeLowerVersions_internal_protected_set = value };
+            return new CSharpCompilationOptions(this) { ReferencesSupersedeLowerVersions = value };
         }
 
         public new CSharpCompilationOptions WithXmlReferenceResolver(XmlReferenceResolver? resolver)

--- a/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
@@ -161,17 +161,12 @@ namespace Microsoft.CodeAnalysis
         /// Used for time-based version generation when <see cref="System.Reflection.AssemblyVersionAttribute"/> contains a wildcard.
         /// If equal to default(<see cref="DateTime"/>) the actual current local time will be used.
         /// </summary>
-        internal DateTime CurrentLocalTime { get; private set; }
-
-        internal DateTime CurrentLocalTime_internal_protected_set { set { CurrentLocalTime = value; } }
+        internal DateTime CurrentLocalTime { get; private protected set; }
 
         /// <summary>
         /// Emit mode that favors debuggability. 
         /// </summary>
-        internal bool DebugPlusMode { get; private set; }
-
-        // TODO: change visibility of the DebugPlusMode setter to internal & protected
-        internal bool DebugPlusMode_internal_protected_set { set { DebugPlusMode = value; } }
+        internal bool DebugPlusMode { get; private protected set; }
 
         /// <summary>
         /// Specifies whether to import members with accessibility other than public or protected by default. 
@@ -185,10 +180,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Apply additional disambiguation rules during resolution of referenced assemblies.
         /// </summary>
-        internal bool ReferencesSupersedeLowerVersions { get; private set; }
-
-        // TODO: change visibility of the ReferencesSupersedeLowerVersions setter to internal & protected
-        internal bool ReferencesSupersedeLowerVersions_internal_protected_set { set { ReferencesSupersedeLowerVersions = value; } }
+        internal bool ReferencesSupersedeLowerVersions { get; private protected set; }
 
         /// <summary>
         /// Modifies the incoming diagnostic, for example escalating its severity, or discarding it (returning null) based on the compilation options.

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -672,7 +672,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me
             End If
 
-            Return New VisualBasicCompilationOptions(Me) With {.CurrentLocalTime_internal_protected_set = value}
+            Return New VisualBasicCompilationOptions(Me) With {.CurrentLocalTime = value}
         End Function
 
         ''' <summary>
@@ -685,7 +685,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me
             End If
 
-            Return New VisualBasicCompilationOptions(Me) With {.DebugPlusMode_internal_protected_set = debugPlusMode}
+            Return New VisualBasicCompilationOptions(Me) With {.DebugPlusMode = debugPlusMode}
         End Function
 
         ''' <summary>
@@ -910,7 +910,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me
             End If
 
-            Return New VisualBasicCompilationOptions(Me) With {.ReferencesSupersedeLowerVersions_internal_protected_set = value}
+            Return New VisualBasicCompilationOptions(Me) With {.ReferencesSupersedeLowerVersions = value}
         End Function
 
         ''' <summary>


### PR DESCRIPTION
Walked to them randomly. VB seems support it.