### PR TITLE
Show Analyzers that only contain source generators

### DIFF
--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzerItem/AnalyzerItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzerItem/AnalyzerItemSource.cs
@@ -217,10 +217,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 // Analyzer dependency:
                 // 1. Must be an Analyzer file reference (we don't understand other analyzer dependencies).
                 // 2. Mush have no diagnostic analyzers.
-                // 3. Must have non-null full path.
-                // 4. Must not have any assembly or analyzer load failures.
+                // 3. Must have no source generators.
+                // 4. Must have non-null full path.
+                // 5. Must not have any assembly or analyzer load failures.
                 if (analyzerReference is AnalyzerFileReference &&
                     analyzerReference.GetAnalyzers(project.Language).IsDefaultOrEmpty &&
+                    analyzerReference.GetGenerators().IsDefaultOrEmpty &&
                     analyzerReference.FullPath != null &&
                     !analyzersWithLoadErrors.Contains(analyzerReference.FullPath))
                 {


### PR DESCRIPTION
We have logic where we try to hide assemblies that were passed with the /analyzer flag, that were really dependencies of other analyzers. This was incorrectly firing on an assembly that only contains source generators.