### PR TITLE
Test insert when merging to master

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -106,10 +106,8 @@ stages:
           MasterValidationBuild
       condition: and(succeeded(), eq(variables['SourceBranchName'], 'dev/rigibson/test-insert-master'))
 
-    - task: PowerShell@2
+    - powershell: git pull origin master-vs-deps
       displayName: Merge master-vs-deps into source branch
-      inputs:
-        script: 'git pull origin master-vs-deps'
       condition: and(succeeded(), eq(variables['SourceBranchName'], 'dev/rigibson/test-insert-master'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -98,6 +98,20 @@ stages:
         arguments: '-sourceBranchName $(SourceBranchName) -prNumber $(PRNumber)'
       condition: and(succeeded(), ne(variables['PRNumber'], 'default'))
 
+    - task: tagBuildOrRelease@0
+      displayName: Tag master validation build
+      inputs:
+        type: 'Build'
+        tags: |
+          MasterValidationBuild
+      condition: and(succeeded(), eq(variables['SourceBranchName'], 'dev/rigibson/test-insert-master'))
+
+    - task: PowerShell@2
+      displayName: Merge master-vs-deps into source branch
+      inputs:
+        script: 'git pull origin master-vs-deps'
+      condition: and(succeeded(), eq(variables['SourceBranchName'], 'dev/rigibson/test-insert-master'))
+
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
 

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -104,11 +104,11 @@ stages:
         type: 'Build'
         tags: |
           MasterValidationBuild
-      condition: and(succeeded(), eq(variables['SourceBranchName'], 'dev/rigibson/test-insert-master'))
+      condition: and(succeeded(), eq(variables['SourceBranchName'], 'master'))
 
     - powershell: git pull origin master-vs-deps
       displayName: Merge master-vs-deps into source branch
-      condition: and(succeeded(), eq(variables['SourceBranchName'], 'dev/rigibson/test-insert-master'))
+      condition: and(succeeded(), eq(variables['SourceBranchName'], 'master'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable


### PR DESCRIPTION
Tagging @dotnet/roslyn-infrastructure @genlu @JoeRobich 

This config change makes it so that when we merge to master, we kick a signed build that implicitly merges in master-vs-deps. Then an [internal pipeline](https://dev.azure.com/devdiv/DevDiv/_release?definitionId=2733) takes that build and creates an insertion to VS.