### PR TITLE
Add feature to remove unnecessary discards.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
+++ b/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AddRequiredParentheses\CSharpAddRequiredPatternParenthesesDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConvertTypeofToNameof\CSharpConvertTypeOfToNameOfDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveRedundantEquality\CSharpRemoveRedundantEqualityDiagnosticAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryDiscardDesignation\CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessarySuppressions\CSharpRemoveUnnecessaryPragmaSuppressionsDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessarySuppressions\CSharpRemoveUnnecessaryAttributeSuppressionsDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryParentheses\CSharpRemoveUnnecessaryPatternParenthesesDiagnosticAnalyzer.cs" />

--- a/src/Analyzers/CSharp/Analyzers/CSharpAnalyzersResources.resx
+++ b/src/Analyzers/CSharp/Analyzers/CSharpAnalyzersResources.resx
@@ -299,4 +299,10 @@
   <data name="new_expression_can_be_simplified" xml:space="preserve">
     <value>'new' expression can be simplified</value>
   </data>
+  <data name="Discard_can_be_removed" xml:space="preserve">
+    <value>Discard can be removed</value>
+  </data>
+  <data name="Remove_unnessary_discard" xml:space="preserve">
+    <value>Remove unnecessary discard</value>
+  </data>
 </root>

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
+{
+    /// <summary>
+    /// Supports code like <c>o switch { int _ => ... }</c> to just <c>o switch { int => ... }</c> in C# 9 and above.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal sealed class CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer
+        : AbstractBuiltInCodeStyleDiagnosticAnalyzer
+    {
+        public CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer()
+            : base(IDEDiagnosticIds.RemoveUnnecessaryDiscardDesignationDiagnosticId,
+                   option: null,
+                   new LocalizableResourceString(nameof(CSharpAnalyzersResources.Remove_unnessary_discard), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
+                   new LocalizableResourceString(nameof(CSharpAnalyzersResources.Discard_can_be_removed), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
+                   isUnnecessary: true)
+        {
+        }
+
+        public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+        protected override void InitializeWorker(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeDiscardDesignation, SyntaxKind.DiscardDesignation);
+        }
+
+        private void AnalyzeDiscardDesignation(SyntaxNodeAnalysisContext context)
+        {
+            var syntaxTree = context.SemanticModel.SyntaxTree;
+            if (((CSharpParseOptions)syntaxTree.Options).LanguageVersion < LanguageVersion.CSharp9)
+                return;
+
+            var discard = (DiscardDesignationSyntax)context.Node;
+            if (discard.Parent is DeclarationPatternSyntax)
+            {
+                Report(discard);
+            }
+            else if (discard.Parent is RecursivePatternSyntax recursivePattern)
+            {
+                // can't remove from `(int i) _` as `(int i)` is not a legal pattern itself.
+                if (recursivePattern.PositionalPatternClause != null &&
+                    recursivePattern.PositionalPatternClause.Subpatterns.Count == 1)
+                {
+                    return;
+                }
+
+                Report(discard);
+            }
+
+            return;
+
+            void Report(DiscardDesignationSyntax discard)
+            {
+                context.ReportDiagnostic(DiagnosticHelper.Create(
+                    this.Descriptor,
+                    discard.GetLocation(),
+                    ReportDiagnostic.Default,
+                    SpecializedCollections.EmptyEnumerable<Location>(),
+                    ImmutableDictionary<string, string>.Empty));
+            }
+        }
+    }
+}

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer.cs
@@ -61,12 +61,9 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
 
             void Report(DiscardDesignationSyntax discard)
             {
-                context.ReportDiagnostic(DiagnosticHelper.Create(
+                context.ReportDiagnostic(Diagnostic.Create(
                     this.Descriptor,
-                    discard.GetLocation(),
-                    ReportDiagnostic.Default,
-                    SpecializedCollections.EmptyEnumerable<Location>(),
-                    ImmutableDictionary<string, string>.Empty));
+                    discard.GetLocation()));
             }
         }
     }

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.cs.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Volání delegáta se dá zjednodušit.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">Indexování se dá zjednodušit.</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Odebrat nepotřebný operátor potlačení</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.de.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Der Delegataufruf kann vereinfacht werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">Die Indizierung kann vereinfacht werden</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Unnötigen Unterdrückungsoperator entfernen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.es.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">La invocación del delegado se puede simplificar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">La indexación de direcciones puede ser simplificado</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Quitar operador de supresión innecesario</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.fr.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">L'appel de délégué peut être simplifié.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">L'indexation peut être simplifiée</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Supprimer l'opérateur de suppression inutile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.it.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">La chiamata del delegato può essere semplificata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">L'indicizzazione può essere semplificata</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Rimuovi l'operatore di eliminazione non necessario</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.ja.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">デリゲート呼び出しを簡略化できます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">インデックスの作成を簡略化することができます</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">不要な抑制演算子を削除します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.ko.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">대리자 호출을 간단하게 만들 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">인덱싱은 단순화될 수 있습니다.</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">불필요한 비표시 오류(Suppression) 연산자 제거</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.pl.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Wywołanie delegata można uprościć.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">Indeksowanie można uprościć</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Usuń niepotrzebny operator pomijania</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.pt-BR.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">A invocação de delegado pode ser simplificada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">A indexação pode ser simplificada</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Remover operador de supressão desnecessário</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.ru.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Вызов делегата можно упростить.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">Вы можете упростить индексирование</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Удалить ненужный оператор подавления</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.tr.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Temsilci çağrısı basitleştirilebilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">Dizin oluşturma basitleştirilebilir</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">Gereksiz gizleme işlecini kaldır</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.zh-Hans.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">可简化委托调用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">索引可以简化</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">请删除不必要的忽略运算符</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.zh-Hant.xlf
+++ b/src/Analyzers/CSharp/Analyzers/xlf/CSharpAnalyzersResources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">可以簡化委派引動的過程。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard_can_be_removed">
+        <source>Discard can be removed</source>
+        <target state="new">Discard can be removed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indexing_can_be_simplified">
         <source>Indexing can be simplified</source>
         <target state="translated">可簡化索引</target>
