### PR TITLE
Add an enforcement for a layering separation between Cci instances used for metadata emit and compiler symbols.

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/ExpandedVarargsMethodReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ExpandedVarargsMethodReference.cs
@@ -229,13 +229,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/FunctionPointerTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/FunctionPointerTypeSymbolAdapter.cs
@@ -130,11 +130,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override bool Equals(object? obj)
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw ExceptionUtilities.Unreachable;
             }
 
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             public override int GetHashCode() => throw ExceptionUtilities.Unreachable;
 
             public override string ToString() => _underlying.ToDisplayString(SymbolDisplayFormat.ILVisualizationFormat);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs
@@ -54,26 +54,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private MethodSymbolAdapter _lazyAdapter;
 
         protected sealed override SymbolAdapter GetCciAdapterImpl() => GetCciAdapter();
-#endif
-        internal new
-#if DEBUG
-            MethodSymbolAdapter
-#else
-            MethodSymbol
-#endif
-            GetCciAdapter()
+
+        internal new MethodSymbolAdapter GetCciAdapter()
         {
-#if DEBUG
             if (_lazyAdapter is null)
             {
-                return InterlockedOperations.Initialize(ref _lazyAdapter, new MethodSymbolAdapter(this));
+                return InterlockedOperations.Initialize(ref _lazyAdapter, CreateCciAdapter());
             }
 
             return _lazyAdapter;
-#else
-            return this;
-#endif
         }
+
+        protected virtual MethodSymbolAdapter CreateCciAdapter()
+        {
+            return new MethodSymbolAdapter(this);
+        }
+#else
+        internal new MethodSymbol GetCciAdapter()
+        {
+            return this;
+        }
+#endif 
     }
 
     internal partial class

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeReference.cs
@@ -157,13 +157,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/ParameterTypeInformation.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ParameterTypeInformation.cs
@@ -68,13 +68,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/ParameterTypeInformation.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ParameterTypeInformation.cs
@@ -119,11 +119,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         public sealed override bool Equals(object obj)
         {
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SymbolAdapter.cs
@@ -37,13 +37,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeMemberReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeMemberReference.cs
@@ -52,13 +52,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/CodeGen/ArrayMembers.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ArrayMembers.cs
@@ -368,13 +368,13 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public sealed override bool Equals(object? obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -437,13 +437,13 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public sealed override bool Equals(object? obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }
@@ -604,13 +604,13 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public sealed override bool Equals(object? obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/Emit/ErrorType.cs
+++ b/src/Compilers/Core/Portable/Emit/ErrorType.cs
@@ -182,13 +182,13 @@ namespace Microsoft.CodeAnalysis.Emit
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMember.cs
@@ -118,13 +118,13 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             public sealed override bool Equals(object obj)
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
 
             public sealed override int GetHashCode()
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
         }

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedParameter.cs
@@ -272,13 +272,13 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             public sealed override bool Equals(object obj)
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
 
             public sealed override int GetHashCode()
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
         }

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -706,13 +706,13 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             public sealed override bool Equals(object obj)
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
 
             public sealed override int GetHashCode()
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
         }

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedTypeParameter.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedTypeParameter.cs
@@ -226,13 +226,13 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
             public sealed override bool Equals(object obj)
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
 
             public sealed override int GetHashCode()
             {
-                // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+                // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
                 throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
             }
         }

