### PR TITLE
Disable code cleanup in LSP

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -178,6 +179,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         private Task<bool> FixTextBufferAsync(TextBufferCodeCleanUpScope textBufferScope, ICodeCleanUpExecutionContext context)
         {
             var buffer = textBufferScope.SubjectBuffer;
+
+            // Let LSP handle code cleanup in the cloud scenario
+            if (buffer.IsInCloudEnvironmentClientContext())
+            {
+                return SpecializedTasks.False;
+            }
+
             var document = buffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {


### PR DESCRIPTION
Code cleanup currently doesn't work in LSP - tracking issue here: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1094627
We should disable code cleanup for now.

Closes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1193339/