### PR TITLE
Cache RegexPatternDetector per compilation

### DIFF
--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/AbstractRegexDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/AbstractRegexDiagnosticAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions
                 return;
             }
 
-            var detector = RegexPatternDetector.TryGetOrCreate(semanticModel, _info);
+            var detector = RegexPatternDetector.TryGetOrCreate(semanticModel.Compilation, _info);
             if (detector == null)
             {
                 return;
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions
         {
             if (token.RawKind == _info.StringLiteralTokenKind)
             {
-                var tree = detector.TryParseRegexPattern(token, cancellationToken);
+                var tree = detector.TryParseRegexPattern(token, context.SemanticModel, cancellationToken);
                 if (tree != null)
                 {
                     foreach (var diag in tree.Diagnostics)

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexSyntaxClassifier.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexSyntaxClassifier.cs
@@ -56,8 +56,8 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions.LanguageSe
                 return;
             }
 
-            var detector = RegexPatternDetector.TryGetOrCreate(semanticModel, _info);
-            var tree = detector?.TryParseRegexPattern(token, cancellationToken);
+            var detector = RegexPatternDetector.TryGetOrCreate(semanticModel.Compilation, _info);
+            var tree = detector?.TryParseRegexPattern(token, semanticModel, cancellationToken);
             if (tree == null)
             {
                 return;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexEmbeddedLanguage.cs
@@ -50,8 +50,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions
                 return default;
 
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var detector = RegexPatternDetector.TryGetOrCreate(semanticModel, this.Info);
-            var tree = detector?.TryParseRegexPattern(token, cancellationToken);
+            var detector = RegexPatternDetector.TryGetOrCreate(semanticModel.Compilation, this.Info);
+            var tree = detector?.TryParseRegexPattern(token, semanticModel, cancellationToken);
             return tree == null ? default : (tree, token);
         }
 


### PR DESCRIPTION
This reduces the number of `RegexPatternDetector` instances needed, since the state information it contains is specific to a whole `Compilation` and not just a single `SemanticModel`.

This change contributes to fixing [AB#1242125](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1242125) by eliminating a GC root for some costly `SemanticModel` instances.