### PR TITLE
Implement IEquatable on Microsoft.Cci.DefinitionWithLocation structure

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/Units.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Units.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Cci
     }
 
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    internal struct DefinitionWithLocation
+    internal struct DefinitionWithLocation : IEquatable<DefinitionWithLocation>
     {
         public readonly IDefinition Definition;
         public readonly int StartLine;


### PR DESCRIPTION
Closes #48946.