@@ -80,6 +85,11 @@
       <trans-unit id="Remove_unnecessary_suppression_operator">
         <source>Remove unnecessary suppression operator</source>
         <target state="translated">移除隱藏運算子中不需要的運算子</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Remove_unnessary_discard">
+        <source>Remove unnecessary discard</source>
+        <target state="new">Remove unnecessary discard</target>
         <note />
       </trans-unit>
       <trans-unit id="Simplify_default_expression">

--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
@@ -30,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PopulateSwitch\CSharpPopulateSwitchStatementCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QualifyMemberAccess\CSharpQualifyMemberAccessCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCast\CSharpRemoveUnnecessaryCastCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryDiscardDesignation\RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryImports\CSharpRemoveUnnecessaryImportsCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveConfusingSuppression\CSharpRemoveConfusingSuppressionCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveConfusingSuppression\CSharpRemoveConfusingSuppressionFixAllProvider.cs" />

--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
@@ -30,7 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PopulateSwitch\CSharpPopulateSwitchStatementCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QualifyMemberAccess\CSharpQualifyMemberAccessCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryCast\CSharpRemoveUnnecessaryCastCodeFixProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryDiscardDesignation\RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryDiscardDesignation\CSharpRemoveUnnecessaryDiscardDesignationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryImports\CSharpRemoveUnnecessaryImportsCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveConfusingSuppression\CSharpRemoveConfusingSuppressionCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveConfusingSuppression\CSharpRemoveConfusingSuppressionFixAllProvider.cs" />

