### PR TITLE
Avoid realizing documents in DiagnosticDataSerializer

### DIFF
--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
 
             var documentId = document != null
                 ? document.Id
-                : project.State.DocumentStates.FirstOrDefault(d => d.Value.FilePath == originalFile).Key;
+                : project.Solution.GetDocumentIdsWithFilePath(originalFile).FirstOrDefault(documentId => documentId.ProjectId == project.Id);
 
             return new DiagnosticDataLocation(documentId, sourceSpan,
                 originalFile, originalStartLine, originalStartColumn, originalEndLine, originalEndColumn,

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
 
             var documentId = document != null
                 ? document.Id
-                : project.Documents.FirstOrDefault(d => d.FilePath == originalFile)?.Id;
+                : project.State.DocumentStates.FirstOrDefault(d => d.Value.FilePath == originalFile).Key;
 
             return new DiagnosticDataLocation(documentId, sourceSpan,
                 originalFile, originalStartLine, originalStartColumn, originalEndLine, originalEndColumn,


### PR DESCRIPTION
This change gives a 25% performance improvement for a recent internal trace.