### PR TITLE
Do not cast when refactoring 'foreach var'

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
@@ -1953,5 +1953,40 @@ class Test
 ";
             await TestMissingAsync(text);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)]
+        [WorkItem(48950, "https://github.com/dotnet/roslyn/issues/48950")]
+        public async Task NullableReferenceVar()
+        {
+            var text = @"
+#nullable enable
+class Test
+{
+    void Method()
+    {
+        foreach [||] (var s in new string[10])
+        {
+            Console.WriteLine(s);
+        }
+    }
+}
+";
+            var expected = @"
+#nullable enable
+class Test
+{
+    void Method()
+    {
+        var {|Rename:array|} = new string[10];
+        for (var {|Rename:i|} = 0; i < array.Length; i++)
+        {
+            var s = array[i];
+            Console.WriteLine(s);
+        }
+    }
+}
+";
+            await TestInRegularAndScriptAsync(text, expected, options: ImplicitTypeEverywhere);
+        }
     }
 }

--- a/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
@@ -138,8 +138,13 @@ namespace Microsoft.CodeAnalysis.ConvertForEachToFor
             var memberAccess = generator.ElementAccessExpression(
                     collectionVariable, generator.IdentifierName(indexVariable));
 
+            if (castType != null)
+            {
+                memberAccess = generator.CastExpression(castType, memberAccess);
+            }
+
             var localDecl = generator.LocalDeclarationStatement(
-                type, foreachVariable, generator.CastExpression(castType, memberAccess));
+                type, foreachVariable, memberAccess);
 
             return (TStatementSyntax)localDecl.WithAdditionalAnnotations(Formatter.Annotation);
         }


### PR DESCRIPTION
Fixes #48950. Replaces #49100.

Not bothering so much - just testing the most common case.