### PR TITLE
[Refactoring] Convert string concatenation to interpolated string

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertStri
     public class ConvertStringConcatToInterpolatedTests
     {
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
-        public async Task IfExpressionAndConcatedTextAreRefactoredToInterpolated()
+        public async Task IfExpressionAndConcatenatedTextAreRefactoredToInterpolated()
         {
             const string InitialMarkup = @"
 class Program
@@ -43,7 +43,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
-        public async Task IfExpressionSurroundedByConcatedTextAreRefactoredToInterpolated()
+        public async Task IfExpressionSurroundedByConcatenatedTextAreRefactoredToInterpolated()
         {
             const string InitialMarkup = @"
 class Program
@@ -70,7 +70,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
-        public async Task TwoIfExpressionSurroundedByConcatedTextAreRefactoredToInterpolated()
+        public async Task TwoIfExpressionSurroundedByConcatenatedTextAreRefactoredToInterpolated()
         {
             const string InitialMarkup = @"
 class Program
@@ -93,6 +93,28 @@ class Program
                 TestCode = InitialMarkup,
                 FixedCode = ExpectedMarkup,
                 CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
+            }.RunAsync();
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
+        [InlineData(@"""a"" [|+|] ""b""")]
+        [InlineData(@"""a"" [|+|] @""b""")]
+        [InlineData(@"""a"" [|+|] @""b"" + ""c""")]
+        public async Task DontOfferIfOnlyStringLiteralsAreConcatenated(string concatenations)
+        {
+            var initialMarkup = @$"
+class Program
+{{
+    public static void Main()
+    {{
+        var x = {concatenations};
+    }}
+}}";
+            await new VerifyCS.Test
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+                OffersEmptyRefactoring = false,
             }.RunAsync();
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertStri
     public class ConvertStringConcatToInterpolatedTests
     {
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
-        public async Task IfExpressionAndConcatedTextAreRefacoredToInterpolated()
+        public async Task IfExpressionAndConcatedTextAreRefactoredToInterpolated()
         {
             const string InitialMarkup = @"
 class Program
@@ -38,7 +38,61 @@ class Program
             {
                 TestCode = InitialMarkup,
                 FixedCode = ExpectedMarkup,
-                CodeActionValidationMode = CodeActionValidationMode.Full,
+                CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
+        public async Task IfExpressionSurroundedByConcatedTextAreRefactoredToInterpolated()
+        {
+            const string InitialMarkup = @"
+class Program
+{
+    public static void Main()
+    {
+        var x = ""a"" + (true ? ""t"" : ""f"") [|+|] ""b"";
+    }
+}";
+            const string ExpectedMarkup = @"
+class Program
+{
+    public static void Main()
+    {
+        var x = $""a{(true ? ""t"" : ""f"")}b"";
+    }
+}";
+            await new VerifyCS.Test
+            {
+                TestCode = InitialMarkup,
+                FixedCode = ExpectedMarkup,
+                CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
+        public async Task TwoIfExpressionSurroundedByConcatedTextAreRefactoredToInterpolated()
+        {
+            const string InitialMarkup = @"
+class Program
+{
+    public static void Main()
+    {
+        var x = ""a"" + (true ? ""t"" : ""f"") [|+|] ""b"" + (false ? ""t"" : ""f"") + ""c"";
+    }
+}";
+            const string ExpectedMarkup = @"
+class Program
+{
+    public static void Main()
+    {
+        var x = $""a{(true ? ""t"" : ""f"")}b{(false ? ""t"" : ""f"")}c"";
+    }
+}";
+            await new VerifyCS.Test
+            {
+                TestCode = InitialMarkup,
+                FixedCode = ExpectedMarkup,
+                CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
             }.RunAsync();
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
@@ -117,5 +117,38 @@ class Program
                 OffersEmptyRefactoring = false,
             }.RunAsync();
         }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
+        [InlineData(@"""a"" [|+|] ""b"" + (true ? ""t"" : ""f"")",
+                   @"$""ab{(true ? ""t"" : ""f"")}""")]
+        [InlineData(@"""a"" [|+|] ""b"" + ""c"" + (true ? ""t"" : ""f"")",
+                   @"$""abc{(true ? ""t"" : ""f"")}""")]
+        [InlineData(@"""a"" [|+|] ""b"" + @""c"" + (true ? ""t"" : ""f"")",
+                   @"$""ab{@""c""}{(true ? ""t"" : ""f"")}""")]
+        public async Task ContiguousStringLiteralsAreMerged(string before, string after)
+        {
+            var initialMarkup = @$"
+class Program
+{{
+    public static void Main()
+    {{
+        var x = {before};
+    }}
+}}";
+            var expectedMarkup = @$"
+class Program
+{{
+    public static void Main()
+    {{
+        var x = {after};
+    }}
+}}";
+            await new VerifyCS.Test
+            {
+                TestCode = initialMarkup,
+                FixedCode = expectedMarkup,
+                CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
+            }.RunAsync();
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
@@ -5,13 +5,23 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToInterpolated;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertStringConcatToInterpolated
 {
     using VerifyCS = CSharpCodeRefactoringVerifier<CSharpConvertStringConcatToInterpolatedRefactoringProvider>;
+
+    // Temporary work around to avoid merge conflicts with master until VS 16.8 is released
+    internal static class Traits
+    {
+        public const string Feature = nameof(Feature);
+
+        internal static class Features
+        {
+            public const string CodeActionsConvertStringConcatToInterpolated = "CodeActions.ConvertStringConcatToInterpolated";
+        }
+    }
 
     public class ConvertStringConcatToInterpolatedTests
     {

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
@@ -226,5 +226,42 @@ class Program
                 CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
             }.RunAsync();
         }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
+        [InlineData(@"""\t"" [|+|] (1 + 1)",
+                   @"$""\t{1 + 1}""")]
+        [InlineData(@"""😀"" [|+|] (1 + 1)",
+                   @"$""😀{1 + 1}""")]
+        [InlineData(@"""\u2764"" [|+|] (1 + 1)",
+                   @"$""\u2764{1 + 1}""")]
+        [InlineData(@"""\"""" [|+|] (1 + 1)",
+                   @"$""\""{1 + 1}""")]
+        [InlineData(@"""{}"" [|+|] (1 + 1)",
+                   @"$""{{}}{1 + 1}""")]
+        public async Task EscapedStringsAreMergedProperly(string before, string after)
+        {
+            var initialMarkup = @$"
+class Program
+{{
+    public static void Main()
+    {{
+        var x = {before};
+    }}
+}}";
+            var expectedMarkup = @$"
+class Program
+{{
+    public static void Main()
+    {{
+        var x = {after};
+    }}
+}}";
+            await new VerifyCS.Test
+            {
+                TestCode = initialMarkup,
+                FixedCode = expectedMarkup,
+                CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
+            }.RunAsync();
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertStringConcatToInterpolated/ConvertStringConcatToInterpolatedTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToInterpolated;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertStringConcatToInterpolated
+{
+    using VerifyCS = CSharpCodeRefactoringVerifier<CSharpConvertStringConcatToInterpolatedRefactoringProvider>;
+
+    public class ConvertStringConcatToInterpolatedTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertStringConcatToInterpolated)]
+        public async Task IfExpressionAndConcatedTextAreRefacoredToInterpolated()
+        {
+            const string InitialMarkup = @"
+class Program
+{
+    public static void Main()
+    {
+        var x = (true ? ""t"" : ""f"") [|+|] ""a"";
+    }
+}";
+            const string ExpectedMarkup = @"
+class Program
+{
+    public static void Main()
+    {
+        var x = $""{(true ? ""t"" : ""f"")}a"";
+    }
+}";
+            await new VerifyCS.Test
+            {
+                TestCode = InitialMarkup,
+                FixedCode = ExpectedMarkup,
+                CodeActionValidationMode = CodeActionValidationMode.Full,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToInterpolated
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = "TODO" /* PredefinedCodeRefactoringProviderNames.AddAwait*/), Shared]
+    internal sealed class CSharpConvertStringConcatToInterpolatedRefactoringProvider : CodeRefactoringProvider
+    {
+        [ImportingConstructor]
+        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        public CSharpConvertStringConcatToInterpolatedRefactoringProvider()
+        {
+        }
+
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var (document, _, cancellationToken) = context;
+            if (document.Project.Solution.Workspace.Kind == WorkspaceKind.MiscellaneousFiles)
+            {
+                return;
+            }
+
+            var binaryExpression = await context.TryGetRelevantNodeAsync<BinaryExpressionSyntax>().ConfigureAwait(false);
+            if (binaryExpression?.IsKind(SyntaxKind.AddExpression) == true)
+            {
+                while (binaryExpression.Parent is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.AddExpression } parent)
+                {
+                    binaryExpression = parent;
+                }
+                var sematicModel = await context.Document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                if (IsStringConcatination(sematicModel, binaryExpression, cancellationToken))
+                {
+                    context.RegisterRefactoring(new MyCodeAction(
+                        title: "TODO",
+                        c => UpdateDocumentAsync(document, binaryExpression, c)),
+                        binaryExpression.Span);
+                }
+            }
+        }
+
+        private static bool IsStringConcatination(SemanticModel semanticModel, BinaryExpressionSyntax binaryExpression, CancellationToken cancellationToken)
+        {
+            var operation = semanticModel.GetOperation(binaryExpression, cancellationToken);
+            if (operation is IBinaryOperation binaryOperation)
+            {
+                return (binaryOperation.OperatorKind == BinaryOperatorKind.Add && binaryOperation.Type.Equals(semanticModel.Compilation.GetSpecialType(SpecialType.System_String)));
+            }
+
+            return false;
+        }
+
+        private static void WalkBinaryExpression(SemanticModel semanticModel, ArrayBuilder<ExpressionSyntax> arrayBuilder, BinaryExpressionSyntax binaryExpression, CancellationToken cancellationToken)
+        {
+            WalkBinaryExpression(semanticModel, arrayBuilder, binaryExpression.Left, cancellationToken);
+            WalkBinaryExpression(semanticModel, arrayBuilder, binaryExpression.Right, cancellationToken);
+        }
+
+        private static void WalkBinaryExpression(SemanticModel semanticModel, ArrayBuilder<ExpressionSyntax> arrayBuilder, ExpressionSyntax expression, CancellationToken cancellationToken)
+        {
+            if (expression is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.AddExpression } potentialStringConcatination &&
+                IsStringConcatination(semanticModel, potentialStringConcatination, cancellationToken))
+            {
+                WalkBinaryExpression(semanticModel, arrayBuilder, potentialStringConcatination, cancellationToken);
+            }
+            else
+            {
+                arrayBuilder.Add(expression);
+            }
+        }
+
+        private static async Task<Document> UpdateDocumentAsync(Document document, BinaryExpressionSyntax binaryExpression, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            using var _ = ArrayBuilder<ExpressionSyntax>.GetInstance(out var builder);
+            WalkBinaryExpression(semanticModel, builder, binaryExpression, cancellationToken);
+            MergeContiguousStringLiterals(builder);
+            var concatExpressions = builder.ToImmutable();
+
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var editor = new SyntaxEditor(root, CSharpSyntaxGenerator.Instance);
+            var interpolatedContent = List(concatExpressions.Select<ExpressionSyntax, InterpolatedStringContentSyntax>(expr => expr switch
+            {
+                var expression when IsStringLiteralExpression(expression, out var literal)
+                    => InterpolatedStringText(StringLiteralTokenToInterpolatedStringTextToken(literal.Token)),
+                // ToDo: Handle expr is interpolated string
+                _ => Interpolation(expr.WithoutTrivia()) // ToDo: Use ParenthesizedExpressionSyntaxExtensions.CanRemoveParentheses to remove any superfluous paranthesis
+            }));
+            var interpolated = InterpolatedStringExpression(
+                Token(SyntaxKind.InterpolatedStringStartToken),
+                interpolatedContent);
+            editor.ReplaceNode(binaryExpression, interpolated);
+            return document.WithSyntaxRoot(editor.GetChangedRoot());
+        }
+
+        private static void MergeContiguousStringLiterals(ArrayBuilder<ExpressionSyntax> builder)
+        {
+            ExpressionSyntax? lastElement = null;
+            var i = 0;
+            while (i < builder.Count)
+            {
+                if (IsStringLiteralExpression(lastElement, out var literal1) &&
+                    IsStringLiteralExpression(builder[i], out var literal2))
+                {
+                    var valueText = $"{literal1.Token.ValueText}{literal2.Token.ValueText}";
+                    builder[i] = LiteralExpression(SyntaxKind.StringLiteralExpression, Token(TriviaList(), SyntaxKind.StringLiteralToken, $"\"{valueText}\"", valueText, TriviaList()));
+                    lastElement = builder[i];
+                    builder.RemoveAt(i - 1);
+                }
+                else
+                {
+                    lastElement = builder[i];
+                    i++;
+                }
+            }
+        }
+
+        private static SyntaxToken StringLiteralTokenToInterpolatedStringTextToken(SyntaxToken stringLiteralToken)
+            => Token(TriviaList(), SyntaxKind.InterpolatedStringTextToken, stringLiteralToken.ValueText, stringLiteralToken.ValueText, TriviaList());
+
+        private static bool IsStringLiteralExpression(ExpressionSyntax? expression, [NotNullWhen(true)] out LiteralExpressionSyntax? literal)
+        {
+            if (expression is LiteralExpressionSyntax foundLiteral &&
+                foundLiteral.IsKind(SyntaxKind.StringLiteralExpression) &&
+                !foundLiteral.Token.IsVerbatimStringLiteral())
+            {
+                literal = foundLiteral;
+                return true;
+            }
+
+            literal = null;
+            return false;
+        }
+
+        private sealed class MyCodeAction : CodeActions.CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
@@ -46,13 +46,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
             var binaryExpression = await context.TryGetRelevantNodeAsync<BinaryExpressionSyntax>().ConfigureAwait(false);
             if (binaryExpression?.IsKind(SyntaxKind.AddExpression) == true)
             {
+                // Walk up to get the full sequence of conjunctive concatenations
                 while (binaryExpression.Parent is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.AddExpression } parent)
                 {
                     binaryExpression = parent;
                 }
+
                 var semanticModel = await context.Document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 if (IsStringConcatenation(semanticModel, binaryExpression, cancellationToken))
                 {
+                    // Collect the expression parts ("a" + "b" + expr) into an array { "a", "b", expr }
                     using var _ = ArrayBuilder<ExpressionSyntax>.GetInstance(out var builder);
                     WalkBinaryExpression(semanticModel, builder, binaryExpression, cancellationToken);
                     var concatParts = builder.ToImmutable();
@@ -106,20 +109,26 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
             var interpolated = InterpolatedStringExpression(
                 Token(SyntaxKind.InterpolatedStringStartToken),
                 List(interpolatedStringContent));
+            // expressions may have superfluous parenthesis after the conversion to an interpolated string:
+            // "a" + (1 + 1) -> $"a{(1 + 1)}"
+            // if there is any (InterpolationSyntax.Expression is ParenthesizedExpressionSyntax) we need to
+            // recompile and check via parenthesized.CanRemoveParentheses(semanticModel) if it can be removed.
             var anyPotentiallyRemovableParenthesis = interpolated.Contents.Any(IsParenthesizedInterpolation);
             var annotation = new SyntaxAnnotation("InterpolatedStringExpressionWithPotentiallyRemovableParanthesisKind");
             if (anyPotentiallyRemovableParenthesis)
             {
+                // annotate "interpolated" because we need to find it after the changes are applied
                 interpolated = interpolated.WithAdditionalAnnotations(annotation);
             }
-            editor.ReplaceNode(binaryExpression, interpolated.WithAdditionalAnnotations(annotation));
+            editor.ReplaceNode(binaryExpression, interpolated);
 
             if (anyPotentiallyRemovableParenthesis)
             {
+                // Take the changed document and go through interpolatedNode.Contents to check if any parenthesis can be removed.
                 var newDocument = document.WithSyntaxRoot(editor.GetChangedRoot());
                 var newRoot = await newDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var interpolatedNode = (InterpolatedStringExpressionSyntax)newRoot.GetAnnotatedNodes(annotation).Single();
-                var semanticModel = await newDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var semanticModel = await newDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 editor = new SyntaxEditor(newRoot, CSharpSyntaxGenerator.Instance);
                 foreach (var content in interpolatedNode.Contents.Where(IsParenthesizedInterpolation).Cast<InterpolationSyntax>())
                 {
@@ -147,19 +156,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
                     case var expression when IsStringLiteralExpression(expression, out var literal):
                         if (result.LastOrDefault() is InterpolatedStringTextSyntax text)
                         {
+                            // Merge the string literal with the last InterpolatedStringTextSyntax
                             var newText = text.TextToken.ValueText + literal.Token.ValueText;
                             result[^1] = InterpolatedStringText(InterpolatedStringTextToken(newText));
                         }
                         else
                         {
-                            result.Add(InterpolatedStringText(StringLiteralTokenToInterpolatedStringTextToken(literal.Token)));
+                            result.Add(InterpolatedStringText(InterpolatedStringTextToken(literal.Token.ValueText)));
                         }
                         break;
                     case InterpolatedStringExpressionSyntax interpolated when !interpolated.StringStartToken.IsKind(SyntaxKind.InterpolatedVerbatimStringStartToken):
+                        // One of the concatParts is itself an interpolated string at should be in-lined:
+                        // "a" + $"b{expr}c" -> $"ab{expr}c"
+                        // Here "interpolated" is $"b{expr}c"
                         foreach (var contentPart in interpolated.Contents)
                         {
                             if (contentPart is InterpolatedStringTextSyntax textFromOther && result.LastOrDefault() is InterpolatedStringTextSyntax previousText)
                             {
+                                // The last added content was a text and the first part in interpolated is a text. We can merge these two.
+                                // "a" + $"b{expr}" -> "a" and "b" can be merged
                                 var newText = previousText.TextToken.ValueText + textFromOther.TextToken.ValueText;
                                 result[^1] = InterpolatedStringText(InterpolatedStringTextToken(newText));
                             }
@@ -170,6 +185,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
                         }
                         break;
                     default:
+                        // "part" might be parenthesized here. Superfluous parenthesizes are removed later.
+                        // "+" usually has whitespace before and after. We remove that and other trivia.
                         result.Add(Interpolation(part.WithoutTrivia()));
                         break;
                 }
@@ -180,9 +197,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
 
         private static SyntaxToken InterpolatedStringTextToken(string text)
             => Token(TriviaList(), SyntaxKind.InterpolatedStringTextToken, text, text, TriviaList());
-
-        private static SyntaxToken StringLiteralTokenToInterpolatedStringTextToken(SyntaxToken stringLiteralToken)
-            => InterpolatedStringTextToken(stringLiteralToken.ValueText);
 
         private static bool IsStringLiteralExpression(ExpressionSyntax? expression, [NotNullWhen(true)] out LiteralExpressionSyntax? literal)
         {

--- a/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
                     binaryExpression = parent;
                 }
                 var sematicModel = await context.Document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                if (IsStringConcatination(sematicModel, binaryExpression, cancellationToken))
+                if (IsStringConcatenation(sematicModel, binaryExpression, cancellationToken))
                 {
                     context.RegisterRefactoring(new MyCodeAction(
                         title: "TODO",
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
             }
         }
 
-        private static bool IsStringConcatination(SemanticModel semanticModel, BinaryExpressionSyntax binaryExpression, CancellationToken cancellationToken)
+        private static bool IsStringConcatenation(SemanticModel semanticModel, BinaryExpressionSyntax binaryExpression, CancellationToken cancellationToken)
         {
             var operation = semanticModel.GetOperation(binaryExpression, cancellationToken);
             if (operation is IBinaryOperation binaryOperation)
@@ -79,10 +79,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertStringConcatToIn
 
         private static void WalkBinaryExpression(SemanticModel semanticModel, ArrayBuilder<ExpressionSyntax> arrayBuilder, ExpressionSyntax expression, CancellationToken cancellationToken)
         {
-            if (expression is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.AddExpression } potentialStringConcatination &&
-                IsStringConcatination(semanticModel, potentialStringConcatination, cancellationToken))
+            if (expression is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.AddExpression } potentialStringConcatenation &&
+                IsStringConcatenation(semanticModel, potentialStringConcatenation, cancellationToken))
             {
-                WalkBinaryExpression(semanticModel, arrayBuilder, potentialStringConcatination, cancellationToken);
+                WalkBinaryExpression(semanticModel, arrayBuilder, potentialStringConcatenation, cancellationToken);
             }
             else
             {

--- a/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ConvertStringConcatToInterpolated/CSharpConvertStringConcatToInterpolatedRefactoringProvider.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public const string Feature = nameof(Feature);
         public static class Features
         {
+            public const string CodeActionsConvertStringConcatToInterpolated = "CodeActions.ConvertStringConcatToInterpolated";
             public const string AddAwait = "Refactoring.AddAwait";
             public const string AddMissingImports = "Refactoring.AddMissingImports";
             public const string AddMissingReference = nameof(AddMissingReference);
@@ -70,7 +71,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsConvertLocalFunctionToMethod = "CodeActions.ConvertLocalFunctionToMethod";
             public const string CodeActionsConvertNumericLiteral = "CodeActions.ConvertNumericLiteral";
             public const string CodeActionsConvertQueryToForEach = "CodeActions.ConvertQueryToForEach";
-            public const string CodeActionsConvertStringConcatToInterpolated = "CodeActions.ConvertStringConcatToInterpolated";
             public const string CodeActionsConvertSwitchStatementToExpression = "CodeActions.ConvertSwitchStatementToExpression";
             public const string CodeActionsConvertToInterpolatedString = "CodeActions.ConvertToInterpolatedString";
             public const string CodeActionsConvertToIterator = "CodeActions.ConvertToIterator";

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public const string Feature = nameof(Feature);
         public static class Features
         {
-            public const string CodeActionsConvertStringConcatToInterpolated = "CodeActions.ConvertStringConcatToInterpolated";
             public const string AddAwait = "Refactoring.AddAwait";
             public const string AddMissingImports = "Refactoring.AddMissingImports";
             public const string AddMissingReference = nameof(AddMissingReference);

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsConvertLocalFunctionToMethod = "CodeActions.ConvertLocalFunctionToMethod";
             public const string CodeActionsConvertNumericLiteral = "CodeActions.ConvertNumericLiteral";
             public const string CodeActionsConvertQueryToForEach = "CodeActions.ConvertQueryToForEach";
+            public const string CodeActionsConvertStringConcatToInterpolated = "CodeActions.ConvertStringConcatToInterpolated";
             public const string CodeActionsConvertSwitchStatementToExpression = "CodeActions.ConvertSwitchStatementToExpression";
             public const string CodeActionsConvertToInterpolatedString = "CodeActions.ConvertToInterpolatedString";
             public const string CodeActionsConvertToIterator = "CodeActions.ConvertToIterator";


### PR DESCRIPTION
Fixes #48900

![clZE4GmCdX](https://user-images.githubusercontent.com/24472128/98444308-31e23100-2111-11eb-8fe8-d900c89b801e.gif)

The current design of the feature:
* Conjunctive concatenations are treated as a unit
* Conjunctive string literal concatenations are merged and any trivia is removed (e.g. newline)
* Any existing interpolated string expressions are inlined (`"a" + $"{expr}"`-> `$"a{expr}"`)
* Verbatim strings and verbatim interpolated strings are kept
* Superfluous parenthesis are removed: `"a" + (1 + 1)` -> `$"a{1 + 1}"`). Logic relies on the existing `ParenthesizedExpressionSyntaxExtensions.CanRemoveParentheses` and therefore *if expressions* are keeping theire parenthesis.

Open issues:
* Trivia handling
* Better handling of verbatim strings (e.g. currently: `@"a" + (1 + 1)` -> `$"{@"a"}{1 + 1}"`)
* Tests for handling of escaped characters.
* Don't offer in constant context (e.g. attribute arguments)
* Support `string.Concat`?