--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
@@ -22,12 +22,12 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp,
-        Name = nameof(RemoveUnnecessaryDiscardDesignationCodeFixProvider)), Shared]
-    internal partial class RemoveUnnecessaryDiscardDesignationCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+        Name = nameof(CSharpRemoveUnnecessaryDiscardDesignationCodeFixProvider)), Shared]
+    internal partial class CSharpRemoveUnnecessaryDiscardDesignationCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public RemoveUnnecessaryDiscardDesignationCodeFixProvider()
+        public CSharpRemoveUnnecessaryDiscardDesignationCodeFixProvider()
         {
         }
 

--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
     internal partial class RemoveUnnecessaryDiscardDesignationCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public RemoveUnnecessaryDiscardDesignationCodeFixProvider()
         {
         }

--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp,
+        Name = nameof(RemoveUnnecessaryDiscardDesignationCodeFixProvider)), Shared]
+    internal partial class RemoveUnnecessaryDiscardDesignationCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+    {
+        [ImportingConstructor]
+        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        public RemoveUnnecessaryDiscardDesignationCodeFixProvider()
+        {
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(IDEDiagnosticIds.RemoveUnnecessaryDiscardDesignationDiagnosticId);
+
+        internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            context.RegisterCodeFix(
+                new MyCodeAction(c => FixAsync(context.Document, diagnostic, c)),
+                diagnostic);
+
+            return Task.CompletedTask;
+        }
+
+        protected override Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var generator = editor.Generator;
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var discard = diagnostic.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
+                switch (discard.Parent)
+                {
+                    case DeclarationPatternSyntax declarationPattern:
+                        if (declarationPattern.Parent is IsPatternExpressionSyntax isPattern)
+                        {
+                            editor.ReplaceNode(
+                                isPattern,
+                                (current, _) =>
+                                {
+                                    var currentIsPattern = (IsPatternExpressionSyntax)isPattern;
+                                    return SyntaxFactory.BinaryExpression(
+                                        SyntaxKind.IsExpression,
+                                        currentIsPattern.Expression,
+                                        currentIsPattern.IsKeyword,
+                                        ((DeclarationPatternSyntax)isPattern.Pattern).Type)
+                                            .WithAdditionalAnnotations(Formatter.Annotation);
+                                });
+                        }
+                        else
+                        {
+                            editor.ReplaceNode(
+                                declarationPattern,
+                                (current, _) =>
+                                    SyntaxFactory.TypePattern(((DeclarationPatternSyntax)current).Type)
+                                                 .WithAdditionalAnnotations(Formatter.Annotation));
+                        }
+                        break;
+                    case RecursivePatternSyntax recursivePattern:
+                        editor.ReplaceNode(
+                            recursivePattern,
+                            (current, _) =>
+                                ((RecursivePatternSyntax)current).WithDesignation(null)
+                                                                 .WithAdditionalAnnotations(Formatter.Annotation));
+                        break;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private class MyCodeAction : CustomCodeActions.DocumentChangeAction
+        {
+            public MyCodeAction(
+                Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpAnalyzersResources.Remove_unnessary_discard, createChangedDocument, CSharpAnalyzersResources.Remove_unnessary_discard)
+            {
+            }
+        }
+    }
+}

