### PR TITLE
Correctly use langword for this and base keywords

### DIFF
--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -453,7 +453,7 @@ class C
 
         [WorkItem(38370, "https://github.com/dotnet/roslyn/issues/38370")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
-        public async Task TextBaseKeyword()
+        public async Task TestBaseKeyword()
         {
             await TestInRegularAndScriptAsync(
 @"

--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -450,5 +450,41 @@ class C
     void WriteLine<TKey>(TKey value) { }
 }");
         }
+
+        [WorkItem(38370, "https://github.com/dotnet/roslyn/issues/38370")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TextBaseKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// Testing keyword [||]base.
+class C<TKey>
+{
+}",
+
+@"
+/// Testing keyword <see langword=""base""/>.
+class C<TKey>
+{
+}");
+        }
+
+        [WorkItem(38370, "https://github.com/dotnet/roslyn/issues/38370")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestThisKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// Testing keyword [||]this.
+class C<TKey>
+{
+}",
+
+@"
+/// Testing keyword <see langword=""this""/>.
+class C<TKey>
+{
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
@@ -351,5 +351,33 @@ class C
     end sub
 end class")
         End Function
+
+        <WorkItem(38370, "https://github.com/dotnet/roslyn/issues/38370")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMyBase() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' Testing keyword [||]MyBase.
+class C(Of TKey)
+end class",
+"
+''' Testing keyword <see langword=""MyBase""/>.
+class C(Of TKey)
+end class")
+        End Function
+
+        <WorkItem(38370, "https://github.com/dotnet/roslyn/issues/38370")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMyClass() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' Testing keyword [||]MyClass.
+class C(Of TKey)
+end class",
+"
+''' Testing keyword <see langword=""MyClass""/>.
+class C(Of TKey)
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -26,7 +26,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
             SyntaxFacts.GetText(SyntaxKind.AbstractKeyword),
             SyntaxFacts.GetText(SyntaxKind.SealedKeyword),
             SyntaxFacts.GetText(SyntaxKind.AsyncKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword));
+            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword),
+            SyntaxFacts.GetText(SyntaxKind.BaseKeyword),
+            SyntaxFacts.GetText(SyntaxKind.ThisKeyword));
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -23,7 +23,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
             SyntaxFacts.GetText(SyntaxKind.MustInheritKeyword),
             SyntaxFacts.GetText(SyntaxKind.NotOverridableKeyword),
             SyntaxFacts.GetText(SyntaxKind.AsyncKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)
+            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword),
+            SyntaxFacts.GetText(SyntaxKind.MyBaseKeyword),
+            SyntaxFacts.GetText(SyntaxKind.MyClassKeyword)
             }
 
         <ImportingConstructor>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38370

"This" is a very common keyword that probably doesn't need to offer a refactoring, but given that this doesn't show squiggles to the user, it seemed not worth the trouble to create a deny list for one keyword.

Happy to follow up if others disagree.