### PR TITLE
Change our test run process

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -62,15 +62,6 @@ jobs:
       condition: not(succeeded())
 
     - task: PublishBuildArtifacts@1
-      displayName: Publish Secondary Logs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log2\$(_configuration)'
-        ArtifactName: '$(System.JobAttempt)-Secondary Logs $(_configuration) OOP64_$(_oop64bit) $(Build.BuildNumber)'
-        publishLocation: Container
-      continueOnError: true
-      condition: not(succeeded())
-
-    - task: PublishBuildArtifacts@1
       displayName: Publish Screenshots
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.LanguageServices.IntegrationTests\$(_configuration)\net472\xUnitResults'

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -41,7 +41,7 @@ jobs:
       displayName: Build and Test
       inputs:
         filePath: eng/build.ps1
-        arguments: -ci -restore -build -pack -sign -publish -binaryLog -configuration $(_configuration) -prepareMachine -testVsi -oop64bit:$$(_oop64bit) -procdump
+        arguments: -ci -restore -build -pack -sign -publish -binaryLog -configuration $(_configuration) -prepareMachine -testVsi -oop64bit:$$(_oop64bit) -collectDumps
 
     - task: PublishTestResults@2
       displayName: Publish xUnit Test Results

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -365,7 +365,7 @@ function TestUsingOptimizedRunner() {
     }
 
     $dlls += @(Get-ChildItem -Recurse -Include "*.IntegrationTests.dll" $binDir)
