### PR TITLE
Run CSharpCastReducer before CSharpVarReducer to fix nullable cast.

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
@@ -1953,5 +1953,42 @@ class Test
 ";
             await TestMissingAsync(text);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)]
+        [WorkItem(48950, "https://github.com/dotnet/roslyn/issues/48950")]
+        public async Task NullableReferenceVar()
+        {
+            var text = @"
+#nullable enable
+
+class Test
+{
+    void Method()
+    {
+        foreach [||] (var s in new string[10])
+        {
+            Console.WriteLine(s);
+        }
+    }
+}
+";
+            var expected = @"
+#nullable enable
+
+class Test
+{
+    void Method()
+    {
+        var {|Rename:array|} = new string[10];
+        for (var {|Rename:i|} = 0; i < array.Length; i++)
+        {
+            var s = array[i];
+            Console.WriteLine(s);
+        }
+    }
+}
+";
+            await TestInRegularAndScriptAsync(text, expected, options: ImplicitTypeEverywhere);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -27,10 +27,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
         // 2. Extension method reducer may insert parentheses.  So run it before the parentheses remover.
         private static readonly ImmutableArray<AbstractReducer> s_reducers =
             ImmutableArray.Create<AbstractReducer>(
+                new CSharpCastReducer(),
                 new CSharpVarReducer(),
                 new CSharpNameReducer(),
                 new CSharpNullableAnnotationReducer(),
-                new CSharpCastReducer(),
                 new CSharpExtensionMethodReducer(),
                 new CSharpParenthesizedExpressionReducer(),
                 new CSharpParenthesizedPatternReducer(),


### PR DESCRIPTION
Fixes #48950.
I think I'm doing correct thing, because the comment says "the cast simplifier should run earlier then everything else".