### PR TITLE
Use lazy cancellation in RemoteEndPoint.InvokeAsync<T>

### DIFF
--- a/src/Workspaces/Remote/Core/RemoteEndPoint.cs
+++ b/src/Workspaces/Remote/Core/RemoteEndPoint.cs
@@ -191,16 +191,22 @@ namespace Microsoft.CodeAnalysis.Remote
                 // if invoke throws an exception, make sure we raise cancellation.
                 RaiseCancellationIfInvokeFailed(task, linkedCancellationSource, cancellationToken);
 
-                // wait for asset source to respond
-                await pipe.WaitForConnectionAsync(linkedCancellationSource.Token).ConfigureAwait(false);
+                var task2 = Task.Run(async () =>
+                {
+                    // wait for asset source to respond
+                    await pipe.WaitForConnectionAsync(linkedCancellationSource.Token).ConfigureAwait(false);
 
-                // run user task with direct stream
-                var result = await dataReader(stream, linkedCancellationSource.Token).ConfigureAwait(false);
+                    // run user task with direct stream
+                    return await dataReader(stream, linkedCancellationSource.Token).ConfigureAwait(false);
+                }, linkedCancellationSource.Token);
 
-                // wait task to finish
-                await task.ConfigureAwait(false);
+                // Wait for all tasks to finish. If we return while one of the tasks is still in flight, the task would
+                // operate as a fire-and-forget operation where the caller might release state objects still in use by
+                // the task.
+                await Task.WhenAll(task, task2).ConfigureAwait(false);
 
-                return result;
+                Debug.Assert(task2.Status == TaskStatus.RanToCompletion);
+                return task2.Result;
             }
             catch (Exception ex) when (!logError || ReportUnlessCanceled(ex, linkedCancellationSource.Token, cancellationToken))
             {


### PR DESCRIPTION
This change ensures that SolutionAssetStorage does not release a pinned data scope while it is still in use.