-    $args += " --testVsi"
+    $args += " --testvsi"
   } else {
     $dlls = Get-ChildItem -Recurse -Include "*.IntegrationTests.dll" $binDir
     $args += " --trait:Feature=NetCore"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -341,8 +341,6 @@ function TestUsingOptimizedRunner() {
     $env:ROSLYN_TEST_IOPERATION = "true"
   }
 
-  $secondaryLogDir = Join-Path (Join-Path $ArtifactsDir "log2") $configuration
-  Create-Directory $secondaryLogDir
   $testResultsDir = Join-Path $ArtifactsDir "TestResults\$configuration"
   $binDir = Join-Path $ArtifactsDir "bin" 
   $runTests = GetProjectOutputBinary "RunTests.exe"
@@ -356,7 +354,6 @@ function TestUsingOptimizedRunner() {
   $args += " --dotnet `"$dotnetExe`""
   $args += " --out `"$testResultsDir`""
   $args += " --logs `"$LogDir`""
-  $args += " --secondarylogs `"$secondaryLogDir`""
   $args += " --tfm net472"
 
   if ($testDesktop -or $testIOperation) {

--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -15,11 +15,3 @@ steps:
       artifactName: '${{ parameters.jobName }} Logs'
     continueOnError: true
     condition: not(succeeded())
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Dumps
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/artifacts/log2/${{ parameters.configuration }}'
-      artifactName: '${{ parameters.jobName }} Dumps'
-    continueOnError: true
-    condition: not(succeeded())

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -44,7 +44,7 @@ jobs:
       displayName: Run Unit Tests
       inputs:
         filePath: eng/build.ps1
-        arguments: -ci -configuration ${{ parameters.configuration }} ${{ parameters.testArguments }} -procdump
+        arguments: -ci -configuration ${{ parameters.configuration }} ${{ parameters.testArguments }} -collectDumps
 
     - task: PublishTestResults@2
       displayName: Publish xUnit Test Results

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -74,9 +74,9 @@ namespace RunTests
         public bool Retry { get; set; }
 
         /// <summary>
-        /// Whether or not to use proc dump to monitor running processes for failures.
+        /// Whether or not to collect dumps on crashes and timeouts.
         /// </summary>
-        public bool UseProcDump { get; set; }
+        public bool CollectDumps { get; set; }
 
         /// <summary>
         /// The path to procdump.exe
@@ -134,14 +134,14 @@ namespace RunTests
             string resultFileDirectory = Path.Combine(Directory.GetCurrentDirectory(), "TestResults");
             string? logFileDirectory = null;
             var display = Display.None;
-            var useProcDump = false;
+            var collectDumps = false;
             string? procDumpFilePath = null;
             var optionSet = new OptionSet()
             {
                 { "dotnet=", "Path to dotnet", (string s) => dotnetFilePath = s },
                 { "platform=", "Platform to test: x86 or x64", (string s) => platform = s },
                 { "tfm=", "Target framework to test", (string s) => targetFramework = s },
-                { "testVsi", "Test Visual Studio", o => testVsi = o is object },
+                { "testvsi", "Test Visual Studio", o => testVsi = o is object },
                 { "html", "Include HTML file output", o => includeHtml = o is object },
                 { "sequential", "Run tests sequentially", o => sequential = o is object },
                 { "traits=", "xUnit traits to include (semicolon delimited)", (string s) => traits = s },
@@ -151,7 +151,7 @@ namespace RunTests
                 { "logs=", "Log file directory", (string s) => logFileDirectory = s },
                 { "display=", "Display", (Display d) => display = d },
                 { "procdumppath=", "Path to procdump", (string s) => procDumpFilePath = s },
-                { "useprocdump", "Whether or not to use procdump", o => useProcDump = o is object },
+                { "collectdumps", "Whether or not to gather dumps on timeouts and crashes", o => collectDumps = o is object },
                 { "retry", "Retry failed test a few times", o => retry = o is object },
             };
 
@@ -173,16 +173,15 @@ namespace RunTests
                 return null;
             }
 
-            if (useProcDump && string.IsNullOrEmpty(procDumpFilePath))
-            {
-                Console.WriteLine($"The option 'useprocdump' was specified but 'procdumppath' was not provided");
-                return null;
-            }
-
             if (retry && includeHtml)
             {
                 Console.WriteLine($"Cannot specify both --retry and --html");
                 return null;
+            }
+
+            if (procDumpFilePath is { } && !collectDumps)
+            {
+                Console.WriteLine($"procdumppath was specified without collectdumps hence it will not be used");
             }
 
             if (logFileDirectory is null)
@@ -201,7 +200,7 @@ namespace RunTests
                 TestVsi = testVsi,
                 Display = display,
                 ProcDumpFilePath = procDumpFilePath,
-                UseProcDump = useProcDump,
+                CollectDumps = collectDumps,
                 Sequential = sequential,
                 IncludeHtml = includeHtml,
                 Trait = traits,

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -103,25 +103,18 @@ namespace RunTests
         /// </summary>
         public string LogFilesDirectory { get; set; }
 
-        /// <summary>
-        /// Directory to hold secondary dump files created while running tests.
-        /// </summary>
-        public string LogFilesSecondaryDirectory { get; set; }
-
         public string Platform { get; set; }
 
         public Options(
             string dotnetFilePath,
             string testResultsDirectory,
             string logFilesDirectory,
-            string logFilesSecondaryDirectory,
             string targetFramework,
             string platform)
         {
             DotnetFilePath = dotnetFilePath;
             TestResultsDirectory = testResultsDirectory;
             LogFilesDirectory = logFilesDirectory;
-            LogFilesSecondaryDirectory = logFilesSecondaryDirectory;
             TargetFramework = targetFramework;
             Platform = platform;
         }
@@ -140,7 +133,6 @@ namespace RunTests
             int? timeout = null;
             string resultFileDirectory = Path.Combine(Directory.GetCurrentDirectory(), "TestResults");
             string? logFileDirectory = null;
-            string? logFileSecondaryDirectory = null;
             var display = Display.None;
             var useProcDump = false;
             string? procDumpFilePath = null;
@@ -157,7 +149,6 @@ namespace RunTests
                 { "timeout=", "Minute timeout to limit the tests to", (int i) => timeout = i },
                 { "out=", "Test result file directory", (string s) => resultFileDirectory = s },
                 { "logs=", "Log file directory", (string s) => logFileDirectory = s },
-                { "secondarylogs=", "Log secondary file directory", (string s) => logFileSecondaryDirectory = s },
                 { "display=", "Display", (Display d) => display = d },
                 { "procdumppath=", "Path to procdump", (string s) => procDumpFilePath = s },
                 { "useprocdump", "Whether or not to use procdump", o => useProcDump = o is object },
@@ -199,13 +190,10 @@ namespace RunTests
                 logFileDirectory = resultFileDirectory;
             }
 
-            logFileSecondaryDirectory ??= logFileDirectory;
-
             return new Options(
                 dotnetFilePath: dotnetFilePath,
                 testResultsDirectory: resultFileDirectory,
                 logFilesDirectory: logFileDirectory,
-                logFilesSecondaryDirectory: logFileSecondaryDirectory,
                 targetFramework: targetFramework,
                 platform: platform)
             {

--- a/src/Tools/Source/RunTests/ProcDumpUtil.cs
+++ b/src/Tools/Source/RunTests/ProcDumpUtil.cs
@@ -13,27 +13,22 @@ namespace RunTests
     {
         private const string KeyProcDumpFilePath = "ProcDumpFilePath";
         private const string KeyProcDumpDirectory = "ProcDumpOutputPath";
-        private const string KeyProcDumpSecondaryDirectory = "ProcDumpSecondaryOutputPath";
 
         internal string ProcDumpFilePath { get; }
         internal string DumpDirectory { get; }
-        internal string SecondaryDumpDirectory { get; }
 
-        internal ProcDumpInfo(string procDumpFilePath, string dumpDirectory, string secondaryDumpDirectory)
+        internal ProcDumpInfo(string procDumpFilePath, string dumpDirectory)
         {
             Debug.Assert(Path.IsPathRooted(procDumpFilePath));
             Debug.Assert(Path.IsPathRooted(dumpDirectory));
-            Debug.Assert(Path.IsPathRooted(secondaryDumpDirectory));
             ProcDumpFilePath = procDumpFilePath;
             DumpDirectory = dumpDirectory;
-            SecondaryDumpDirectory = secondaryDumpDirectory;
         }
 
         internal void WriteEnvironmentVariables(Dictionary<string, string> environment)
         {
             environment[KeyProcDumpFilePath] = ProcDumpFilePath;
             environment[KeyProcDumpDirectory] = DumpDirectory;
-            environment[KeyProcDumpSecondaryDirectory] = SecondaryDumpDirectory;
         }
 
         internal static ProcDumpInfo? ReadFromEnvironment()
@@ -42,14 +37,13 @@ namespace RunTests
 
             var procDumpFilePath = Environment.GetEnvironmentVariable(KeyProcDumpFilePath);
             var dumpDirectory = Environment.GetEnvironmentVariable(KeyProcDumpDirectory);
-            var secondaryDumpDirectory = Environment.GetEnvironmentVariable(KeyProcDumpSecondaryDirectory);
 
-            if (!validate(procDumpFilePath) || !validate(dumpDirectory) || !validate(secondaryDumpDirectory))
+            if (!validate(procDumpFilePath) || !validate(dumpDirectory))
             {
                 return null;
             }
 
-            return new ProcDumpInfo(procDumpFilePath, dumpDirectory, secondaryDumpDirectory);
+            return new ProcDumpInfo(procDumpFilePath, dumpDirectory);
         }
     }
 

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -161,20 +161,6 @@ namespace RunTests
                     cancellationToken: cancellationToken);
                 Logger.Log($"Create xunit process with id {dotnetProcessInfo.Id} for test {assemblyInfo.DisplayName}");
 
