### PR TITLE
Remove workaround in PEMethodSymbol.ExplicitInterfaceImplementations

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -11,7 +11,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.CSharp.Emit;
@@ -1194,9 +1193,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations
         {
-            // Disabling optimization to work around a JIT bug in .NET 5.
-            // See https://github.com/dotnet/roslyn/issues/46575
-            [MethodImpl(MethodImplOptions.NoOptimization)]
             get
             {
                 var explicitInterfaceImplementations = _lazyExplicitMethodImplementations;


### PR DESCRIPTION
Related to #46575

dotnet/runtime#41100 has shipped, so we can remove this workaround now.

I have verified that checking out `dotnet/runtime:release/5.0` branch and [using a compiler with this change to build locally](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building,%20Debugging,%20and%20Testing%20on%20Windows.md#testing-on-the-dotnetruntime-repo) succeeds, after modifying some build props to suppress new nullable warnings.