--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationCodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
                                 isPattern,
                                 (current, _) =>
                                 {
-                                    var currentIsPattern = (IsPatternExpressionSyntax)isPattern;
+                                    var currentIsPattern = (IsPatternExpressionSyntax)current;
                                     return SyntaxFactory.BinaryExpression(
                                         SyntaxKind.IsExpression,
                                         currentIsPattern.Expression,

--- a/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
+++ b/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)RemoveUnnecessaryDiscardDesignation\RemoveUnnecessaryDiscardDesignationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AddAccessibilityModifiers\AddAccessibilityModifiersTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AddBraces\AddBracesFixAllTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AddBraces\AddBracesTests.cs" />

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationTests.cs
@@ -1,0 +1,276 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryDiscardDesignation
+{
+    using VerifyCS = CSharpCodeFixVerifier<
+        CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer,
+        RemoveUnnecessaryDiscardDesignationCodeFixProvider>;
+
+    public class RemoveUnnecessaryDiscardDesignationTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestDeclarationPatternInSwitchStatement()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        switch (o)
+        {
+            case int [|_|]:
+                break;
+        }
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void M(object o)
+    {
+        switch (o)
+        {
+            case int:
+                break;
+        }
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestNotInCSharp8()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        switch (o)
+        {
+            case int _:
+                break;
+        }
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestDeclarationPatternInSwitchExpression()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            int [|_|] => 0,
+        };
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            int => 0,
+        };
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestDeclarationPatternInIfStatement()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        if (o is int [|_|]) { }
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void M(object o)
+    {
+        if (o is int) { }
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestRecursivePropertyPattern()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            { } [|_|] => 0,
+        };
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            { } => 0,
+        };
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestEmptyRecursiveParameterPattern()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            () [|_|] => 0,
+        };
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            () => 0,
+        };
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestTwoElementRecursiveParameterPattern()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            (int i, int j) [|_|] => 0,
+        };
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            (int i, int j) => 0,
+        };
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestNotWithOneElementRecursiveParameterPattern()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(object o)
+    {
+        var v = o switch
+        {
+            (int i) _ => 0,
+        };
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryDiscardDesignation)]
+        public async Task TestNestedFixAll()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void M(string o)
+    {
+        var v = o switch
+        {
+            { Length: int [|_|] } [|_|] => 1,
+        };
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void M(string o)
+    {
+        var v = o switch
+        {
+            { Length: int } => 1,
+        };
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryDiscardDesignation/RemoveUnnecessaryDiscardDesignationTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryDiscar
 {
     using VerifyCS = CSharpCodeFixVerifier<
         CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer,
-        RemoveUnnecessaryDiscardDesignationCodeFixProvider>;
+        CSharpRemoveUnnecessaryDiscardDesignationCodeFixProvider>;
 
     public class RemoveUnnecessaryDiscardDesignationTests
     {

--- a/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
@@ -151,6 +151,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string RemoveRedundantEqualityDiagnosticId = "IDE0100";
 
+        public const string RemoveUnnecessaryDiscardDesignationDiagnosticId = "IDE0110";
+
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";
         public const string AnalyzerDependencyConflictId = "IDE1002";

--- a/src/Compilers/Test/Core/Traits/Traits.cs
+++ b/src/Compilers/Test/Core/Traits/Traits.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsRemoveInKeyword = "CodeActions.RemoveInKeyword";
             public const string CodeActionsRemoveUnnecessarySuppressions = "CodeActions.RemoveUnnecessarySuppressions";
             public const string CodeActionsRemoveUnnecessaryCast = "CodeActions.RemoveUnnecessaryCast";
+            public const string CodeActionsRemoveUnnecessaryDiscardDesignation = "CodeActions.RemoveUnnecessaryDiscardDesignation";
             public const string CodeActionsRemoveUnnecessaryImports = "CodeActions.RemoveUnnecessaryImports";
             public const string CodeActionsRemoveUnnecessaryParentheses = "CodeActions.RemoveUnnecessaryParentheses";
             public const string CodeActionsRemoveUnreachableCode = "CodeActions.RemoveUnreachableCode";

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -385,6 +385,9 @@ dotnet_diagnostic.IDE0083.severity = %value%
 # IDE0090
 dotnet_diagnostic.IDE0090.severity = %value%
 
+# IDE0110
+dotnet_diagnostic.IDE0110.severity = %value%
+
 # IDE0100
 dotnet_diagnostic.IDE0100.severity = %value%
 
@@ -947,6 +950,9 @@ csharp_style_prefer_not_pattern = true
 
 # IDE0090, ImplicitObjectCreationWhenTypeIsApparent
 csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# IDE0110
+No editorconfig based code style option
 
 # IDE0100
 No editorconfig based code style option


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/42210

C# 9.0 makes discards non-required in several locations.  So this PR adds an analyzer that fades those locations out and now offers to remove them when unnecessary.