-                // Now that xunit is running we should kick off a procDump process if it was specified
-                if (Options.ProcDumpInfo != null)
-                {
-                    var procDumpInfo = Options.ProcDumpInfo.Value;
-                    var procDumpStartInfo = ProcessRunner.CreateProcessStartInfo(
-                        procDumpInfo.ProcDumpFilePath,
-                        ProcDumpUtil.GetProcDumpCommandLine(dotnetProcessInfo.Id, procDumpInfo.DumpDirectory),
-                        captureOutput: true,
-                        displayWindow: false);
-                    Directory.CreateDirectory(procDumpInfo.DumpDirectory);
-                    procDumpProcessInfo = ProcessRunner.CreateProcess(procDumpStartInfo, cancellationToken: cancellationToken);
-                    Logger.Log($"Create procdump process with id {procDumpProcessInfo.Value.Id} for xunit {dotnetProcessInfo.Id} for test {assemblyInfo.DisplayName}");
-                }
-
                 var xunitProcessResult = await dotnetProcessInfo.Result;
                 var span = DateTime.UtcNow - start;
 

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -55,27 +55,33 @@ namespace RunTests
                 }
             }
 
-            // Setup cancellation for ctrl-c key presses
-            using var cts = new CancellationTokenSource();
-            Console.CancelKeyPress += delegate
+            try
             {
-                cts.Cancel();
+                // Setup cancellation for ctrl-c key presses
+                using var cts = new CancellationTokenSource();
+                Console.CancelKeyPress += delegate
+                {
+                    cts.Cancel();
+                    DisableRegistryDumpCollection();
+                };
+
+                int result;
+                if (options.Timeout is { } timeout)
+                {
+                    result = await RunAsync(options, timeout, cts.Token);
+                }
+                else
+                {
+                    result = await RunAsync(options, cts.Token);
+                }
+
+                CheckTotalDumpFilesSize();
+                return result;
+            }
+            finally
+            {
                 DisableRegistryDumpCollection();
-            };
-
-            int result;
-            if (options.Timeout is { } timeout)
-            {
-                result = await RunAsync(options, timeout, cts.Token);
             }