--- a/src/Compilers/Core/Portable/Emit/NoPia/VtblGap.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/VtblGap.cs
@@ -259,13 +259,13 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
@@ -298,13 +298,13 @@ namespace Microsoft.Cci
 
         public sealed override bool Equals(object? obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/PEWriter/ModifiedTypeReference.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ModifiedTypeReference.cs
@@ -149,13 +149,13 @@ namespace Microsoft.Cci
 
         public sealed override bool Equals(object? obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/PEWriter/ReturnValueParameter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReturnValueParameter.cs
@@ -116,13 +116,13 @@ namespace Microsoft.Cci
 
         public sealed override bool Equals(object? obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/PEWriter/RootModuleStaticConstructor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/RootModuleStaticConstructor.cs
@@ -165,13 +165,13 @@ namespace Microsoft.Cci
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
+++ b/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
@@ -315,13 +315,13 @@ namespace Microsoft.Cci
 
         public sealed override bool Equals(object? obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
@@ -1105,7 +1105,7 @@ OtherExpressions:
                 _builder.EmitOpCode(ILOpCode.[Call], stackAdjustment:=0)
                 _builder.EmitToken(stringHashMethodRef, syntaxNode, _diagnostics)
 
-                Dim UInt32Type = DirectCast(_module.GetSpecialType(SpecialType.System_UInt32, syntaxNode, _diagnostics), TypeSymbol)
+                Dim UInt32Type = DirectCast(_module.GetSpecialType(SpecialType.System_UInt32, syntaxNode, _diagnostics).GetInternalSymbol(), TypeSymbol)
                 keyHash = AllocateTemp(UInt32Type, syntaxNode)
 
                 _builder.EmitLocalStore(keyHash)

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -596,7 +596,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Debug.Assert(sharedConstructorDelegateRelaxationIdDispenser = 0)
 
                     If _moduleBeingBuiltOpt IsNot Nothing Then
-                        _moduleBeingBuiltOpt.AddSynthesizedDefinition(sourceTypeSymbol, sharedDefaultConstructor)
+                        _moduleBeingBuiltOpt.AddSynthesizedDefinition(sourceTypeSymbol, sharedDefaultConstructor.GetCciAdapter())
                     End If
                 End If
             End If
@@ -805,7 +805,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         End If
 
                         f.CloseMethod(body)
-                        _moduleBeingBuiltOpt.AddSynthesizedDefinition(method.ContainingType, DirectCast(matchingStub, Microsoft.Cci.IMethodDefinition))
+                        _moduleBeingBuiltOpt.AddSynthesizedDefinition(method.ContainingType, DirectCast(matchingStub.GetCciAdapter(), Microsoft.Cci.IMethodDefinition))
                     End If
 
                     matchingStub.AddImplementedMethod(implemented)
@@ -842,7 +842,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(_moduleBeingBuiltOpt IsNot Nothing)
 
             Dim compilationState As New TypeCompilationState(_compilation, _moduleBeingBuiltOpt, initializeComponentOpt:=Nothing)
-            For Each method As MethodSymbol In privateImplClass.GetMethods(Nothing)
+            For Each methodDef In privateImplClass.GetMethods(Nothing)
+                Dim method = DirectCast(methodDef.GetInternalSymbol(), MethodSymbol)
                 Dim diagnosticsThisMethod = DiagnosticBag.GetInstance()
 
                 Dim boundBody = method.GetBoundMethodBody(compilationState, diagnosticsThisMethod)
@@ -1307,7 +1308,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' no need to rewrite getter, they are pretty simple and 
                 ' are already in a lowered form.
                 compilationState.AddMethodWrapper(getter, getter, getterBody)
-                _moduleBeingBuiltOpt.AddSynthesizedDefinition(containingType, getter)
+                _moduleBeingBuiltOpt.AddSynthesizedDefinition(containingType, getter.GetCciAdapter())
 
                 ' setter needs to rewritten as it may require lambda conversions
                 Dim setterBody = setter.GetBoundMethodBody(compilationState, diagnostics, containingTypeBinder)
@@ -1340,10 +1341,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 closureDebugInfoBuilder.Free()
 
                 compilationState.AddMethodWrapper(setter, setter, setterBody)
-                _moduleBeingBuiltOpt.AddSynthesizedDefinition(containingType, setter)
+                _moduleBeingBuiltOpt.AddSynthesizedDefinition(containingType, setter.GetCciAdapter())
 
                 ' add property too
-                _moduleBeingBuiltOpt.AddSynthesizedDefinition(containingType, prop)
+                _moduleBeingBuiltOpt.AddSynthesizedDefinition(containingType, prop.GetCciAdapter())
                 withEventPropertyIdDispenser += 1
             Next
         End Sub
@@ -1558,7 +1559,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' So it is undesirable to consider these exceptions "user unhandled" since there may well be user code that is awaiting the task.
                     ' This is a heuristic since it's possible that there is no user code awaiting the task.
                     moveNextBodyDebugInfoOpt = New AsyncMoveNextBodyDebugInfo(
-                        kickoffMethod,
+                        kickoffMethod.GetCciAdapter(),
                         If(kickoffMethod.IsSub, asyncCatchHandlerOffset, -1),
                         asyncYieldPoints,
                         asyncResumePoints)
@@ -1566,7 +1567,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     codeGen.Generate()
 
                     If kickoffMethod IsNot Nothing Then
-                        moveNextBodyDebugInfoOpt = New IteratorMoveNextBodyDebugInfo(kickoffMethod)
+                        moveNextBodyDebugInfoOpt = New IteratorMoveNextBodyDebugInfo(kickoffMethod.GetCciAdapter())
                     End If
                 End If
 
@@ -1610,7 +1611,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Return New MethodBody(builder.RealizedIL,
                                       builder.MaxStack,
-                                      If(method.PartialDefinitionPart, method),
+                                      If(method.PartialDefinitionPart, method).GetCciAdapter(),
                                       If(variableSlotAllocatorOpt?.MethodId, New DebugId(methodOrdinal, moduleBuilder.CurrentGenerationOrdinal)),
                                       builder.LocalSlotManager.LocalsInOrder(),
                                       builder.RealizedSequencePoints,
@@ -1645,7 +1646,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim hoistedVariables = ArrayBuilder(Of EncHoistedLocalInfo).GetInstance()
             Dim awaiters = ArrayBuilder(Of Cci.ITypeReference).GetInstance()
 
-            For Each field As StateMachineFieldSymbol In fieldDefs
+            For Each def In fieldDefs
+                Dim field = DirectCast(def.GetInternalSymbol(), StateMachineFieldSymbol)
                 Dim index = field.SlotIndex
 
                 If field.SlotDebugInfo.SynthesizedKind = SynthesizedLocalKind.AwaiterField Then

--- a/src/Compilers/VisualBasic/Portable/Compilation/NamespaceScopeBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/NamespaceScopeBuilder.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each aliasImport In aliasImportsOpt
                     Dim target = aliasImport.Alias.Target
                     If target.IsNamespace Then
-                        scopeBuilder.Add(Cci.UsedNamespaceOrType.CreateNamespace(DirectCast(target, NamespaceSymbol), aliasOpt:=aliasImport.Alias.Name))
+                        scopeBuilder.Add(Cci.UsedNamespaceOrType.CreateNamespace(DirectCast(target, NamespaceSymbol).GetCciAdapter(), aliasOpt:=aliasImport.Alias.Name))
                     ElseIf target.Kind <> SymbolKind.ErrorType AndAlso Not target.ContainingAssembly.IsLinked Then
                         ' It is not an error to import a non-existing type (unlike C#), skip the error types.
                         ' We also skip alias imports of embedded types to avoid breaking existing code that
@@ -53,7 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(target.Kind <> SymbolKind.ErrorType)
 
                 If target.IsNamespace Then
-                    scopeBuilder.Add(Cci.UsedNamespaceOrType.CreateNamespace(DirectCast(target, NamespaceSymbol)))
+                    scopeBuilder.Add(Cci.UsedNamespaceOrType.CreateNamespace(DirectCast(target, NamespaceSymbol).GetCciAdapter()))
                 ElseIf Not target.ContainingAssembly.IsLinked Then
                     ' We skip imports of embedded types to avoid breaking existing code that
                     ' imports types that can't be embedded but doesn't use them anywhere else in the code.

--- a/src/Compilers/VisualBasic/Portable/Emit/ArrayTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ArrayTypeSymbolAdapter.vb
@@ -8,13 +8,67 @@ Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
+#If DEBUG Then
+    Partial Friend NotInheritable Class ArrayTypeSymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend Class ArrayTypeSymbol
+#End If
         Implements Cci.IArrayTypeReference
+
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedArrayTypeSymbol As ArrayTypeSymbol
+
+        Friend Sub New(underlyingArrayTypeSymbol As ArrayTypeSymbol)
+            AdaptedArrayTypeSymbol = underlyingArrayTypeSymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedArrayTypeSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedArrayTypeSymbol As ArrayTypeSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class ArrayTypeSymbol
+#If DEBUG Then
+        Private _lazyAdapter As ArrayTypeSymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As ArrayTypeSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, New ArrayTypeSymbolAdapter(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As ArrayTypeSymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ArrayTypeSymbolAdapter
+#End If
 
         Private Function IArrayTypeReferenceGetElementType(context As EmitContext) As Cci.ITypeReference Implements Cci.IArrayTypeReference.GetElementType
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
-            Dim customModifiers As ImmutableArray(Of CustomModifier) = Me.CustomModifiers
-            Dim type = moduleBeingBuilt.Translate(Me.ElementType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+            Dim customModifiers As ImmutableArray(Of CustomModifier) = AdaptedArrayTypeSymbol.CustomModifiers
+            Dim type = moduleBeingBuilt.Translate(AdaptedArrayTypeSymbol.ElementType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
 
             If customModifiers.Length = 0 Then
                 Return type
@@ -25,25 +79,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IArrayTypeReferenceIsSZArray As Boolean Implements Cci.IArrayTypeReference.IsSZArray
             Get
-                Return Me.IsSZArray
+                Return AdaptedArrayTypeSymbol.IsSZArray
             End Get
         End Property
 
         Private ReadOnly Property IArrayTypeReferenceLowerBounds As ImmutableArray(Of Integer) Implements Cci.IArrayTypeReference.LowerBounds
             Get
-                Return LowerBounds
+                Return AdaptedArrayTypeSymbol.LowerBounds
             End Get
         End Property
 
         Private ReadOnly Property IArrayTypeReferenceRank As Integer Implements Cci.IArrayTypeReference.Rank
             Get
-                Return Rank
+                Return AdaptedArrayTypeSymbol.Rank
             End Get
         End Property
 
         Private ReadOnly Property IArrayTypeReferenceSizes As ImmutableArray(Of Integer) Implements Cci.IArrayTypeReference.Sizes
             Get
-                Return Sizes
+                Return AdaptedArrayTypeSymbol.Sizes
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -131,12 +131,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 If GeneratedNames.TryParseAnonymousTypeTemplateName(GeneratedNames.AnonymousTypeTemplateNamePrefix, name, index) Then
                     Dim type = DirectCast(metadataDecoder.GetTypeOfToken(handle), NamedTypeSymbol)
                     Dim key = GetAnonymousTypeKey(type)
-                    Dim value = New AnonymousTypeValue(name, index, type)
+                    Dim value = New AnonymousTypeValue(name, index, type.GetCciAdapter())
                     result.Add(key, value)
                 ElseIf GeneratedNames.TryParseAnonymousTypeTemplateName(GeneratedNames.AnonymousDelegateTemplateNamePrefix, name, index) Then
                     Dim type = DirectCast(metadataDecoder.GetTypeOfToken(handle), NamedTypeSymbol)
                     Dim key = GetAnonymousDelegateKey(type)
-                    Dim value = New AnonymousTypeValue(name, index, type)
+                    Dim value = New AnonymousTypeValue(name, index, type.GetCciAdapter())
                     result.Add(key, value)
                 End If
             Next
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Dim embeddedTypesManager = Me.EmbeddedTypesManagerOpt
             If embeddedTypesManager IsNot Nothing Then
                 For Each embeddedType In embeddedTypesManager.EmbeddedTypesMap.Keys
-                    diagnostics.Add(ErrorFactory.ErrorInfo(ERRID.ERR_EncNoPIAReference, embeddedType), Location.None)
+                    diagnostics.Add(ErrorFactory.ErrorInfo(ERRID.ERR_EncNoPIAReference, embeddedType.AdaptedNamedTypeSymbol), Location.None)
                 Next
             End If
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicDefinitionMap.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicDefinitionMap.vb
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Friend Overrides Function TryGetTypeHandle(def As Cci.ITypeDefinition, <Out> ByRef handle As TypeDefinitionHandle) As Boolean
-            Dim other = TryCast(_mapToMetadata.MapDefinition(def), PENamedTypeSymbol)
+            Dim other = TryCast(_mapToMetadata.MapDefinition(def)?.GetInternalSymbol(), PENamedTypeSymbol)
             If other IsNot Nothing Then
                 handle = other.Handle
                 Return True
@@ -81,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Friend Overrides Function TryGetEventHandle(def As Cci.IEventDefinition, <Out> ByRef handle As EventDefinitionHandle) As Boolean
-            Dim other = TryCast(_mapToMetadata.MapDefinition(def), PEEventSymbol)
+            Dim other = TryCast(_mapToMetadata.MapDefinition(def)?.GetInternalSymbol(), PEEventSymbol)
             If other IsNot Nothing Then
                 handle = other.Handle
                 Return True
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Friend Overrides Function TryGetFieldHandle(def As Cci.IFieldDefinition, <Out> ByRef handle As FieldDefinitionHandle) As Boolean
-            Dim other = TryCast(_mapToMetadata.MapDefinition(def), PEFieldSymbol)
+            Dim other = TryCast(_mapToMetadata.MapDefinition(def)?.GetInternalSymbol(), PEFieldSymbol)
             If other IsNot Nothing Then
                 handle = other.Handle
                 Return True
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Friend Overrides Function TryGetMethodHandle(def As Cci.IMethodDefinition, <Out> ByRef handle As MethodDefinitionHandle) As Boolean
-            Dim other = TryCast(_mapToMetadata.MapDefinition(def), PEMethodSymbol)
+            Dim other = TryCast(_mapToMetadata.MapDefinition(def)?.GetInternalSymbol(), PEMethodSymbol)
             If other IsNot Nothing Then
                 handle = other.Handle
                 Return True
@@ -114,7 +114,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Friend Overrides Function TryGetPropertyHandle(def As Cci.IPropertyDefinition, <Out> ByRef handle As PropertyDefinitionHandle) As Boolean
-            Dim other = TryCast(_mapToMetadata.MapDefinition(def), PEPropertySymbol)
+            Dim other = TryCast(_mapToMetadata.MapDefinition(def)?.GetInternalSymbol(), PEPropertySymbol)
             If other IsNot Nothing Then
                 handle = other.Handle
                 Return True
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Debug.Assert(TypeOf stateMachineType.ContainingAssembly Is PEAssemblySymbol)
 
             Dim hoistedLocals = New Dictionary(Of EncHoistedLocalInfo, Integer)()
-            Dim awaiters = New Dictionary(Of Cci.ITypeReference, Integer)
+            Dim awaiters = New Dictionary(Of Cci.ITypeReference, Integer)(DirectCast(Cci.SymbolEquivalentEqualityComparer.Instance, IEqualityComparer(Of Cci.IReference)))
             Dim maxAwaiterSlotIndex = -1
 
             For Each member In DirectCast(stateMachineType, TypeSymbol).GetMembers()
@@ -156,10 +156,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                         Case GeneratedNameKind.StateMachineAwaiterField
 
                             If GeneratedNames.TryParseSlotIndex(StringConstants.StateMachineAwaiterFieldPrefix, name, slotIndex) Then
-                                Dim field = DirectCast(member, IFieldSymbol)
+                                Dim field = DirectCast(member, FieldSymbol)
 
                                 ' Correct metadata won't contain duplicates, but malformed might, ignore the duplicate:
-                                awaiters(DirectCast(field.Type, Cci.ITypeReference)) = slotIndex
+                                awaiters(DirectCast(field.Type.GetCciAdapter(), Cci.ITypeReference)) = slotIndex
 
                                 If slotIndex > maxAwaiterSlotIndex Then
                                     maxAwaiterSlotIndex = slotIndex
@@ -172,13 +172,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                             Dim _name As String = Nothing
                             If GeneratedNames.TryParseSlotIndex(StringConstants.HoistedSynthesizedLocalPrefix, name, slotIndex) OrElse
                                GeneratedNames.TryParseStateMachineHoistedUserVariableName(name, _name, slotIndex) Then
-                                Dim field = DirectCast(member, IFieldSymbol)
+                                Dim field = DirectCast(member, FieldSymbol)
                                 If slotIndex >= localSlotDebugInfo.Length Then
                                     ' Invalid metadata
                                     Continue For
                                 End If
 
-                                Dim key = New EncHoistedLocalInfo(localSlotDebugInfo(slotIndex), DirectCast(field.Type, Cci.ITypeReference))
+                                Dim key = New EncHoistedLocalInfo(localSlotDebugInfo(slotIndex), DirectCast(field.Type.GetCciAdapter(), Cci.ITypeReference))
 
                                 ' Correct metadata won't contain duplicates, but malformed might, ignore the duplicate:
                                 hoistedLocals(key) = slotIndex
@@ -230,7 +230,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                         ' We do Not emit custom modifiers on locals so ignore the
                         ' previous version of the local if it had custom modifiers.
                         If metadata.CustomModifiers.IsDefaultOrEmpty Then
-                            Dim local = New EncLocalInfo(slot, DirectCast(metadata.Type, Cci.ITypeReference), metadata.Constraints, metadata.SignatureOpt)
+                            Dim local = New EncLocalInfo(slot, DirectCast(metadata.Type.GetCciAdapter(), Cci.ITypeReference), metadata.Constraints, metadata.SignatureOpt)
                             map.Add(local, slotIndex)
                         End If
                     End If

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -42,23 +42,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Sub
 
         Public Overrides Function MapDefinition(definition As Cci.IDefinition) As Cci.IDefinition
-            Dim symbol As Symbol = TryCast(definition, Symbol)
+            Dim symbol As Symbol = TryCast(definition?.GetInternalSymbol(), Symbol)
             If symbol IsNot Nothing Then
-                Return DirectCast(_symbols.Visit(symbol), Cci.IDefinition)
+                Return DirectCast(_symbols.Visit(symbol)?.GetCciAdapter(), Cci.IDefinition)
             End If
 
             Return _defs.VisitDef(definition)
         End Function
 
         Public Overrides Function MapNamespace([namespace] As Cci.INamespace) As Cci.INamespace
-            Debug.Assert(TypeOf [namespace] Is NamespaceSymbol)
-            Return DirectCast(_symbols.Visit(CType([namespace], NamespaceSymbol)), Cci.INamespace)
+            Debug.Assert(TypeOf [namespace]?.GetInternalSymbol() Is NamespaceSymbol)
+            Return DirectCast(_symbols.Visit(DirectCast([namespace]?.GetInternalSymbol(), NamespaceSymbol))?.GetCciAdapter(), Cci.INamespace)
         End Function
 
         Public Overrides Function MapReference(reference As Cci.ITypeReference) As Cci.ITypeReference
-            Dim symbol As Symbol = TryCast(reference, Symbol)
+            Dim symbol As Symbol = TryCast(reference?.GetInternalSymbol(), Symbol)
             If symbol IsNot Nothing Then
-                Return DirectCast(_symbols.Visit(symbol), Cci.ITypeReference)
+                Return DirectCast(_symbols.Visit(symbol)?.GetCciAdapter(), Cci.ITypeReference)
             End If
             Return Nothing
         End Function
@@ -191,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                     If member.Kind = SymbolKind.Namespace Then
                         GetTopLevelTypes(builder, DirectCast(member, NamespaceSymbol))
                     Else
-                        builder.Add(DirectCast(member, Cci.INamespaceTypeDefinition))
+                        builder.Add(DirectCast(member.GetCciAdapter(), Cci.INamespaceTypeDefinition))
                     End If
                 Next
             End Sub
@@ -435,7 +435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                             Debug.Assert(otherContainer Is _otherAssembly.GlobalNamespace)
                             Dim value As AnonymousTypeValue = Nothing
                             TryFindAnonymousType(template, value)
-                            Return DirectCast(value.Type, NamedTypeSymbol)
+                            Return DirectCast(value.Type?.GetInternalSymbol(), NamedTypeSymbol)
                         End If
 
                         If type.IsAnonymousType Then

--- a/src/Compilers/VisualBasic/Portable/Emit/EventSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EventSymbolAdapter.vb
@@ -7,26 +7,79 @@ Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
+#If DEBUG Then
+    Partial Friend NotInheritable Class EventSymbolAdapter
+        Inherits SymbolAdapter
+#Else
+    Partial Friend Class EventSymbol
+#End If
+        Implements Cci.IEventDefinition
+
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedEventSymbol As EventSymbol
+
+        Friend Sub New(underlyingEventSymbol As EventSymbol)
+            AdaptedEventSymbol = underlyingEventSymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedEventSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedEventSymbol As EventSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
 
     Partial Friend Class EventSymbol
-        Implements Cci.IEventDefinition
+#If DEBUG Then
+        Private _lazyAdapter As EventSymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As EventSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, New EventSymbolAdapter(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As EventSymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class EventSymbolAdapter
+#End If
 
         Private Iterator Function IEventDefinitionAccessors(context As EmitContext) As IEnumerable(Of Cci.IMethodReference) Implements Cci.IEventDefinition.GetAccessors
             CheckDefinitionInvariant()
 
-            Dim addMethod = Me.AddMethod
+            Dim addMethod = AdaptedEventSymbol.AddMethod.GetCciAdapter()
             Debug.Assert(addMethod IsNot Nothing)
             If addMethod.ShouldInclude(context) Then
                 Yield addMethod
             End If
 
-            Dim removeMethod = Me.RemoveMethod
+            Dim removeMethod = AdaptedEventSymbol.RemoveMethod.GetCciAdapter()
             Debug.Assert(removeMethod IsNot Nothing)
             If removeMethod.ShouldInclude(context) Then
                 Yield removeMethod
             End If
 
-            Dim raiseMethod = Me.RaiseMethod
+            Dim raiseMethod = AdaptedEventSymbol.RaiseMethod?.GetCciAdapter()
             If raiseMethod IsNot Nothing AndAlso raiseMethod.ShouldInclude(context) Then
                 Yield raiseMethod
             End If
@@ -35,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IEventDefinitionAdder As Cci.IMethodReference Implements Cci.IEventDefinition.Adder
             Get
                 CheckDefinitionInvariant()
-                Dim addMethod As MethodSymbol = Me.AddMethod
+                Dim addMethod = AdaptedEventSymbol.AddMethod.GetCciAdapter()
                 Debug.Assert(addMethod IsNot Nothing)
                 Return addMethod
             End Get
@@ -45,7 +98,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IEventDefinitionRemover As Cci.IMethodReference Implements Cci.IEventDefinition.Remover
             Get
                 CheckDefinitionInvariant()
-                Dim removeMethod As MethodSymbol = Me.RemoveMethod
+                Dim removeMethod = AdaptedEventSymbol.RemoveMethod.GetCciAdapter()
                 Debug.Assert(removeMethod IsNot Nothing)
                 Return removeMethod
             End Get
@@ -55,10 +108,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IEventDefinitionIsRuntimeSpecial As Boolean Implements Cci.IEventDefinition.IsRuntimeSpecial
             Get
                 CheckDefinitionInvariant()
-                Return HasRuntimeSpecialName
+                Return AdaptedEventSymbol.HasRuntimeSpecialName
             End Get
 
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class EventSymbol
+#End If
 
         Friend Overridable ReadOnly Property HasRuntimeSpecialName As Boolean
             Get
@@ -67,10 +126,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class EventSymbolAdapter
+#End If
+
         Private ReadOnly Property IEventDefinitionIsSpecialName As Boolean Implements Cci.IEventDefinition.IsSpecialName
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasSpecialName
+                Return AdaptedEventSymbol.HasSpecialName
             End Get
 
         End Property
@@ -78,19 +143,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IEventDefinitionCaller As Cci.IMethodReference Implements Cci.IEventDefinition.Caller
             Get
                 CheckDefinitionInvariant()
-                Return Me.RaiseMethod
+                Return AdaptedEventSymbol.RaiseMethod?.GetCciAdapter()
             End Get
 
         End Property
 
         Private Overloads Function IEventDefinitionGetType(context As EmitContext) As Cci.ITypeReference Implements Cci.IEventDefinition.GetType
-            Return (DirectCast(context.Module, PEModuleBuilder)).Translate(Me.Type, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+            Return (DirectCast(context.Module, PEModuleBuilder)).Translate(AdaptedEventSymbol.Type, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
         End Function
 
         Private ReadOnly Property IEventDefinitionContainingTypeDefinition As Cci.ITypeDefinition Implements Cci.IEventDefinition.ContainingTypeDefinition
             Get
                 CheckDefinitionInvariant()
-                Return Me.ContainingType
+                Return AdaptedEventSymbol.ContainingType.GetCciAdapter()
             End Get
 
         End Property
@@ -98,14 +163,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IEventDefinitionVisibility As Cci.TypeMemberVisibility Implements Cci.IEventDefinition.Visibility
             Get
                 CheckDefinitionInvariant()
-                Return PEModuleBuilder.MemberVisibility(Me)
+                Return PEModuleBuilder.MemberVisibility(AdaptedEventSymbol)
             End Get
 
         End Property
 
         Private Function ITypeMemberReferenceGetContainingType(context As EmitContext) As Cci.ITypeReference Implements Cci.ITypeMemberReference.GetContainingType
             CheckDefinitionInvariant()
-            Return Me.ContainingType
+            Return AdaptedEventSymbol.ContainingType.GetCciAdapter()
         End Function
 
         Friend Overrides Sub IReferenceDispatch(visitor As Cci.MetadataVisitor) ' Implements Cci.IReference.Dispatch
@@ -121,7 +186,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IEventDefinitionName As String Implements Cci.IEventDefinition.Name
             Get
                 CheckDefinitionInvariant()
-                Return Me.MetadataName
+                Return AdaptedEventSymbol.MetadataName
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/FieldSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/FieldSymbolAdapter.vb
@@ -9,18 +9,81 @@ Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
-
+#If DEBUG Then
+    Partial Friend Class FieldSymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend Class FieldSymbol
+#End If
         Implements IFieldReference
         Implements IFieldDefinition
         Implements ITypeMemberReference
         Implements ITypeDefinitionMember
         Implements ISpecializedFieldReference
 
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedFieldSymbol As FieldSymbol
+
+        Protected Sub New(underlyingFieldSymbol As FieldSymbol)
+            AdaptedFieldSymbol = underlyingFieldSymbol
+        End Sub
+
+        Friend Shared Function Create(underlyingFieldSymbol As FieldSymbol) As FieldSymbolAdapter
+            Dim synthesizedStaticLocalBackingField = TryCast(underlyingFieldSymbol, SynthesizedStaticLocalBackingField)
+
+            If synthesizedStaticLocalBackingField IsNot Nothing Then
+                Return New SynthesizedStaticLocalBackingFieldAdapter(synthesizedStaticLocalBackingField)
+            End If
+
+            Return New FieldSymbolAdapter(underlyingFieldSymbol)
+        End Function
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedFieldSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedFieldSymbol As FieldSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class FieldSymbol
+#If DEBUG Then
+        Private _lazyAdapter As FieldSymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As FieldSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, FieldSymbolAdapter.Create(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As FieldSymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class FieldSymbolAdapter
+#End If
+
         Private Function IFieldReferenceGetType(context As EmitContext) As ITypeReference Implements IFieldReference.GetType
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
-            Dim customModifiers = Me.CustomModifiers
-            Dim type = moduleBeingBuilt.Translate(Me.Type, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+            Dim customModifiers = AdaptedFieldSymbol.CustomModifiers
+            Dim type = moduleBeingBuilt.Translate(AdaptedFieldSymbol.Type, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
             If customModifiers.Length = 0 Then
                 Return type
             Else
@@ -35,7 +98,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function ResolvedFieldImpl(moduleBeingBuilt As PEModuleBuilder) As IFieldDefinition
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            If Me.IsDefinition AndAlso Me.ContainingModule = moduleBeingBuilt.SourceModule Then
+            If AdaptedFieldSymbol.IsDefinition AndAlso AdaptedFieldSymbol.ContainingModule = moduleBeingBuilt.SourceModule Then
                 Return Me
             End If
 
@@ -46,7 +109,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 Debug.Assert(Me.IsDefinitionOrDistinct())
 
-                If Not Me.IsDefinition Then
+                If Not AdaptedFieldSymbol.IsDefinition Then
                     Return Me
                 End If
 
@@ -58,16 +121,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            Return moduleBeingBuilt.Translate(Me.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics, needDeclaration:=Me.IsDefinition)
+            Return moduleBeingBuilt.Translate(AdaptedFieldSymbol.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics, needDeclaration:=AdaptedFieldSymbol.IsDefinition)
         End Function
 
         Friend NotOverridable Overrides Sub IReferenceDispatch(visitor As MetadataVisitor) ' Implements IReference.Dispatch
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            If Not Me.IsDefinition Then
+            If Not AdaptedFieldSymbol.IsDefinition Then
                 visitor.Visit(DirectCast(Me, ISpecializedFieldReference))
             Else
-                If Me.ContainingModule = (DirectCast(visitor.Context.Module, PEModuleBuilder)).SourceModule Then
+                If AdaptedFieldSymbol.ContainingModule = (DirectCast(visitor.Context.Module, PEModuleBuilder)).SourceModule Then
                     visitor.Visit(DirectCast(Me, IFieldDefinition))
                 Else
                     visitor.Visit(DirectCast(Me, IFieldReference))
@@ -82,13 +145,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property INamedEntityName As String Implements INamedEntity.Name
             Get
-                Return Me.MetadataName
+                Return AdaptedFieldSymbol.MetadataName
             End Get
         End Property
 
-        Friend Overridable ReadOnly Property IFieldReferenceIsContextualNamedEntity As Boolean Implements IFieldReference.IsContextualNamedEntity
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class FieldSymbol
+#End If
+
+        Friend Overridable ReadOnly Property IsContextualNamedEntity As Boolean
             Get
                 Return False
+            End Get
+        End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class FieldSymbolAdapter
+#End If
+        Private ReadOnly Property IFieldReference_IsContextualNamedEntity As Boolean Implements IFieldReference.IsContextualNamedEntity
+            Get
+                Return AdaptedFieldSymbol.IsContextualNamedEntity
             End Get
         End Property
 
@@ -101,8 +181,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function GetMetadataConstantValue(context As EmitContext) As MetadataConstant
             ' do not return a compile time value for const fields of types DateTime or Decimal because they
             ' are only const from a VB point of view
-            If Me.IsMetadataConstant Then
-                Return DirectCast(context.Module, PEModuleBuilder).CreateConstant(Me.Type, Me.ConstantValue, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+            If AdaptedFieldSymbol.IsMetadataConstant Then
+                Return DirectCast(context.Module, PEModuleBuilder).CreateConstant(AdaptedFieldSymbol.Type, AdaptedFieldSymbol.ConstantValue, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
             End If
 
             Return Nothing
@@ -120,7 +200,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 ' const fields of types DateTime or Decimal are not compile time constant, because they are only const 
                 ' from a VB point of view
-                If Me.IsMetadataConstant Then
+                If AdaptedFieldSymbol.IsMetadataConstant Then
                     Return True
                 End If
 
@@ -131,7 +211,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IFieldDefinitionIsNotSerialized As Boolean Implements IFieldDefinition.IsNotSerialized
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsNotSerialized
+                Return AdaptedFieldSymbol.IsNotSerialized
             End Get
         End Property
 
@@ -140,38 +220,44 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 CheckDefinitionInvariant()
 
                 ' a const field of type DateTime or Decimal is ReadOnly in IL.
-                Return Me.IsReadOnly OrElse
-                        Me.IsConstButNotMetadataConstant
+                Return AdaptedFieldSymbol.IsReadOnly OrElse
+                        AdaptedFieldSymbol.IsConstButNotMetadataConstant
             End Get
         End Property
 
         Private ReadOnly Property IFieldDefinitionIsRuntimeSpecial As Boolean Implements IFieldDefinition.IsRuntimeSpecial
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasRuntimeSpecialName
+                Return AdaptedFieldSymbol.HasRuntimeSpecialName
             End Get
         End Property
 
         Private ReadOnly Property IFieldDefinitionIsSpecialName As Boolean Implements IFieldDefinition.IsSpecialName
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasSpecialName
+                Return AdaptedFieldSymbol.HasSpecialName
             End Get
         End Property
 
         Private ReadOnly Property IFieldDefinitionIsStatic As Boolean Implements IFieldDefinition.IsStatic
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsShared
+                Return AdaptedFieldSymbol.IsShared
             End Get
         End Property
 
         Private ReadOnly Property IFieldDefinitionIsMarshalledExplicitly As Boolean Implements IFieldDefinition.IsMarshalledExplicitly
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMarshalledExplicitly
+                Return AdaptedFieldSymbol.IsMarshalledExplicitly
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class FieldSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsMarshalledExplicitly As Boolean
             Get
@@ -180,19 +266,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class FieldSymbolAdapter
+#End If
+
         Private ReadOnly Property IFieldDefinitionMarshallingInformation As IMarshallingInformation Implements IFieldDefinition.MarshallingInformation
             Get
                 CheckDefinitionInvariant()
-                Return Me.MarshallingInformation
+                Return AdaptedFieldSymbol.MarshallingInformation
             End Get
         End Property
 
         Private ReadOnly Property IFieldDefinitionMarshallingDescriptor As ImmutableArray(Of Byte) Implements IFieldDefinition.MarshallingDescriptor
             Get
                 CheckDefinitionInvariant()
-                Return Me.MarshallingDescriptor
+                Return AdaptedFieldSymbol.MarshallingDescriptor
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class FieldSymbol
+#End If
 
         Friend Overridable ReadOnly Property MarshallingDescriptor As ImmutableArray(Of Byte)
             Get
@@ -201,31 +299,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class FieldSymbolAdapter
+#End If
+
         Private ReadOnly Property IFieldDefinitionOffset As Integer Implements IFieldDefinition.Offset
             Get
                 CheckDefinitionInvariant()
-                Return If(TypeLayoutOffset, 0)
+                Return If(AdaptedFieldSymbol.TypeLayoutOffset, 0)
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionMemberContainingTypeDefinition As ITypeDefinition Implements ITypeDefinitionMember.ContainingTypeDefinition
             Get
                 CheckDefinitionInvariant()
-                Return Me.ContainingType
+                Return AdaptedFieldSymbol.ContainingType.GetCciAdapter()
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionMemberVisibility As TypeMemberVisibility Implements ITypeDefinitionMember.Visibility
             Get
                 CheckDefinitionInvariant()
-                Return PEModuleBuilder.MemberVisibility(Me)
+                Return PEModuleBuilder.MemberVisibility(AdaptedFieldSymbol)
             End Get
         End Property
 
         Private ReadOnly Property ISpecializedFieldReferenceUnspecializedVersion As IFieldReference Implements ISpecializedFieldReference.UnspecializedVersion
             Get
-                Debug.Assert(Not Me.IsDefinition)
-                Return Me.OriginalDefinition
+                Debug.Assert(Not AdaptedFieldSymbol.IsDefinition)
+                Return AdaptedFieldSymbol.OriginalDefinition.GetCciAdapter()
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/MethodSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/MethodSymbolAdapter.vb
@@ -10,7 +10,12 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
+#If DEBUG Then
+    Partial Friend Class MethodSymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend Class MethodSymbol
+#End If
         Implements Cci.ITypeMemberReference
         Implements Cci.IMethodReference
         Implements Cci.IGenericMethodInstanceReference
@@ -18,13 +23,66 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Implements Cci.ITypeDefinitionMember
         Implements Cci.IMethodDefinition
 
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedMethodSymbol As MethodSymbol
+
+        Friend Sub New(underlyingMethodSymbol As MethodSymbol)
+            AdaptedMethodSymbol = underlyingMethodSymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedMethodSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedMethodSymbol As MethodSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class MethodSymbol
+#If DEBUG Then
+        Private _lazyAdapter As MethodSymbolAdapter
+
+        Protected NotOverridable Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As MethodSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, Me.CreateCciAdapter())
+            End If
+
+            Return _lazyAdapter
+        End Function
+
+        Protected Overridable Function CreateCciAdapter() As MethodSymbolAdapter
+            Return New MethodSymbolAdapter(Me)
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As MethodSymbol
+            return Me
+        End Function
+#End If
+
         Public Const DisableJITOptimizationFlags As MethodImplAttributes = MethodImplAttributes.NoInlining Or MethodImplAttributes.NoOptimization
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
 
         Private ReadOnly Property IMethodReferenceAsGenericMethodInstanceReference As Cci.IGenericMethodInstanceReference Implements Cci.IMethodReference.AsGenericMethodInstanceReference
             Get
                 Debug.Assert(Me.IsDefinitionOrDistinct())
 
-                If Not Me.IsDefinition AndAlso Me.IsGenericMethod AndAlso Me IsNot Me.ConstructedFrom Then
+                If Not AdaptedMethodSymbol.IsDefinition AndAlso AdaptedMethodSymbol.IsGenericMethod AndAlso AdaptedMethodSymbol IsNot AdaptedMethodSymbol.ConstructedFrom Then
                     Return Me
                 End If
 
@@ -36,8 +94,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 Debug.Assert(Me.IsDefinitionOrDistinct())
 
-                If Not Me.IsDefinition AndAlso (Not Me.IsGenericMethod OrElse Me Is Me.ConstructedFrom) Then
-                    Debug.Assert(Me.ContainingType IsNot Nothing AndAlso IsOrInGenericType(Me.ContainingType))
+                If Not AdaptedMethodSymbol.IsDefinition AndAlso (Not AdaptedMethodSymbol.IsGenericMethod OrElse AdaptedMethodSymbol Is AdaptedMethodSymbol.ConstructedFrom) Then
+                    Debug.Assert(AdaptedMethodSymbol.ContainingType IsNot Nothing AndAlso IsOrInGenericType(AdaptedMethodSymbol.ContainingType))
                     Return Me
                 End If
 
@@ -53,22 +111,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            If Not Me.IsDefinition Then
-                Return moduleBeingBuilt.Translate(Me.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
-            ElseIf TypeOf Me Is SynthesizedGlobalMethodBase Then
+            If Not AdaptedMethodSymbol.IsDefinition Then
+                Return moduleBeingBuilt.Translate(AdaptedMethodSymbol.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+            ElseIf TypeOf AdaptedMethodSymbol Is SynthesizedGlobalMethodBase Then
                 Dim privateImplClass = moduleBeingBuilt.GetPrivateImplClass(syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
                 Debug.Assert(privateImplClass IsNot Nothing)
                 Return privateImplClass
             End If
 
-            Return moduleBeingBuilt.Translate(Me.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics, needDeclaration:=True)
+            Return moduleBeingBuilt.Translate(AdaptedMethodSymbol.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics, needDeclaration:=True)
         End Function
 
         Friend NotOverridable Overrides Sub IReferenceDispatch(visitor As Cci.MetadataVisitor) ' Implements IReference.Dispatch
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            If Not Me.IsDefinition Then
-                If Me.IsGenericMethod AndAlso Me IsNot Me.ConstructedFrom Then
+            If Not AdaptedMethodSymbol.IsDefinition Then
+                If AdaptedMethodSymbol.IsGenericMethod AndAlso AdaptedMethodSymbol IsNot AdaptedMethodSymbol.ConstructedFrom Then
                     Debug.Assert((DirectCast(Me, Cci.IMethodReference)).AsGenericMethodInstanceReference IsNot Nothing)
                     visitor.Visit(DirectCast(Me, Cci.IGenericMethodInstanceReference))
                 Else
@@ -77,7 +135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             Else
                 Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(visitor.Context.Module, PEModuleBuilder)
-                If Me.ContainingModule = moduleBeingBuilt.SourceModule Then
+                If AdaptedMethodSymbol.ContainingModule = moduleBeingBuilt.SourceModule Then
                     Debug.Assert((DirectCast(Me, Cci.IMethodReference)).GetResolvedMethod(visitor.Context) IsNot Nothing)
                     visitor.Visit(DirectCast(Me, Cci.IMethodDefinition))
                 Else
@@ -88,31 +146,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property INamedEntityName As String Implements Cci.INamedEntity.Name
             Get
-                Return Me.MetadataName
+                Return AdaptedMethodSymbol.MetadataName
             End Get
         End Property
 
         Private ReadOnly Property IMethodReferenceAcceptsExtraArguments As Boolean Implements Cci.IMethodReference.AcceptsExtraArguments
             Get
-                Return Me.IsVararg
+                Return AdaptedMethodSymbol.IsVararg
             End Get
         End Property
 
         Private ReadOnly Property IMethodReferenceGenericParameterCount As UShort Implements Cci.IMethodReference.GenericParameterCount
             Get
-                Return CType(Me.Arity, UShort)
+                Return CType(AdaptedMethodSymbol.Arity, UShort)
             End Get
         End Property
 
         Private ReadOnly Property IMethodReferenceIsGeneric As Boolean Implements Cci.IMethodReference.IsGeneric
             Get
-                Return Me.IsGenericMethod
+                Return AdaptedMethodSymbol.IsGenericMethod
             End Get
         End Property
 
         Private ReadOnly Property IMethodReferenceParameterCount As UShort Implements Cci.ISignature.ParameterCount
             Get
-                Return CType(Me.ParameterCount, UShort)
+                Return CType(AdaptedMethodSymbol.ParameterCount, UShort)
             End Get
         End Property
 
@@ -125,9 +183,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ' Can't be generic instantiation
             ' must be declared in the module we are building
-            If Me.IsDefinition AndAlso
-                Me.ContainingModule = moduleBeingBuilt.SourceModule Then
-                Debug.Assert(Me.PartialDefinitionPart Is Nothing) ' must be definition
+            If AdaptedMethodSymbol.IsDefinition AndAlso
+                AdaptedMethodSymbol.ContainingModule = moduleBeingBuilt.SourceModule Then
+                Debug.Assert(AdaptedMethodSymbol.PartialDefinitionPart Is Nothing) ' must be definition
                 Return Me
             End If
 
@@ -142,7 +200,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ISignatureCallingConvention As Cci.CallingConvention Implements Cci.ISignature.CallingConvention
             Get
-                Return Me.CallingConvention
+                Return AdaptedMethodSymbol.CallingConvention
             End Get
         End Property
 
@@ -151,46 +209,49 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Debug.Assert(Me.IsDefinitionOrDistinct())
 #If DEBUG Then
-            For Each p In Me.Parameters
+            For Each p In AdaptedMethodSymbol.Parameters
                 Debug.Assert(p Is p.OriginalDefinition)
             Next
 #End If
 
-            If Me.IsDefinition AndAlso Me.ContainingModule = moduleBeingBuilt.SourceModule Then
+            If AdaptedMethodSymbol.IsDefinition AndAlso AdaptedMethodSymbol.ContainingModule = moduleBeingBuilt.SourceModule Then
                 Return EnumerateDefinitionParameters()
             Else
-                Return moduleBeingBuilt.Translate(Me.Parameters)
+                Return moduleBeingBuilt.Translate(AdaptedMethodSymbol.Parameters)
             End If
         End Function
 
         Private Function EnumerateDefinitionParameters() As ImmutableArray(Of Cci.IParameterTypeInformation)
-            Debug.Assert(Me.Parameters.All(Function(p) p.IsDefinition))
-
-            Return StaticCast(Of Cci.IParameterTypeInformation).From(Me.Parameters)
+            Debug.Assert(AdaptedMethodSymbol.Parameters.All(Function(p) p.IsDefinition))
+#If DEBUG Then
+            Return AdaptedMethodSymbol.Parameters.SelectAsArray(Of Cci.IParameterTypeInformation)(Function(p) p.GetCciAdapter())
+#Else
+            Return StaticCast(Of Cci.IParameterTypeInformation).From(AdaptedMethodSymbol.Parameters)
+#End If
         End Function
 
         Private ReadOnly Property ISignatureReturnValueCustomModifiers As ImmutableArray(Of Cci.ICustomModifier) Implements Cci.ISignature.ReturnValueCustomModifiers
             Get
-                Return Me.ReturnTypeCustomModifiers.As(Of Cci.ICustomModifier)
+                Return AdaptedMethodSymbol.ReturnTypeCustomModifiers.As(Of Cci.ICustomModifier)
             End Get
         End Property
 
         Private ReadOnly Property ISignatureRefCustomModifiers As ImmutableArray(Of Cci.ICustomModifier) Implements Cci.ISignature.RefCustomModifiers
             Get
-                Return Me.RefCustomModifiers.As(Of Cci.ICustomModifier)
+                Return AdaptedMethodSymbol.RefCustomModifiers.As(Of Cci.ICustomModifier)
             End Get
         End Property
 
         Private ReadOnly Property ISignatureReturnValueIsByRef As Boolean Implements Cci.ISignature.ReturnValueIsByRef
             Get
-                Return ReturnsByRef
+                Return AdaptedMethodSymbol.ReturnsByRef
             End Get
         End Property
 
         Private Function ISignatureGetType(context As EmitContext) As Cci.ITypeReference Implements Cci.ISignature.GetType
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
 
-            Dim returnType As TypeSymbol = Me.ReturnType
+            Dim returnType As TypeSymbol = AdaptedMethodSymbol.ReturnType
             Return moduleBeingBuilt.Translate(returnType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
         End Function
 
@@ -199,37 +260,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Debug.Assert((DirectCast(Me, Cci.IMethodReference)).AsGenericMethodInstanceReference IsNot Nothing)
 
-            Return From arg In Me.TypeArguments
+            Return From arg In AdaptedMethodSymbol.TypeArguments
                    Select moduleBeingBuilt.Translate(arg, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
         End Function
 
         Private Function IGenericMethodInstanceReferenceGetGenericMethod(context As EmitContext) As Cci.IMethodReference Implements Cci.IGenericMethodInstanceReference.GetGenericMethod
             Debug.Assert((DirectCast(Me, Cci.IMethodReference)).AsGenericMethodInstanceReference IsNot Nothing)
 
-            If Me.OriginalDefinition IsNot Me.ConstructedFrom Then
-                Return Me.ConstructedFrom
-            End If
-
-            Dim container As NamedTypeSymbol = Me.ContainingType
+            Dim container As NamedTypeSymbol = AdaptedMethodSymbol.ContainingType
 
             If (Not container.IsOrInGenericType()) Then
-                Return Me.OriginalDefinition
                 ' NoPia method might come through here.
                 Return DirectCast(context.Module, PEModuleBuilder).Translate(
-                    Me.OriginalDefinition,
+                    AdaptedMethodSymbol.OriginalDefinition,
                     DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
                     context.Diagnostics,
                     needDeclaration:=True)
             End If
 
-            Dim methodSymbol As MethodSymbol = Me.ConstructedFrom
+            Dim methodSymbol As MethodSymbol = AdaptedMethodSymbol.ConstructedFrom
             Return New SpecializedMethodReference(methodSymbol)
         End Function
 
         Private ReadOnly Property ISpecializedMethodReferenceUnspecializedVersion As Cci.IMethodReference Implements Cci.ISpecializedMethodReference.UnspecializedVersion
             Get
                 Debug.Assert((DirectCast(Me, Cci.IMethodReference)).AsSpecializedMethodReference IsNot Nothing)
-                Return Me.OriginalDefinition
+                Return AdaptedMethodSymbol.OriginalDefinition.GetCciAdapter()
             End Get
         End Property
 
@@ -237,55 +293,65 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 CheckDefinitionInvariant()
 
-                Dim synthesizedGlobalMethod = TryCast(Me, SynthesizedGlobalMethodBase)
+                Dim synthesizedGlobalMethod = TryCast(AdaptedMethodSymbol, SynthesizedGlobalMethodBase)
                 If synthesizedGlobalMethod IsNot Nothing Then
                     Return synthesizedGlobalMethod.ContainingPrivateImplementationDetailsType
                 End If
 
-                Return Me.ContainingType
+                Return AdaptedMethodSymbol.ContainingType.GetCciAdapter()
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionMemberVisibility As Cci.TypeMemberVisibility Implements Cci.ITypeDefinitionMember.Visibility
             Get
                 CheckDefinitionInvariant()
-                Return PEModuleBuilder.MemberVisibility(Me)
+                Return PEModuleBuilder.MemberVisibility(AdaptedMethodSymbol)
             End Get
         End Property
 
         Private Function IMethodDefinitionGetBody(context As EmitContext) As Cci.IMethodBody Implements Cci.IMethodDefinition.GetBody
             CheckDefinitionInvariant()
-            Return (DirectCast(context.Module, PEModuleBuilder)).GetMethodBody(Me)
+            Return (DirectCast(context.Module, PEModuleBuilder)).GetMethodBody(AdaptedMethodSymbol)
         End Function
 
         Private ReadOnly Property IMethodDefinitionGenericParameters As IEnumerable(Of Cci.IGenericMethodParameter) Implements Cci.IMethodDefinition.GenericParameters
             Get
                 CheckDefinitionInvariant()
-                Debug.Assert(Me.TypeParameters.All(Function(param) param Is param.OriginalDefinition))
-                Return Me.TypeParameters
+                Debug.Assert(AdaptedMethodSymbol.TypeParameters.All(Function(param) param Is param.OriginalDefinition))
+#If DEBUG Then
+                Return AdaptedMethodSymbol.TypeParameters.Select(Function(t) t.GetCciAdapter())
+#Else
+                Return AdaptedMethodSymbol.TypeParameters
+#End If
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionHasDeclarativeSecurity As Boolean Implements Cci.IMethodDefinition.HasDeclarativeSecurity
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasDeclarativeSecurity
+                Return AdaptedMethodSymbol.HasDeclarativeSecurity
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionIsAbstract As Boolean Implements Cci.IMethodDefinition.IsAbstract
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMustOverride
+                Return AdaptedMethodSymbol.IsMustOverride
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionIsAccessCheckedOnOverride As Boolean Implements Cci.IMethodDefinition.IsAccessCheckedOnOverride
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsAccessCheckedOnOverride
+                Return AdaptedMethodSymbol.IsAccessCheckedOnOverride
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsAccessCheckedOnOverride As Boolean
             Get
@@ -294,19 +360,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private ReadOnly Property IMethodDefinitionIsConstructor As Boolean Implements Cci.IMethodDefinition.IsConstructor
             Get
                 CheckDefinitionInvariant()
-                Return Me.MethodKind = MethodKind.Constructor
+                Return AdaptedMethodSymbol.MethodKind = MethodKind.Constructor
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionIsExternal As Boolean Implements Cci.IMethodDefinition.IsExternal
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsExternal
+                Return AdaptedMethodSymbol.IsExternal
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsExternal As Boolean
             Get
@@ -315,18 +393,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private Function IMethodDefinitionGetImplementationOptions(context As EmitContext) As MethodImplAttributes Implements Cci.IMethodDefinition.GetImplementationAttributes
             CheckDefinitionInvariant()
-            Return Me.ImplementationAttributes Or
-                   If(DirectCast(context.Module, PEModuleBuilder).JITOptimizationIsDisabled(Me), DisableJITOptimizationFlags, Nothing)
+            Return AdaptedMethodSymbol.ImplementationAttributes Or
+                   If(DirectCast(context.Module, PEModuleBuilder).JITOptimizationIsDisabled(AdaptedMethodSymbol), MethodSymbol.DisableJITOptimizationFlags, Nothing)
         End Function
 
         Private ReadOnly Property IMethodDefinitionIsHiddenBySignature As Boolean Implements Cci.IMethodDefinition.IsHiddenBySignature
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsHiddenBySignature
+                Return AdaptedMethodSymbol.IsHiddenBySignature
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsHiddenBySignature As Boolean
             Get
@@ -335,12 +425,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private ReadOnly Property IMethodDefinitionIsNewSlot As Boolean Implements Cci.IMethodDefinition.IsNewSlot
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMetadataNewSlot()
+                Return AdaptedMethodSymbol.IsMetadataNewSlot()
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         ''' <summary>
         ''' This method indicates whether or not the runtime will regard the method
@@ -361,26 +463,38 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private ReadOnly Property IMethodDefinitionIsPlatformInvoke As Boolean Implements Cci.IMethodDefinition.IsPlatformInvoke
             Get
                 CheckDefinitionInvariant()
-                Return Me.GetDllImportData() IsNot Nothing
+                Return AdaptedMethodSymbol.GetDllImportData() IsNot Nothing
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionPlatformInvokeData As Cci.IPlatformInvokeInformation Implements Cci.IMethodDefinition.PlatformInvokeData
             Get
                 CheckDefinitionInvariant()
-                Return Me.GetDllImportData()
+                Return AdaptedMethodSymbol.GetDllImportData()
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionIsRuntimeSpecial As Boolean Implements Cci.IMethodDefinition.IsRuntimeSpecial
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasRuntimeSpecialName
+                Return AdaptedMethodSymbol.HasRuntimeSpecialName
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         Friend Overridable ReadOnly Property HasRuntimeSpecialName As Boolean
             Get
@@ -395,12 +509,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private ReadOnly Property IMethodDefinitionIsSealed As Boolean Implements Cci.IMethodDefinition.IsSealed
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMetadataFinal
+                Return AdaptedMethodSymbol.IsMetadataFinal
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsMetadataFinal As Boolean
             Get
@@ -411,24 +537,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private ReadOnly Property IMethodDefinitionIsSpecialName As Boolean Implements Cci.IMethodDefinition.IsSpecialName
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasSpecialName
+                Return AdaptedMethodSymbol.HasSpecialName
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionIsStatic As Boolean Implements Cci.IMethodDefinition.IsStatic
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsShared
+                Return AdaptedMethodSymbol.IsShared
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionIsVirtual As Boolean Implements Cci.IMethodDefinition.IsVirtual
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMetadataVirtual()
+                Return AdaptedMethodSymbol.IsMetadataVirtual()
             End Get
         End Property
 
@@ -437,11 +569,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 CheckDefinitionInvariant()
 
 #If DEBUG Then
-                For Each p In Me.Parameters
+                For Each p In AdaptedMethodSymbol.Parameters
                     Debug.Assert(p Is p.OriginalDefinition)
                 Next
+
+                Return AdaptedMethodSymbol.Parameters.SelectAsArray(Of Cci.IParameterDefinition)(Function(p) p.GetCciAdapter())
+#Else
+                Return StaticCast(Of Cci.IParameterDefinition).From(AdaptedMethodSymbol.Parameters)
 #End If
-                Return StaticCast(Of Cci.IParameterDefinition).From(Me.Parameters)
             End Get
         End Property
 
@@ -458,20 +593,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim userDefined As ImmutableArray(Of VisualBasicAttributeData)
             Dim synthesized As ArrayBuilder(Of SynthesizedAttributeData) = Nothing
 
-            userDefined = Me.GetReturnTypeAttributes()
-            Me.AddSynthesizedReturnTypeAttributes(synthesized)
+            userDefined = AdaptedMethodSymbol.GetReturnTypeAttributes()
+            AdaptedMethodSymbol.AddSynthesizedReturnTypeAttributes(synthesized)
 
             ' Note that callers of this method (CCI and ReflectionEmitter) have to enumerate 
             ' all items of the returned iterator, otherwise the synthesized ArrayBuilder may leak.
-            Return GetCustomAttributesToEmit(userDefined, synthesized, isReturnType:=True, emittingAssemblyAttributesInNetModule:=False)
+            Return AdaptedMethodSymbol.GetCustomAttributesToEmit(userDefined, synthesized, isReturnType:=True, emittingAssemblyAttributesInNetModule:=False)
         End Function
 
         Private ReadOnly Property IMethodDefinitionReturnValueIsMarshalledExplicitly As Boolean Implements Cci.IMethodDefinition.ReturnValueIsMarshalledExplicitly
             Get
                 CheckDefinitionInvariant()
-                Return Me.ReturnValueIsMarshalledExplicitly
+                Return AdaptedMethodSymbol.ReturnValueIsMarshalledExplicitly
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         Friend Overridable ReadOnly Property ReturnValueIsMarshalledExplicitly As Boolean
             Get
@@ -480,19 +621,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private ReadOnly Property IMethodDefinitionReturnValueMarshallingInformation As Cci.IMarshallingInformation Implements Cci.IMethodDefinition.ReturnValueMarshallingInformation
             Get
                 CheckDefinitionInvariant()
-                Return ReturnTypeMarshallingInformation
+                Return AdaptedMethodSymbol.ReturnTypeMarshallingInformation
             End Get
         End Property
 
         Private ReadOnly Property IMethodDefinitionReturnValueMarshallingDescriptor As ImmutableArray(Of Byte) Implements Cci.IMethodDefinition.ReturnValueMarshallingDescriptor
             Get
                 CheckDefinitionInvariant()
-                Return ReturnValueMarshallingDescriptor
+                Return AdaptedMethodSymbol.ReturnValueMarshallingDescriptor
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbol
+#End If
 
         Friend Overridable ReadOnly Property ReturnValueMarshallingDescriptor As ImmutableArray(Of Byte)
             Get
@@ -501,11 +654,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class MethodSymbolAdapter
+#End If
+
         Private ReadOnly Property IMethodDefinitionSecurityAttributes As IEnumerable(Of Cci.SecurityAttribute) Implements Cci.IMethodDefinition.SecurityAttributes
             Get
                 CheckDefinitionInvariant()
-                Debug.Assert(Me.HasDeclarativeSecurity)
-                Dim securityAttributes As IEnumerable(Of Cci.SecurityAttribute) = Me.GetSecurityInformation()
+                Debug.Assert(AdaptedMethodSymbol.HasDeclarativeSecurity)
+                Dim securityAttributes As IEnumerable(Of Cci.SecurityAttribute) = AdaptedMethodSymbol.GetSecurityInformation()
                 Debug.Assert(securityAttributes IsNot Nothing)
                 Return securityAttributes
             End Get
@@ -513,7 +672,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IMethodDefinition_ContainingNamespace As Cci.INamespace Implements Cci.IMethodDefinition.ContainingNamespace
             Get
-                Return ContainingNamespace
+                Return AdaptedMethodSymbol.ContainingNamespace.GetCciAdapter()
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeReference.vb
@@ -114,5 +114,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private Function IReferenceGetInternalSymbol() As CodeAnalysis.Symbols.ISymbolInternal Implements Cci.IReference.GetInternalSymbol
             Return m_UnderlyingNamedType
         End Function
+
+        Public NotOverridable Overrides Function Equals(obj As Object) As Boolean
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
+
+        Public NotOverridable Overrides Function GetHashCode() As Integer
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -13,7 +13,12 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
+#If DEBUG Then
+    Partial Friend NotInheritable Class NamedTypeSymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend Class NamedTypeSymbol
+#End If
         Implements ITypeReference
         Implements ITypeDefinition
         Implements INamedTypeReference
@@ -25,32 +30,80 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Implements IGenericTypeInstanceReference
         Implements ISpecializedNestedTypeReference
 
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedNamedTypeSymbol As NamedTypeSymbol
+
+        Friend Sub New(underlyingNamedTypeSymbol As NamedTypeSymbol)
+            AdaptedNamedTypeSymbol = underlyingNamedTypeSymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedNamedTypeSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedNamedTypeSymbol As NamedTypeSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#If DEBUG Then
+        Private _lazyAdapter As NamedTypeSymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As NamedTypeSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, New NamedTypeSymbolAdapter(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As NamedTypeSymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
         Private ReadOnly Property ITypeReferenceIsEnum As Boolean Implements ITypeReference.IsEnum
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
-                Return Me.TypeKind = TypeKind.Enum
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
+                Return AdaptedNamedTypeSymbol.TypeKind = TypeKind.Enum
             End Get
         End Property
 
         Private ReadOnly Property ITypeReferenceIsValueType As Boolean Implements ITypeReference.IsValueType
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
-                Return Me.IsValueType
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
+                Return AdaptedNamedTypeSymbol.IsValueType
             End Get
         End Property
 
         Private Function ITypeReferenceGetResolvedType(context As EmitContext) As ITypeDefinition Implements ITypeReference.GetResolvedType
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Return AsTypeDefinitionImpl(moduleBeingBuilt)
         End Function
 
         Private ReadOnly Property ITypeReferenceTypeCode As Cci.PrimitiveTypeCode Implements ITypeReference.TypeCode
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 Debug.Assert(Me.IsDefinitionOrDistinct())
-                If Me.IsDefinition Then
-                    Return Me.PrimitiveTypeCode
+                If AdaptedNamedTypeSymbol.IsDefinition Then
+                    Return AdaptedNamedTypeSymbol.PrimitiveTypeCode
                 End If
                 Return Cci.PrimitiveTypeCode.NotPrimitive
             End Get
@@ -58,8 +111,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeReferenceTypeDef As TypeDefinitionHandle Implements ITypeReference.TypeDef
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
-                Dim peNamedType As PENamedTypeSymbol = TryCast(Me, PENamedTypeSymbol)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
+                Dim peNamedType As PENamedTypeSymbol = TryCast(AdaptedNamedTypeSymbol, PENamedTypeSymbol)
                 If peNamedType IsNot Nothing Then
                     Return peNamedType.Handle
                 End If
@@ -70,16 +123,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeReferenceAsGenericMethodParameterReference As IGenericMethodParameterReference Implements ITypeReference.AsGenericMethodParameterReference
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 Return Nothing
             End Get
         End Property
 
         Private ReadOnly Property ITypeReferenceAsGenericTypeInstanceReference As IGenericTypeInstanceReference Implements ITypeReference.AsGenericTypeInstanceReference
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 Debug.Assert(Me.IsDefinitionOrDistinct())
-                If Not Me.IsDefinition AndAlso Me.Arity > 0 AndAlso Me.ConstructedFrom IsNot Me Then
+                If Not AdaptedNamedTypeSymbol.IsDefinition AndAlso AdaptedNamedTypeSymbol.Arity > 0 AndAlso AdaptedNamedTypeSymbol.ConstructedFrom IsNot AdaptedNamedTypeSymbol Then
                     Return Me
                 End If
                 Return Nothing
@@ -88,16 +141,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeReferenceAsGenericTypeParameterReference As IGenericTypeParameterReference Implements ITypeReference.AsGenericTypeParameterReference
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 Return Nothing
             End Get
         End Property
 
         Private ReadOnly Property ITypeReferenceAsNamespaceTypeReference As INamespaceTypeReference Implements ITypeReference.AsNamespaceTypeReference
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 Debug.Assert(Me.IsDefinitionOrDistinct())
-                If Me.IsDefinition AndAlso Me.ContainingType Is Nothing Then
+                If AdaptedNamedTypeSymbol.IsDefinition AndAlso AdaptedNamedTypeSymbol.ContainingType Is Nothing Then
                     Return Me
                 End If
                 Return Nothing
@@ -105,10 +158,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Private Function ITypeReferenceAsNamespaceTypeDefinition(context As EmitContext) As INamespaceTypeDefinition Implements ITypeReference.AsNamespaceTypeDefinition
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Debug.Assert(Me.IsDefinitionOrDistinct())
-            If Me.ContainingType Is Nothing AndAlso Me.IsDefinition AndAlso Me.ContainingModule.Equals(moduleBeingBuilt.SourceModule) Then
+            If AdaptedNamedTypeSymbol.ContainingType Is Nothing AndAlso AdaptedNamedTypeSymbol.IsDefinition AndAlso AdaptedNamedTypeSymbol.ContainingModule.Equals(moduleBeingBuilt.SourceModule) Then
                 Return Me
             End If
             Return Nothing
@@ -116,8 +169,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeReferenceAsNestedTypeReference As INestedTypeReference Implements ITypeReference.AsNestedTypeReference
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
-                If Me.ContainingType IsNot Nothing Then
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
+                If AdaptedNamedTypeSymbol.ContainingType IsNot Nothing Then
                     Return Me
                 End If
                 Return Nothing
@@ -125,14 +178,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Private Function ITypeReferenceAsNestedTypeDefinition(context As EmitContext) As INestedTypeDefinition Implements ITypeReference.AsNestedTypeDefinition
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Return AsNestedTypeDefinitionImpl(moduleBeingBuilt)
         End Function
 
         Private Function AsNestedTypeDefinitionImpl(moduleBeingBuilt As PEModuleBuilder) As INestedTypeDefinition
             Debug.Assert(Me.IsDefinitionOrDistinct())
-            If Me.ContainingType IsNot Nothing AndAlso Me.IsDefinition AndAlso Me.ContainingModule.Equals(moduleBeingBuilt.SourceModule) Then
+            If AdaptedNamedTypeSymbol.ContainingType IsNot Nothing AndAlso AdaptedNamedTypeSymbol.IsDefinition AndAlso AdaptedNamedTypeSymbol.ContainingModule.Equals(moduleBeingBuilt.SourceModule) Then
                 Return Me
             End If
             Return Nothing
@@ -140,10 +193,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeReferenceAsSpecializedNestedTypeReference As ISpecializedNestedTypeReference Implements ITypeReference.AsSpecializedNestedTypeReference
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 Debug.Assert(Me.IsDefinitionOrDistinct())
-                If Not Me.IsDefinition AndAlso (Me.Arity = 0 OrElse Me.ConstructedFrom Is Me) Then
-                    Debug.Assert(Me.ContainingType IsNot Nothing AndAlso Me.ContainingType.IsOrInGenericType())
+                If Not AdaptedNamedTypeSymbol.IsDefinition AndAlso (AdaptedNamedTypeSymbol.Arity = 0 OrElse AdaptedNamedTypeSymbol.ConstructedFrom Is AdaptedNamedTypeSymbol) Then
+                    Debug.Assert(AdaptedNamedTypeSymbol.ContainingType IsNot Nothing AndAlso AdaptedNamedTypeSymbol.ContainingType.IsOrInGenericType())
                     Return Me
                 End If
                 Return Nothing
@@ -151,7 +204,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Private Function ITypeReferenceAsTypeDefinition(context As EmitContext) As ITypeDefinition Implements ITypeReference.AsTypeDefinition
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Return AsTypeDefinitionImpl(moduleBeingBuilt)
         End Function
@@ -161,8 +214,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ' Can't be generic instantiation
             ' must be declared in the module we are building
-            If Me.IsDefinition AndAlso
-                Me.ContainingModule.Equals(moduleBeingBuilt.SourceModule) Then
+            If AdaptedNamedTypeSymbol.IsDefinition AndAlso
+                AdaptedNamedTypeSymbol.ContainingModule.Equals(moduleBeingBuilt.SourceModule) Then
                 Return Me
             End If
             Return Nothing
@@ -171,8 +224,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend NotOverridable Overrides Sub IReferenceDispatch(visitor As MetadataVisitor) ' Implements IReference.Dispatch
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            If Not Me.IsDefinition Then
-                If Me.Arity > 0 AndAlso Me.ConstructedFrom IsNot Me Then
+            If Not AdaptedNamedTypeSymbol.IsDefinition Then
+                If AdaptedNamedTypeSymbol.Arity > 0 AndAlso AdaptedNamedTypeSymbol.ConstructedFrom IsNot AdaptedNamedTypeSymbol Then
                     Debug.Assert((DirectCast(Me, ITypeReference)).AsGenericTypeInstanceReference IsNot Nothing)
                     visitor.Visit(DirectCast(Me, IGenericTypeInstanceReference))
                 Else
@@ -181,8 +234,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             Else
                 Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(visitor.Context.Module, PEModuleBuilder)
-                Dim asDefinition As Boolean = (Me.ContainingModule.Equals(moduleBeingBuilt.SourceModule))
-                If Me.ContainingType Is Nothing Then
+                Dim asDefinition As Boolean = (AdaptedNamedTypeSymbol.ContainingModule.Equals(moduleBeingBuilt.SourceModule))
+                If AdaptedNamedTypeSymbol.ContainingType Is Nothing Then
                     If asDefinition Then
                         Debug.Assert((DirectCast(Me, ITypeReference)).AsNamespaceTypeDefinition(visitor.Context) IsNot Nothing)
                         visitor.Visit(DirectCast(Me, INamespaceTypeDefinition))
@@ -210,22 +263,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property ITypeDefinitionAlignment As UShort Implements ITypeDefinition.Alignment
             Get
                 CheckDefinitionInvariant()
-                Dim layout = Me.Layout
+                Dim layout = AdaptedNamedTypeSymbol.Layout
                 Return CUShort(layout.Alignment)
             End Get
         End Property
 
         Private Function ITypeDefinitionGetBaseClass(context As EmitContext) As ITypeReference Implements ITypeDefinition.GetBaseClass
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Debug.Assert((DirectCast(Me, ITypeReference)).AsTypeDefinition(context) IsNot Nothing)
 
-            Dim baseType As NamedTypeSymbol = Me.BaseTypeNoUseSiteDiagnostics
+            Dim baseType As NamedTypeSymbol = AdaptedNamedTypeSymbol.BaseTypeNoUseSiteDiagnostics
 
-            If Me.TypeKind = TypeKind.Submission Then
+            If AdaptedNamedTypeSymbol.TypeKind = TypeKind.Submission Then
                 ' although submission semantically doesn't have a base we need to emit one into metadata:
                 Debug.Assert(baseType Is Nothing)
-                baseType = Me.ContainingAssembly.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object)
+                baseType = AdaptedNamedTypeSymbol.ContainingAssembly.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_Object)
             End If
 
             If baseType IsNot Nothing Then
@@ -236,19 +289,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Private Iterator Function ITypeDefinitionEvents(context As EmitContext) As IEnumerable(Of IEventDefinition) Implements ITypeDefinition.GetEvents
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
             ' can't be generic instantiation
             ' must be declared in the module we are building
             CheckDefinitionInvariant()
 
-            For Each e As IEventDefinition In GetEventsToEmit()
-                If e.ShouldInclude(context) OrElse Not e.GetAccessors(context).IsEmpty() Then
-                    Yield e
+            For Each e As EventSymbol In AdaptedNamedTypeSymbol.GetEventsToEmit()
+                Dim adapter As IEventDefinition = e.GetCciAdapter()
+                If adapter.ShouldInclude(context) OrElse Not adapter.GetAccessors(context).IsEmpty() Then
+                    Yield adapter
                 End If
             Next
         End Function
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
 
         Friend Overridable Iterator Function GetEventsToEmit() As IEnumerable(Of EventSymbol)
             CheckDefinitionInvariant()
@@ -260,32 +320,38 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
+
         Private Function ITypeDefinitionGetExplicitImplementationOverrides(context As EmitContext) As IEnumerable(Of Cci.MethodImplementation) Implements ITypeDefinition.GetExplicitImplementationOverrides
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
             ' can't be generic instantiation
             ' must be declared in the module we are building
             CheckDefinitionInvariant()
 
-            If Me.IsInterface Then
+            If AdaptedNamedTypeSymbol.IsInterface Then
                 Return SpecializedCollections.EmptyEnumerable(Of Cci.MethodImplementation)()
             End If
 
             Dim moduleBeingBuilt = DirectCast(context.Module, PEModuleBuilder)
-            Dim sourceNamedType = TryCast(Me, SourceNamedTypeSymbol)
+            Dim sourceNamedType = TryCast(AdaptedNamedTypeSymbol, SourceNamedTypeSymbol)
             Dim explicitImplements As ArrayBuilder(Of Cci.MethodImplementation) = ArrayBuilder(Of Cci.MethodImplementation).GetInstance()
 
-            For Each member In Me.GetMembersForCci()
+            For Each member In AdaptedNamedTypeSymbol.GetMembersForCci()
                 If member.Kind = SymbolKind.Method Then
                     AddExplicitImplementations(context, DirectCast(member, MethodSymbol), explicitImplements, sourceNamedType, moduleBeingBuilt)
                 End If
             Next
 
-            Dim syntheticMethods = moduleBeingBuilt.GetSynthesizedMethods(Me)
+            Dim syntheticMethods = moduleBeingBuilt.GetSynthesizedMethods(AdaptedNamedTypeSymbol)
             If syntheticMethods IsNot Nothing Then
                 For Each synthetic In syntheticMethods
-                    Dim method = TryCast(synthetic, MethodSymbol)
+                    Dim method = TryCast(synthetic.GetInternalSymbol(), MethodSymbol)
                     If method IsNot Nothing Then
                         AddExplicitImplementations(context, method, explicitImplements, sourceNamedType, moduleBeingBuilt)
                     End If
@@ -302,32 +368,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                moduleBeingBuilt As PEModuleBuilder)
 
             Debug.Assert(implementingMethod.PartialDefinitionPart Is Nothing) ' must be definition
+            Debug.Assert(implementingMethod.IsDefinition)
 
             For Each implemented In implementingMethod.ExplicitInterfaceImplementations
                 ' If signature doesn't match, we have created a stub with matching signature that delegates to the implementingMethod.
                 ' The stub will implement the implemented method in metadata.
                 If MethodSignatureComparer.CustomModifiersAndParametersAndReturnTypeSignatureComparer.Equals(implementingMethod, implemented) Then
-                    explicitImplements.Add(New Cci.MethodImplementation(implementingMethod,
+                    explicitImplements.Add(New Cci.MethodImplementation(implementingMethod.GetCciAdapter(),
                         moduleBeingBuilt.TranslateOverriddenMethodReference(implemented, DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), context.Diagnostics)))
                 End If
             Next
 
             ' Explicit overrides needed in some overriding situations.
             If OverrideHidingHelper.RequiresExplicitOverride(implementingMethod) Then
-                explicitImplements.Add(New Cci.MethodImplementation(implementingMethod, implementingMethod.OverriddenMethod))
+                explicitImplements.Add(New Cci.MethodImplementation(implementingMethod.GetCciAdapter(),
+                                                                    moduleBeingBuilt.TranslateOverriddenMethodReference(implementingMethod.OverriddenMethod, DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), context.Diagnostics)))
             End If
 
             If sourceNamedType IsNot Nothing Then
                 Dim comMethod As MethodSymbol = sourceNamedType.GetCorrespondingComClassInterfaceMethod(implementingMethod)
 
                 If comMethod IsNot Nothing Then
-                    explicitImplements.Add(New Cci.MethodImplementation(implementingMethod, comMethod))
+                    explicitImplements.Add(New Cci.MethodImplementation(implementingMethod.GetCciAdapter(),
+                                                                        moduleBeingBuilt.TranslateOverriddenMethodReference(comMethod, DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), context.Diagnostics)))
                 End If
             End If
         End Sub
 
         Private Iterator Function ITypeDefinitionGetFields(context As EmitContext) As IEnumerable(Of IFieldDefinition) Implements ITypeDefinition.GetFields
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             'Debug.Assert(((ITypeReference)this).AsTypeDefinition(moduleBeingBuilt) != null);
 
             ' can't be generic instantiation
@@ -335,15 +404,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             CheckDefinitionInvariant()
 
             ' All fields in a struct should be emitted
-            Dim isStruct = Me.IsStructureType()
+            Dim isStruct = AdaptedNamedTypeSymbol.IsStructureType()
 
-            For Each field In Me.GetFieldsToEmit()
-                If isStruct OrElse field.ShouldInclude(context) Then
-                    Yield field
+            For Each field In AdaptedNamedTypeSymbol.GetFieldsToEmit()
+                Dim adapter = field.GetCciAdapter()
+                If isStruct OrElse adapter.ShouldInclude(context) Then
+                    Yield adapter
                 End If
             Next
 
-            Dim syntheticFields = DirectCast(context.Module, PEModuleBuilder).GetSynthesizedFields(Me)
+            Dim syntheticFields = DirectCast(context.Module, PEModuleBuilder).GetSynthesizedFields(AdaptedNamedTypeSymbol)
             If syntheticFields IsNot Nothing Then
                 For Each field In syntheticFields
                     If isStruct OrElse field.ShouldInclude(context) Then
@@ -353,24 +423,40 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
+
         Friend MustOverride Function GetFieldsToEmit() As IEnumerable(Of FieldSymbol)
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
 
         Private ReadOnly Property ITypeDefinitionGenericParameters As IEnumerable(Of IGenericTypeParameter) Implements ITypeDefinition.GenericParameters
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition(moduleBeingBuilt) != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return Me.TypeParameters
+#If DEBUG Then
+                Return AdaptedNamedTypeSymbol.TypeParameters.Select(Function(t) t.GetCciAdapter())
+#Else
+                Return AdaptedNamedTypeSymbol.TypeParameters
+#End If
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionGenericParameterCount As UShort Implements ITypeDefinition.GenericParameterCount
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
@@ -383,21 +469,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property GenericParameterCountImpl As UShort
             Get
-                Return CType(Me.Arity, UShort)
+                Return CType(AdaptedNamedTypeSymbol.Arity, UShort)
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionHasDeclarativeSecurity As Boolean Implements ITypeDefinition.HasDeclarativeSecurity
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
-                Return Me.HasDeclarativeSecurity
+                Return AdaptedNamedTypeSymbol.HasDeclarativeSecurity
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
 
         ''' <summary>
         ''' Should return Nothing if there are none.
@@ -406,21 +498,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
+
         Private Iterator Function ITypeDefinitionInterfaces(context As EmitContext) _
             As IEnumerable(Of Cci.TypeReferenceWithAttributes) Implements ITypeDefinition.Interfaces
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             Debug.Assert((DirectCast(Me, ITypeReference)).AsTypeDefinition(context) IsNot Nothing)
 
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
-            For Each [interface] In GetInterfacesToEmit()
+            For Each [interface] In AdaptedNamedTypeSymbol.GetInterfacesToEmit()
                 Dim typeRef = moduleBeingBuilt.Translate([interface],
                                                             syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
                                                             diagnostics:=context.Diagnostics,
                                                             fromImplements:=True)
 
-                Yield [interface].GetTypeRefWithAttributes(Me.DeclaringCompilation, typeRef)
+                Yield [interface].GetTypeRefWithAttributes(AdaptedNamedTypeSymbol.DeclaringCompilation, typeRef)
             Next
         End Function
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
+
 
         Friend Overridable Function GetInterfacesToEmit() As IEnumerable(Of NamedTypeSymbol)
             Debug.Assert(IsDefinition)
@@ -449,17 +554,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return If(synthesized Is Nothing, result, synthesized.Concat(result))
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
+
         Private ReadOnly Property ITypeDefinitionIsAbstract As Boolean Implements ITypeDefinition.IsAbstract
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
-                Return IsMetadataAbstract
+                Return AdaptedNamedTypeSymbol.IsMetadataAbstract
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsMetadataAbstract As Boolean
             Get
@@ -468,9 +585,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolADapter
+#End If
+
         Private ReadOnly Property ITypeDefinitionIsBeforeFieldInit As Boolean Implements ITypeDefinition.IsBeforeFieldInit
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
@@ -478,17 +601,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 CheckDefinitionInvariant()
 
                 ' enums or interfaces or delegates are not BeforeFieldInit
-                Select Case Me.TypeKind
+                Select Case AdaptedNamedTypeSymbol.TypeKind
                     Case TypeKind.Enum, TypeKind.Interface, TypeKind.Delegate
                         Return False
                 End Select
 
                 ' apply the beforefieldinit attribute only if there is an implicitly specified static constructor (e.g. caused by
                 ' a Decimal or DateTime field with an initialization).
-                Dim cctor = Me.SharedConstructors.FirstOrDefault
+                Dim cctor = AdaptedNamedTypeSymbol.SharedConstructors.FirstOrDefault
                 If cctor IsNot Nothing Then
 
-                    Debug.Assert(Me.SharedConstructors.Length = 1)
+                    Debug.Assert(AdaptedNamedTypeSymbol.SharedConstructors.Length = 1)
 
                     ' NOTE: Partial methods without implementation should be skipped in the 
                     '       analysis above, see native compiler: PRBuilder.cpp, 'DWORD PEBuilder::GetTypeDefFlags'
@@ -499,7 +622,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     ' if the found constructor contains a generated AddHandler for a method,
                     '       beforefieldinit should not be applied.
-                    For Each member In GetMembers()
+                    For Each member In AdaptedNamedTypeSymbol.GetMembers()
                         If member.Kind = SymbolKind.Method Then
                             Dim methodSym = DirectCast(member, MethodSymbol)
                             Dim handledEvents = methodSym.HandledEvents
@@ -521,7 +644,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 ' if there is a const field of type Decimal or DateTime, the synthesized shared constructor does not
                 ' appear in the member list. We need to check this separately.
-                Dim sourceNamedType = TryCast(Me, SourceMemberContainerTypeSymbol)
+                Dim sourceNamedType = TryCast(AdaptedNamedTypeSymbol, SourceMemberContainerTypeSymbol)
                 If sourceNamedType IsNot Nothing AndAlso Not sourceNamedType.StaticInitializers.IsDefaultOrEmpty Then
                     Return sourceNamedType.AnyInitializerToBeInjectedIntoConstructor(sourceNamedType.StaticInitializers,
                                                                                      includingNonMetadataConstants:=True)
@@ -533,58 +656,58 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeDefinitionIsComObject As Boolean Implements ITypeDefinition.IsComObject
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return IsComImport
+                Return AdaptedNamedTypeSymbol.IsComImport
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionIsGeneric As Boolean Implements ITypeDefinition.IsGeneric
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return Me.Arity <> 0
+                Return AdaptedNamedTypeSymbol.Arity <> 0
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionIsInterface As Boolean Implements ITypeDefinition.IsInterface
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return Me.IsInterface
+                Return AdaptedNamedTypeSymbol.IsInterface
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionIsDelegate As Boolean Implements ITypeDefinition.IsDelegate
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return Me.IsDelegateType()
+                Return AdaptedNamedTypeSymbol.IsDelegateType()
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionIsRuntimeSpecial As Boolean Implements ITypeDefinition.IsRuntimeSpecial
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
@@ -597,54 +720,60 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeDefinitionIsSerializable As Boolean Implements ITypeDefinition.IsSerializable
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return Me.IsSerializable
+                Return AdaptedNamedTypeSymbol.IsSerializable
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionIsSpecialName As Boolean Implements ITypeDefinition.IsSpecialName
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return HasSpecialName
+                Return AdaptedNamedTypeSymbol.HasSpecialName
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionIsWindowsRuntimeImport As Boolean Implements ITypeDefinition.IsWindowsRuntimeImport
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Return Me.IsWindowsRuntimeImport
+                Return AdaptedNamedTypeSymbol.IsWindowsRuntimeImport
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionIsSealed As Boolean Implements ITypeDefinition.IsSealed
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
-                Return IsMetadataSealed
+                Return AdaptedNamedTypeSymbol.IsMetadataSealed
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsMetadataSealed As Boolean
             Get
@@ -663,34 +792,53 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
+
         Private ReadOnly Property ITypeDefinitionLayout As LayoutKind Implements ITypeDefinition.Layout
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 CheckDefinitionInvariant()
 
-                Return Me.Layout.Kind
+                Return AdaptedNamedTypeSymbol.Layout.Kind
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
 
         Friend Overridable Function GetMembersForCci() As ImmutableArray(Of Symbol)
             Return Me.GetMembers()
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
+
         Private Iterator Function ITypeDefinitionGetMethods(context As EmitContext) As IEnumerable(Of IMethodDefinition) Implements ITypeDefinition.GetMethods
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             ' Debug.Assert(((ITypeReference)this).AsTypeDefinition(moduleBeingBuilt) != null);
 
             ' can't be generic instantiation
             ' must be declared in the module we are building
             CheckDefinitionInvariant()
 
-            For Each method In Me.GetMethodsToEmit()
-                If method.ShouldInclude(context) Then
-                    Yield method
+            For Each method In AdaptedNamedTypeSymbol.GetMethodsToEmit()
+                Dim adapter = method.GetCciAdapter()
+                If adapter.ShouldInclude(context) Then
+                    Yield adapter
                 End If
             Next
 
-            Dim syntheticMethods = DirectCast(context.Module, PEModuleBuilder).GetSynthesizedMethods(Me)
+            Dim syntheticMethods = DirectCast(context.Module, PEModuleBuilder).GetSynthesizedMethods(AdaptedNamedTypeSymbol)
             If syntheticMethods IsNot Nothing Then
                 For Each method In syntheticMethods
                     If method.ShouldInclude(context) Then
@@ -699,6 +847,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Next
             End If
         End Function
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
+
 
         Friend Overridable Iterator Function GetMethodsToEmit() As IEnumerable(Of MethodSymbol)
             For Each member In Me.GetMembersForCci()
@@ -715,8 +870,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
+
         Private Function ITypeDefinitionGetNestedTypes(context As EmitContext) As IEnumerable(Of INestedTypeDefinition) Implements ITypeDefinition.GetNestedTypes
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             'Debug.Assert(((ITypeReference)this).AsTypeDefinition(moduleBeingBuilt) != null);
 
             ' can't be generic instantiation
@@ -726,17 +887,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim containingModule = DirectCast(context.Module, PEModuleBuilder)
 
             Dim result As IEnumerable(Of INestedTypeDefinition)
-            Dim nestedTypes = Me.GetTypeMembers() ' Ordered.
+            Dim nestedTypes = AdaptedNamedTypeSymbol.GetTypeMembers() ' Ordered.
             If nestedTypes.Length = 0 Then
                 result = SpecializedCollections.EmptyEnumerable(Of INestedTypeDefinition)()
-            ElseIf Me.IsEmbedded Then
-                ' filter out embedded nested types that are not referenced
-                result = nestedTypes.Where(containingModule.SourceModule.ContainingSourceAssembly.DeclaringCompilation.EmbeddedSymbolManager.IsReferencedPredicate)
             Else
-                result = nestedTypes
+                Dim filtered As IEnumerable(Of NamedTypeSymbol)
+
+                If AdaptedNamedTypeSymbol.IsEmbedded Then
+                    ' filter out embedded nested types that are not referenced
+                    filtered = nestedTypes.Where(containingModule.SourceModule.ContainingSourceAssembly.DeclaringCompilation.EmbeddedSymbolManager.IsReferencedPredicate)
+                Else
+                    filtered = nestedTypes
+                End If
+
+#If DEBUG Then
+                result = filtered.Select(Function(t) t.GetCciAdapter())
+#Else
+                result = filtered
+#End If
             End If
 
-            Dim syntheticNested = containingModule.GetSynthesizedTypes(Me)
+            Dim syntheticNested = containingModule.GetSynthesizedTypes(AdaptedNamedTypeSymbol)
             If syntheticNested IsNot Nothing Then
                 result = result.Concat(syntheticNested)
             End If
@@ -745,21 +916,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Private Iterator Function ITypeDefinitionGetProperties(context As EmitContext) As IEnumerable(Of IPropertyDefinition) Implements ITypeDefinition.GetProperties
-            Debug.Assert(Not Me.IsAnonymousType)
+            Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
             'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
             ' can't be generic instantiation
             ' must be declared in the module we are building
             CheckDefinitionInvariant()
 
-            For Each [property] As IPropertyDefinition In Me.GetPropertiesToEmit()
+            For Each [property] As PropertySymbol In AdaptedNamedTypeSymbol.GetPropertiesToEmit()
                 Debug.Assert([property] IsNot Nothing)
-                If [property].ShouldInclude(context) OrElse Not [property].GetAccessors(context).IsEmpty() Then
-                    Yield [property]
+                Dim adapter As IPropertyDefinition = [property].GetCciAdapter()
+                If adapter.ShouldInclude(context) OrElse Not adapter.GetAccessors(context).IsEmpty() Then
+                    Yield adapter
                 End If
             Next
 
-            Dim syntheticProperties = DirectCast(context.Module, PEModuleBuilder).GetSynthesizedProperties(Me)
+            Dim syntheticProperties = DirectCast(context.Module, PEModuleBuilder).GetSynthesizedProperties(AdaptedNamedTypeSymbol)
             If syntheticProperties IsNot Nothing Then
                 For Each prop In syntheticProperties
                     If prop.ShouldInclude(context) OrElse Not prop.GetAccessors(context).IsEmpty() Then
@@ -768,6 +940,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Next
             End If
         End Function
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbol
+#End If
 
         Friend Overridable Iterator Function GetPropertiesToEmit() As IEnumerable(Of PropertySymbol)
             CheckDefinitionInvariant()
@@ -779,17 +957,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
         End Function
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamedTypeSymbolAdapter
+#End If
+
         Private ReadOnly Property ITypeDefinitionSecurityAttributes As IEnumerable(Of SecurityAttribute) Implements ITypeDefinition.SecurityAttributes
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 'Debug.Assert(((ITypeReference)this).AsTypeDefinition != null);
 
                 ' can't be generic instantiation
                 ' must be declared in the module we are building
                 CheckDefinitionInvariant()
 
-                Debug.Assert(Me.HasDeclarativeSecurity)
-                Dim securityAttributes As IEnumerable(Of SecurityAttribute) = Me.GetSecurityInformation()
+                Debug.Assert(AdaptedNamedTypeSymbol.HasDeclarativeSecurity)
+                Dim securityAttributes As IEnumerable(Of SecurityAttribute) = AdaptedNamedTypeSymbol.GetSecurityInformation()
                 Debug.Assert(securityAttributes IsNot Nothing)
                 Return securityAttributes
             End Get
@@ -797,19 +981,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeDefinitionSizeOf As UInteger Implements ITypeDefinition.SizeOf
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 CheckDefinitionInvariant()
 
-                Return CUInt(Me.Layout.Size)
+                Return CUInt(AdaptedNamedTypeSymbol.Layout.Size)
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionStringFormat As CharSet Implements ITypeDefinition.StringFormat
             Get
-                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Not AdaptedNamedTypeSymbol.IsAnonymousType)
                 CheckDefinitionInvariant()
 
-                Return Me.MarshallingCharSet
+                Return AdaptedNamedTypeSymbol.MarshallingCharSet
             End Get
         End Property
 
@@ -821,27 +1005,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property INamedTypeReferenceMangleName As Boolean Implements INamedTypeReference.MangleName
             Get
-                Return MangleName
+                Return AdaptedNamedTypeSymbol.MangleName
             End Get
         End Property
 
         Private ReadOnly Property INamedEntityName As String Implements INamedEntity.Name
             Get
                 ' CCI automatically adds the arity suffix, so we return Name, not MetadataName here.
-                Return Me.Name
+                Return AdaptedNamedTypeSymbol.Name
             End Get
         End Property
 
         Private Function INamespaceTypeReferenceGetUnit(context As EmitContext) As IUnitReference Implements INamespaceTypeReference.GetUnit
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Debug.Assert((DirectCast(Me, ITypeReference)).AsNamespaceTypeReference IsNot Nothing)
-            Return moduleBeingBuilt.Translate(Me.ContainingModule, context.Diagnostics)
+            Return moduleBeingBuilt.Translate(AdaptedNamedTypeSymbol.ContainingModule, context.Diagnostics)
         End Function
 
         Private ReadOnly Property INamespaceTypeReferenceNamespaceName As String Implements INamespaceTypeReference.NamespaceName
             Get
                 Debug.Assert((DirectCast(Me, ITypeReference)).AsNamespaceTypeReference IsNot Nothing)
-                Return If(Me.GetEmittedNamespaceName(), Me.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))
+                Return If(AdaptedNamedTypeSymbol.GetEmittedNamespaceName(), AdaptedNamedTypeSymbol.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))
             End Get
         End Property
 
@@ -849,7 +1033,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 'Debug.Assert(((ITypeReference)this).AsNamespaceTypeDefinition != null);
                 CheckDefinitionInvariant()
-                Return PEModuleBuilder.MemberVisibility(Me) = Cci.TypeMemberVisibility.Public
+                Return PEModuleBuilder.MemberVisibility(AdaptedNamedTypeSymbol) = Cci.TypeMemberVisibility.Public
             End Get
         End Property
 
@@ -859,27 +1043,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert((DirectCast(Me, ITypeReference)).AsNestedTypeReference IsNot Nothing)
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            Return moduleBeingBuilt.Translate(Me.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics, needDeclaration:=Me.IsDefinition)
+            Return moduleBeingBuilt.Translate(AdaptedNamedTypeSymbol.ContainingType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics, needDeclaration:=AdaptedNamedTypeSymbol.IsDefinition)
         End Function
 
         Private ReadOnly Property ITypeDefinitionMemberContainingTypeDefinition As ITypeDefinition Implements ITypeDefinitionMember.ContainingTypeDefinition
             Get
                 'Debug.Assert(((ITypeReference)this).AsNestedTypeDefinition != null);
                 'return (ITypeDefinition)moduleBeingBuilt.Translate(this.ContainingType, true);
-                Debug.Assert(Me.ContainingType IsNot Nothing)
+                Debug.Assert(AdaptedNamedTypeSymbol.ContainingType IsNot Nothing)
                 CheckDefinitionInvariant()
 
-                Return Me.ContainingType
+                Return AdaptedNamedTypeSymbol.ContainingType.GetCciAdapter()
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionMemberVisibility As TypeMemberVisibility Implements ITypeDefinitionMember.Visibility
             Get
                 'Debug.Assert(((ITypeReference)this).AsNestedTypeDefinition != null);
-                Debug.Assert(Me.ContainingType IsNot Nothing)
+                Debug.Assert(AdaptedNamedTypeSymbol.ContainingType IsNot Nothing)
                 CheckDefinitionInvariant()
 
-                Return PEModuleBuilder.MemberVisibility(Me)
+                Return PEModuleBuilder.MemberVisibility(AdaptedNamedTypeSymbol)
             End Get
         End Property
 
@@ -887,15 +1071,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             Debug.Assert((DirectCast(Me, ITypeReference)).AsGenericTypeInstanceReference IsNot Nothing)
 
-            Dim hasModifiers = Me.HasTypeArgumentsCustomModifiers
+            Dim hasModifiers = AdaptedNamedTypeSymbol.HasTypeArgumentsCustomModifiers
 
             Dim builder = ArrayBuilder(Of ITypeReference).GetInstance()
-            Dim arguments = Me.TypeArgumentsNoUseSiteDiagnostics
+            Dim arguments = AdaptedNamedTypeSymbol.TypeArgumentsNoUseSiteDiagnostics
             For i As Integer = 0 To arguments.Length - 1
                 Dim arg = moduleBeingBuilt.Translate(arguments(i), syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
 
                 If hasModifiers Then
-                    Dim modifiers = Me.GetTypeArgumentCustomModifiers(i)
+                    Dim modifiers = AdaptedNamedTypeSymbol.GetTypeArgumentCustomModifiers(i)
                     If Not modifiers.IsDefaultOrEmpty Then
                         arg = New Cci.ModifiedTypeReference(arg, modifiers.As(Of Cci.ICustomModifier))
                     End If
@@ -915,7 +1099,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property GenericTypeImpl(context As EmitContext) As INamedTypeReference
             Get
                 Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
-                Return moduleBeingBuilt.Translate(Me.OriginalDefinition, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                Return moduleBeingBuilt.Translate(AdaptedNamedTypeSymbol.OriginalDefinition, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
                                                   diagnostics:=context.Diagnostics, needDeclaration:=True)
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Portable/Emit/NamespaceSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamespaceSymbolAdapter.vb
@@ -5,23 +5,77 @@
 Imports Microsoft.Cci
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
+#If DEBUG Then
+    Partial Friend NotInheritable Class NamespaceSymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend MustInherit Class NamespaceSymbol
+#End If
         Implements Cci.INamespace
+
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedNamespaceSymbol As NamespaceSymbol
+
+        Friend Sub New(underlyingNamespaceSymbol As NamespaceSymbol)
+            AdaptedNamespaceSymbol = underlyingNamespaceSymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedNamespaceSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedNamespaceSymbol As NamespaceSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class NamespaceSymbol
+#If DEBUG Then
+        Private _lazyAdapter As NamespaceSymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As NamespaceSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, New NamespaceSymbolAdapter(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As NamespaceSymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class NamespaceSymbolAdapter
+#End If
 
         Private ReadOnly Property INamedEntity_Name As String Implements INamedEntity.Name
             Get
-                Return Me.MetadataName
+                Return AdaptedNamespaceSymbol.MetadataName
             End Get
         End Property
 
         Private ReadOnly Property INamespaceSymbol_ContainingNamespace As Cci.INamespace Implements Cci.INamespace.ContainingNamespace
             Get
-                Return Me.ContainingNamespace
+                Return AdaptedNamespaceSymbol.ContainingNamespace?.GetCciAdapter()
             End Get
         End Property
 
         Private Function INamespaceSymbol_GetInternalSymbol() As CodeAnalysis.Symbols.INamespaceSymbolInternal Implements Cci.INamespace.GetInternalSymbol
-            Return Me
+            Return AdaptedNamespaceSymbol
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedField.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedField.vb
@@ -7,12 +7,16 @@ Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
+#If Not DEBUG Then
+Imports FieldSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.FieldSymbol
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
     Friend NotInheritable Class EmbeddedField
         Inherits EmbeddedTypesManager.CommonEmbeddedField
 
-        Public Sub New(containingType As EmbeddedType, underlyingField As FieldSymbol)
+        Public Sub New(containingType As EmbeddedType, underlyingField As FieldSymbolAdapter)
             MyBase.New(containingType, underlyingField)
         End Sub
 
@@ -23,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         End Property
 
         Protected Overrides Function GetCustomAttributesToEmit(moduleBuilder As PEModuleBuilder) As IEnumerable(Of VisualBasicAttributeData)
-            Return UnderlyingField.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
+            Return UnderlyingField.AdaptedFieldSymbol.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
         End Function
 
         Protected Overrides Function GetCompileTimeValue(context As EmitContext) As MetadataConstant
@@ -32,73 +36,73 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Protected Overrides ReadOnly Property IsCompileTimeConstant As Boolean
             Get
-                Return UnderlyingField.IsMetadataConstant
+                Return UnderlyingField.AdaptedFieldSymbol.IsMetadataConstant
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsNotSerialized As Boolean
             Get
-                Return UnderlyingField.IsNotSerialized
+                Return UnderlyingField.AdaptedFieldSymbol.IsNotSerialized
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsReadOnly As Boolean
             Get
-                Return UnderlyingField.IsReadOnly
+                Return UnderlyingField.AdaptedFieldSymbol.IsReadOnly
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsRuntimeSpecial As Boolean
             Get
-                Return UnderlyingField.HasRuntimeSpecialName
+                Return UnderlyingField.AdaptedFieldSymbol.HasRuntimeSpecialName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsSpecialName As Boolean
             Get
-                Return UnderlyingField.HasSpecialName
+                Return UnderlyingField.AdaptedFieldSymbol.HasSpecialName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsStatic As Boolean
             Get
-                Return UnderlyingField.IsShared
+                Return UnderlyingField.AdaptedFieldSymbol.IsShared
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsMarshalledExplicitly As Boolean
             Get
-                Return UnderlyingField.IsMarshalledExplicitly
+                Return UnderlyingField.AdaptedFieldSymbol.IsMarshalledExplicitly
             End Get
         End Property
 
         Protected Overrides ReadOnly Property MarshallingInformation As Cci.IMarshallingInformation
             Get
-                Return UnderlyingField.MarshallingInformation
+                Return UnderlyingField.AdaptedFieldSymbol.MarshallingInformation
             End Get
         End Property
 
         Protected Overrides ReadOnly Property MarshallingDescriptor As ImmutableArray(Of Byte)
             Get
-                Return UnderlyingField.MarshallingDescriptor
+                Return UnderlyingField.AdaptedFieldSymbol.MarshallingDescriptor
             End Get
         End Property
 
         Protected Overrides ReadOnly Property TypeLayoutOffset As Integer?
             Get
-                Return UnderlyingField.TypeLayoutOffset
+                Return UnderlyingField.AdaptedFieldSymbol.TypeLayoutOffset
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Visibility As Cci.TypeMemberVisibility
             Get
-                Return PEModuleBuilder.MemberVisibility(UnderlyingField)
+                Return PEModuleBuilder.MemberVisibility(UnderlyingField.AdaptedFieldSymbol)
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Name As String
             Get
-                Return UnderlyingField.MetadataName
+                Return UnderlyingField.AdaptedFieldSymbol.MetadataName
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedMethod.vb
@@ -7,12 +7,16 @@ Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
+#If Not DEBUG Then
+Imports MethodSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.MethodSymbol
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
     Friend NotInheritable Class EmbeddedMethod
         Inherits EmbeddedTypesManager.CommonEmbeddedMethod
 
-        Public Sub New(containingType As EmbeddedType, underlyingMethod As MethodSymbol)
+        Public Sub New(containingType As EmbeddedType, underlyingMethod As MethodSymbolAdapter)
             MyBase.New(containingType, underlyingMethod)
         End Sub
 
@@ -23,126 +27,126 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         End Property
 
         Protected Overrides Function GetCustomAttributesToEmit(moduleBuilder As PEModuleBuilder) As IEnumerable(Of VisualBasicAttributeData)
-            Return UnderlyingMethod.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
+            Return UnderlyingMethod.AdaptedMethodSymbol.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
         End Function
 
         Protected Overrides Function GetParameters() As ImmutableArray(Of EmbeddedParameter)
-            Return EmbeddedTypesManager.EmbedParameters(Me, UnderlyingMethod.Parameters)
+            Return EmbeddedTypesManager.EmbedParameters(Me, UnderlyingMethod.AdaptedMethodSymbol.Parameters)
         End Function
 
         Protected Overrides Function GetTypeParameters() As ImmutableArray(Of EmbeddedTypeParameter)
-            Return UnderlyingMethod.TypeParameters.SelectAsArray(Function(typeParameter, container) New EmbeddedTypeParameter(container, typeParameter), Me)
+            Return UnderlyingMethod.AdaptedMethodSymbol.TypeParameters.SelectAsArray(Function(typeParameter, container) New EmbeddedTypeParameter(container, typeParameter.GetCciAdapter()), Me)
         End Function
 
         Protected Overrides ReadOnly Property IsAbstract As Boolean
             Get
-                Return UnderlyingMethod.IsMustOverride
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsMustOverride
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsAccessCheckedOnOverride As Boolean
             Get
-                Return UnderlyingMethod.IsAccessCheckedOnOverride
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsAccessCheckedOnOverride
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsConstructor As Boolean
             Get
-                Return UnderlyingMethod.MethodKind = MethodKind.Constructor
+                Return UnderlyingMethod.AdaptedMethodSymbol.MethodKind = MethodKind.Constructor
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsExternal As Boolean
             Get
-                Return UnderlyingMethod.IsExternal
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsExternal
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsHiddenBySignature As Boolean
             Get
-                Return UnderlyingMethod.IsHiddenBySignature
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsHiddenBySignature
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsNewSlot As Boolean
             Get
-                Return UnderlyingMethod.IsMetadataNewSlot()
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataNewSlot()
             End Get
         End Property
 
         Protected Overrides ReadOnly Property PlatformInvokeData As Cci.IPlatformInvokeInformation
             Get
-                Return UnderlyingMethod.GetDllImportData()
+                Return UnderlyingMethod.AdaptedMethodSymbol.GetDllImportData()
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsRuntimeSpecial As Boolean
             Get
-                Return UnderlyingMethod.HasRuntimeSpecialName
+                Return UnderlyingMethod.AdaptedMethodSymbol.HasRuntimeSpecialName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsSpecialName As Boolean
             Get
-                Return UnderlyingMethod.HasSpecialName
+                Return UnderlyingMethod.AdaptedMethodSymbol.HasSpecialName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsSealed As Boolean
             Get
-                Return UnderlyingMethod.IsMetadataFinal
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataFinal
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsStatic As Boolean
             Get
-                Return UnderlyingMethod.IsShared
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsShared
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsVirtual As Boolean
             Get
-                Return UnderlyingMethod.IsMetadataVirtual()
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataVirtual()
             End Get
         End Property
 
         Protected Overrides Function GetImplementationAttributes(context As EmitContext) As Reflection.MethodImplAttributes
-            Return UnderlyingMethod.ImplementationAttributes
+            Return UnderlyingMethod.AdaptedMethodSymbol.ImplementationAttributes
         End Function
 
         Protected Overrides ReadOnly Property ReturnValueIsMarshalledExplicitly As Boolean
             Get
-                Return UnderlyingMethod.ReturnValueIsMarshalledExplicitly
+                Return UnderlyingMethod.AdaptedMethodSymbol.ReturnValueIsMarshalledExplicitly
             End Get
         End Property
 
         Protected Overrides ReadOnly Property ReturnValueMarshallingInformation As Cci.IMarshallingInformation
             Get
-                Return UnderlyingMethod.ReturnTypeMarshallingInformation
+                Return UnderlyingMethod.AdaptedMethodSymbol.ReturnTypeMarshallingInformation
             End Get
         End Property
 
         Protected Overrides ReadOnly Property ReturnValueMarshallingDescriptor As ImmutableArray(Of Byte)
             Get
-                Return UnderlyingMethod.ReturnValueMarshallingDescriptor
+                Return UnderlyingMethod.AdaptedMethodSymbol.ReturnValueMarshallingDescriptor
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Visibility As Cci.TypeMemberVisibility
             Get
-                Return PEModuleBuilder.MemberVisibility(UnderlyingMethod)
+                Return PEModuleBuilder.MemberVisibility(UnderlyingMethod.AdaptedMethodSymbol)
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Name As String
             Get
-                Return UnderlyingMethod.MetadataName
+                Return UnderlyingMethod.AdaptedMethodSymbol.MetadataName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property AcceptsExtraArguments As Boolean
             Get
-                Return UnderlyingMethod.IsVararg
+                Return UnderlyingMethod.AdaptedMethodSymbol.IsVararg
             End Get
         End Property
 
@@ -154,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Protected Overrides ReadOnly Property ContainingNamespace As INamespace
             Get
-                Return UnderlyingMethod.ContainingNamespace
+                Return UnderlyingMethod.AdaptedMethodSymbol.ContainingNamespace.GetCciAdapter()
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedParameter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedParameter.vb
@@ -7,23 +7,27 @@ Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
+#If Not DEBUG Then
+Imports ParameterSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
     Friend NotInheritable Class EmbeddedParameter
         Inherits EmbeddedTypesManager.CommonEmbeddedParameter
 
-        Public Sub New(containingPropertyOrMethod As EmbeddedTypesManager.CommonEmbeddedMember, underlyingParameter As ParameterSymbol)
+        Public Sub New(containingPropertyOrMethod As EmbeddedTypesManager.CommonEmbeddedMember, underlyingParameter As ParameterSymbolAdapter)
             MyBase.New(containingPropertyOrMethod, underlyingParameter)
-            Debug.Assert(underlyingParameter.IsDefinition)
+            Debug.Assert(underlyingParameter.AdaptedParameterSymbol.IsDefinition)
         End Sub
 
         Protected Overrides Function GetCustomAttributesToEmit(moduleBuilder As PEModuleBuilder) As IEnumerable(Of VisualBasicAttributeData)
-            Return UnderlyingParameter.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
+            Return UnderlyingParameter.AdaptedParameterSymbol.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
         End Function
 
         Protected Overrides ReadOnly Property HasDefaultValue As Boolean
             Get
-                Return UnderlyingParameter.HasMetadataConstantValue
+                Return UnderlyingParameter.AdaptedParameterSymbol.HasMetadataConstantValue
             End Get
         End Property
 
@@ -33,43 +37,43 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Protected Overrides ReadOnly Property IsIn As Boolean
             Get
-                Return UnderlyingParameter.IsMetadataIn
+                Return UnderlyingParameter.AdaptedParameterSymbol.IsMetadataIn
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsOut As Boolean
             Get
-                Return UnderlyingParameter.IsMetadataOut
+                Return UnderlyingParameter.AdaptedParameterSymbol.IsMetadataOut
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsOptional As Boolean
             Get
-                Return UnderlyingParameter.IsMetadataOptional
+                Return UnderlyingParameter.AdaptedParameterSymbol.IsMetadataOptional
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsMarshalledExplicitly As Boolean
             Get
-                Return UnderlyingParameter.IsMarshalledExplicitly
+                Return UnderlyingParameter.AdaptedParameterSymbol.IsMarshalledExplicitly
             End Get
         End Property
 
         Protected Overrides ReadOnly Property MarshallingInformation As Cci.IMarshallingInformation
             Get
-                Return UnderlyingParameter.MarshallingInformation
+                Return UnderlyingParameter.AdaptedParameterSymbol.MarshallingInformation
             End Get
         End Property
 
         Protected Overrides ReadOnly Property MarshallingDescriptor As ImmutableArray(Of Byte)
             Get
-                Return UnderlyingParameter.MarshallingDescriptor
+                Return UnderlyingParameter.AdaptedParameterSymbol.MarshallingDescriptor
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Name As String
             Get
-                Return UnderlyingParameter.MetadataName
+                Return UnderlyingParameter.AdaptedParameterSymbol.MetadataName
             End Get
         End Property
 
@@ -81,7 +85,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Protected Overrides ReadOnly Property Index As UShort
             Get
-                Return CUShort(UnderlyingParameter.Ordinal)
+                Return CUShort(UnderlyingParameter.AdaptedParameterSymbol.Ordinal)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedProperty.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedProperty.vb
@@ -7,32 +7,36 @@ Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
+#If Not DEBUG Then
+Imports PropertySymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.PropertySymbol
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
     Friend NotInheritable Class EmbeddedProperty
         Inherits EmbeddedTypesManager.CommonEmbeddedProperty
 
-        Public Sub New(underlyingProperty As PropertySymbol, getter As EmbeddedMethod, setter As EmbeddedMethod)
+        Public Sub New(underlyingProperty As PropertySymbolAdapter, getter As EmbeddedMethod, setter As EmbeddedMethod)
             MyBase.New(underlyingProperty, getter, setter)
         End Sub
 
         Protected Overrides Function GetCustomAttributesToEmit(moduleBuilder As PEModuleBuilder) As IEnumerable(Of VisualBasicAttributeData)
-            Return UnderlyingProperty.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
+            Return UnderlyingProperty.AdaptedPropertySymbol.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
         End Function
 
         Protected Overrides Function GetParameters() As ImmutableArray(Of EmbeddedParameter)
-            Return EmbeddedTypesManager.EmbedParameters(Me, UnderlyingProperty.Parameters)
+            Return EmbeddedTypesManager.EmbedParameters(Me, UnderlyingProperty.AdaptedPropertySymbol.Parameters)
         End Function
 
         Protected Overrides ReadOnly Property IsRuntimeSpecial As Boolean
             Get
-                Return UnderlyingProperty.HasRuntimeSpecialName
+                Return UnderlyingProperty.AdaptedPropertySymbol.HasRuntimeSpecialName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsSpecialName As Boolean
             Get
-                Return UnderlyingProperty.HasSpecialName
+                Return UnderlyingProperty.AdaptedPropertySymbol.HasSpecialName
             End Get
         End Property
 
@@ -50,13 +54,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Protected Overrides ReadOnly Property Visibility As Cci.TypeMemberVisibility
             Get
-                Return PEModuleBuilder.MemberVisibility(UnderlyingProperty)
+                Return PEModuleBuilder.MemberVisibility(UnderlyingProperty.AdaptedPropertySymbol)
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Name As String
             Get
-                Return UnderlyingProperty.MetadataName
+                Return UnderlyingProperty.AdaptedPropertySymbol.MetadataName
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
@@ -6,6 +6,14 @@ Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
+#If Not DEBUG Then
+Imports NamedTypeSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol
+Imports FieldSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.FieldSymbol
+Imports MethodSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.MethodSymbol
+Imports EventSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.EventSymbol
+Imports PropertySymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.PropertySymbol
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
     Friend NotInheritable Class EmbeddedType
@@ -13,16 +21,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Private _embeddedAllMembersOfImplementedInterface As Boolean
 
-        Public Sub New(typeManager As EmbeddedTypesManager, underlyingNamedType As NamedTypeSymbol)
+        Public Sub New(typeManager As EmbeddedTypesManager, underlyingNamedType As NamedTypeSymbolAdapter)
             MyBase.New(typeManager, underlyingNamedType)
 
-            Debug.Assert(underlyingNamedType.IsDefinition)
-            Debug.Assert(underlyingNamedType.IsTopLevelType())
-            Debug.Assert(Not underlyingNamedType.IsGenericType)
+            Debug.Assert(underlyingNamedType.AdaptedNamedTypeSymbol.IsDefinition)
+            Debug.Assert(underlyingNamedType.AdaptedNamedTypeSymbol.IsTopLevelType())
+            Debug.Assert(Not underlyingNamedType.AdaptedNamedTypeSymbol.IsGenericType)
         End Sub
 
         Public Sub EmbedAllMembersOfImplementedInterface(syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag)
-            Debug.Assert(UnderlyingNamedType.IsInterfaceType())
+            Debug.Assert(UnderlyingNamedType.AdaptedNamedTypeSymbol.IsInterfaceType())
 
             If _embeddedAllMembersOfImplementedInterface Then
                 Return
@@ -31,9 +39,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             _embeddedAllMembersOfImplementedInterface = True
 
             ' Embed all members
-            For Each m In UnderlyingNamedType.GetMethodsToEmit()
+            For Each m In UnderlyingNamedType.AdaptedNamedTypeSymbol.GetMethodsToEmit()
                 If m IsNot Nothing Then
-                    TypeManager.EmbedMethod(Me, m, syntaxNodeOpt, diagnostics)
+                    TypeManager.EmbedMethod(Me, m.GetCciAdapter(), syntaxNodeOpt, diagnostics)
                 End If
             Next
 
@@ -41,41 +49,57 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             ' because accessors embed them automatically.
 
             ' Do the same for implemented interfaces.
-            For Each [interface] In UnderlyingNamedType.GetInterfacesToEmit()
+            For Each [interface] In UnderlyingNamedType.AdaptedNamedTypeSymbol.GetInterfacesToEmit()
                 TypeManager.ModuleBeingBuilt.Translate([interface], syntaxNodeOpt, diagnostics, fromImplements:=True)
             Next
         End Sub
 
         Protected Overrides Function GetAssemblyRefIndex() As Integer
             Dim refs = TypeManager.ModuleBeingBuilt.SourceModule.GetReferencedAssemblySymbols()
-            Return refs.IndexOf(UnderlyingNamedType.ContainingAssembly, ReferenceEqualityComparer.Instance)
+            Return refs.IndexOf(UnderlyingNamedType.AdaptedNamedTypeSymbol.ContainingAssembly, ReferenceEqualityComparer.Instance)
         End Function
 
         Protected Overrides ReadOnly Property IsPublic As Boolean
             Get
-                Return UnderlyingNamedType.DeclaredAccessibility = Accessibility.Public
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.DeclaredAccessibility = Accessibility.Public
             End Get
         End Property
 
         Protected Overrides Function GetBaseClass(moduleBuilder As PEModuleBuilder, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As Cci.ITypeReference
-            Dim baseType = UnderlyingNamedType.BaseTypeNoUseSiteDiagnostics
+            Dim baseType = UnderlyingNamedType.AdaptedNamedTypeSymbol.BaseTypeNoUseSiteDiagnostics
             Return If(baseType IsNot Nothing, moduleBuilder.Translate(baseType, syntaxNodeOpt, diagnostics), Nothing)
         End Function
 
-        Protected Overrides Function GetFieldsToEmit() As IEnumerable(Of FieldSymbol)
-            Return UnderlyingNamedType.GetFieldsToEmit()
+        Protected Overrides Function GetFieldsToEmit() As IEnumerable(Of FieldSymbolAdapter)
+#If DEBUG Then
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetFieldsToEmit().Select(Function(s) s.GetCciAdapter())
+#Else
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetFieldsToEmit()
+#End If
         End Function
 
-        Protected Overrides Function GetMethodsToEmit() As IEnumerable(Of MethodSymbol)
-            Return UnderlyingNamedType.GetMethodsToEmit()
+        Protected Overrides Function GetMethodsToEmit() As IEnumerable(Of MethodSymbolAdapter)
+#If DEBUG Then
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetMethodsToEmit().Select(Function(s) s?.GetCciAdapter())
+#Else
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetMethodsToEmit()
+#End If
         End Function
 
-        Protected Overrides Function GetEventsToEmit() As IEnumerable(Of EventSymbol)
-            Return UnderlyingNamedType.GetEventsToEmit()
+        Protected Overrides Function GetEventsToEmit() As IEnumerable(Of EventSymbolAdapter)
+#If DEBUG Then
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetEventsToEmit().Select(Function(s) s.GetCciAdapter())
+#Else
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetEventsToEmit()
+#End If
         End Function
 
-        Protected Overrides Function GetPropertiesToEmit() As IEnumerable(Of PropertySymbol)
-            Return UnderlyingNamedType.GetPropertiesToEmit()
+        Protected Overrides Function GetPropertiesToEmit() As IEnumerable(Of PropertySymbolAdapter)
+#If DEBUG Then
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetPropertiesToEmit().Select(Function(s) s.GetCciAdapter())
+#Else
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetPropertiesToEmit()
+#End If
         End Function
 
         Protected Overrides Iterator Function GetInterfaces(context As EmitContext) As IEnumerable(Of Cci.TypeReferenceWithAttributes)
@@ -83,24 +107,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
             Dim moduleBeingBuilt = DirectCast(context.Module, PEModuleBuilder)
 
-            For Each [interface] In UnderlyingNamedType.GetInterfacesToEmit()
+            For Each [interface] In UnderlyingNamedType.AdaptedNamedTypeSymbol.GetInterfacesToEmit()
                 Dim typeRef = moduleBeingBuilt.Translate([interface],
                                                             DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
                                                             context.Diagnostics)
 
-                Yield [interface].GetTypeRefWithAttributes(UnderlyingNamedType.DeclaringCompilation, typeRef)
+                Yield [interface].GetTypeRefWithAttributes(UnderlyingNamedType.AdaptedNamedTypeSymbol.DeclaringCompilation, typeRef)
             Next
         End Function
 
         Protected Overrides ReadOnly Property IsAbstract As Boolean
             Get
-                Return UnderlyingNamedType.IsMetadataAbstract
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.IsMetadataAbstract
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsBeforeFieldInit As Boolean
             Get
-                Select Case UnderlyingNamedType.TypeKind
+                Select Case UnderlyingNamedType.AdaptedNamedTypeSymbol.TypeKind
                     Case TypeKind.Enum, TypeKind.Delegate, TypeKind.Interface
                         Return False
                 End Select
@@ -112,58 +136,58 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Protected Overrides ReadOnly Property IsComImport As Boolean
             Get
-                Return UnderlyingNamedType.IsComImport
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.IsComImport
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsInterface As Boolean
             Get
-                Return UnderlyingNamedType.IsInterfaceType()
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.IsInterfaceType()
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsDelegate As Boolean
             Get
-                Return UnderlyingNamedType.IsDelegateType()
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.IsDelegateType()
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsSerializable As Boolean
             Get
-                Return UnderlyingNamedType.IsSerializable
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.IsSerializable
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsSpecialName As Boolean
             Get
-                Return UnderlyingNamedType.HasSpecialName
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.HasSpecialName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsWindowsRuntimeImport As Boolean
             Get
-                Return UnderlyingNamedType.IsWindowsRuntimeImport
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.IsWindowsRuntimeImport
             End Get
         End Property
 
         Protected Overrides ReadOnly Property IsSealed As Boolean
             Get
-                Return UnderlyingNamedType.IsMetadataSealed
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.IsMetadataSealed
             End Get
         End Property
 
         Protected Overrides Function GetTypeLayoutIfStruct() As TypeLayout?
-            Return If(UnderlyingNamedType.IsStructureType(), UnderlyingNamedType.Layout, Nothing)
+            Return If(UnderlyingNamedType.AdaptedNamedTypeSymbol.IsStructureType(), UnderlyingNamedType.AdaptedNamedTypeSymbol.Layout, Nothing)
         End Function
 
         Protected Overrides ReadOnly Property StringFormat As System.Runtime.InteropServices.CharSet
             Get
-                Return UnderlyingNamedType.MarshallingCharSet
+                Return UnderlyingNamedType.AdaptedNamedTypeSymbol.MarshallingCharSet
             End Get
         End Property
 
         Protected Overrides Function GetCustomAttributesToEmit(moduleBuilder As PEModuleBuilder) As IEnumerable(Of VisualBasicAttributeData)
-            Return UnderlyingNamedType.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
+            Return UnderlyingNamedType.AdaptedNamedTypeSymbol.GetCustomAttributesToEmit(moduleBuilder.CompilationState)
         End Function
 
         Protected Overrides Function CreateTypeIdentifierAttribute(hasGuid As Boolean, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As VisualBasicAttributeData
@@ -190,10 +214,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                 Dim stringType = TypeManager.GetSystemStringType(syntaxNodeOpt, diagnostics)
 
                 If stringType IsNot Nothing Then
-                    Dim guidString = TypeManager.GetAssemblyGuidString(UnderlyingNamedType.ContainingAssembly)
+                    Dim guidString = TypeManager.GetAssemblyGuidString(UnderlyingNamedType.AdaptedNamedTypeSymbol.ContainingAssembly)
                     Return New SynthesizedAttributeData(ctor,
                         ImmutableArray.Create(New TypedConstant(stringType, TypedConstantKind.Primitive, guidString),
-                            New TypedConstant(stringType, TypedConstantKind.Primitive, UnderlyingNamedType.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))),
+                            New TypedConstant(stringType, TypedConstantKind.Primitive, UnderlyingNamedType.AdaptedNamedTypeSymbol.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))),
                         ImmutableArray(Of KeyValuePair(Of String, TypedConstant)).Empty)
                 End If
             End If
@@ -202,20 +226,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         End Function
 
         Protected Overrides Sub ReportMissingAttribute(description As AttributeDescription, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag)
-            EmbeddedTypesManager.ReportDiagnostic(diagnostics, ERRID.ERR_NoPIAAttributeMissing2, syntaxNodeOpt, UnderlyingNamedType, description.FullName)
+            EmbeddedTypesManager.ReportDiagnostic(diagnostics, ERRID.ERR_NoPIAAttributeMissing2, syntaxNodeOpt, UnderlyingNamedType.AdaptedNamedTypeSymbol, description.FullName)
         End Sub
 
         Protected Overrides Sub EmbedDefaultMembers(defaultMember As String, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag)
-            For Each s In UnderlyingNamedType.GetMembers(defaultMember)
+            For Each s In UnderlyingNamedType.AdaptedNamedTypeSymbol.GetMembers(defaultMember)
                 Select Case s.Kind
                     Case SymbolKind.Field
-                        TypeManager.EmbedField(Me, DirectCast(s, FieldSymbol), syntaxNodeOpt, diagnostics)
+                        TypeManager.EmbedField(Me, DirectCast(s, FieldSymbol).GetCciAdapter(), syntaxNodeOpt, diagnostics)
                     Case SymbolKind.Method
-                        TypeManager.EmbedMethod(Me, DirectCast(s, MethodSymbol), syntaxNodeOpt, diagnostics)
+                        TypeManager.EmbedMethod(Me, DirectCast(s, MethodSymbol).GetCciAdapter(), syntaxNodeOpt, diagnostics)
                     Case SymbolKind.Property
-                        TypeManager.EmbedProperty(Me, DirectCast(s, PropertySymbol), syntaxNodeOpt, diagnostics)
+                        TypeManager.EmbedProperty(Me, DirectCast(s, PropertySymbol).GetCciAdapter(), syntaxNodeOpt, diagnostics)
                     Case SymbolKind.Event
-                        TypeManager.EmbedEvent(Me, DirectCast(s, EventSymbol), syntaxNodeOpt, diagnostics, isUsedForComAwareEventBinding:=False)
+                        TypeManager.EmbedEvent(Me, DirectCast(s, EventSymbol).GetCciAdapter(), syntaxNodeOpt, diagnostics, isUsedForComAwareEventBinding:=False)
                 End Select
             Next
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypeParameter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypeParameter.vb
@@ -5,14 +5,18 @@
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
+#If Not DEBUG Then
+Imports TypeParameterSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeParameterSymbol
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
     Friend NotInheritable Class EmbeddedTypeParameter
         Inherits EmbeddedTypesManager.CommonEmbeddedTypeParameter
 
-        Public Sub New(containingMethod As EmbeddedMethod, underlyingTypeParameter As TypeParameterSymbol)
+        Public Sub New(containingMethod As EmbeddedMethod, underlyingTypeParameter As TypeParameterSymbolAdapter)
             MyBase.New(containingMethod, underlyingTypeParameter)
-            Debug.Assert(underlyingTypeParameter.IsDefinition)
+            Debug.Assert(underlyingTypeParameter.AdaptedTypeParameterSymbol.IsDefinition)
         End Sub
 
         Protected Overrides Function GetConstraints(context As EmitContext) As IEnumerable(Of Cci.TypeReferenceWithAttributes)
@@ -21,31 +25,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Protected Overrides ReadOnly Property MustBeReferenceType As Boolean
             Get
-                Return UnderlyingTypeParameter.HasReferenceTypeConstraint
+                Return UnderlyingTypeParameter.AdaptedTypeParameterSymbol.HasReferenceTypeConstraint
             End Get
         End Property
 
         Protected Overrides ReadOnly Property MustBeValueType As Boolean
             Get
-                Return UnderlyingTypeParameter.HasValueTypeConstraint
+                Return UnderlyingTypeParameter.AdaptedTypeParameterSymbol.HasValueTypeConstraint
             End Get
         End Property
 
         Protected Overrides ReadOnly Property MustHaveDefaultConstructor As Boolean
             Get
-                Return UnderlyingTypeParameter.HasConstructorConstraint
+                Return UnderlyingTypeParameter.AdaptedTypeParameterSymbol.HasConstructorConstraint
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Name As String
             Get
-                Return UnderlyingTypeParameter.MetadataName
+                Return UnderlyingTypeParameter.AdaptedTypeParameterSymbol.MetadataName
             End Get
         End Property
 
         Protected Overrides ReadOnly Property Index As UShort
             Get
-                Return CUShort(UnderlyingTypeParameter.Ordinal)
+                Return CUShort(UnderlyingTypeParameter.AdaptedTypeParameterSymbol.Ordinal)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -8,10 +8,23 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports System.Collections.Concurrent
 Imports System.Threading
 
+#If Not DEBUG Then
+Imports SymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbol
+Imports NamedTypeSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol
+Imports FieldSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.FieldSymbol
+Imports MethodSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.MethodSymbol
+Imports EventSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.EventSymbol
+Imports PropertySymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.PropertySymbol
+Imports ParameterSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol
+Imports TypeParameterSymbolAdapter = Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeParameterSymbol
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
     Friend NotInheritable Class EmbeddedTypesManager
-        Inherits Microsoft.CodeAnalysis.Emit.NoPia.EmbeddedTypesManager(Of PEModuleBuilder, ModuleCompilationState, EmbeddedTypesManager, SyntaxNode, VisualBasicAttributeData, Symbol, AssemblySymbol, NamedTypeSymbol, FieldSymbol, MethodSymbol, EventSymbol, PropertySymbol, ParameterSymbol, TypeParameterSymbol, EmbeddedType, EmbeddedField, EmbeddedMethod, EmbeddedEvent, EmbeddedProperty, EmbeddedParameter, EmbeddedTypeParameter)
+        Inherits Microsoft.CodeAnalysis.Emit.NoPia.EmbeddedTypesManager(Of PEModuleBuilder, ModuleCompilationState, EmbeddedTypesManager, SyntaxNode, VisualBasicAttributeData,
+                                                                           SymbolAdapter, AssemblySymbol, NamedTypeSymbolAdapter, FieldSymbolAdapter, MethodSymbolAdapter, EventSymbolAdapter, PropertySymbolAdapter, ParameterSymbolAdapter, TypeParameterSymbolAdapter,
+                                                                           EmbeddedType, EmbeddedField, EmbeddedMethod, EmbeddedEvent, EmbeddedProperty, EmbeddedParameter, EmbeddedTypeParameter)
 
         Private ReadOnly _assemblyGuidMap As New ConcurrentDictionary(Of AssemblySymbol, String)(ReferenceEqualityComparer.Instance)
         Private ReadOnly _reportedSymbolsMap As New ConcurrentDictionary(Of Symbol, Boolean)(ReferenceEqualityComparer.Instance)
@@ -67,8 +80,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Return lazyMethod
         End Function
 
-        Friend Overrides Function GetTargetAttributeSignatureIndex(underlyingSymbol As Symbol, attrData As VisualBasicAttributeData, description As AttributeDescription) As Integer
-            Return attrData.GetTargetAttributeSignatureIndex(underlyingSymbol, description)
+        Friend Overrides Function GetTargetAttributeSignatureIndex(underlyingSymbol As SymbolAdapter, attrData As VisualBasicAttributeData, description As AttributeDescription) As Integer
+            Return attrData.GetTargetAttributeSignatureIndex(underlyingSymbol.AdaptedSymbol, description)
         End Function
 
         Friend Overrides Function CreateSynthesizedAttribute(constructor As WellKnownMember, attrData As VisualBasicAttributeData, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As VisualBasicAttributeData
@@ -117,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         Protected Overrides Sub OnGetTypesCompleted(types As ImmutableArray(Of EmbeddedType), diagnostics As DiagnosticBag)
             For Each t In types
                 ' Note, once we reached this point we are no longer interested in guid values, using null.
-                _assemblyGuidMap.TryAdd(t.UnderlyingNamedType.ContainingAssembly, Nothing)
+                _assemblyGuidMap.TryAdd(t.UnderlyingNamedType.AdaptedNamedTypeSymbol.ContainingAssembly, Nothing)
             Next
 
             For Each a In ModuleBeingBuilt.GetReferencedAssembliesUsedSoFar()
@@ -126,8 +139,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         End Sub
 
         Protected Overrides Sub ReportNameCollisionBetweenEmbeddedTypes(typeA As EmbeddedType, typeB As EmbeddedType, diagnostics As DiagnosticBag)
-            Dim underlyingTypeA = typeA.UnderlyingNamedType
-            Dim underlyingTypeB = typeB.UnderlyingNamedType
+            Dim underlyingTypeA = typeA.UnderlyingNamedType.AdaptedNamedTypeSymbol
+            Dim underlyingTypeB = typeB.UnderlyingNamedType.AdaptedNamedTypeSymbol
             ReportDiagnostic(diagnostics,
                 ERRID.ERR_DuplicateLocalTypes3,
                 Nothing,
@@ -137,7 +150,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         End Sub
 
         Protected Overrides Sub ReportNameCollisionWithAlreadyDeclaredType(type As EmbeddedType, diagnostics As DiagnosticBag)
-            Dim underlyingType = type.UnderlyingNamedType
+            Dim underlyingType = type.UnderlyingNamedType.AdaptedNamedTypeSymbol
             ReportDiagnostic(diagnostics,
                 ERRID.ERR_LocalTypeNameClash2,
                 Nothing,
@@ -271,14 +284,15 @@ checksForAllEmbedabbleTypes:
                 Return EmbedType(namedType, fromImplements, syntaxNodeOpt, diagnostics)
             End If
 
-            Return namedType
+            Return Nothing
         End Function
 
         Private Function EmbedType(namedType As NamedTypeSymbol, fromImplements As Boolean, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As EmbeddedType
             Debug.Assert(namedType.IsDefinition)
 
-            Dim embedded = New EmbeddedType(Me, namedType)
-            Dim cached = EmbeddedTypesMap.GetOrAdd(namedType, embedded)
+            Dim adapter = namedType.GetCciAdapter()
+            Dim embedded = New EmbeddedType(Me, adapter)
+            Dim cached = EmbeddedTypesMap.GetOrAdd(adapter, embedded)
 
             Dim isInterface = (namedType.IsInterface)
 
@@ -312,11 +326,11 @@ checksForAllEmbedabbleTypes:
                 End If
 
                 For Each f In namedType.GetFieldsToEmit()
-                    EmbedField(embedded, f, syntaxNodeOpt, diagnostics)
+                    EmbedField(embedded, f.GetCciAdapter(), syntaxNodeOpt, diagnostics)
                 Next
 
                 For Each m In namedType.GetMethodsToEmit()
-                    EmbedMethod(embedded, m, syntaxNodeOpt, diagnostics)
+                    EmbedMethod(embedded, m.GetCciAdapter(), syntaxNodeOpt, diagnostics)
                 Next
 
                 ' We also should embed properties and events, but we don't need to do this explicitly here
@@ -328,12 +342,12 @@ checksForAllEmbedabbleTypes:
 
         Friend Overrides Function EmbedField(
             type As EmbeddedType,
-            field As FieldSymbol,
+            field As FieldSymbolAdapter,
             syntaxNodeOpt As SyntaxNode,
             diagnostics As DiagnosticBag
         ) As EmbeddedField
 
-            Debug.Assert(field.IsDefinition)
+            Debug.Assert(field.AdaptedFieldSymbol.IsDefinition)
 
             Dim embedded = New EmbeddedField(type, field)
             Dim cached = EmbeddedFieldsMap.GetOrAdd(field, embedded)
@@ -348,14 +362,14 @@ checksForAllEmbedabbleTypes:
             ' Embed types referenced by this field declaration.
             EmbedReferences(embedded, syntaxNodeOpt, diagnostics)
 
-            Dim containerKind = field.ContainingType.TypeKind
+            Dim containerKind = field.AdaptedFieldSymbol.ContainingType.TypeKind
 
             ' Structures may contain only public instance fields.
             If containerKind = TypeKind.Interface OrElse
                 containerKind = TypeKind.Delegate OrElse
-                (containerKind = TypeKind.Structure AndAlso (field.IsShared OrElse field.DeclaredAccessibility <> Accessibility.Public)) Then
+                (containerKind = TypeKind.Structure AndAlso (field.AdaptedFieldSymbol.IsShared OrElse field.AdaptedFieldSymbol.DeclaredAccessibility <> Accessibility.Public)) Then
                 ' ERRID.ERR_InvalidStructMemberNoPIA1/ERR_InteropStructContainsMethods
-                ReportNotEmbeddableSymbol(ERRID.ERR_InvalidStructMemberNoPIA1, type.UnderlyingNamedType, syntaxNodeOpt, diagnostics, Me)
+                ReportNotEmbeddableSymbol(ERRID.ERR_InvalidStructMemberNoPIA1, type.UnderlyingNamedType.AdaptedNamedTypeSymbol, syntaxNodeOpt, diagnostics, Me)
             End If
 
             Return embedded
@@ -363,13 +377,13 @@ checksForAllEmbedabbleTypes:
 
         Friend Overrides Function EmbedMethod(
             type As EmbeddedType,
-            method As MethodSymbol,
+            method As MethodSymbolAdapter,
             syntaxNodeOpt As SyntaxNode,
             diagnostics As DiagnosticBag
         ) As EmbeddedMethod
 
-            Debug.Assert(method.IsDefinition)
-            Debug.Assert(Not method.IsDefaultValueTypeConstructor())
+            Debug.Assert(method.AdaptedMethodSymbol.IsDefinition)
+            Debug.Assert(Not method.AdaptedMethodSymbol.IsDefaultValueTypeConstructor())
 
             Dim embedded = New EmbeddedMethod(type, method)
             Dim cached = EmbeddedMethodsMap.GetOrAdd(method, embedded)
@@ -384,25 +398,25 @@ checksForAllEmbedabbleTypes:
             ' Embed types referenced by this method declaration.
             EmbedReferences(embedded, syntaxNodeOpt, diagnostics)
 
-            Select Case type.UnderlyingNamedType.TypeKind
+            Select Case type.UnderlyingNamedType.AdaptedNamedTypeSymbol.TypeKind
                 Case TypeKind.Structure, TypeKind.Enum
                     ' ERRID.ERR_InvalidStructMemberNoPIA1/ERR_InteropStructContainsMethods
-                    ReportNotEmbeddableSymbol(ERRID.ERR_InvalidStructMemberNoPIA1, type.UnderlyingNamedType, syntaxNodeOpt, diagnostics, Me)
+                    ReportNotEmbeddableSymbol(ERRID.ERR_InvalidStructMemberNoPIA1, type.UnderlyingNamedType.AdaptedNamedTypeSymbol, syntaxNodeOpt, diagnostics, Me)
                 Case Else
                     If Cci.Extensions.HasBody(embedded) Then
                         ' ERRID.ERR_InteropMethodWithBody1/ERR_InteropMethodWithBody
-                        ReportDiagnostic(diagnostics, ERRID.ERR_InteropMethodWithBody1, syntaxNodeOpt, method.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat))
+                        ReportDiagnostic(diagnostics, ERRID.ERR_InteropMethodWithBody1, syntaxNodeOpt, method.AdaptedMethodSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat))
                     End If
             End Select
 
             ' If this proc happens to belong to a property/event, we should include the property/event as well.
-            Dim propertyOrEvent = method.AssociatedSymbol
+            Dim propertyOrEvent = method.AdaptedMethodSymbol.AssociatedSymbol
             If propertyOrEvent IsNot Nothing Then
                 Select Case propertyOrEvent.Kind
                     Case SymbolKind.Property
-                        EmbedProperty(type, DirectCast(propertyOrEvent, PropertySymbol), syntaxNodeOpt, diagnostics)
+                        EmbedProperty(type, DirectCast(propertyOrEvent, PropertySymbol).GetCciAdapter(), syntaxNodeOpt, diagnostics)
                     Case SymbolKind.Event
-                        EmbedEvent(type, DirectCast(propertyOrEvent, EventSymbol), syntaxNodeOpt, diagnostics, isUsedForComAwareEventBinding:=False)
+                        EmbedEvent(type, DirectCast(propertyOrEvent, EventSymbol).GetCciAdapter(), syntaxNodeOpt, diagnostics, isUsedForComAwareEventBinding:=False)
                     Case Else
                         Throw ExceptionUtilities.UnexpectedValue(propertyOrEvent.Kind)
                 End Select
@@ -413,19 +427,19 @@ checksForAllEmbedabbleTypes:
 
         Friend Overrides Function EmbedProperty(
             type As EmbeddedType,
-            [property] As PropertySymbol,
+            [property] As PropertySymbolAdapter,
             syntaxNodeOpt As SyntaxNode,
             diagnostics As DiagnosticBag
         ) As EmbeddedProperty
 
-            Debug.Assert([property].IsDefinition)
+            Debug.Assert([property].AdaptedPropertySymbol.IsDefinition)
 
             ' Make sure accessors are embedded.
-            Dim getMethod = [property].GetMethod
-            Dim setMethod = [property].SetMethod
+            Dim getMethod = [property].AdaptedPropertySymbol.GetMethod
+            Dim setMethod = [property].AdaptedPropertySymbol.SetMethod
 
-            Dim embeddedGet = If(getMethod IsNot Nothing, EmbedMethod(type, getMethod, syntaxNodeOpt, diagnostics), Nothing)
-            Dim embeddedSet = If(setMethod IsNot Nothing, EmbedMethod(type, setMethod, syntaxNodeOpt, diagnostics), Nothing)
+            Dim embeddedGet = If(getMethod IsNot Nothing, EmbedMethod(type, getMethod.GetCciAdapter(), syntaxNodeOpt, diagnostics), Nothing)
+            Dim embeddedSet = If(setMethod IsNot Nothing, EmbedMethod(type, setMethod.GetCciAdapter(), syntaxNodeOpt, diagnostics), Nothing)
 
             Dim embedded = New EmbeddedProperty([property], embeddedGet, embeddedSet)
             Dim cached = EmbeddedPropertiesMap.GetOrAdd([property], embedded)
@@ -446,22 +460,22 @@ checksForAllEmbedabbleTypes:
 
         Friend Overrides Function EmbedEvent(
             type As EmbeddedType,
-            [event] As EventSymbol,
+            [event] As EventSymbolAdapter,
             syntaxNodeOpt As SyntaxNode,
             diagnostics As DiagnosticBag,
             isUsedForComAwareEventBinding As Boolean
         ) As EmbeddedEvent
 
-            Debug.Assert([event].IsDefinition)
+            Debug.Assert([event].AdaptedEventSymbol.IsDefinition)
 
             ' Make sure accessors are embedded.
-            Dim addMethod = [event].AddMethod
-            Dim removeMethod = [event].RemoveMethod
-            Dim callMethod = [event].RaiseMethod
+            Dim addMethod = [event].AdaptedEventSymbol.AddMethod
+            Dim removeMethod = [event].AdaptedEventSymbol.RemoveMethod
+            Dim callMethod = [event].AdaptedEventSymbol.RaiseMethod
 
-            Dim embeddedAdd = If(addMethod IsNot Nothing, EmbedMethod(type, addMethod, syntaxNodeOpt, diagnostics), Nothing)
-            Dim embeddedRemove = If(removeMethod IsNot Nothing, EmbedMethod(type, removeMethod, syntaxNodeOpt, diagnostics), Nothing)
-            Dim embeddedCall = If(callMethod IsNot Nothing, EmbedMethod(type, callMethod, syntaxNodeOpt, diagnostics), Nothing)
+            Dim embeddedAdd = If(addMethod IsNot Nothing, EmbedMethod(type, addMethod.GetCciAdapter(), syntaxNodeOpt, diagnostics), Nothing)
+            Dim embeddedRemove = If(removeMethod IsNot Nothing, EmbedMethod(type, removeMethod.GetCciAdapter(), syntaxNodeOpt, diagnostics), Nothing)
+            Dim embeddedCall = If(callMethod IsNot Nothing, EmbedMethod(type, callMethod.GetCciAdapter(), syntaxNodeOpt, diagnostics), Nothing)
 
             Dim embedded = New EmbeddedEvent([event], embeddedAdd, embeddedRemove, embeddedCall)
             Dim cached = EmbeddedEventsMap.GetOrAdd([event], embedded)
@@ -485,11 +499,11 @@ checksForAllEmbedabbleTypes:
             Return embedded
         End Function
 
-        Protected Overrides Function GetEmbeddedTypeForMember(member As Symbol, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As EmbeddedType
-            Debug.Assert(member.IsDefinition)
+        Protected Overrides Function GetEmbeddedTypeForMember(member As SymbolAdapter, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As EmbeddedType
+            Debug.Assert(member.AdaptedSymbol.IsDefinition)
             Debug.Assert(ModuleBeingBuilt.SourceModule.AnyReferencedAssembliesAreLinked)
 
-            Dim namedType = member.ContainingType
+            Dim namedType = member.AdaptedSymbol.ContainingType
 
             If IsValidEmbeddableType(namedType, syntaxNodeOpt, diagnostics, Me) Then
                 ' It is possible that we have found a reference to a member before
@@ -501,7 +515,7 @@ checksForAllEmbedabbleTypes:
         End Function
 
         Friend Shared Function EmbedParameters(containingPropertyOrMethod As CommonEmbeddedMember, underlyingParameters As ImmutableArray(Of ParameterSymbol)) As ImmutableArray(Of EmbeddedParameter)
-            Return underlyingParameters.SelectAsArray(Function(parameter, container) New EmbeddedParameter(container, parameter), containingPropertyOrMethod)
+            Return underlyingParameters.SelectAsArray(Function(parameter, container) New EmbeddedParameter(container, parameter.GetCciAdapter()), containingPropertyOrMethod)
         End Function
 
         Protected Overrides Function CreateCompilerGeneratedAttribute() As VisualBasicAttributeData

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -226,7 +226,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                         location = GetSmallestSourceLocationOrNull(symbol)
                         If location IsNot Nothing Then
                             ' add this named type location
-                            AddSymbolLocation(result, location, DirectCast(symbol, Cci.IDefinition))
+                            AddSymbolLocation(result, location, DirectCast(symbol.GetCciAdapter(), Cci.IDefinition))
 
                             For Each member In symbol.GetMembers()
                                 Select Case member.Kind
@@ -272,7 +272,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private Sub AddSymbolLocation(result As MultiDictionary(Of Cci.DebugSourceDocument, Cci.DefinitionWithLocation), symbol As Symbol)
             Dim location As Location = GetSmallestSourceLocationOrNull(symbol)
             If location IsNot Nothing Then
-                AddSymbolLocation(result, location, DirectCast(symbol, Cci.IDefinition))
+                AddSymbolLocation(result, location, DirectCast(symbol.GetCciAdapter(), Cci.IDefinition))
             End If
         End Sub
 
@@ -341,7 +341,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Return SpecializedCollections.EmptyEnumerable(Of Cci.INamespaceTypeDefinition)
             End If
 
+#If DEBUG Then
+            Return SourceModule.ContainingSourceAssembly.DeclaringCompilation.AnonymousTypeManager.AllCreatedTemplates.Select(Function(t) t.GetCciAdapter())
+#Else
             Return SourceModule.ContainingSourceAssembly.DeclaringCompilation.AnonymousTypeManager.AllCreatedTemplates
+#End If
         End Function
 
         Public Overrides Iterator Function GetTopLevelSourceTypeDefinitions(context As EmitContext) As IEnumerable(Of Cci.INamespaceTypeDefinition)
@@ -359,7 +363,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                     ' Skip unreferenced embedded types.
                     If Not sym.IsEmbedded OrElse embeddedSymbolManager.IsSymbolReferenced(sym) Then
-                        Yield DirectCast(sym, Cci.INamespaceTypeDefinition)
+                        Yield DirectCast(sym, NamedTypeSymbol).GetCciAdapter()
                     End If
                 Else
                     Debug.Assert(sym.Kind = SymbolKind.Namespace)
@@ -428,7 +432,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Dim exportedNamesMap = New Dictionary(Of String, NamedTypeSymbol)()
 
             For Each exportedType In _lazyExportedTypes
-                Dim type = DirectCast(exportedType.Type, NamedTypeSymbol)
+                Dim typeReference As Cci.ITypeReference = exportedType.Type
+                Dim type = DirectCast(typeReference.GetInternalSymbol(), NamedTypeSymbol)
 
                 Debug.Assert(type.IsDefinition)
 
@@ -437,8 +442,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 End If
 
                 Dim fullEmittedName As String = MetadataHelpers.BuildQualifiedName(
-                    DirectCast(type, Cci.INamespaceTypeReference).NamespaceName,
-                    Cci.MetadataWriter.GetMangledName(type))
+                    DirectCast(typeReference, Cci.INamespaceTypeReference).NamespaceName,
+                    Cci.MetadataWriter.GetMangledName(DirectCast(typeReference, Cci.INamedTypeReference)))
 
                 ' First check against types declared in the primary module
                 If ContainsTopLevelType(fullEmittedName) Then
@@ -498,7 +503,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                 Debug.Assert(symbol.IsDefinition)
                 index = builder.Count
-                builder.Add(New Cci.ExportedType(DirectCast(symbol, Cci.ITypeReference), parentIndex, isForwarder:=False))
+                builder.Add(New Cci.ExportedType(DirectCast(symbol, NamedTypeSymbol).GetCciAdapter(), parentIndex, isForwarder:=False))
             Else
                 index = -1
             End If
@@ -554,7 +559,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                             ' NOTE: not bothering to put nested types in seenTypes - the top-level type is adequate protection.
                             Dim index = builderOpt.Count
-                            builderOpt.Add(New Cci.ExportedType(entry.type, entry.parentIndex, isForwarder:=True))
+                            builderOpt.Add(New Cci.ExportedType(entry.type.GetCciAdapter(), entry.parentIndex, isForwarder:=True))
 
                             ' Iterate backwards so they get popped in forward order.
                             Dim nested As ImmutableArray(Of NamedTypeSymbol) = entry.type.GetTypeMembers() ' Ordered.
@@ -611,11 +616,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Public NotOverridable Overrides Function GetInitArrayHelper() As Cci.IMethodReference
-            Return DirectCast(Compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__InitializeArrayArrayRuntimeFieldHandle), MethodSymbol)
+            Return DirectCast(Compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__InitializeArrayArrayRuntimeFieldHandle), MethodSymbol)?.GetCciAdapter()
         End Function
 
         Public NotOverridable Overrides Function IsPlatformType(typeRef As Cci.ITypeReference, platformType As Cci.PlatformType) As Boolean
-            Dim namedType = TryCast(typeRef, NamedTypeSymbol)
+            Dim namedType = TryCast(typeRef.GetInternalSymbol(), NamedTypeSymbol)
 
             If namedType IsNot Nothing Then
                 If platformType = Cci.PlatformType.SystemType Then
@@ -656,15 +661,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Protected NotOverridable Overrides Function CreatePrivateImplementationDetailsStaticConstructor(details As PrivateImplementationDetails, syntaxOpt As SyntaxNode, diagnostics As DiagnosticBag) As Cci.IMethodDefinition
-            Return New SynthesizedPrivateImplementationDetailsSharedConstructor(SourceModule, details, GetUntranslatedSpecialType(SpecialType.System_Void, syntaxOpt, diagnostics))
+            Return New SynthesizedPrivateImplementationDetailsSharedConstructor(SourceModule, details, GetUntranslatedSpecialType(SpecialType.System_Void, syntaxOpt, diagnostics)).GetCciAdapter()
         End Function
 
         Public Overrides Function GetAdditionalTopLevelTypeDefinitions(context As EmitContext) As IEnumerable(Of Cci.INamespaceTypeDefinition)
+#If DEBUG Then
+            Return GetAdditionalTopLevelTypes(context.Diagnostics).Select(Function(t) t.GetCciAdapter())
+#Else
             Return GetAdditionalTopLevelTypes(context.Diagnostics)
+#End If
         End Function
 
         Public Overrides Function GetEmbeddedTypeDefinitions(context As EmitContext) As IEnumerable(Of Cci.INamespaceTypeDefinition)
+#If DEBUG Then
+            Return GetEmbeddedTypes(context.Diagnostics).Select(Function(t) t.GetCciAdapter())
+#Else
             Return GetEmbeddedTypes(context.Diagnostics)
+#End If
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ParameterSymbolAdapter.vb
@@ -9,38 +9,90 @@ Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
-
+#If DEBUG Then
+    Partial Friend NotInheritable Class ParameterSymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend Class ParameterSymbol
+#End If
         Implements IParameterTypeInformation
         Implements IParameterDefinition
 
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedParameterSymbol As ParameterSymbol
+
+        Friend Sub New(underlyingParameterSymbol As ParameterSymbol)
+            AdaptedParameterSymbol = underlyingParameterSymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedParameterSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedParameterSymbol As ParameterSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class ParameterSymbol
+#If DEBUG Then
+        Private _lazyAdapter As ParameterSymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As ParameterSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, New ParameterSymbolAdapter(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As ParameterSymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbolAdapter
+#End If
         Private ReadOnly Property IParameterTypeInformationCustomModifiers As ImmutableArray(Of Cci.ICustomModifier) Implements IParameterTypeInformation.CustomModifiers
             Get
-                Return Me.CustomModifiers.As(Of Cci.ICustomModifier)
+                Return AdaptedParameterSymbol.CustomModifiers.As(Of Cci.ICustomModifier)
             End Get
         End Property
 
         Private ReadOnly Property IParameterTypeInformationRefCustomModifiers As ImmutableArray(Of Cci.ICustomModifier) Implements IParameterTypeInformation.RefCustomModifiers
             Get
-                Return Me.RefCustomModifiers.As(Of Cci.ICustomModifier)
+                Return AdaptedParameterSymbol.RefCustomModifiers.As(Of Cci.ICustomModifier)
             End Get
         End Property
 
         Private ReadOnly Property IParameterTypeInformationIsByReference As Boolean Implements IParameterTypeInformation.IsByReference
             Get
-                Return Me.IsByRef
+                Return AdaptedParameterSymbol.IsByRef
             End Get
         End Property
 
         Private Function IParameterTypeInformationGetType(context As EmitContext) As ITypeReference Implements IParameterTypeInformation.GetType
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
-            Dim paramType As TypeSymbol = Me.Type
+            Dim paramType As TypeSymbol = AdaptedParameterSymbol.Type
             Return moduleBeingBuilt.Translate(paramType, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
         End Function
 
         Private ReadOnly Property IParameterListEntryIndex As UShort Implements IParameterListEntry.Index
             Get
-                Return CType(Me.Ordinal, UShort)
+                Return CType(AdaptedParameterSymbol.Ordinal, UShort)
             End Get
         End Property
 
@@ -50,12 +102,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Friend Function GetMetadataConstantValue(context As EmitContext) As MetadataConstant
-            If Me.HasMetadataConstantValue Then
-                Return DirectCast(context.Module, PEModuleBuilder).CreateConstant(Me.Type, Me.ExplicitDefaultConstantValue.Value, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+            If AdaptedParameterSymbol.HasMetadataConstantValue Then
+                Return DirectCast(context.Module, PEModuleBuilder).CreateConstant(AdaptedParameterSymbol.Type, AdaptedParameterSymbol.ExplicitDefaultConstantValue.Value, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
             Else
                 Return Nothing
             End If
         End Function
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbol
+#End If
 
         Friend Overridable ReadOnly Property HasMetadataConstantValue As Boolean
             Get
@@ -68,19 +126,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbolAdapter
+#End If
+
+
         Private ReadOnly Property IParameterDefinition_HasDefaultValue As Boolean Implements IParameterDefinition.HasDefaultValue
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasMetadataConstantValue
+                Return AdaptedParameterSymbol.HasMetadataConstantValue
             End Get
         End Property
 
         Private ReadOnly Property IParameterDefinitionIsOptional As Boolean Implements IParameterDefinition.IsOptional
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMetadataOptional
+                Return AdaptedParameterSymbol.IsMetadataOptional
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsMetadataOptional As Boolean
             Get
@@ -89,26 +160,38 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbolAdapter
+#End If
+
         Private ReadOnly Property IParameterDefinitionIsIn As Boolean Implements IParameterDefinition.IsIn
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMetadataIn
+                Return AdaptedParameterSymbol.IsMetadataIn
             End Get
         End Property
 
         Private ReadOnly Property IParameterDefinitionIsOut As Boolean Implements IParameterDefinition.IsOut
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMetadataOut
+                Return AdaptedParameterSymbol.IsMetadataOut
             End Get
         End Property
 
         Private ReadOnly Property IParameterDefinitionIsMarshalledExplicitly As Boolean Implements IParameterDefinition.IsMarshalledExplicitly
             Get
                 CheckDefinitionInvariant()
-                Return Me.IsMarshalledExplicitly
+                Return AdaptedParameterSymbol.IsMarshalledExplicitly
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbol
+#End If
 
         Friend Overridable ReadOnly Property IsMarshalledExplicitly As Boolean
             Get
@@ -117,19 +200,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbolAdapter
+#End If
+
         Private ReadOnly Property IParameterDefinitionMarshallingInformation As IMarshallingInformation Implements IParameterDefinition.MarshallingInformation
             Get
                 CheckDefinitionInvariant()
-                Return MarshallingInformation
+                Return AdaptedParameterSymbol.MarshallingInformation
             End Get
         End Property
 
         Private ReadOnly Property IParameterDefinitionMarshallingDescriptor As ImmutableArray(Of Byte) Implements IParameterDefinition.MarshallingDescriptor
             Get
                 CheckDefinitionInvariant()
-                Return Me.MarshallingDescriptor
+                Return AdaptedParameterSymbol.MarshallingDescriptor
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbol
+#End If
 
         Friend Overridable ReadOnly Property MarshallingDescriptor As ImmutableArray(Of Byte)
             Get
@@ -138,13 +233,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class ParameterSymbolAdapter
+#End If
+
         Friend NotOverridable Overrides Sub IReferenceDispatch(visitor As MetadataVisitor) ' Implements IReference.Dispatch
             Debug.Assert(Me.IsDefinitionOrDistinct())
 
-            If Not Me.IsDefinition Then
+            If Not AdaptedParameterSymbol.IsDefinition Then
                 visitor.Visit(DirectCast(Me, IParameterTypeInformation))
             Else
-                If Me.ContainingModule = (DirectCast(visitor.Context.Module, PEModuleBuilder)).SourceModule Then
+                If AdaptedParameterSymbol.ContainingModule = (DirectCast(visitor.Context.Module, PEModuleBuilder)).SourceModule Then
                     visitor.Visit(DirectCast(Me, IParameterDefinition))
                 Else
                     visitor.Visit(DirectCast(Me, IParameterTypeInformation))
@@ -157,7 +258,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
 
-            If Me.IsDefinition AndAlso Me.ContainingModule = moduleBeingBuilt.SourceModule Then
+            If AdaptedParameterSymbol.IsDefinition AndAlso AdaptedParameterSymbol.ContainingModule = moduleBeingBuilt.SourceModule Then
                 Return Me
             End If
 
@@ -166,7 +267,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property INamedEntityName As String Implements INamedEntity.Name
             Get
-                Return Me.MetadataName
+                Return AdaptedParameterSymbol.MetadataName
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/ParameterTypeInformation.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ParameterTypeInformation.vb
@@ -47,5 +47,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Return CType(_underlyingParameter.Ordinal, UShort)
             End Get
         End Property
+
+        Public Overrides Function Equals(obj As Object) As Boolean
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
+
+        Public Overrides Function GetHashCode() As Integer
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/PropertySymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PropertySymbolAdapter.vb
@@ -9,19 +9,71 @@ Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
-
+#If DEBUG Then
+    Partial Friend NotInheritable Class PropertySymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend Class PropertySymbol
+#End If
         Implements IPropertyDefinition
 
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedPropertySymbol As PropertySymbol
+
+        Friend Sub New(underlyingPropertySymbol As PropertySymbol)
+            AdaptedPropertySymbol = underlyingPropertySymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedPropertySymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedPropertySymbol As PropertySymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class PropertySymbol
+#If DEBUG Then
+        Private _lazyAdapter As PropertySymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As PropertySymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, New PropertySymbolAdapter(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As PropertySymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class PropertySymbolAdapter
+#End If
         Private Iterator Function IPropertyDefinitionAccessors(context As EmitContext) As IEnumerable(Of IMethodReference) Implements IPropertyDefinition.GetAccessors
             CheckDefinitionInvariant()
 
-            Dim getter As MethodSymbol = Me.GetMethod
+            Dim getter = AdaptedPropertySymbol.GetMethod?.GetCciAdapter()
             If getter IsNot Nothing AndAlso getter.ShouldInclude(context) Then
                 Yield getter
             End If
 
-            Dim setter As MethodSymbol = Me.SetMethod
+            Dim setter = AdaptedPropertySymbol.SetMethod?.GetCciAdapter()
             If setter IsNot Nothing AndAlso setter.ShouldInclude(context) Then
                 Yield setter
             End If
@@ -37,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IPropertyDefinitionGetter As IMethodReference Implements IPropertyDefinition.Getter
             Get
                 CheckDefinitionInvariant()
-                Return Me.GetMethod
+                Return AdaptedPropertySymbol.GetMethod?.GetCciAdapter()
             End Get
         End Property
 
@@ -51,9 +103,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property IPropertyDefinitionIsRuntimeSpecial As Boolean Implements IPropertyDefinition.IsRuntimeSpecial
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasRuntimeSpecialName
+                Return AdaptedPropertySymbol.HasRuntimeSpecialName
             End Get
         End Property
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class PropertySymbol
+#End If
 
         Friend Overridable ReadOnly Property HasRuntimeSpecialName As Boolean
             Get
@@ -62,98 +120,113 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class PropertySymbolAdapter
+#End If
+
         Private ReadOnly Property IPropertyDefinitionIsSpecialName As Boolean Implements IPropertyDefinition.IsSpecialName
             Get
                 CheckDefinitionInvariant()
-                Return Me.HasSpecialName
+                Return AdaptedPropertySymbol.HasSpecialName
             End Get
         End Property
 
         Private ReadOnly Property IPropertyDefinitionParameters As ImmutableArray(Of IParameterDefinition) Implements IPropertyDefinition.Parameters
             Get
                 CheckDefinitionInvariant()
-                Return StaticCast(Of IParameterDefinition).From(Me.Parameters)
+
+#If DEBUG Then
+                Return AdaptedPropertySymbol.Parameters.SelectAsArray(Of IParameterDefinition)(Function(p) p.GetCciAdapter())
+#Else
+                Return StaticCast(Of IParameterDefinition).From(AdaptedPropertySymbol.Parameters)
+#End If
             End Get
         End Property
 
         Private ReadOnly Property IPropertyDefinitionSetter As IMethodReference Implements IPropertyDefinition.Setter
             Get
                 CheckDefinitionInvariant()
-                Return Me.SetMethod
+                Return AdaptedPropertySymbol.SetMethod?.GetCciAdapter()
             End Get
         End Property
 
         <Conditional("DEBUG")>
         Protected Friend Sub CheckDefinitionInvariantAllowEmbedded()
             ' can't be generic instantiation
-            Debug.Assert(Me.IsDefinition)
+            Debug.Assert(AdaptedPropertySymbol.IsDefinition)
 
             ' must be declared in the module we are building
-            Debug.Assert(TypeOf Me.ContainingModule Is SourceModuleSymbol OrElse Me.ContainingAssembly.IsLinked)
+            Debug.Assert(TypeOf AdaptedPropertySymbol.ContainingModule Is SourceModuleSymbol OrElse AdaptedPropertySymbol.ContainingAssembly.IsLinked)
         End Sub
 
         Private ReadOnly Property ISignatureCallingConvention As CallingConvention Implements ISignature.CallingConvention
             Get
                 CheckDefinitionInvariantAllowEmbedded()
-                Return Me.CallingConvention
+                Return AdaptedPropertySymbol.CallingConvention
             End Get
         End Property
 
         Private ReadOnly Property ISignatureParameterCount As UShort Implements ISignature.ParameterCount
             Get
                 CheckDefinitionInvariant()
-                Return CType(Me.ParameterCount, UShort)
+                Return CType(AdaptedPropertySymbol.ParameterCount, UShort)
             End Get
         End Property
 
         Private Function ISignatureGetParameters(context As EmitContext) As ImmutableArray(Of IParameterTypeInformation) Implements ISignature.GetParameters
             CheckDefinitionInvariant()
-            Return StaticCast(Of IParameterTypeInformation).From(Me.Parameters)
+#If DEBUG Then
+            Return AdaptedPropertySymbol.Parameters.SelectAsArray(Of IParameterTypeInformation)(Function(p) p.GetCciAdapter())
+#Else
+            Return StaticCast(Of IParameterTypeInformation).From(AdaptedPropertySymbol.Parameters)
+#End If
         End Function
 
         Private ReadOnly Property ISignatureReturnValueCustomModifiers As ImmutableArray(Of Cci.ICustomModifier) Implements ISignature.ReturnValueCustomModifiers
             Get
                 CheckDefinitionInvariantAllowEmbedded()
-                Return Me.TypeCustomModifiers.As(Of Cci.ICustomModifier)
+                Return AdaptedPropertySymbol.TypeCustomModifiers.As(Of Cci.ICustomModifier)
             End Get
         End Property
 
         Private ReadOnly Property ISignatureRefCustomModifiers As ImmutableArray(Of Cci.ICustomModifier) Implements ISignature.RefCustomModifiers
             Get
                 CheckDefinitionInvariantAllowEmbedded()
-                Return Me.RefCustomModifiers.As(Of Cci.ICustomModifier)
+                Return AdaptedPropertySymbol.RefCustomModifiers.As(Of Cci.ICustomModifier)
             End Get
         End Property
 
         Private ReadOnly Property ISignatureReturnValueIsByRef As Boolean Implements ISignature.ReturnValueIsByRef
             Get
                 CheckDefinitionInvariantAllowEmbedded()
-                Return Me.ReturnsByRef
+                Return AdaptedPropertySymbol.ReturnsByRef
             End Get
         End Property
 
         Private Function ISignatureGetType(context As EmitContext) As ITypeReference Implements ISignature.GetType
             CheckDefinitionInvariantAllowEmbedded()
-            Return (DirectCast(context.Module, PEModuleBuilder)).Translate(Me.Type, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+            Return (DirectCast(context.Module, PEModuleBuilder)).Translate(AdaptedPropertySymbol.Type, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
         End Function
 
         Private ReadOnly Property ITypeDefinitionMemberContainingTypeDefinition As ITypeDefinition Implements ITypeDefinitionMember.ContainingTypeDefinition
             Get
                 CheckDefinitionInvariant()
-                Return Me.ContainingType
+                Return AdaptedPropertySymbol.ContainingType.GetCciAdapter()
             End Get
         End Property
 
         Private ReadOnly Property ITypeDefinitionMemberVisibility As TypeMemberVisibility Implements ITypeDefinitionMember.Visibility
             Get
                 CheckDefinitionInvariant()
-                Return PEModuleBuilder.MemberVisibility(Me)
+                Return PEModuleBuilder.MemberVisibility(AdaptedPropertySymbol)
             End Get
         End Property
 
         Private Function ITypeMemberReferenceGetContainingType(context As EmitContext) As ITypeReference Implements ITypeMemberReference.GetContainingType
             CheckDefinitionInvariant()
-            Return Me.ContainingType
+            Return AdaptedPropertySymbol.ContainingType.GetCciAdapter()
         End Function
 
         Friend NotOverridable Overrides Sub IReferenceDispatch(visitor As MetadataVisitor) ' Implements IReference.Dispatch
@@ -169,7 +242,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property INamedEntityName As String Implements INamedEntity.Name
             Get
                 CheckDefinitionInvariant()
-                Return Me.MetadataName
+                Return AdaptedPropertySymbol.MetadataName
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/SpecializedFieldReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SpecializedFieldReference.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private ReadOnly Property ISpecializedFieldReferenceUnspecializedVersion As Cci.IFieldReference Implements Cci.ISpecializedFieldReference.UnspecializedVersion
             Get
                 Debug.Assert(_underlyingField.OriginalDefinition Is _underlyingField.OriginalDefinition.OriginalDefinition)
-                Return _underlyingField.OriginalDefinition
+                Return _underlyingField.OriginalDefinition.GetCciAdapter()
             End Get
         End Property
 
@@ -70,12 +70,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Private Sub AssociateWithMetadataWriter(metadataWriter As Cci.MetadataWriter) Implements Cci.IContextualNamedEntity.AssociateWithMetadataWriter
-            DirectCast(_underlyingField, Cci.IContextualNamedEntity).AssociateWithMetadataWriter(metadataWriter)
+            DirectCast(_underlyingField, SynthesizedStaticLocalBackingField).AssociateWithMetadataWriter(metadataWriter)
         End Sub
 
         Private ReadOnly Property IsContextualNamedEntity As Boolean Implements Cci.IFieldReference.IsContextualNamedEntity
             Get
-                Return _underlyingField.IFieldReferenceIsContextualNamedEntity
+                Return _underlyingField.IsContextualNamedEntity
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/SpecializedMethodReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SpecializedMethodReference.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
         Private ReadOnly Property ISpecializedMethodReferenceUnspecializedVersion As Microsoft.Cci.IMethodReference Implements Microsoft.Cci.ISpecializedMethodReference.UnspecializedVersion
             Get
-                Return m_UnderlyingMethod.OriginalDefinition
+                Return m_UnderlyingMethod.OriginalDefinition.GetCciAdapter()
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Emit/SymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SymbolAdapter.vb
@@ -10,7 +10,11 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
+#If DEBUG Then
+    Partial Friend MustInherit Class SymbolAdapter
+#Else
     Partial Friend Class Symbol
+#End If
         Implements Cci.IReference
 
         Friend Overridable Function IReferenceAsDefinition(context As EmitContext) As Cci.IDefinition _
@@ -19,19 +23,71 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Private Function IReferenceGetInternalSymbol() As CodeAnalysis.Symbols.ISymbolInternal Implements Cci.IReference.GetInternalSymbol
-            Return Me
+#If DEBUG Then
+        Friend MustOverride ReadOnly Property AdaptedSymbol As Symbol
+
+        Public NotOverridable Overrides Function ToString() As String
+            Return AdaptedSymbol.ToString()
         End Function
 
-        Private Function ISymbolInternalGetAdapter() As Cci.IReference Implements CodeAnalysis.Symbols.ISymbolInternal.GetCciAdapter
+        Public NotOverridable Overrides Function Equals(obj As Object) As Boolean
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
+
+        Public NotOverridable Overrides Function GetHashCode() As Integer
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
+#Else
+        Friend ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+        Private Function IReferenceGetInternalSymbol() As CodeAnalysis.Symbols.ISymbolInternal Implements Cci.IReference.GetInternalSymbol
+            Return AdaptedSymbol
+        End Function
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class Symbol
+        Friend Function GetCciAdapter() As SymbolAdapter
+            Return GetCciAdapterImpl()
+        End Function
+
+        Protected Overridable Function GetCciAdapterImpl() As SymbolAdapter
+            Throw ExceptionUtilities.Unreachable
+        End Function
+#Else
+        Friend Function GetCciAdapter() As Symbol
             Return Me
         End Function
+#End If
+
+        Private Function ISymbolInternalGetCciAdapter() As Cci.IReference Implements CodeAnalysis.Symbols.ISymbolInternal.GetCciAdapter
+            Return GetCciAdapter()
+        End Function
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class SymbolAdapter
+#End If
 
         Friend Overridable Sub IReferenceDispatch(visitor As Cci.MetadataVisitor) _
             Implements Cci.IReference.Dispatch
 
             Throw ExceptionUtilities.Unreachable
         End Sub
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class Symbol
+#End If
 
         ''' <summary>
         ''' Return whether the symbol is either the original definition
@@ -42,9 +98,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Me.IsDefinition OrElse Not Me.Equals(Me.OriginalDefinition)
         End Function
 
-        Private Function IReferenceGetAttributes(context As EmitContext) As IEnumerable(Of Cci.ICustomAttribute) Implements Cci.IReference.GetAttributes
-            Return GetCustomAttributesToEmit(DirectCast(context.Module, PEModuleBuilder).CompilationState)
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class SymbolAdapter
+        Friend Function IsDefinitionOrDistinct() As Boolean
+            Return AdaptedSymbol.IsDefinitionOrDistinct()
         End Function
+#End If
+
+        Private Function IReferenceGetAttributes(context As EmitContext) As IEnumerable(Of Cci.ICustomAttribute) Implements Cci.IReference.GetAttributes
+            Return AdaptedSymbol.GetCustomAttributesToEmit(DirectCast(context.Module, PEModuleBuilder).CompilationState)
+        End Function
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class Symbol
+#End If
 
         Friend Overridable Function GetCustomAttributesToEmit(compilationState As ModuleCompilationState) As IEnumerable(Of VisualBasicAttributeData)
             Return GetCustomAttributesToEmit(compilationState, emittingAssemblyAttributesInNetModule:=False)
@@ -116,7 +187,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' must be declared in the module we are building
             Debug.Assert(TypeOf Me.ContainingModule Is SourceModuleSymbol)
         End Sub
-
     End Class
+
+#If DEBUG Then
+    Partial Friend Class SymbolAdapter
+        <Conditional("DEBUG")>
+        Protected Friend Sub CheckDefinitionInvariant()
+            AdaptedSymbol.CheckDefinitionInvariant()
+        End Sub
+    End Class
+#End If
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/SynthesizedPrivateImplementationDetailsSharedConstructor.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SynthesizedPrivateImplementationDetailsSharedConstructor.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             For Each payloadRoot As KeyValuePair(Of Integer, InstrumentationPayloadRootField) In _privateImplementationType.GetInstrumentationPayloadRoots()
 
                 Dim analysisKind As Integer = payloadRoot.Key
-                Dim payloadArrayType As ArrayTypeSymbol = DirectCast(payloadRoot.Value.Type, ArrayTypeSymbol)
+                Dim payloadArrayType As ArrayTypeSymbol = DirectCast(payloadRoot.Value.Type.GetInternalSymbol(), ArrayTypeSymbol)
 
                 body.Add(
                     factory.Assignment(

--- a/src/Compilers/VisualBasic/Portable/Emit/TypeMemberReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/TypeMemberReference.vb
@@ -39,5 +39,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private Function IReferenceGetInternalSymbol() As CodeAnalysis.Symbols.ISymbolInternal Implements Cci.IReference.GetInternalSymbol
             Return UnderlyingSymbol
         End Function
+
+        Public NotOverridable Overrides Function Equals(obj As Object) As Boolean
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
+
+        Public NotOverridable Overrides Function GetHashCode() As Integer
+            ' It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
@@ -9,8 +9,12 @@ Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
-
+#If DEBUG Then
+    Partial Friend NotInheritable Class TypeParameterSymbolAdapter
+        Inherits SymbolAdapter
+#Else
     Partial Friend Class TypeParameterSymbol
+#End If
         Implements IGenericParameterReference
         Implements IGenericMethodParameterReference
         Implements IGenericTypeParameterReference
@@ -18,6 +22,54 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Implements IGenericMethodParameter
         Implements IGenericTypeParameter
 
+#If DEBUG Then
+        Friend ReadOnly Property AdaptedTypeParameterSymbol As TypeParameterSymbol
+
+        Friend Sub New(underlyingTypeParameterSymbol As TypeParameterSymbol)
+            AdaptedTypeParameterSymbol = underlyingTypeParameterSymbol
+        End Sub
+
+        Friend Overrides ReadOnly Property AdaptedSymbol As Symbol
+            Get
+                Return AdaptedTypeParameterSymbol
+            End Get
+        End Property
+#Else
+        Friend ReadOnly Property AdaptedTypeParameterSymbol As TypeParameterSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+#End If
+
+    End Class
+
+    Partial Friend Class TypeParameterSymbol
+#If DEBUG Then
+        Private _lazyAdapter As TypeParameterSymbolAdapter
+
+        Protected Overrides Function GetCciAdapterImpl() As SymbolAdapter
+            Return GetCciAdapter()
+        End Function
+
+        Friend Shadows Function GetCciAdapter() As TypeParameterSymbolAdapter
+            If _lazyAdapter Is Nothing Then
+                Return InterlockedOperations.Initialize(_lazyAdapter, New TypeParameterSymbolAdapter(Me))
+            End If
+
+            Return _lazyAdapter
+        End Function
+#Else
+        Friend Shadows Function GetCciAdapter() As TypeParameterSymbol
+            return Me
+        End Function
+#End If
+
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class TypeParameterSymbolAdapter
+#End If
         Private ReadOnly Property ITypeReferenceIsEnum As Boolean Implements ITypeReference.IsEnum
             Get
                 Return False
@@ -50,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 CheckDefinitionInvariant()
 
-                If Me.ContainingSymbol.Kind = SymbolKind.Method Then
+                If AdaptedTypeParameterSymbol.ContainingSymbol.Kind = SymbolKind.Method Then
                     Return Me
                 End If
                 Return Nothing
@@ -59,9 +111,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeReferenceAsGenericMethodParameterReference As IGenericMethodParameterReference Implements ITypeReference.AsGenericMethodParameterReference
             Get
-                Debug.Assert(Me.IsDefinition)
+                Debug.Assert(AdaptedTypeParameterSymbol.IsDefinition)
 
-                If Me.ContainingSymbol.Kind = SymbolKind.Method Then
+                If AdaptedTypeParameterSymbol.ContainingSymbol.Kind = SymbolKind.Method Then
                     Return Me
                 End If
 
@@ -79,7 +131,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 CheckDefinitionInvariant()
 
-                If Me.ContainingSymbol.Kind = SymbolKind.NamedType Then
+                If AdaptedTypeParameterSymbol.ContainingSymbol.Kind = SymbolKind.NamedType Then
                     Return Me
                 End If
 
@@ -89,9 +141,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeReferenceAsGenericTypeParameterReference As IGenericTypeParameterReference Implements ITypeReference.AsGenericTypeParameterReference
             Get
-                Debug.Assert(Me.IsDefinition)
+                Debug.Assert(AdaptedTypeParameterSymbol.IsDefinition)
 
-                If Me.ContainingSymbol.Kind = SymbolKind.NamedType Then
+                If AdaptedTypeParameterSymbol.ContainingSymbol.Kind = SymbolKind.NamedType Then
                     Return Me
                 End If
 
@@ -130,10 +182,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Friend NotOverridable Overrides Sub IReferenceDispatch(visitor As MetadataVisitor) ' Implements IReference.Dispatch
-            Debug.Assert(Me.IsDefinition)
-            Dim kind As SymbolKind = Me.ContainingSymbol.Kind
+            Debug.Assert(AdaptedTypeParameterSymbol.IsDefinition)
+            Dim kind As SymbolKind = AdaptedTypeParameterSymbol.ContainingSymbol.Kind
 
-            If (DirectCast(visitor.Context.Module, PEModuleBuilder)).SourceModule = Me.ContainingModule Then
+            If (DirectCast(visitor.Context.Module, PEModuleBuilder)).SourceModule = AdaptedTypeParameterSymbol.ContainingModule Then
                 If kind = SymbolKind.NamedType Then
                     visitor.Visit(DirectCast(Me, IGenericTypeParameter))
                 Else
@@ -157,33 +209,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Sub
 
         Friend NotOverridable Overrides Function IReferenceAsDefinition(context As EmitContext) As IDefinition ' Implements IReference.AsDefinition
-            Debug.Assert(Me.IsDefinition)
+            Debug.Assert(AdaptedTypeParameterSymbol.IsDefinition)
             Return Nothing
         End Function
 
         Private ReadOnly Property INamedEntityName As String Implements INamedEntity.Name
             Get
-                Return Me.MetadataName
+                Return AdaptedTypeParameterSymbol.MetadataName
             End Get
         End Property
 
         Private ReadOnly Property IParameterListEntryIndex As UShort Implements IParameterListEntry.Index
             Get
-                Return CType(Me.Ordinal, UShort)
+                Return CType(AdaptedTypeParameterSymbol.Ordinal, UShort)
             End Get
         End Property
 
         Private ReadOnly Property IGenericMethodParameterReferenceDefiningMethod As IMethodReference Implements IGenericMethodParameterReference.DefiningMethod
             Get
-                Debug.Assert(Me.IsDefinition)
-                Return DirectCast(Me.ContainingSymbol, MethodSymbol)
+                Debug.Assert(AdaptedTypeParameterSymbol.IsDefinition)
+                Return DirectCast(AdaptedTypeParameterSymbol.ContainingSymbol, MethodSymbol).GetCciAdapter()
             End Get
         End Property
 
         Private ReadOnly Property IGenericTypeParameterReferenceDefiningType As ITypeReference Implements IGenericTypeParameterReference.DefiningType
             Get
-                Debug.Assert(Me.IsDefinition)
-                Return DirectCast(Me.ContainingSymbol, NamedTypeSymbol)
+                Debug.Assert(AdaptedTypeParameterSymbol.IsDefinition)
+                Return DirectCast(AdaptedTypeParameterSymbol.ContainingSymbol, NamedTypeSymbol).GetCciAdapter()
             End Get
         End Property
 
@@ -191,7 +243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             As IEnumerable(Of TypeReferenceWithAttributes) Implements IGenericParameter.GetConstraints
             Dim _module = DirectCast(context.Module, PEModuleBuilder)
             Dim seenValueType = False
-            For Each t In Me.ConstraintTypesNoUseSiteDiagnostics
+            For Each t In AdaptedTypeParameterSymbol.ConstraintTypesNoUseSiteDiagnostics
                 If t.SpecialType = SpecialType.System_ValueType Then
                     seenValueType = True
                 End If
@@ -200,9 +252,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                                   syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
                                                                   diagnostics:=context.Diagnostics)
 
-                Yield t.GetTypeRefWithAttributes(Me.DeclaringCompilation, typeRef)
+                Yield t.GetTypeRefWithAttributes(AdaptedTypeParameterSymbol.DeclaringCompilation, typeRef)
             Next
-            If Me.HasValueTypeConstraint AndAlso Not seenValueType Then
+            If AdaptedTypeParameterSymbol.HasValueTypeConstraint AndAlso Not seenValueType Then
                 ' Add System.ValueType constraint to comply with Dev11 C# output
                 Dim typeRef As INamedTypeReference = _module.GetSpecialType(CodeAnalysis.SpecialType.System_ValueType,
                                              DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), context.Diagnostics)
@@ -213,13 +265,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IGenericParameterMustBeReferenceType As Boolean Implements IGenericParameter.MustBeReferenceType
             Get
-                Return Me.HasReferenceTypeConstraint
+                Return AdaptedTypeParameterSymbol.HasReferenceTypeConstraint
             End Get
         End Property
 
         Private ReadOnly Property IGenericParameterMustBeValueType As Boolean Implements IGenericParameter.MustBeValueType
             Get
-                Return Me.HasValueTypeConstraint
+                Return AdaptedTypeParameterSymbol.HasValueTypeConstraint
             End Get
         End Property
 
@@ -227,13 +279,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 '  add constructor constraint for value type constrained 
                 '  type parameters to comply with Dev11 output
-                Return Me.HasConstructorConstraint OrElse Me.HasValueTypeConstraint
+                Return AdaptedTypeParameterSymbol.HasConstructorConstraint OrElse AdaptedTypeParameterSymbol.HasValueTypeConstraint
             End Get
         End Property
 
         Private ReadOnly Property IGenericParameterVariance As TypeParameterVariance Implements IGenericParameter.Variance
             Get
-                Select Case Me.Variance
+                Select Case AdaptedTypeParameterSymbol.Variance
                     Case VarianceKind.None
                         Return TypeParameterVariance.NonVariant
                     Case VarianceKind.In
@@ -241,7 +293,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Case VarianceKind.Out
                         Return TypeParameterVariance.Covariant
                     Case Else
-                        Throw ExceptionUtilities.UnexpectedValue(Me.Variance)
+                        Throw ExceptionUtilities.UnexpectedValue(AdaptedTypeParameterSymbol.Variance)
                 End Select
             End Get
         End Property
@@ -250,7 +302,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 CheckDefinitionInvariant()
 
-                Return DirectCast(Me.ContainingSymbol, MethodSymbol)
+                Return DirectCast(AdaptedTypeParameterSymbol.ContainingSymbol, MethodSymbol).GetCciAdapter()
             End Get
         End Property
 
@@ -258,10 +310,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 CheckDefinitionInvariant()
 
-                Return DirectCast(Me.ContainingSymbol, NamedTypeSymbol)
+                Return DirectCast(AdaptedTypeParameterSymbol.ContainingSymbol, NamedTypeSymbol).GetCciAdapter()
             End Get
         End Property
 
+#If DEBUG Then
+    End Class
+
+    Partial Friend Class TypeParameterSymbol
+#End If
         Friend Overrides Function GetUnificationUseSiteDiagnosticRecursive(owner As Symbol, ByRef checkedTypes As HashSet(Of TypeSymbol)) As DiagnosticInfo
             Return Nothing
         End Function

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -289,7 +289,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 _frames(scope) = frame
 
-                CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(_topLevelMethod.ContainingType, frame)
+                CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(_topLevelMethod.ContainingType, frame.GetCciAdapter())
                 ' NOTE: we will add this ctor to compilation state after we know all captured locals
                 '       we need them to generate copy constructor, if needed
             End If
@@ -323,7 +323,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim frame = Me._lazyStaticLambdaFrame
 
                     ' add frame type
-                    CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(_topLevelMethod.ContainingType, frame)
+                    CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(_topLevelMethod.ContainingType, frame.GetCciAdapter())
 
                     ' associate the frame with the first lambda that caused it to exist. 
                     ' we need to associate this with some syntax.
@@ -552,7 +552,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
 
-                    CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, capturedFrame)
+                    CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, capturedFrame.GetCciAdapter())
 
                     Proxies(_innermostFramePointer) = capturedFrame
                 End If
@@ -1072,7 +1072,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' Move the body of the lambda to a freshly generated synthetic method on its container.
             Dim synthesizedMethod = New SynthesizedLambdaMethod(translatedLambdaContainer, closureKind, _topLevelMethod, topLevelMethodId, node, lambdaId, Me.Diagnostics)
 
-            CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(translatedLambdaContainer, synthesizedMethod)
+            CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(translatedLambdaContainer, synthesizedMethod.GetCciAdapter())
 
             For Each parameter In node.LambdaSymbol.Parameters
                 ParameterMap.Add(parameter, synthesizedMethod.Parameters(parameter.Ordinal))
@@ -1189,7 +1189,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                            accessibility:=Accessibility.Public,
                                                                            isShared:=(closureKind = ClosureKind.Static))
 
-                CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(translatedLambdaContainer, cacheField)
+                CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(translatedLambdaContainer, cacheField.GetCciAdapter())
 
                 Dim F = New SyntheticBoundNodeFactory(Me._topLevelMethod, Me._currentMethod, node.Syntax, CompilationState, Diagnostics)
                 Dim fieldToAccess As FieldSymbol = cacheField.AsMember(constructedFrame)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
@@ -285,7 +285,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' but the com event binder needs the event to exist on the local type. We'll poke the pia reference
             ' cache directly so that the event is embedded.
             If _emitModule IsNot Nothing Then
-                _emitModule.EmbeddedTypesManagerOpt.EmbedEventIfNeedTo([event], node.Syntax, _diagnostics, isUsedForComAwareEventBinding:=True)
+                _emitModule.EmbeddedTypesManagerOpt.EmbedEventIfNeedTo([event].GetCciAdapter(), node.Syntax, _diagnostics, isUsedForComAwareEventBinding:=True)
             End If
 
             If result IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.vb
@@ -138,10 +138,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                 If(hasInitializer, New SynthesizedStaticLocalBackingField(localSymbol, isValueField:=False, reportErrorForLongNames:=True), Nothing))
 
             If _emitModule IsNot Nothing Then
-                _emitModule.AddSynthesizedDefinition(Me._topMethod.ContainingType, result.Key)
+                _emitModule.AddSynthesizedDefinition(Me._topMethod.ContainingType, result.Key.GetCciAdapter())
 
                 If result.Value IsNot Nothing Then
-                    _emitModule.AddSynthesizedDefinition(Me._topMethod.ContainingType, result.Value)
+                    _emitModule.AddSynthesizedDefinition(Me._topMethod.ContainingType, result.Value.GetCciAdapter())
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SelectCase.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SelectCase.vb
@@ -189,7 +189,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim method = New SynthesizedStringSwitchHashMethod(_emitModule.SourceModule, privateImplClass)
-            privateImplClass.TryAddSynthesizedMethod(method)
+            privateImplClass.TryAddSynthesizedMethod(method.GetCciAdapter())
         End Sub
 
         Private Function RewriteSelectExpression(

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.MyBaseMyClassWrapper.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.MyBaseMyClassWrapper.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' register a new method
             If Me.CompilationState.ModuleBuilderOpt IsNot Nothing Then
-                Me.CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(containingType, wrapperMethod)
+                Me.CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(containingType, wrapperMethod.GetCciAdapter())
             End If
 
             ' generate method body

--- a/src/Compilers/VisualBasic/Portable/Lowering/SynthesizedSubmissionFields.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SynthesizedSubmissionFields.vb
@@ -84,12 +84,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Sub AddToType(containingType As NamedTypeSymbol, moduleBeingBuilt As PEModuleBuilder)
             For Each field In FieldSymbols
-                moduleBeingBuilt.AddSynthesizedDefinition(containingType, field)
+                moduleBeingBuilt.AddSynthesizedDefinition(containingType, field.GetCciAdapter())
             Next
 
             Dim hostObjectField As FieldSymbol = GetHostObjectField()
             If hostObjectField IsNot Nothing Then
-                moduleBeingBuilt.AddSynthesizedDefinition(containingType, hostObjectField)
+                moduleBeingBuilt.AddSynthesizedDefinition(containingType, hostObjectField.GetCciAdapter())
             End If
         End Sub
     End Class

--- a/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Sub AddNestedType(nestedType As NamedTypeSymbol)
             Dim [module] As PEModuleBuilder = Me.EmitModule
             If [module] IsNot Nothing Then
-                [module].AddSynthesizedDefinition(_currentClass, nestedType)
+                [module].AddSynthesizedDefinition(_currentClass, nestedType.GetCciAdapter())
             End If
         End Sub
 
@@ -93,21 +93,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Sub AddField(containingType As NamedTypeSymbol, field As FieldSymbol)
             Dim [module] As PEModuleBuilder = Me.EmitModule
             If [module] IsNot Nothing Then
-                [module].AddSynthesizedDefinition(containingType, field)
+                [module].AddSynthesizedDefinition(containingType, field.GetCciAdapter())
             End If
         End Sub
 
         Public Sub AddMethod(containingType As NamedTypeSymbol, method As MethodSymbol)
             Dim [module] As PEModuleBuilder = Me.EmitModule
             If [module] IsNot Nothing Then
-                [module].AddSynthesizedDefinition(containingType, method)
+                [module].AddSynthesizedDefinition(containingType, method.GetCciAdapter())
             End If
         End Sub
 
         Public Sub AddProperty(containingType As NamedTypeSymbol, prop As PropertySymbol)
             Dim [module] As PEModuleBuilder = Me.EmitModule
             If [module] IsNot Nothing Then
-                [module].AddSynthesizedDefinition(containingType, prop)
+                [module].AddSynthesizedDefinition(containingType, prop.GetCciAdapter())
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
@@ -254,7 +254,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             For Each template In builder
                 Dim nameAndIndex = template.NameAndIndex
                 Dim key = template.GetAnonymousTypeKey()
-                Dim value = New Microsoft.CodeAnalysis.Emit.AnonymousTypeValue(nameAndIndex.Name, nameAndIndex.Index, template)
+                Dim value = New Microsoft.CodeAnalysis.Emit.AnonymousTypeValue(nameAndIndex.Name, nameAndIndex.Index, template.GetCciAdapter())
                 result.Add(key, value)
             Next
             builder.Free()

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -1867,7 +1867,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim interfaces As ImmutableArray(Of NamedTypeSymbol) = _comClassData.GetSynthesizedInterfaces()
 
-            Return If(interfaces.IsEmpty, Nothing, interfaces.AsEnumerable())
+            If interfaces.IsEmpty Then
+                Return Nothing
+            End If
+
+#If DEBUG Then
+            Return interfaces.Select(Function(i) i.GetCciAdapter())
+#Else
+            return interfaces.AsEnumerable()
+#End If
         End Function
 
         Friend Overrides Function GetSynthesizedImplements() As IEnumerable(Of NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethodBase.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethodBase.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Public NotOverridable Overrides ReadOnly Property ReturnsByRef As Boolean
+        Public Overrides ReadOnly Property ReturnsByRef As Boolean
             Get
                 Return False
             End Get

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -3555,7 +3555,7 @@ end structure
                     Assert.NotNull(hostProtectionAttr)
 
                     ' Verify type security attributes
-                    Dim type = DirectCast([module].GlobalNamespace.GetMember("EventDescriptor"), Microsoft.Cci.ITypeDefinition)
+                    Dim type = DirectCast([module].GlobalNamespace.GetMember("EventDescriptor").GetCciAdapter(), Microsoft.Cci.ITypeDefinition)
                     Debug.Assert(type.HasDeclarativeSecurity)
                     Dim typeSecurityAttributes As IEnumerable(Of Microsoft.Cci.SecurityAttribute) = type.SecurityAttributes
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -11640,7 +11640,7 @@ End Class
                                                                  Assert.True(typeB.IsComImport())
                                                                  Assert.Equal(1, typeB.GetAttributes().Length)
                                                                  Dim ctorB = typeB.InstanceConstructors.First()
-                                                                 Assert.True(DirectCast(ctorB, Cci.IMethodDefinition).IsExternal)
+                                                                 Assert.True(DirectCast(ctorB.GetCciAdapter(), Cci.IMethodDefinition).IsExternal)
                                                                  Assert.Equal(expectedMethodImplAttributes, ctorB.ImplementationAttributes)
                                                              End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -2935,8 +2935,8 @@ end namespace
                     Dim assembly = [module].ContainingAssembly
                     Dim ns = DirectCast([module].GlobalNamespace.GetMembers("N").Single, NamespaceSymbol)
                     Dim namedType = DirectCast(ns.GetMembers("C1").Single, NamedTypeSymbol)
-                    Dim type = DirectCast(namedType, Microsoft.Cci.ITypeDefinition)
-                    Dim method = DirectCast(namedType.GetMembers("goo1").Single, Microsoft.Cci.IMethodDefinition)
+                    Dim type = DirectCast(namedType.GetCciAdapter(), Microsoft.Cci.ITypeDefinition)
+                    Dim method = DirectCast(namedType.GetMembers("goo1").Single.GetCciAdapter(), Microsoft.Cci.IMethodDefinition)
 
                     Dim sourceAssembly = DirectCast(assembly, SourceAssemblySymbol)
                     Dim compilation = sourceAssembly.DeclaringCompilation

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -969,7 +969,7 @@ End Class
             Dim members = compilation1.GetMember(Of NamedTypeSymbol)("A.B").GetMembers("M")
             Assert.Equal(members.Length, 2)
             For Each member In members
-                Dim other = DirectCast(matcher.MapDefinition(DirectCast(member, Cci.IMethodDefinition)), MethodSymbol)
+                Dim other = DirectCast(matcher.MapDefinition(DirectCast(member.GetCciAdapter(), Cci.IMethodDefinition)).GetInternalSymbol(), MethodSymbol)
                 Assert.NotNull(other)
             Next
         End Sub
@@ -993,7 +993,7 @@ End Class
 
             Dim matcher = CreateMatcher(compilation1, compilation0)
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.M")
-            Dim other = DirectCast(matcher.MapDefinition(DirectCast(member, Cci.IMethodDefinition)), MethodSymbol)
+            Dim other = DirectCast(matcher.MapDefinition(DirectCast(member.GetCciAdapter(), Cci.IMethodDefinition)).GetInternalSymbol(), MethodSymbol)
             Assert.NotNull(other)
         End Sub
 
@@ -1027,7 +1027,7 @@ End Class
             Assert.Equal(nModifiers, DirectCast(member1.ReturnType, ArrayTypeSymbol).CustomModifiers.Length)
 
             Dim matcher = CreateMatcher(compilation1, compilation0)
-            Dim other = DirectCast(matcher.MapDefinition(DirectCast(member1, Cci.IMethodDefinition)), MethodSymbol)
+            Dim other = DirectCast(matcher.MapDefinition(DirectCast(member1.GetCciAdapter(), Cci.IMethodDefinition)).GetInternalSymbol(), MethodSymbol)
             Assert.NotNull(other)
             Assert.Equal(nModifiers, DirectCast(other.ReturnType, ArrayTypeSymbol).CustomModifiers.Length)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
@@ -80,7 +80,7 @@ End Class"
             Dim n As Integer = members.Length
             For i = 0 To n - 1
                 Dim member = members((i + startAt) Mod n)
-                Dim other = matcher.MapDefinition(DirectCast(member, Cci.IDefinition))
+                Dim other = matcher.MapDefinition(DirectCast(member.GetCciAdapter(), Cci.IDefinition))
                 Assert.NotNull(other)
             Next
         End Sub
@@ -113,7 +113,7 @@ End Class
 
             Assert.Equal(members.Length, 2)
             For Each member In members
-                Dim other = matcher.MapDefinition(DirectCast(member, Cci.IMethodDefinition))
+                Dim other = matcher.MapDefinition(DirectCast(member.GetCciAdapter(), Cci.IMethodDefinition))
                 Assert.NotNull(other)
             Next
         End Sub
@@ -133,7 +133,7 @@ End Class
             Dim compilation1 = compilation0.WithSource(source)
             Dim matcher = CreateMatcher(compilation1, compilation0)
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.M")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             Assert.NotNull(other)
         End Sub
 
@@ -165,7 +165,7 @@ End Class
             Assert.Equal(DirectCast(member1.ReturnType, ArrayTypeSymbol).CustomModifiers.Length, 1)
 
             Dim matcher = CreateMatcher(compilation1, compilation0)
-            Dim other = DirectCast(matcher.MapDefinition(member1), MethodSymbol)
+            Dim other = DirectCast(matcher.MapDefinition(member1.GetCciAdapter()).GetInternalSymbol(), MethodSymbol)
             Assert.NotNull(other)
             Assert.Equal(DirectCast(other.ReturnType, ArrayTypeSymbol).CustomModifiers.Length, 1)
         End Sub
@@ -193,7 +193,7 @@ End Class
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
 
-            Dim mf1 = matcher.MapDefinition(f1)
+            Dim mf1 = matcher.MapDefinition(f1.GetCciAdapter()).GetInternalSymbol()
             Assert.Equal(f0, mf1)
         End Sub
 
@@ -226,7 +226,7 @@ End Class
             Dim matcher = CreateMatcher(compilation1, compilation0)
             Dim elementType = compilation1.GetMember(Of TypeSymbol)("C.D")
             Dim member = compilation1.CreateArrayTypeSymbol(elementType)
-            Dim other = matcher.MapReference(member)
+            Dim other = matcher.MapReference(member.GetCciAdapter())
             Assert.NotNull(other)
         End Sub
 
@@ -258,7 +258,7 @@ End Class
             Dim matcher = CreateMatcher(compilation1, compilation0)
             Dim elementType = compilation1.GetMember(Of TypeSymbol)("C.D")
             Dim member = compilation1.CreateArrayTypeSymbol(elementType)
-            Dim other = matcher.MapReference(member)
+            Dim other = matcher.MapReference(member.GetCciAdapter())
             ' For a newly added type, there is no match in the previous generation.
             Assert.Null(other)
         End Sub
@@ -293,7 +293,7 @@ End Class
             Dim compilation1 = compilation0.WithSource(sources1)
             Dim matcher = CreateMatcher(compilation1, compilation0)
             Dim member = compilation1.GetMember(Of FieldSymbol)("C.y")
-            Dim other = matcher.MapReference(DirectCast(member.Type, Cci.ITypeReference))
+            Dim other = matcher.MapReference(DirectCast(member.Type.GetCciAdapter(), Cci.ITypeReference))
             ' For a newly added type, there is no match in the previous generation.
             Assert.Null(other)
         End Sub
@@ -540,7 +540,7 @@ Class C
                 Nothing)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("C.x")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' If a type changes within a tuple, we do not expect types to match.
             Assert.Null(other)
         End Sub
@@ -570,9 +570,9 @@ Class C
                 Nothing)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("C.x")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Types must match because just an element name was changed.
-            Dim otherSymbol = DirectCast(other, SourceFieldSymbol)
+            Dim otherSymbol = DirectCast(other.GetInternalSymbol(), SourceFieldSymbol)
             Assert.NotNull(otherSymbol)
             Assert.Equal("C.x As (a As System.Int32, b As System.Int32)", otherSymbol.ToTestDisplayString())
         End Sub
@@ -605,7 +605,7 @@ End Class
                 Nothing)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Types should not match: one is tuple and another is not.
             Assert.Null(other)
         End Sub
@@ -638,7 +638,7 @@ End Class
                 Nothing)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Types should not match: one is tuple and another is not.
             Assert.Null(other)
         End Sub
@@ -671,7 +671,7 @@ End Class
                 Nothing)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' If a type changes within a tuple, we do not expect types to match.
             Assert.Null(other)
         End Sub
@@ -704,9 +704,9 @@ End Class
                 Nothing)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Types must match because just an element name was changed.
-            Dim otherSymbol = DirectCast(other, SourceMemberMethodSymbol)
+            Dim otherSymbol = DirectCast(other.GetInternalSymbol(), SourceMemberMethodSymbol)
             Assert.NotNull(otherSymbol)
             Assert.Equal("Function C.X() As (a As System.Int32, b As System.Int32)", otherSymbol.ToTestDisplayString())
         End Sub
@@ -743,7 +743,7 @@ End Class
                 Nothing)
 
             Dim member = compilation1.GetMember(Of PropertySymbol)("C.X")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' If a type changes within a tuple, we do not expect types to match.
             Assert.Null(other)
         End Sub
@@ -780,9 +780,9 @@ End Class
                 Nothing)
 
             Dim member = compilation1.GetMember(Of PropertySymbol)("C.X")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Types must match because just an element name was changed.
-            Dim otherSymbol = DirectCast(other, SourcePropertySymbol)
+            Dim otherSymbol = DirectCast(other.GetInternalSymbol(), SourcePropertySymbol)
             Assert.NotNull(otherSymbol)
             Assert.Equal("ReadOnly Property C.X As (a As System.Int32, b As System.Int32)", otherSymbol.ToTestDisplayString())
         End Sub
@@ -811,7 +811,7 @@ End Structure
                 Nothing)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("Vector.Coordinates")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' If a type changes within a tuple, we do not expect types to match.
             Assert.Null(other)
         End Sub
@@ -840,9 +840,9 @@ End Structure
                 Nothing)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("Vector.Coordinates")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Types must match because just an element name was changed.
-            Dim otherSymbol = DirectCast(other, SourceFieldSymbol)
+            Dim otherSymbol = DirectCast(other.GetInternalSymbol(), SourceFieldSymbol)
             Assert.NotNull(otherSymbol)
             Assert.Equal("Vector.Coordinates As (x As System.Int32, y As System.Int32)", otherSymbol.ToTestDisplayString())
         End Sub
@@ -871,9 +871,9 @@ End Class
                 Nothing)
 
             Dim member = compilation1.GetMember(Of SourceNamedTypeSymbol)("C.F")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Tuple delegate defines a type. We should be able to match old and new types by name.
-            Dim otherSymbol = DirectCast(other, SourceNamedTypeSymbol)
+            Dim otherSymbol = DirectCast(other.GetInternalSymbol(), SourceNamedTypeSymbol)
             Assert.NotNull(otherSymbol)
             Assert.Equal("C.F", otherSymbol.ToTestDisplayString())
         End Sub
@@ -901,9 +901,9 @@ End Class"
                 Nothing)
 
             Dim member = compilation1.GetMember(Of SourceNamedTypeSymbol)("C.F")
-            Dim other = matcher.MapDefinition(member)
+            Dim other = matcher.MapDefinition(member.GetCciAdapter())
             ' Types must match because just an element name was changed.
-            Dim otherSymbol = DirectCast(other, SourceNamedTypeSymbol)
+            Dim otherSymbol = DirectCast(other.GetInternalSymbol(), SourceNamedTypeSymbol)
             Assert.NotNull(otherSymbol)
             Assert.Equal("C.F", otherSymbol.ToTestDisplayString())
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
@@ -1508,11 +1508,11 @@ String
         End Function
 
         Private Shared Function IsBeforeFieldInit(typeSymbol As NamedTypeSymbol) As Boolean
-            Return (DirectCast(typeSymbol, Microsoft.Cci.ITypeDefinition)).IsBeforeFieldInit
+            Return (DirectCast(typeSymbol.GetCciAdapter(), Microsoft.Cci.ITypeDefinition)).IsBeforeFieldInit
         End Function
 
         Private Shared Function IsStatic(symbol As Symbol) As Boolean
-            Return (DirectCast(symbol, Microsoft.Cci.IFieldDefinition)).IsStatic
+            Return (DirectCast(symbol.GetCciAdapter(), Microsoft.Cci.IFieldDefinition)).IsStatic
         End Function
 
         Private Shared Sub CompileAndCheckInitializers(sources As Xml.Linq.XElement, expectedInstanceInitializers As IEnumerable(Of ExpectedInitializer), expectedStaticInitializers As IEnumerable(Of ExpectedInitializer))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EnumTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/EnumTests.vb
@@ -1368,7 +1368,7 @@ BC30060: Conversion from 'E' to 'Integer' cannot occur in a constant expression.
             Assert.Equal(expectedEnumValues.Length, fields.Count - 1)
             For count = 0 To fields.Count - 1
                 Dim field = DirectCast(fields(count), FieldSymbol)
-                Dim fieldDefinition = DirectCast(field, Cci.IFieldDefinition)
+                Dim fieldDefinition = DirectCast(field.GetCciAdapter(), Cci.IFieldDefinition)
                 If count = 0 Then
                     Assert.Equal(field.Name, "value__")
                     Assert.False(field.IsShared)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/PropertyTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/PropertyTests.vb
@@ -8197,23 +8197,23 @@ End Class
             Assert.Equal(interfacePropertyGetter, classPropertyGetter.ExplicitInterfaceImplementations.Single())
             Assert.Equal(interfacePropertySetter, classPropertySetter.ExplicitInterfaceImplementations.Single())
 
-            Dim typeDef = DirectCast([class], Cci.ITypeDefinition)
+            Dim typeDef = DirectCast([class].GetCciAdapter(), Cci.ITypeDefinition)
             Dim [module] = New PEAssemblyBuilder(DirectCast([class].ContainingAssembly, SourceAssemblySymbol), EmitOptions.Default, OutputKind.DynamicallyLinkedLibrary, GetDefaultModulePropertiesForSerialization(), SpecializedCollections.EmptyEnumerable(Of ResourceDescription)())
 
             Dim context = New EmitContext([module], Nothing, New DiagnosticBag(), metadataOnly:=False, includePrivateMembers:=True)
             Dim explicitOverrides = typeDef.GetExplicitImplementationOverrides(context)
             Assert.Equal(2, explicitOverrides.Count())
-            Assert.True(explicitOverrides.All(Function(override) [class] Is override.ContainingType))
+            Assert.True(explicitOverrides.All(Function(override) [class] Is override.ContainingType.GetInternalSymbol()))
 
             ' We're not actually asserting that the overrides are in this order - set comparison just seems like overkill for two elements
             Dim getterOverride = explicitOverrides.First()
-            Assert.Equal(classPropertyGetter, getterOverride.ImplementingMethod)
-            Assert.Equal(interfacePropertyGetter.ContainingType, getterOverride.ImplementedMethod.GetContainingType(context))
+            Assert.Equal(classPropertyGetter, getterOverride.ImplementingMethod.GetInternalSymbol())
+            Assert.Equal(interfacePropertyGetter.ContainingType, getterOverride.ImplementedMethod.GetContainingType(context).GetInternalSymbol())
             Assert.Equal(interfacePropertyGetter.Name, getterOverride.ImplementedMethod.Name)
 
             Dim setterOverride = explicitOverrides.Last()
-            Assert.Equal(classPropertySetter, setterOverride.ImplementingMethod)
-            Assert.Equal(interfacePropertySetter.ContainingType, setterOverride.ImplementedMethod.GetContainingType(context))
+            Assert.Equal(classPropertySetter, setterOverride.ImplementingMethod.GetInternalSymbol())
+            Assert.Equal(interfacePropertySetter.ContainingType, setterOverride.ImplementedMethod.GetContainingType(context).GetInternalSymbol())
             Assert.Equal(interfacePropertySetter.Name, setterOverride.ImplementedMethod.Name)
 
             context.Diagnostics.Verify()

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NamespaceTypeDefinitionNoBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NamespaceTypeDefinitionNoBase.cs
@@ -125,13 +125,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
         public sealed override bool Equals(object obj)
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
         public sealed override int GetHashCode()
         {
-            // It is not supported to rely on default equality of these CCi objects, an explicit way to compare and hash them should be used.
+            // It is not supported to rely on default equality of these Cci objects, an explicit way to compare and hash them should be used.
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
     }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     ''' </summary>
     Friend NotInheritable Class PlaceholderMethodSymbol
         Inherits SynthesizedMethodBase
-        Implements Cci.ISignature
 
         Friend Delegate Function GetTypeParameters(method As PlaceholderMethodSymbol) As ImmutableArray(Of TypeParameterSymbol)
         Friend Delegate Function GetParameters(method As PlaceholderMethodSymbol) As ImmutableArray(Of ParameterSymbol)
@@ -111,12 +110,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Private ReadOnly Property ReturnValueIsByRef As Boolean Implements Cci.ISignature.ReturnValueIsByRef
-            Get
-                Return True
-            End Get
-        End Property
-
         Public Overrides ReadOnly Property TypeArguments As ImmutableArray(Of TypeSymbol)
             Get
                 Return ImmutableArrayExtensions.Cast(Of TypeParameterSymbol, TypeSymbol)(_typeParameters)
@@ -156,6 +149,36 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overrides Function CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer
             Throw ExceptionUtilities.Unreachable
         End Function
+
+#If DEBUG Then
+        Protected Overrides Function CreateCciAdapter() As MethodSymbolAdapter
+            Return New PlaceholderMethodSymbolAdapter(Me)
+        End Function
+#End If
+    End Class
+
+#If DEBUG Then
+    Friend NotInheritable Class PlaceholderMethodSymbolAdapter
+        Inherits MethodSymbolAdapter
+
+        Friend Sub New(underlying As PlaceholderMethodSymbol)
+            MyBase.New(underlying)
+        End Sub
+    End Class
+#End If
+
+#If DEBUG Then
+    Partial Friend Class PlaceholderMethodSymbolAdapter
+#Else
+    Partial Friend Class PlaceholderMethodSymbol
+#End If
+        Implements Cci.ISignature
+
+        Private ReadOnly Property ReturnValueIsByRef As Boolean Implements Cci.ISignature.ReturnValueIsByRef
+            Get
+                Return True
+            End Get
+        End Property
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -2034,7 +2034,7 @@ End Function, Func(Of E(Of T)))()")
             Assert.Equal(locals.Length, 2)
             ' All locals of type E(Of T) with type argument T from <>x(Of T).
             For Each local In locals
-                Dim localType = DirectCast(local.Type, NamedTypeSymbol)
+                Dim localType = DirectCast(local.Type.GetInternalSymbol(), NamedTypeSymbol)
                 Dim typeArg = localType.TypeArguments(0)
                 Assert.Equal(typeArg.ContainingSymbol, containingType.ContainingType)
             Next
@@ -2089,7 +2089,7 @@ End Class"
             Assert.Equal(returnType.ContainingSymbol, method)
 
             Dim locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder()
-            Assert.Equal(method, DirectCast(locals.Single().Type, TypeSymbol).ContainingSymbol)
+            Assert.Equal(method, DirectCast(locals.Single().Type.GetInternalSymbol(), TypeSymbol).ContainingSymbol)
 
             testData.GetMethodData("<>x.<>m0").VerifyIL("
 {
@@ -2145,13 +2145,13 @@ End Class"
 }
 "
                     AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL)
-                    Assert.Equal(Cci.CallingConvention.Generic, (DirectCast(methodData.Method, Cci.IMethodDefinition)).CallingConvention)
+                    Assert.Equal(Cci.CallingConvention.Generic, (DirectCast(methodData.Method.GetCciAdapter(), Cci.IMethodDefinition)).CallingConvention)
 
                     context = CreateMethodContext(runtime, "A.B.M2")
                     testData = New CompilationTestData()
                     context.CompileExpression("If(GetType(T), GetType(U))", errorMessage, testData)
                     methodData = testData.GetMethodData("<>x(Of T, U, V).<>m0")
-                    Assert.Equal(Cci.CallingConvention.Default, (DirectCast(methodData.Method, Cci.IMethodDefinition)).CallingConvention)
+                    Assert.Equal(Cci.CallingConvention.Default, (DirectCast(methodData.Method.GetCciAdapter(), Cci.IMethodDefinition)).CallingConvention)
                 End Sub)
         End Sub
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -847,7 +847,7 @@ End Namespace"
             ExpressionCompilerTestHelpers.EmitCorLibWithAssemblyReferences(
                 compCorLib,
                 Nothing,
-                Function(moduleBuilder, emitOptions) New PEAssemblyBuilderWithAdditionalReferences(moduleBuilder, emitOptions, objectType),
+                Function(moduleBuilder, emitOptions) New PEAssemblyBuilderWithAdditionalReferences(moduleBuilder, emitOptions, objectType.GetCciAdapter()),
                 peBytes,
                 pdbBytes)
 


### PR DESCRIPTION
This is a VB side of changes started in #48838.
Related to #45758.