### PR TITLE
Fix RazorRemoteHostClient to maintain binary back-compat

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Remote/RazorRemoteHostClient.cs
+++ b/src/Tools/ExternalAccess/Razor/Remote/RazorRemoteHostClient.cs
@@ -16,7 +16,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    internal readonly struct RazorRemoteHostClient
+    internal sealed class RazorRemoteHostClient
     {
         private readonly ServiceHubRemoteHostClient _client;
         private readonly RazorServiceDescriptorsWrapper _serviceDescriptors;


### PR DESCRIPTION
#48776 breaks binary back-compat for Razor, this fixes it. Note the constructor signature was changed too but Razor is not calling it directly so it should be OK.

https://github.com/dotnet/aspnetcore-tooling/search?q=RazorRemoteHostClient

@RikkiGibson @NTaylorMullen 