-            else
-            {
-                result = await RunAsync(options, cts.Token);
-            }
-
-            CheckTotalDumpFilesSize();
-            DisableRegistryDumpCollection();
-            return result;
 
             void DisableRegistryDumpCollection()
             {

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -220,17 +220,14 @@ namespace RunTests
             }
 
             ConsoleUtil.WriteLine("Roslyn Error: test timeout exceeded, dumping remaining processes");
-            var procDumpInfo = GetProcDumpInfo(options);
-            if (procDumpInfo != null)
+            if (GetProcDumpInfo(options) is { } procDumpInfo)
             {
                 var counter = 0;
                 foreach (var proc in ProcessUtil.GetProcessTree(Process.GetCurrentProcess()).OrderBy(x => x.ProcessName))
                 {
-                    var dumpDir = PrimaryProcessNames.Contains(proc.ProcessName)
-                        ? procDumpInfo.Value.DumpDirectory
-                        : procDumpInfo.Value.SecondaryDumpDirectory;
+                    var dumpDir = procDumpInfo.DumpDirectory;
                     var dumpFilePath = Path.Combine(dumpDir, $"{proc.ProcessName}-{counter}.dmp");
-                    await DumpProcess(proc, procDumpInfo.Value.ProcDumpFilePath, dumpFilePath);
+                    await DumpProcess(proc, procDumpInfo.ProcDumpFilePath, dumpFilePath);
                     counter++;
                 }
             }
@@ -246,7 +243,7 @@ namespace RunTests
         {
             if (!string.IsNullOrEmpty(options.ProcDumpFilePath))
             {
-                return new ProcDumpInfo(options.ProcDumpFilePath, options.LogFilesDirectory, options.LogFilesSecondaryDirectory);
+                return new ProcDumpInfo(options.ProcDumpFilePath, options.LogFilesDirectory);
             }
 
             return null;


### PR DESCRIPTION
Makes two changes to our test running process (each in a separate commit):

1. Use a single log directory. If the issues around log uploading come back we will follow up with AzDO, file a bug and consider reverting. 
1. Use registry to collect crash dumps in unit tests. This also unifies the process of dump collection between unit and integration tests. 