### PR TITLE
Nullable enable Operation files

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -501,11 +501,17 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.UsingLocalDeclarations:
                     {
                         var declarations = ((BoundMultipleLocalDeclarationsBase)declaration).LocalDeclarations;
-                        BoundTypeExpression? declaredTypeOpt = declarations[0].DeclaredTypeOpt;
-                        Debug.Assert(declarations.Length == 0 || declaredTypeOpt != null);
-                        var dimensions = declarations.Length > 0
-                            ? declaredTypeOpt!.BoundDimensionsOpt
-                            : ImmutableArray<BoundExpression>.Empty;
+                        ImmutableArray<BoundExpression> dimensions;
+                        if (declarations.Length > 0)
+                        {
+                            BoundTypeExpression? declaredTypeOpt = declarations[0].DeclaredTypeOpt;
+                            Debug.Assert(declaredTypeOpt != null);
+                            dimensions = declaredTypeOpt.BoundDimensionsOpt;
+                        }
+                        else
+                        {
+                            dimensions = ImmutableArray<BoundExpression>.Empty;
+                        }
                         return CreateFromArray<BoundExpression, IOperation>(dimensions);
                     }
                 default:

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -34,7 +32,6 @@ namespace Microsoft.CodeAnalysis.Operations
             _cachedCreateInternal = CreateInternal;
         }
 
-#nullable enable
         [return: NotNullIfNotNull("boundNode")]
         public IOperation? Create(BoundNode? boundNode)
         {
@@ -67,7 +64,6 @@ namespace Microsoft.CodeAnalysis.Operations
             }
             return builder.ToImmutableAndFree();
         }
-#nullable disable
 
         internal IOperation CreateInternal(BoundNode boundNode)
         {
@@ -334,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.TypeOrValueExpression:
                 case BoundKind.IndexOrRangePatternIndexerAccess:
 
-                    ConstantValue constantValue = (boundNode as BoundExpression)?.ConstantValue;
+                    ConstantValue? constantValue = (boundNode as BoundExpression)?.ConstantValue;
                     bool isImplicit = boundNode.WasCompilerGenerated;
 
                     if (!isImplicit)
@@ -355,7 +351,6 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
-#nullable enable
         private IMethodBodyOperation CreateMethodBodyOperation(BoundNonConstructorMethodBody boundNode)
         {
             return new MethodBodyOperation(
@@ -482,7 +477,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return new NoneOperation(children, _semanticModel, syntax, type, constantValue: null, isImplicit);
         }
 
-#nullable disable
         private IOperation CreateBoundUnconvertedAddressOfOperatorOperation(BoundUnconvertedAddressOfOperator boundUnconvertedAddressOf)
         {
             return new AddressOfOperation(
@@ -499,14 +493,18 @@ namespace Microsoft.CodeAnalysis.Operations
             {
                 case BoundKind.LocalDeclaration:
                     {
-                        return CreateFromArray<BoundExpression, IOperation>(((BoundLocalDeclaration)declaration).DeclaredTypeOpt.BoundDimensionsOpt);
+                        BoundTypeExpression? declaredTypeOpt = ((BoundLocalDeclaration)declaration).DeclaredTypeOpt;
+                        Debug.Assert(declaredTypeOpt != null);
+                        return CreateFromArray<BoundExpression, IOperation>(declaredTypeOpt.BoundDimensionsOpt);
                     }
                 case BoundKind.MultipleLocalDeclarations:
                 case BoundKind.UsingLocalDeclarations:
                     {
                         var declarations = ((BoundMultipleLocalDeclarationsBase)declaration).LocalDeclarations;
+                        BoundTypeExpression? declaredTypeOpt = declarations[0].DeclaredTypeOpt;
+                        Debug.Assert(declarations.Length == 0 || declaredTypeOpt != null);
                         var dimensions = declarations.Length > 0
-                            ? declarations[0].DeclaredTypeOpt.BoundDimensionsOpt
+                            ? declaredTypeOpt!.BoundDimensionsOpt
                             : ImmutableArray<BoundExpression>.Empty;
                         return CreateFromArray<BoundExpression, IOperation>(dimensions);
                     }
@@ -515,7 +513,6 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
-#nullable enable
         internal IOperation CreateBoundLocalOperation(BoundLocal boundLocal, bool createDeclaration = true)
         {
             ILocalSymbol local = boundLocal.LocalSymbol.GetPublicSymbol();
@@ -2243,7 +2240,6 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isImplicit = boundQueryClause.WasCompilerGenerated;
             return new TranslatedQueryOperation(operation, _semanticModel, syntax, type, isImplicit);
         }
-#nullable disable
 
         private IOperation CreateBoundRangeVariableOperation(BoundRangeVariable boundRangeVariable)
         {
@@ -2251,7 +2247,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return Create(boundRangeVariable.Value);
         }
 
-#nullable enable
         private IOperation CreateBoundDiscardExpressionOperation(BoundDiscardExpression boundNode)
         {
             return new DiscardOperation(

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -1,8 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -17,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Operations
 {
     internal sealed partial class CSharpOperationFactory
     {
-        internal ImmutableArray<BoundStatement> ToStatements(BoundStatement statement)
+        internal ImmutableArray<BoundStatement> ToStatements(BoundStatement? statement)
         {
             if (statement == null)
             {
@@ -32,7 +30,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return ImmutableArray.Create(statement);
         }
 
-#nullable enable
         private IInstanceReferenceOperation CreateImplicitReceiver(SyntaxNode syntax, TypeSymbol type) =>
             new InstanceReferenceOperation(InstanceReferenceKind.ImplicitReceiver, _semanticModel, syntax, type.GetPublicSymbol(), isImplicit: true);
 
@@ -139,7 +136,6 @@ namespace Microsoft.CodeAnalysis.Operations
 
             return new EventReferenceOperation(@event, instance, _semanticModel, eventAccessSyntax, @event.Type, isImplicit);
         }
-#nullable disable
 
         internal IOperation CreateDelegateTargetOperation(BoundNode delegateNode)
         {
@@ -150,6 +146,7 @@ namespace Microsoft.CodeAnalysis.Operations
                     // We don't check HasErrors on the conversion here because if we actually have a MethodGroup conversion,
                     // overload resolution succeeded. The resulting method could be invalid for other reasons, but we don't
                     // hide the resolved method.
+                    Debug.Assert(boundConversion.SymbolOpt is not null);
                     return CreateBoundMethodGroupSingleMethodOperation((BoundMethodGroup)boundConversion.Operand,
                                                                        boundConversion.SymbolOpt,
                                                                        boundConversion.SuppressVirtualCalls);
@@ -179,7 +176,6 @@ namespace Microsoft.CodeAnalysis.Operations
             }
         }
 
-#nullable enable
         internal IOperation CreateMemberInitializerInitializedMember(BoundNode initializedMember)
         {
 
@@ -337,9 +333,8 @@ namespace Microsoft.CodeAnalysis.Operations
                  argsToParamsOpt: argumentsToParametersOpt,
                  invokedAsExtensionMethod: invokedAsExtensionMethod);
         }
-#nullable disable
 
-        internal static ImmutableArray<BoundNode> CreateInvalidChildrenFromArgumentsExpression(BoundNode receiverOpt, ImmutableArray<BoundExpression> arguments, BoundExpression additionalNodeOpt = null)
+        internal static ImmutableArray<BoundNode> CreateInvalidChildrenFromArgumentsExpression(BoundNode? receiverOpt, ImmutableArray<BoundExpression> arguments, BoundExpression? additionalNodeOpt = null)
         {
             var builder = ArrayBuilder<BoundNode>.GetInstance();
 
@@ -359,7 +354,6 @@ namespace Microsoft.CodeAnalysis.Operations
             return builder.ToImmutableAndFree();
         }
 
-#nullable enable
         internal ImmutableArray<IOperation> GetAnonymousObjectCreationInitializers(
             ImmutableArray<BoundExpression> arguments,
             ImmutableArray<BoundAnonymousPropertyDeclaration> declarations,

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ICoalesceAssignmentOperation.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
@@ -219,7 +220,7 @@ ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: dynamic) (
         [Fact]
         public void CoalesceAssignment_NullValueAndTarget()
         {
-            string source = @"
+            var comp = CreateCompilation(@"
 class C
 {
     static void M()
@@ -227,7 +228,7 @@ class C
         /*<bind>*/??=/*</bind>*/;
     }
 }
-";
+");
             string expectedOperationTree = @"
 ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInvalid) (Syntax: '/*<bind>*/? ... /*</bind>*/')
   Target: 
@@ -246,7 +247,60 @@ ICoalesceAssignmentOperation (OperationKind.CoalesceAssignment, Type: ?, IsInval
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(6, 33)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(comp, expectedOperationTree, expectedDiagnostics);
+
+            var tree = comp.SyntaxTrees[0];
+            var m = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+            VerifyFlowGraph(comp, m, @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1}
+.locals {R1}
+{
+    CaptureIds: [0]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (1)
+            IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '')
+              Value: 
+                IInvalidOperation (OperationKind.Invalid, Type: null) (Syntax: '')
+                  Children(0)
+        Next (Regular) Block[B2]
+            Entering: {R2}
+    .locals {R2}
+    {
+        CaptureIds: [1]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '')
+                  Value: 
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: null, IsImplicit) (Syntax: '')
+            Jump if True (Regular) to Block[B3]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: '')
+                  Operand: 
+                    IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: null, IsImplicit) (Syntax: '')
+                Leaving: {R2}
+            Next (Regular) Block[B4]
+                Leaving: {R2} {R1}
+    }
+    Block[B3] - Block
+        Predecessors: [B2]
+        Statements (1)
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?, IsInvalid, IsImplicit) (Syntax: '/*<bind>*/? ... /*</bind>*/')
+              Left: 
+                IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: null, IsImplicit) (Syntax: '')
+              Right: 
+                IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: '')
+                  Children(0)
+        Next (Regular) Block[B4]
+            Leaving: {R1}
+}
+Block[B4] - Exit
+    Predecessors: [B2] [B3]
+    Statements (0)
+");
         }
 
         [Fact, CompilerTrait(CompilerFeature.Dataflow)]

--- a/src/Compilers/Core/Portable/Operations/ArgumentKind.cs
+++ b/src/Compilers/Core/Portable/Operations/ArgumentKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/BasicBlock.cs
+++ b/src/Compilers/Core/Portable/Operations/BasicBlock.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 
@@ -23,14 +21,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         private bool _predecessorsAreSealed;
 #endif
 
-        private ControlFlowBranch _lazySuccessor;
-        private ControlFlowBranch _lazyConditionalSuccessor;
+        private ControlFlowBranch? _lazySuccessor;
+        private ControlFlowBranch? _lazyConditionalSuccessor;
         private ImmutableArray<ControlFlowBranch> _lazyPredecessors;
 
         internal BasicBlock(
             BasicBlockKind kind,
             ImmutableArray<IOperation> operations,
-            IOperation branchValue,
+            IOperation? branchValue,
             ControlFlowConditionKind conditionKind,
             int ordinal,
             bool isReachable,
@@ -62,7 +60,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// For non-conditional branches, this value is used to represent the return or throw value associated
         /// with the <see cref="FallThroughSuccessor"/>.
         /// </summary>
-        public IOperation BranchValue { get; }
+        public IOperation? BranchValue { get; }
 
         /// <summary>
         /// Indicates the condition kind for the branch out of the basic block.
@@ -73,7 +71,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// Optional fall through branch executed at the end of the basic block.
         /// This branch is null for exit block, and non-null for all other basic blocks.
         /// </summary>
-        public ControlFlowBranch FallThroughSuccessor
+        public ControlFlowBranch? FallThroughSuccessor
         {
             get
             {
@@ -90,7 +88,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// If non-null, this branch may be taken at the end of the basic block based
         /// on the <see cref="ConditionKind"/> and <see cref="BranchValue"/>.
         /// </summary>
-        public ControlFlowBranch ConditionalSuccessor
+        public ControlFlowBranch? ConditionalSuccessor
         {
             get
             {
@@ -133,7 +131,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// </summary>
         public ControlFlowRegion EnclosingRegion { get; }
 
-        internal void SetSuccessors(ControlFlowBranch successor, ControlFlowBranch conditionalSuccessor)
+        internal void SetSuccessors(ControlFlowBranch? successor, ControlFlowBranch? conditionalSuccessor)
         {
 #if DEBUG
             Debug.Assert(!_successorsAreSealed);

--- a/src/Compilers/Core/Portable/Operations/BinaryOperatorKind.cs
+++ b/src/Compilers/Core/Portable/Operations/BinaryOperatorKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/BranchKind.cs
+++ b/src/Compilers/Core/Portable/Operations/BranchKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/CaseKind.cs
+++ b/src/Compilers/Core/Portable/Operations/CaseKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/CommonConversion.cs
+++ b/src/Compilers/Core/Portable/Operations/CommonConversion.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.Operations
 {
@@ -30,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private readonly ConversionKind _conversionKind;
 
-        internal CommonConversion(bool exists, bool isIdentity, bool isNumeric, bool isReference, bool isImplicit, bool isNullable, IMethodSymbol methodSymbol)
+        internal CommonConversion(bool exists, bool isIdentity, bool isNumeric, bool isReference, bool isImplicit, bool isNullable, IMethodSymbol? methodSymbol)
         {
             _conversionKind = (exists ? ConversionKind.Exists : ConversionKind.None) |
                               (isIdentity ? ConversionKind.IsIdentity : ConversionKind.None) |
@@ -72,11 +71,12 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <summary>
         /// Returns true if the conversion is a user-defined conversion.
         /// </summary>
+        [MemberNotNullWhen(true, nameof(MethodSymbol))]
         public bool IsUserDefined => MethodSymbol != null;
         /// <summary>
         /// Returns the method used to perform the conversion for a user-defined conversion if <see cref="IsUserDefined"/> is true.
         /// Otherwise, returns null.
         /// </summary>
-        public IMethodSymbol MethodSymbol { get; }
+        public IMethodSymbol? MethodSymbol { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowBranch.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowBranch.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -23,7 +21,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
         internal ControlFlowBranch(
             BasicBlock source,
-            BasicBlock destination,
+            BasicBlock? destination,
             ControlFlowBranchSemantics semantics,
             bool isConditionalSuccessor)
         {
@@ -41,7 +39,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Destination basic block of this branch.
         /// </summary>
-        public BasicBlock Destination { get; }
+        public BasicBlock? Destination { get; }
 
         /// <summary>
         /// Semantics associated with this branch (such as "regular", "return", "throw", etc).
@@ -88,6 +86,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             while (!source.ContainsBlock(destinationOrdinal))
             {
                 Debug.Assert(source.Kind != ControlFlowRegionKind.Root);
+                Debug.Assert(source.EnclosingRegion != null);
                 builder.Add(source);
                 source = source.EnclosingRegion;
             }
@@ -135,7 +134,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             {
                 if (_lazyFinallyRegions.IsDefault)
                 {
-                    ArrayBuilder<ControlFlowRegion> builder = null;
+                    ArrayBuilder<ControlFlowRegion>? builder = null;
                     ImmutableArray<ControlFlowRegion> leavingRegions = LeavingRegions;
                     int stopAt = leavingRegions.Length - 1;
                     for (int i = 0; i < stopAt; i++)

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Operations;
@@ -25,12 +24,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
     {
         private readonly ControlFlowGraphBuilder.CaptureIdDispenser _captureIdDispenser;
         private readonly ImmutableDictionary<IMethodSymbol, (ControlFlowRegion region, ILocalFunctionOperation operation, int ordinal)> _localFunctionsMap;
-        private ControlFlowGraph[] _lazyLocalFunctionsGraphs;
+        private ControlFlowGraph?[]? _lazyLocalFunctionsGraphs;
         private readonly ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)> _anonymousFunctionsMap;
-        private ControlFlowGraph[] _lazyAnonymousFunctionsGraphs;
+        private ControlFlowGraph?[]? _lazyAnonymousFunctionsGraphs;
 
         internal ControlFlowGraph(IOperation originalOperation,
-                                  ControlFlowGraph parent,
+                                  ControlFlowGraph? parent,
                                   ControlFlowGraphBuilder.CaptureIdDispenser captureIdDispenser,
                                   ImmutableArray<BasicBlock> blocks, ControlFlowRegion root,
                                   ImmutableArray<IMethodSymbol> localFunctions,
@@ -80,7 +79,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// Returns null if <see cref="SemanticModel.GetOperation(SyntaxNode, CancellationToken)"/> returns null for the given <paramref name="node"/> and <paramref name="semanticModel"/>.
         /// Otherwise, returns a <see cref="ControlFlowGraph"/> for the executable code block.
         /// </returns>
-        public static ControlFlowGraph Create(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken = default)
+        public static ControlFlowGraph? Create(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken = default)
         {
             if (node == null)
             {
@@ -92,7 +91,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 throw new ArgumentNullException(nameof(semanticModel));
             }
 
-            IOperation operation = semanticModel.GetOperation(node, cancellationToken);
+            IOperation? operation = semanticModel.GetOperation(node, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             return operation == null ? null : CreateCore(operation, nameof(operation), cancellationToken);
         }
@@ -205,7 +204,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// Non-null for a control flow graph generated for a local function or a lambda.
         /// Null otherwise.
         /// </summary>
-        public ControlFlowGraph Parent { get; }
+        public ControlFlowGraph? Parent { get; }
 
         /// <summary>
         /// Basic blocks for the control flow graph.
@@ -242,7 +241,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             return controlFlowGraph;
         }
 
-        internal bool TryGetLocalFunctionControlFlowGraph(IMethodSymbol localFunction, CancellationToken cancellationToken, out ControlFlowGraph controlFlowGraph)
+        internal bool TryGetLocalFunctionControlFlowGraph(IMethodSymbol localFunction, CancellationToken cancellationToken, [NotNullWhen(true)] out ControlFlowGraph? controlFlowGraph)
         {
             if (!_localFunctionsMap.TryGetValue(localFunction, out (ControlFlowRegion enclosing, ILocalFunctionOperation operation, int ordinal) info))
             {
@@ -266,7 +265,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 
             controlFlowGraph = _lazyLocalFunctionsGraphs[info.ordinal];
-            Debug.Assert(controlFlowGraph.Parent == this);
+            Debug.Assert(controlFlowGraph!.Parent == this);
             return true;
         }
 
@@ -282,7 +281,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 throw new ArgumentNullException(nameof(anonymousFunction));
             }
 
-            if (!TryGetAnonymousFunctionControlFlowGraph(anonymousFunction, cancellationToken, out ControlFlowGraph controlFlowGraph))
+            if (!TryGetAnonymousFunctionControlFlowGraph(anonymousFunction, cancellationToken, out ControlFlowGraph? controlFlowGraph))
             {
                 throw new ArgumentOutOfRangeException(nameof(anonymousFunction));
             }
@@ -290,7 +289,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             return controlFlowGraph;
         }
 
-        internal bool TryGetAnonymousFunctionControlFlowGraph(IFlowAnonymousFunctionOperation anonymousFunction, CancellationToken cancellationToken, out ControlFlowGraph controlFlowGraph)
+        internal bool TryGetAnonymousFunctionControlFlowGraph(IFlowAnonymousFunctionOperation anonymousFunction, CancellationToken cancellationToken, [NotNullWhen(true)] out ControlFlowGraph? controlFlowGraph)
         {
             if (!_anonymousFunctionsMap.TryGetValue(anonymousFunction, out (ControlFlowRegion enclosing, int ordinal) info))
             {
@@ -312,7 +311,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 
             controlFlowGraph = _lazyAnonymousFunctionsGraphs[info.ordinal];
-            Debug.Assert(controlFlowGraph.Parent == this);
+            Debug.Assert(controlFlowGraph!.Parent == this);
             return true;
         }
     }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
@@ -256,16 +256,17 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 Interlocked.CompareExchange(ref _lazyLocalFunctionsGraphs, new ControlFlowGraph[LocalFunctions.Length], null);
             }
 
-            if (_lazyLocalFunctionsGraphs[info.ordinal] == null)
+            ref ControlFlowGraph? localFunctionGraph = ref _lazyLocalFunctionsGraphs[info.ordinal];
+            if (localFunctionGraph == null)
             {
                 Debug.Assert(localFunction == info.operation.Symbol);
                 ControlFlowGraph graph = ControlFlowGraphBuilder.Create(info.operation, this, info.enclosing, _captureIdDispenser);
                 Debug.Assert(graph.OriginalOperation == info.operation);
-                Interlocked.CompareExchange(ref _lazyLocalFunctionsGraphs[info.ordinal], graph, null);
+                Interlocked.CompareExchange(ref localFunctionGraph, graph, null);
             }
 
-            controlFlowGraph = _lazyLocalFunctionsGraphs[info.ordinal];
-            Debug.Assert(controlFlowGraph!.Parent == this);
+            controlFlowGraph = localFunctionGraph;
+            Debug.Assert(controlFlowGraph.Parent == this);
             return true;
         }
 
@@ -302,15 +303,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 Interlocked.CompareExchange(ref _lazyAnonymousFunctionsGraphs, new ControlFlowGraph[_anonymousFunctionsMap.Count], null);
             }
 
-            if (_lazyAnonymousFunctionsGraphs[info.ordinal] == null)
+            ref ControlFlowGraph? anonymousFlowGraph = ref _lazyAnonymousFunctionsGraphs[info.ordinal];
+            if (anonymousFlowGraph == null)
             {
                 var anonymous = (FlowAnonymousFunctionOperation)anonymousFunction;
                 ControlFlowGraph graph = ControlFlowGraphBuilder.Create(anonymous.Original, this, info.enclosing, _captureIdDispenser, in anonymous.Context);
                 Debug.Assert(graph.OriginalOperation == anonymous.Original);
-                Interlocked.CompareExchange(ref _lazyAnonymousFunctionsGraphs[info.ordinal], graph, null);
+                Interlocked.CompareExchange(ref anonymousFlowGraph, graph, null);
             }
 
-            controlFlowGraph = _lazyAnonymousFunctionsGraphs[info.ordinal];
+            controlFlowGraph = anonymousFlowGraph;
             Debug.Assert(controlFlowGraph!.Parent == this);
             return true;
         }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.BasicBlockBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.BasicBlockBuilder.cs
@@ -2,13 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -20,21 +16,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             public int Ordinal;
             public readonly BasicBlockKind Kind;
-            private ArrayBuilder<IOperation> _statements;
+            private ArrayBuilder<IOperation>? _statements;
 
             // The most common case is that we have one, or two predecessors.
             // Let's avoid allocating a HashSet for these cases.
-            private BasicBlockBuilder _predecessor1;
-            private BasicBlockBuilder _predecessor2;
-            private PooledHashSet<BasicBlockBuilder> _predecessors;
+            private BasicBlockBuilder? _predecessor1;
+            private BasicBlockBuilder? _predecessor2;
+            private PooledHashSet<BasicBlockBuilder>? _predecessors;
 
-            public IOperation BranchValue;
+            public IOperation? BranchValue;
             public ControlFlowConditionKind ConditionKind;
             public Branch Conditional;
             public Branch FallThrough;
 
             public bool IsReachable;
-            public ControlFlowRegion Region;
+            public ControlFlowRegion? Region;
 
             public BasicBlockBuilder(BasicBlockKind kind)
             {
@@ -43,9 +39,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 IsReachable = false;
             }
 
+            [MemberNotNullWhen(true, nameof(StatementsOpt))]
+#pragma warning disable CS8775
             public bool HasStatements => _statements?.Count > 0;
+#pragma warning restore
 
-            public ArrayBuilder<IOperation> StatementsOpt => _statements;
+            public ArrayBuilder<IOperation>? StatementsOpt => _statements;
 
             public void AddStatement(IOperation operation)
             {
@@ -79,6 +78,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             public BasicBlock ToImmutable()
             {
+                Debug.Assert(Region != null);
                 var block = new BasicBlock(Kind,
                                            _statements?.ToImmutableAndFree() ?? ImmutableArray<IOperation>.Empty,
                                            BranchValue,
@@ -107,6 +107,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 }
             }
 
+            [MemberNotNullWhen(true, nameof(BranchValue))]
             public bool HasCondition
             {
                 get
@@ -117,7 +118,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 }
             }
 
-            public BasicBlockBuilder GetSingletonPredecessorOrDefault()
+            public BasicBlockBuilder? GetSingletonPredecessorOrDefault()
             {
                 if (_predecessors != null)
                 {
@@ -288,6 +289,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 void addBranches(BasicBlockBuilder predecessorBlockBuilder)
                 {
                     BasicBlock predecessor = blocks[predecessorBlockBuilder.Ordinal];
+                    Debug.Assert(predecessor.FallThroughSuccessor != null);
                     if (predecessor.FallThroughSuccessor.Destination == block)
                     {
                         branches.Add(predecessor.FallThroughSuccessor);
@@ -314,7 +316,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             internal struct Branch
             {
                 public ControlFlowBranchSemantics Kind { get; set; }
-                public BasicBlockBuilder Destination { get; set; }
+                public BasicBlockBuilder? Destination { get; set; }
             }
         }
     }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.CaptureIdDispenser.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.CaptureIdDispenser.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.Context.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.Context.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -19,11 +17,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// </summary>
         internal struct Context
         {
-            public readonly IOperation ImplicitInstance;
-            public readonly INamedTypeSymbol AnonymousType;
+            public readonly IOperation? ImplicitInstance;
+            public readonly INamedTypeSymbol? AnonymousType;
             public readonly ImmutableArray<KeyValuePair<IPropertySymbol, IOperation>> AnonymousTypePropertyValues;
 
-            internal Context(IOperation implicitInstance, INamedTypeSymbol anonymousType, ImmutableArray<KeyValuePair<IPropertySymbol, IOperation>> anonymousTypePropertyValues)
+            internal Context(IOperation? implicitInstance, INamedTypeSymbol? anonymousType, ImmutableArray<KeyValuePair<IPropertySymbol, IOperation>> anonymousTypePropertyValues)
             {
                 Debug.Assert(!anonymousTypePropertyValues.IsDefault);
                 Debug.Assert(implicitInstance == null || anonymousType == null);

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 get
                 {
                     Debug.Assert((FirstBlock == null) == (LastBlock == null));
-#pragma warning disable CS8775
+#pragma warning disable CS8775 // LastBlock is null when exiting, verified equivalent to FirstBlock above
                     return FirstBlock == null;
 #pragma warning restore CS8775
                 }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
 {
@@ -18,20 +15,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         private class RegionBuilder
         {
             public ControlFlowRegionKind Kind;
-            public RegionBuilder Enclosing { get; private set; } = null;
-            public readonly ITypeSymbol ExceptionType;
-            public BasicBlockBuilder FirstBlock = null;
-            public BasicBlockBuilder LastBlock = null;
-            public ArrayBuilder<RegionBuilder> Regions = null;
+            public RegionBuilder? Enclosing { get; private set; } = null;
+            public readonly ITypeSymbol? ExceptionType;
+            public BasicBlockBuilder? FirstBlock = null;
+            public BasicBlockBuilder? LastBlock = null;
+            public ArrayBuilder<RegionBuilder>? Regions = null;
             public ImmutableArray<ILocalSymbol> Locals;
-            public ArrayBuilder<(IMethodSymbol, ILocalFunctionOperation)> LocalFunctions = null;
-            public ArrayBuilder<CaptureId> CaptureIds = null;
+            public ArrayBuilder<(IMethodSymbol, ILocalFunctionOperation)>? LocalFunctions = null;
+            public ArrayBuilder<CaptureId>? CaptureIds = null;
             public readonly bool IsStackSpillRegion;
 #if DEBUG
             private bool _aboutToFree = false;
 #endif 
 
-            public RegionBuilder(ControlFlowRegionKind kind, ITypeSymbol exceptionType = null, ImmutableArray<ILocalSymbol> locals = default, bool isStackSpillRegion = false)
+            public RegionBuilder(ControlFlowRegionKind kind, ITypeSymbol? exceptionType = null, ImmutableArray<ILocalSymbol> locals = default, bool isStackSpillRegion = false)
             {
                 Debug.Assert(!isStackSpillRegion || (kind == ControlFlowRegionKind.LocalLifetime && locals.IsDefaultOrEmpty));
                 Kind = kind;
@@ -40,15 +37,30 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 IsStackSpillRegion = isStackSpillRegion;
             }
 
-            public bool IsEmpty => FirstBlock == null;
+            [MemberNotNullWhen(false, nameof(FirstBlock), nameof(LastBlock))]
+            public bool IsEmpty
+            {
+                get
+                {
+                    Debug.Assert((FirstBlock == null) == (LastBlock == null));
+#pragma warning disable CS8775
+                    return FirstBlock == null;
+#pragma warning restore CS8775
+                }
+            }
+
+            [MemberNotNullWhen(true, nameof(Regions))]
             public bool HasRegions => Regions?.Count > 0;
+            [MemberNotNullWhen(true, nameof(LocalFunctions))]
             public bool HasLocalFunctions => LocalFunctions?.Count > 0;
+            [MemberNotNullWhen(true, nameof(CaptureIds))]
             public bool HasCaptureIds => CaptureIds?.Count > 0;
 
 #if DEBUG
             public void AboutToFree() => _aboutToFree = true;
 #endif
 
+            [MemberNotNull(nameof(CaptureIds))]
             public void AddCaptureId(int captureId)
             {
                 Debug.Assert(Kind != ControlFlowRegionKind.Root);
@@ -61,7 +73,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 CaptureIds.Add(new CaptureId(captureId));
             }
 
-            public void AddCaptureIds(ArrayBuilder<CaptureId> others)
+            public void AddCaptureIds(ArrayBuilder<CaptureId>? others)
             {
                 Debug.Assert(Kind != ControlFlowRegionKind.Root);
 
@@ -78,6 +90,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 CaptureIds.AddRange(others);
             }
 
+            [MemberNotNull(nameof(LocalFunctions))]
             public void Add(IMethodSymbol symbol, ILocalFunctionOperation operation)
             {
                 Debug.Assert(!IsStackSpillRegion);
@@ -92,7 +105,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 LocalFunctions.Add((symbol, operation));
             }
 
-            public void AddRange(ArrayBuilder<(IMethodSymbol, ILocalFunctionOperation)> others)
+            public void AddRange(ArrayBuilder<(IMethodSymbol, ILocalFunctionOperation)>? others)
             {
                 Debug.Assert(Kind != ControlFlowRegionKind.Root);
 
@@ -111,6 +124,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 LocalFunctions.AddRange(others);
             }
 
+            [MemberNotNull(nameof(Regions))]
             public void Add(RegionBuilder region)
             {
                 if (Regions == null)
@@ -169,6 +183,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             public void Remove(RegionBuilder region)
             {
                 Debug.Assert(region.Enclosing == this);
+                Debug.Assert(Regions != null);
 
                 if (Regions.Count == 1)
                 {
@@ -186,8 +201,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             public void ReplaceRegion(RegionBuilder toReplace, ArrayBuilder<RegionBuilder> replaceWith)
             {
                 Debug.Assert(toReplace.Enclosing == this);
-                Debug.Assert(toReplace.FirstBlock.Ordinal <= replaceWith.First().FirstBlock.Ordinal);
-                Debug.Assert(toReplace.LastBlock.Ordinal >= replaceWith.Last().LastBlock.Ordinal);
+                Debug.Assert(toReplace.FirstBlock!.Ordinal <= replaceWith.First().FirstBlock!.Ordinal);
+                Debug.Assert(toReplace.LastBlock!.Ordinal >= replaceWith.Last().LastBlock!.Ordinal);
+                Debug.Assert(Regions != null);
 
                 int insertAt;
 
@@ -228,13 +244,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 toReplace.Enclosing = null;
             }
 
+            [MemberNotNull(nameof(FirstBlock), nameof(LastBlock))]
             public void ExtendToInclude(BasicBlockBuilder block)
             {
                 Debug.Assert(block != null);
                 Debug.Assert((Kind != ControlFlowRegionKind.FilterAndHandler &&
                               Kind != ControlFlowRegionKind.TryAndCatch &&
                               Kind != ControlFlowRegionKind.TryAndFinally) ||
-                              Regions.Last().LastBlock == block);
+                              Regions!.Last().LastBlock == block);
 
                 if (FirstBlock == null)
                 {
@@ -248,12 +265,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     }
 
                     FirstBlock = Regions.First().FirstBlock;
+                    Debug.Assert(FirstBlock != null);
                     Debug.Assert(Regions.Count == 1 && Regions.First().LastBlock == block);
                 }
                 else
                 {
-                    Debug.Assert(LastBlock.Ordinal < block.Ordinal);
-                    Debug.Assert(!HasRegions || Regions.Last().LastBlock.Ordinal <= block.Ordinal);
+                    Debug.Assert(LastBlock!.Ordinal < block.Ordinal);
+                    Debug.Assert(!HasRegions || Regions.Last().LastBlock!.Ordinal <= block.Ordinal);
                 }
 
                 LastBlock = block;
@@ -278,8 +296,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             public ControlFlowRegion ToImmutableRegionAndFree(ArrayBuilder<BasicBlockBuilder> blocks,
                                                               ArrayBuilder<IMethodSymbol> localFunctions,
                                                               ImmutableDictionary<IMethodSymbol, (ControlFlowRegion region, ILocalFunctionOperation operation, int ordinal)>.Builder localFunctionsMap,
-                                                              ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)>.Builder anonymousFunctionsMapOpt,
-                                                              ControlFlowRegion enclosing)
+                                                              ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)>.Builder? anonymousFunctionsMapOpt,
+                                                              ControlFlowRegion? enclosing)
             {
 #if DEBUG
                 Debug.Assert(!_aboutToFree);
@@ -382,7 +400,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             {
                 public static readonly AnonymousFunctionsMapBuilder Instance = new AnonymousFunctionsMapBuilder();
 
-                public override IOperation VisitFlowAnonymousFunction(
+                public override IOperation? VisitFlowAnonymousFunction(
                     IFlowAnonymousFunctionOperation operation,
                     (ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)>.Builder map, ControlFlowRegion region) argument)
                 {
@@ -390,12 +408,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     return base.VisitFlowAnonymousFunction(operation, argument);
                 }
 
-                internal override IOperation VisitNoneOperation(IOperation operation, (ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)>.Builder map, ControlFlowRegion region) argument)
+                internal override IOperation? VisitNoneOperation(IOperation operation, (ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)>.Builder map, ControlFlowRegion region) argument)
                 {
                     return DefaultVisit(operation, argument);
                 }
 
-                public override IOperation DefaultVisit(
+                public override IOperation? DefaultVisit(
                     IOperation operation,
                     (ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)>.Builder map, ControlFlowRegion region) argument)
                 {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
 
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -21,21 +21,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         private readonly BasicBlockBuilder _entry = new BasicBlockBuilder(BasicBlockKind.Entry);
         private readonly BasicBlockBuilder _exit = new BasicBlockBuilder(BasicBlockKind.Exit);
 
-        private ArrayBuilder<BasicBlockBuilder> _blocks;
-        private PooledDictionary<BasicBlockBuilder, RegionBuilder> _regionMap;
-        private BasicBlockBuilder _currentBasicBlock;
-        private RegionBuilder _currentRegion;
-        private PooledDictionary<ILabelSymbol, BasicBlockBuilder> _labeledBlocks;
+        private readonly ArrayBuilder<BasicBlockBuilder> _blocks;
+        private readonly PooledDictionary<BasicBlockBuilder, RegionBuilder> _regionMap;
+        private BasicBlockBuilder? _currentBasicBlock;
+        private RegionBuilder? _currentRegion;
+        private PooledDictionary<ILabelSymbol, BasicBlockBuilder>? _labeledBlocks;
         private bool _haveAnonymousFunction;
 
-        private IOperation _currentStatement;
-        private ArrayBuilder<(EvalStackFrame frameOpt, IOperation operationOpt)> _evalStack;
+        private IOperation? _currentStatement;
+        private readonly ArrayBuilder<(EvalStackFrame? frameOpt, IOperation? operationOpt)> _evalStack;
         private int _startSpillingAt;
-        private IOperation _currentConditionalAccessInstance;
-        private IOperation _currentSwitchOperationExpression;
-        private IOperation _forToLoopBinaryOperatorLeftOperand;
-        private IOperation _forToLoopBinaryOperatorRightOperand;
-        private IOperation _currentAggregationGroup;
+        private IOperation? _currentConditionalAccessInstance;
+        private IOperation? _currentSwitchOperationExpression;
+        private IOperation? _forToLoopBinaryOperatorLeftOperand;
+        private IOperation? _forToLoopBinaryOperatorRightOperand;
+        private IOperation? _currentAggregationGroup;
         private bool _forceImplicit; // Force all rewritten nodes to be marked as implicit regardless of their original state.
 
         private readonly CaptureIdDispenser _captureIdDispenser;
@@ -47,11 +47,23 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// </summary>
         private ImplicitInstanceInfo _currentImplicitInstance;
 
-        private ControlFlowGraphBuilder(Compilation compilation, CaptureIdDispenser captureIdDispenser)
+        private ControlFlowGraphBuilder(Compilation compilation, CaptureIdDispenser? captureIdDispenser, ArrayBuilder<BasicBlockBuilder> blocks)
         {
             Debug.Assert(compilation != null);
             _compilation = compilation;
             _captureIdDispenser = captureIdDispenser ?? new CaptureIdDispenser();
+            _blocks = blocks;
+            _regionMap = PooledDictionary<BasicBlockBuilder, RegionBuilder>.GetInstance();
+            _evalStack = ArrayBuilder<(EvalStackFrame? frameOpt, IOperation? operationOpt)>.GetInstance();
+        }
+
+        private RegionBuilder CurrentRegionRequired
+        {
+            get
+            {
+                Debug.Assert(_currentRegion != null);
+                return _currentRegion;
+            }
         }
 
         private bool IsImplicit(IOperation operation)
@@ -59,7 +71,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             return _forceImplicit || operation.IsImplicit;
         }
 
-        public static ControlFlowGraph Create(IOperation body, ControlFlowGraph parent = null, ControlFlowRegion enclosing = null, CaptureIdDispenser captureIdDispenser = null, in Context context = default)
+        public static ControlFlowGraph Create(IOperation body, ControlFlowGraph? parent = null, ControlFlowRegion? enclosing = null, CaptureIdDispenser? captureIdDispenser = null, in Context context = default)
         {
             Debug.Assert(body != null);
             Debug.Assert(((Operation)body).OwningSemanticModel != null);
@@ -84,11 +96,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 #endif
 
-            var builder = new ControlFlowGraphBuilder(((Operation)body).OwningSemanticModel.Compilation, captureIdDispenser);
             var blocks = ArrayBuilder<BasicBlockBuilder>.GetInstance();
-            builder._blocks = blocks;
-            builder._evalStack = ArrayBuilder<(EvalStackFrame frameOpt, IOperation operationOpt)>.GetInstance();
-            builder._regionMap = PooledDictionary<BasicBlockBuilder, RegionBuilder>.GetInstance();
+            var builder = new ControlFlowGraphBuilder(((Operation)body).OwningSemanticModel!.Compilation, captureIdDispenser, blocks);
 
             var root = new RegionBuilder(ControlFlowRegionKind.Root);
             builder.EnterRegion(root);
@@ -125,7 +134,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             Pack(blocks, root, builder._regionMap);
             var localFunctions = ArrayBuilder<IMethodSymbol>.GetInstance();
             var localFunctionsMap = ImmutableDictionary.CreateBuilder<IMethodSymbol, (ControlFlowRegion, ILocalFunctionOperation, int)>();
-            ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion, int)>.Builder anonymousFunctionsMapOpt = null;
+            ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion, int)>.Builder? anonymousFunctionsMapOpt = null;
 
             if (builder._haveAnonymousFunction)
             {
@@ -160,8 +169,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             //         update the branch information for the created basic blocks.
             foreach (BasicBlockBuilder blockBuilder in blockBuilders)
             {
-                ControlFlowBranch successor = getFallThroughSuccessor(blockBuilder);
-                ControlFlowBranch conditionalSuccessor = getConditionalSuccessor(blockBuilder);
+                ControlFlowBranch? successor = getFallThroughSuccessor(blockBuilder);
+                ControlFlowBranch? conditionalSuccessor = getConditionalSuccessor(blockBuilder);
                 builder[blockBuilder.Ordinal].SetSuccessors(successor, conditionalSuccessor);
             }
 
@@ -173,14 +182,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             return builder.ToImmutableAndFree();
 
-            ControlFlowBranch getFallThroughSuccessor(BasicBlockBuilder blockBuilder)
+            ControlFlowBranch? getFallThroughSuccessor(BasicBlockBuilder blockBuilder)
             {
                 return blockBuilder.Kind != BasicBlockKind.Exit ?
                            getBranch(in blockBuilder.FallThrough, blockBuilder, isConditionalSuccessor: false) :
                            null;
             }
 
-            ControlFlowBranch getConditionalSuccessor(BasicBlockBuilder blockBuilder)
+            ControlFlowBranch? getConditionalSuccessor(BasicBlockBuilder blockBuilder)
             {
                 return blockBuilder.HasCondition ?
                            getBranch(in blockBuilder.Conditional, blockBuilder, isConditionalSuccessor: true) :
@@ -217,7 +226,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             ArrayBuilder<BasicBlockBuilder> blocks,
             int firstBlockOrdinal,
             int lastBlockOrdinal,
-            ArrayBuilder<BasicBlockBuilder> outOfRangeBlocksToVisit,
+            ArrayBuilder<BasicBlockBuilder>? outOfRangeBlocksToVisit,
             PooledDictionary<ControlFlowRegion, bool> continueDispatchAfterFinally,
             PooledHashSet<ControlFlowRegion> dispatchedExceptionsFromRegions,
             out bool fellThrough)
@@ -234,6 +243,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
                 if (current.Ordinal < firstBlockOrdinal || current.Ordinal > lastBlockOrdinal)
                 {
+                    Debug.Assert(outOfRangeBlocksToVisit != null);
                     outOfRangeBlocksToVisit.Push(current);
                     continue;
                 }
@@ -278,6 +288,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 // If try block is reachable, we should dispatch an exception from it, even if it is empty.
                 // To simplify implementation, we dispatch exception from every reachable basic block and rely
                 // on dispatchedExceptionsFromRegions cache to avoid doing duplicate work.
+                Debug.Assert(current.Region != null);
                 dispatchException(current.Region);
             }
             while (toVisit.Count != 0);
@@ -301,6 +312,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     case ControlFlowBranchSemantics.Regular:
                     case ControlFlowBranchSemantics.Return:
                         Debug.Assert(branch.Destination != null);
+                        Debug.Assert(current.Region != null);
 
                         if (stepThroughFinally(current.Region, branch.Destination))
                         {
@@ -321,6 +333,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 while (!region.ContainsBlock(destinationOrdinal))
                 {
                     Debug.Assert(region.Kind != ControlFlowRegionKind.Root);
+                    Debug.Assert(region.EnclosingRegion != null);
                     ControlFlowRegion enclosing = region.EnclosingRegion;
                     if (region.Kind == ControlFlowRegionKind.Try && enclosing.Kind == ControlFlowRegionKind.TryAndFinally)
                     {
@@ -368,7 +381,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 return continueDispatch;
             }
 
-            void dispatchException(ControlFlowRegion fromRegion)
+            void dispatchException([DisallowNull] ControlFlowRegion? fromRegion)
             {
                 do
                 {
@@ -377,10 +390,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                         return;
                     }
 
-                    ControlFlowRegion enclosing = fromRegion.Kind == ControlFlowRegionKind.Root ? null : fromRegion.EnclosingRegion;
+                    ControlFlowRegion? enclosing = fromRegion.Kind == ControlFlowRegionKind.Root ? null : fromRegion.EnclosingRegion;
                     if (fromRegion.Kind == ControlFlowRegionKind.Try)
                     {
-                        switch (enclosing.Kind)
+                        switch (enclosing!.Kind)
                         {
                             case ControlFlowRegionKind.TryAndFinally:
                                 Debug.Assert(enclosing.NestedRegions[0] == fromRegion);
@@ -404,7 +417,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     else if (fromRegion.Kind == ControlFlowRegionKind.Filter)
                     {
                         // If filter throws, dispatch is resumed at the next catch with an original exception
-                        Debug.Assert(enclosing.Kind == ControlFlowRegionKind.FilterAndHandler);
+                        Debug.Assert(enclosing!.Kind == ControlFlowRegionKind.FilterAndHandler);
+                        Debug.Assert(enclosing.EnclosingRegion != null);
                         ControlFlowRegion tryAndCatch = enclosing.EnclosingRegion;
                         Debug.Assert(tryAndCatch.Kind == ControlFlowRegionKind.TryAndCatch);
 
@@ -545,6 +559,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                 if (subRegion.Kind == ControlFlowRegionKind.LocalLifetime && !subRegion.HasLocalFunctions &&
                                     !subRegion.HasRegions && subRegion.FirstBlock == subRegion.LastBlock)
                                 {
+                                    Debug.Assert(subRegion.FirstBlock != null);
                                     BasicBlockBuilder block = subRegion.FirstBlock;
 
                                     if (!block.HasStatements && block.BranchValue == null)
@@ -585,13 +600,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         private static void MergeSubRegionAndFree(RegionBuilder subRegion, ArrayBuilder<BasicBlockBuilder> blocks, PooledDictionary<BasicBlockBuilder, RegionBuilder> regionMap, bool canHaveEmptyRegion = false)
         {
             Debug.Assert(subRegion.Kind != ControlFlowRegionKind.Root);
+            Debug.Assert(subRegion.Enclosing != null);
             RegionBuilder enclosing = subRegion.Enclosing;
 
 #if DEBUG
             subRegion.AboutToFree();
 #endif
 
-            if (subRegion.FirstBlock is null)
+            if (subRegion.IsEmpty)
             {
                 Debug.Assert(canHaveEmptyRegion);
                 Debug.Assert(!subRegion.HasRegions);
@@ -607,6 +623,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             {
                 foreach (RegionBuilder r in subRegion.Regions)
                 {
+                    Debug.Assert(!r.IsEmpty);
                     for (int i = firstBlockToMove; i < r.FirstBlock.Ordinal; i++)
                     {
                         Debug.Assert(regionMap[blocks[i]] == subRegion);
@@ -638,10 +655,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// </summary>
         private static bool PackBlocks(ArrayBuilder<BasicBlockBuilder> blocks, PooledDictionary<BasicBlockBuilder, RegionBuilder> regionMap)
         {
-            ArrayBuilder<RegionBuilder> fromCurrent = null;
-            ArrayBuilder<RegionBuilder> fromDestination = null;
-            ArrayBuilder<RegionBuilder> fromPredecessor = null;
-            ArrayBuilder<BasicBlockBuilder> predecessorsBuilder = null;
+            ArrayBuilder<RegionBuilder>? fromCurrent = null;
+            ArrayBuilder<RegionBuilder>? fromDestination = null;
+            ArrayBuilder<RegionBuilder>? fromPredecessor = null;
+            ArrayBuilder<BasicBlockBuilder>? predecessorsBuilder = null;
 
             bool anyRemoved = false;
             bool retry;
@@ -662,7 +679,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     if (block.HasStatements)
                     {
                         // See if we can move all statements to the previous block
-                        BasicBlockBuilder predecessor = block.GetSingletonPredecessorOrDefault();
+                        BasicBlockBuilder? predecessor = block.GetSingletonPredecessorOrDefault();
                         if (predecessor != null &&
                             !predecessor.HasCondition &&
                             predecessor.Ordinal < block.Ordinal &&
@@ -723,9 +740,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                 !block.HasPredecessors)
                             {
                                 // Nothing useful is happening in this finally, let's remove it
+                                Debug.Assert(currentRegion.Enclosing != null);
                                 RegionBuilder tryAndFinally = currentRegion.Enclosing;
                                 Debug.Assert(tryAndFinally.Kind == ControlFlowRegionKind.TryAndFinally);
-                                Debug.Assert(tryAndFinally.Regions.Count == 2);
+                                Debug.Assert(tryAndFinally.Regions!.Count == 2);
 
                                 RegionBuilder @try = tryAndFinally.Regions.First();
                                 Debug.Assert(@try.Kind == ControlFlowRegionKind.Try);
@@ -734,6 +752,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                 // If .try region has locals or methods or captures, let's convert it to .locals, otherwise drop it
                                 if (@try.Locals.IsEmpty && !@try.HasLocalFunctions && !@try.HasCaptureIds)
                                 {
+                                    Debug.Assert(@try.FirstBlock != null);
                                     i = @try.FirstBlock.Ordinal - 1; // restart at the first block of removed .try region
                                     MergeSubRegionAndFree(@try, blocks, regionMap);
                                 }
@@ -745,6 +764,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
                                 MergeSubRegionAndFree(currentRegion, blocks, regionMap);
 
+                                Debug.Assert(tryAndFinally.Enclosing != null);
                                 RegionBuilder tryAndFinallyEnclosing = tryAndFinally.Enclosing;
                                 MergeSubRegionAndFree(tryAndFinally, blocks, regionMap);
 
@@ -766,7 +786,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                             // It is safe to drop an unreachable empty basic block
                             if (block.HasPredecessors)
                             {
-                                BasicBlockBuilder predecessor = block.GetSingletonPredecessorOrDefault();
+                                BasicBlockBuilder? predecessor = block.GetSingletonPredecessorOrDefault();
 
                                 if (predecessor == null)
                                 {
@@ -799,9 +819,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                          next.Kind == ControlFlowBranchSemantics.ProgramTermination);
 
                             Debug.Assert(!block.HasCondition); // This is ensured by an "if" above.
-                            IOperation value = block.BranchValue;
+                            IOperation? value = block.BranchValue;
 
-                            RegionBuilder implicitEntryRegion = tryGetImplicitEntryRegion(block, currentRegion);
+                            RegionBuilder? implicitEntryRegion = tryGetImplicitEntryRegion(block, currentRegion);
 
                             if (implicitEntryRegion != null)
                             {
@@ -813,7 +833,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                     continue;
                                 }
 
-                                Debug.Assert(implicitEntryRegion.LastBlock.Ordinal >= next.Destination.Ordinal);
+                                Debug.Assert(implicitEntryRegion.LastBlock!.Ordinal >= next.Destination.Ordinal);
                             }
 
                             if (value != null)
@@ -821,6 +841,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                 if (!block.HasPredecessors && next.Kind == ControlFlowBranchSemantics.Return)
                                 {
                                     // Let's drop an unreachable compiler generated return that VB optimistically adds at the end of a method body
+                                    Debug.Assert(next.Destination != null);
                                     if (next.Destination.Kind != BasicBlockKind.Exit ||
                                         !value.IsImplicit ||
                                         value.Kind != OperationKind.LocalReference ||
@@ -831,7 +852,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                 }
                                 else
                                 {
-                                    BasicBlockBuilder predecessor = block.GetSingletonPredecessorOrDefault();
+                                    BasicBlockBuilder? predecessor = block.GetSingletonPredecessorOrDefault();
                                     if (predecessor == null ||
                                         predecessor.BranchValue != null ||
                                         predecessor.Kind == BasicBlockKind.Entry ||
@@ -849,7 +870,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                             }
 
                             // For throw/re-throw assume there is no specific destination region
-                            RegionBuilder destinationRegionOpt = next.Destination == null ? null : regionMap[next.Destination];
+                            RegionBuilder? destinationRegionOpt = next.Destination == null ? null : regionMap[next.Destination];
 
                             if (block.HasPredecessors)
                             {
@@ -918,7 +939,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                      next.Kind == ControlFlowBranchSemantics.Error ||
                                      next.Kind == ControlFlowBranchSemantics.ProgramTermination);
 
-                        BasicBlockBuilder predecessor = block.GetSingletonPredecessorOrDefault();
+                        BasicBlockBuilder? predecessor = block.GetSingletonPredecessorOrDefault();
 
                         if (predecessor == null)
                         {
@@ -948,7 +969,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                             predecessor.BranchValue = block.BranchValue;
                             predecessor.ConditionKind = block.ConditionKind;
                             predecessor.Conditional = block.Conditional;
-                            BasicBlockBuilder destination = block.Conditional.Destination;
+                            BasicBlockBuilder? destination = block.Conditional.Destination;
                             if (destination != null)
                             {
                                 destination.AddPredecessor(predecessor);
@@ -976,7 +997,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             return anyRemoved;
 
-            RegionBuilder tryGetImplicitEntryRegion(BasicBlockBuilder block, RegionBuilder currentRegion)
+            RegionBuilder? tryGetImplicitEntryRegion(BasicBlockBuilder block, [DisallowNull] RegionBuilder? currentRegion)
             {
                 do
                 {
@@ -1002,6 +1023,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             void removeBlock(BasicBlockBuilder block, RegionBuilder region)
             {
+                Debug.Assert(!region.IsEmpty);
                 Debug.Assert(region.FirstBlock.Ordinal >= 0);
                 Debug.Assert(region.FirstBlock.Ordinal <= region.LastBlock.Ordinal);
                 Debug.Assert(region.FirstBlock.Ordinal <= block.Ordinal);
@@ -1011,10 +1033,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 {
                     BasicBlockBuilder newFirst = blocks[block.Ordinal + 1];
                     region.FirstBlock = newFirst;
+                    Debug.Assert(region.Enclosing != null);
                     RegionBuilder enclosing = region.Enclosing;
                     while (enclosing != null && enclosing.FirstBlock == block)
                     {
                         enclosing.FirstBlock = newFirst;
+                        Debug.Assert(enclosing.Enclosing != null);
                         enclosing = enclosing.Enclosing;
                     }
                 }
@@ -1022,10 +1046,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 {
                     BasicBlockBuilder newLast = blocks[block.Ordinal - 1];
                     region.LastBlock = newLast;
+                    Debug.Assert(region.Enclosing != null);
                     RegionBuilder enclosing = region.Enclosing;
                     while (enclosing != null && enclosing.LastBlock == block)
                     {
                         enclosing.LastBlock = newLast;
+                        Debug.Assert(enclosing.Enclosing != null);
                         enclosing = enclosing.Enclosing;
                     }
                 }
@@ -1058,7 +1084,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 predecessorBranch.Kind = successorBranch.Kind;
             }
 
-            bool checkBranchesFromPredecessors(ArrayBuilder<BasicBlockBuilder> predecessors, RegionBuilder currentRegion, RegionBuilder destinationRegionOpt)
+            bool checkBranchesFromPredecessors(ArrayBuilder<BasicBlockBuilder> predecessors, RegionBuilder currentRegion, RegionBuilder? destinationRegionOpt)
             {
                 foreach (BasicBlockBuilder predecessor in predecessors)
                 {
@@ -1105,7 +1131,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 return true;
             }
 
-            void collectAncestorsAndSelf(RegionBuilder from, ref ArrayBuilder<RegionBuilder> builder)
+            void collectAncestorsAndSelf([DisallowNull] RegionBuilder? from, [NotNull] ref ArrayBuilder<RegionBuilder>? builder)
             {
                 if (builder == null)
                 {
@@ -1143,14 +1169,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Deal with labeled blocks that were not added to the graph because labels were never found
         /// </summary>
-        private static void CheckUnresolvedBranches(ArrayBuilder<BasicBlockBuilder> blocks, PooledDictionary<ILabelSymbol, BasicBlockBuilder> labeledBlocks)
+        private static void CheckUnresolvedBranches(ArrayBuilder<BasicBlockBuilder> blocks, PooledDictionary<ILabelSymbol, BasicBlockBuilder>? labeledBlocks)
         {
             if (labeledBlocks == null)
             {
                 return;
             }
 
-            PooledHashSet<BasicBlockBuilder> unresolved = null;
+            PooledHashSet<BasicBlockBuilder>? unresolved = null;
             foreach (BasicBlockBuilder labeled in labeledBlocks.Values)
             {
                 if (labeled.Ordinal == -1)
@@ -1190,7 +1216,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
         }
 
-        private void VisitStatement(IOperation operation)
+        private void VisitStatement(IOperation? operation)
         {
 #if DEBUG
             int stackDepth = _evalStack.Count;
@@ -1201,7 +1227,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 return;
             }
 
-            IOperation saveCurrentStatement = _currentStatement;
+            IOperation? saveCurrentStatement = _currentStatement;
             _currentStatement = operation;
 
             EvalStackFrame frame = PushStackFrame();
@@ -1228,7 +1254,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         }
 
         private void AddStatement(
-            IOperation statement
+            IOperation? statement
 #if DEBUG
             , bool spillingTheStack = false
 #endif
@@ -1251,9 +1277,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             CurrentBasicBlock.AddStatement(statement);
         }
 
+        [MemberNotNull(nameof(_currentBasicBlock))]
         private void AppendNewBlock(BasicBlockBuilder block, bool linkToPrevious = true)
         {
             Debug.Assert(block != null);
+            Debug.Assert(_currentRegion != null);
 
             if (linkToPrevious)
             {
@@ -1297,6 +1325,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         private void LeaveRegion()
         {
             // Ensure there is at least one block in the region
+            Debug.Assert(_currentRegion != null);
             if (_currentRegion.IsEmpty)
             {
                 AppendNewBlock(new BasicBlockBuilder(BasicBlockKind.Block));
@@ -1306,7 +1335,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
 #if DEBUG
             // We shouldn't be leaving regions that are still associated with stack frames
-            foreach ((EvalStackFrame frameOpt, IOperation operationOpt) in _evalStack)
+            foreach ((EvalStackFrame? frameOpt, IOperation? operationOpt) in _evalStack)
             {
                 Debug.Assert((frameOpt == null) != (operationOpt == null));
 
@@ -1317,6 +1346,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 #endif
             _currentRegion = _currentRegion.Enclosing;
+            Debug.Assert(enclosed.LastBlock != null);
             _currentRegion?.ExtendToInclude(enclosed.LastBlock);
             _currentBasicBlock = null;
         }
@@ -1336,7 +1366,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             _currentBasicBlock = null;
         }
 
-#nullable enable
         public override IOperation? VisitBlock(IBlockOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
@@ -1490,9 +1519,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 VisitStatement(expressionBody);
             }
         }
-#nullable disable
 
-        public override IOperation VisitConditional(IConditionalOperation operation, int? captureIdForResult)
+        public override IOperation? VisitConditional(IConditionalOperation operation, int? captureIdForResult)
         {
             if (operation == _currentStatement)
             {
@@ -1507,7 +1535,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     // consequence;
                     // afterif:
 
-                    BasicBlockBuilder afterIf = null;
+                    BasicBlockBuilder? afterIf = null;
                     VisitConditionalBranch(operation.Condition, ref afterIf, jumpIfTrue: false);
                     VisitStatement(operation.WhenTrue);
                     AppendNewBlock(afterIf);
@@ -1528,7 +1556,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     // alternative;
                     // afterif:
 
-                    BasicBlockBuilder whenFalse = null;
+                    BasicBlockBuilder? whenFalse = null;
                     VisitConditionalBranch(operation.Condition, ref whenFalse, jumpIfTrue: false);
 
                     VisitStatement(operation.WhenTrue);
@@ -1558,9 +1586,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 // afterif:
                 // result = capture
 
+                Debug.Assert(operation is { WhenTrue: not null, WhenFalse: not null });
+
                 SpillEvalStack();
 
-                BasicBlockBuilder whenFalse = null;
+                BasicBlockBuilder? whenFalse = null;
                 VisitConditionalBranch(operation.Condition, ref whenFalse, jumpIfTrue: false);
 
                 var afterIf = new BasicBlockBuilder(BasicBlockKind.Block);
@@ -1570,25 +1600,25 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 // capture for the result because there won't be any result from the throwing branches.
                 if (operation.WhenTrue is IConversionOperation whenTrueConversion && whenTrueConversion.Operand.Kind == OperationKind.Throw)
                 {
-                    IOperation rewrittenThrow = base.Visit(whenTrueConversion.Operand, null);
-                    Debug.Assert(rewrittenThrow.Kind == OperationKind.None);
+                    IOperation? rewrittenThrow = base.Visit(whenTrueConversion.Operand, null);
+                    Debug.Assert(rewrittenThrow!.Kind == OperationKind.None);
                     Debug.Assert(rewrittenThrow.Children.IsEmpty());
 
                     UnconditionalBranch(afterIf);
 
                     AppendNewBlock(whenFalse);
 
-                    result = Visit(operation.WhenFalse);
+                    result = VisitRequired(operation.WhenFalse);
                 }
                 else if (operation.WhenFalse is IConversionOperation whenFalseConversion && whenFalseConversion.Operand.Kind == OperationKind.Throw)
                 {
-                    result = Visit(operation.WhenTrue);
+                    result = VisitRequired(operation.WhenTrue);
 
                     UnconditionalBranch(afterIf);
 
                     AppendNewBlock(whenFalse);
 
-                    IOperation rewrittenThrow = base.Visit(whenFalseConversion.Operand, null);
+                    IOperation rewrittenThrow = BaseVisitRequired(whenFalseConversion.Operand, null);
                     Debug.Assert(rewrittenThrow.Kind == OperationKind.None);
                     Debug.Assert(rewrittenThrow.Children.IsEmpty());
                 }
@@ -1619,7 +1649,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         private void VisitAndCapture(IOperation operation, int captureId)
         {
             EvalStackFrame frame = PushStackFrame();
-            IOperation result = base.Visit(operation, captureId);
+            IOperation result = BaseVisitRequired(operation, captureId);
             PopStackFrame(frame);
             CaptureResultIfNotAlready(operation.Syntax, captureId, result);
             LeaveRegionIfAny(frame);
@@ -1628,7 +1658,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         private IOperation VisitAndCapture(IOperation operation)
         {
             EvalStackFrame frame = PushStackFrame();
-            PushOperand(base.Visit(operation, null));
+            PushOperand(BaseVisitRequired(operation, null));
             SpillEvalStack();
             return PopStackFrame(frame, PopOperand());
         }
@@ -1654,9 +1684,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// </summary>
         private class EvalStackFrame
         {
-            private RegionBuilder _lazyRegionBuilder;
+            private RegionBuilder? _lazyRegionBuilder;
 
-            public RegionBuilder RegionBuilderOpt
+            public RegionBuilder? RegionBuilderOpt
             {
                 get
                 {
@@ -1689,7 +1719,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 _startSpillingAt--;
             }
 
-            (EvalStackFrame frameOpt, IOperation operationOpt) = _evalStack.Pop();
+            (EvalStackFrame? frameOpt, IOperation? operationOpt) = _evalStack.Pop();
             Debug.Assert(frame == frameOpt);
             Debug.Assert(operationOpt == null);
 
@@ -1697,7 +1727,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             {
                 while (_currentRegion != frame.RegionBuilderOpt)
                 {
+                    Debug.Assert(_currentRegion != null);
                     RegionBuilder toMerge = _currentRegion;
+                    Debug.Assert(toMerge.Enclosing != null);
                     _currentRegion = toMerge.Enclosing;
 
                     Debug.Assert(toMerge.IsStackSpillRegion);
@@ -1708,11 +1740,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     // This region can be empty in certain error scenarios, such as `new T {}`, where T does not
                     // have a class constraint. There are no arguments or initializers, so nothing will have
                     // been put into the region at this point
-                    if (toMerge.FirstBlock is null)
-                    {
-                        Debug.Assert(toMerge.LastBlock is null);
-                    }
-                    else
+                    if (!toMerge.IsEmpty)
                     {
                         _currentRegion.ExtendToInclude(toMerge.LastBlock);
                     }
@@ -1729,12 +1757,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
         private void LeaveRegionIfAny(EvalStackFrame frame)
         {
-            RegionBuilder toLeave = frame.RegionBuilderOpt;
+            RegionBuilder? toLeave = frame.RegionBuilderOpt;
             if (toLeave != null)
             {
                 while (_currentRegion != toLeave)
                 {
-                    Debug.Assert(_currentRegion.IsStackSpillRegion);
+                    Debug.Assert(_currentRegion!.IsStackSpillRegion);
                     LeaveRegion();
                 }
 
@@ -1774,7 +1802,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             for (int i = _startSpillingAt - 1; i >= 0; i--)
             {
-                (EvalStackFrame frameOpt, _) = _evalStack[i];
+                (EvalStackFrame? frameOpt, _) = _evalStack[i];
                 if (frameOpt != null)
                 {
                     currentFrameIndex = i;
@@ -1785,7 +1813,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             for (int i = _startSpillingAt; i < _evalStack.Count; i++)
             {
-                (EvalStackFrame frameOpt, IOperation operationOpt) = _evalStack[i];
+                (EvalStackFrame? frameOpt, IOperation? operationOpt) = _evalStack[i];
                 Debug.Assert((frameOpt == null) != (operationOpt == null));
 
                 if (frameOpt != null)
@@ -1796,6 +1824,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     EnterRegion(frameOpt.RegionBuilderOpt, spillingStack: true);
                     continue;
                 }
+
+                Debug.Assert(operationOpt != null);
 
                 // Declarations cannot have control flow, so we don't need to spill them.
                 if (operationOpt.Kind != OperationKind.FlowCaptureReference
@@ -1810,7 +1840,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     // regions that no longer own captures referenced on the stack. The new capture that we create, should belong to
                     // the region that will become current after that. Here we are trying to compute what will be that region.
                     // Obviously, we shouldn’t be leaving the region associated with the frame.
-                    RegionBuilder currentSpillRegion = _evalStack[currentFrameIndex].frameOpt.RegionBuilderOpt;
+                    EvalStackFrame? currentFrame = _evalStack[currentFrameIndex].frameOpt;
+                    Debug.Assert(currentFrame != null);
+                    RegionBuilder? currentSpillRegion = currentFrame.RegionBuilderOpt;
                     Debug.Assert(currentSpillRegion != null);
 
                     if (_currentRegion != currentSpillRegion)
@@ -1819,7 +1851,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
                         for (int j = currentFrameIndex + 1; j < _evalStack.Count; j++)
                         {
-                            IOperation operation = _evalStack[j].operationOpt;
+                            IOperation? operation = _evalStack[j].operationOpt;
                             if (operation != null)
                             {
                                 if (j < i)
@@ -1839,7 +1871,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                             }
                         }
 
-                        RegionBuilder candidate = _currentRegion;
+                        RegionBuilder candidate = CurrentRegionRequired;
                         do
                         {
                             Debug.Assert(candidate.IsStackSpillRegion);
@@ -1849,6 +1881,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                                 break;
                             }
 
+                            Debug.Assert(candidate.Enclosing != null);
                             candidate = candidate.Enclosing;
                         }
                         while (candidate != currentSpillRegion);
@@ -1868,7 +1901,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
                     while (_currentRegion != currentSpillRegion)
                     {
-                        Debug.Assert(_currentRegion.IsStackSpillRegion);
+                        Debug.Assert(CurrentRegionRequired.IsStackSpillRegion);
                         LeaveRegion();
                     }
                 }
@@ -1882,7 +1915,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             for (int i = 0; i < _startSpillingAt; i++)
             {
-                (EvalStackFrame frameOpt, IOperation operationOpt) = _evalStack[i];
+                (EvalStackFrame? frameOpt, IOperation? operationOpt) = _evalStack[i];
                 if (frameOpt != null)
                 {
                     Debug.Assert(operationOpt == null);
@@ -1916,7 +1949,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 _startSpillingAt--;
             }
 
-            (EvalStackFrame frameOpt, IOperation operationOpt) = _evalStack.Pop();
+            (EvalStackFrame? frameOpt, IOperation? operationOpt) = _evalStack.Pop();
             Debug.Assert(frameOpt == null);
             Debug.Assert(operationOpt != null);
 
@@ -1927,23 +1960,23 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             Debug.Assert(_startSpillingAt <= _evalStack.Count);
 
-            (EvalStackFrame frameOpt, IOperation operationOpt) = _evalStack.Peek();
+            (EvalStackFrame? frameOpt, IOperation? operationOpt) = _evalStack.Peek();
             Debug.Assert(frameOpt == null);
             Debug.Assert(operationOpt != null);
 
             return operationOpt;
         }
 
-        private void VisitAndPushArray<T>(ImmutableArray<T> array, Func<T, IOperation> unwrapper = null) where T : IOperation
+        private void VisitAndPushArray<T>(ImmutableArray<T> array, Func<T, IOperation>? unwrapper = null) where T : IOperation
         {
             Debug.Assert(unwrapper != null || typeof(T) == typeof(IOperation));
             foreach (var element in array)
             {
-                PushOperand(Visit(unwrapper == null ? element : unwrapper(element)));
+                PushOperand(VisitRequired(unwrapper == null ? element : unwrapper(element)));
             }
         }
 
-        private ImmutableArray<T> PopArray<T>(ImmutableArray<T> originalArray, Func<IOperation, int, ImmutableArray<T>, T> wrapper = null) where T : IOperation
+        private ImmutableArray<T> PopArray<T>(ImmutableArray<T> originalArray, Func<IOperation, int, ImmutableArray<T>, T>? wrapper = null) where T : IOperation
         {
             Debug.Assert(wrapper != null || typeof(T) == typeof(IOperation));
             int numElements = originalArray.Length;
@@ -1965,7 +1998,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
         }
 
-#nullable enable
         private ImmutableArray<T> VisitArray<T>(ImmutableArray<T> originalArray, Func<T, IOperation>? unwrapper = null, Func<IOperation, int, ImmutableArray<T>, T>? wrapper = null) where T : IOperation
         {
 #if DEBUG
@@ -2004,8 +2036,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         public override IOperation VisitSimpleAssignment(ISimpleAssignmentOperation operation, int? captureIdForResult)
         {
             EvalStackFrame frame = PushStackFrame();
-            PushOperand(Visit(operation.Target));
-            IOperation value = Visit(operation.Value);
+            PushOperand(VisitRequired(operation.Target));
+            IOperation value = VisitRequired(operation.Value);
             return PopStackFrame(frame, new SimpleAssignmentOperation(operation.IsRef, PopOperand(), value, null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation)));
         }
 
@@ -2013,8 +2045,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             EvalStackFrame frame = PushStackFrame();
             var compoundAssignment = (CompoundAssignmentOperation)operation;
-            PushOperand(Visit(compoundAssignment.Target));
-            IOperation value = Visit(compoundAssignment.Value);
+            PushOperand(VisitRequired(compoundAssignment.Target));
+            IOperation value = VisitRequired(compoundAssignment.Value);
 
             return PopStackFrame(frame, new CompoundAssignmentOperation(compoundAssignment.InConversionConvertible, compoundAssignment.OutConversionConvertible, operation.OperatorKind, operation.IsLifted,
                 operation.IsChecked, operation.OperatorMethod, PopOperand(), value, semanticModel: null,
@@ -2024,7 +2056,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         public override IOperation VisitArrayElementReference(IArrayElementReferenceOperation operation, int? captureIdForResult)
         {
             EvalStackFrame frame = PushStackFrame();
-            PushOperand(Visit(operation.ArrayReference));
+            PushOperand(VisitRequired(operation.ArrayReference));
             ImmutableArray<IOperation> visitedIndices = VisitArray(operation.Indices);
             IOperation visitedArrayReference = PopOperand();
             PopStackFrame(frame);
@@ -2085,8 +2117,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 
             EvalStackFrame frame = PushStackFrame();
-            PushOperand(Visit(operation.LeftOperand));
-            IOperation rightOperand = Visit(operation.RightOperand);
+            PushOperand(VisitRequired(operation.LeftOperand));
+            IOperation rightOperand = VisitRequired(operation.RightOperand);
             return PopStackFrame(frame, new BinaryOperation(operation.OperatorKind, PopOperand(), rightOperand, operation.IsLifted, operation.IsChecked, operation.IsCompareText,
                                                             operation.OperatorMethod, ((BinaryOperation)operation).UnaryOperatorMethod, semanticModel: null,
                                                             operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation)));
@@ -2106,7 +2138,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 return VisitConditionalExpression(operation, sense: true, captureIdForResult, fallToTrueOpt: null, fallToFalseOpt: null);
             }
 
-            return new UnaryOperation(operation.OperatorKind, Visit(operation.Operand), operation.IsLifted, operation.IsChecked, operation.OperatorMethod,
+            return new UnaryOperation(operation.OperatorKind, VisitRequired(operation.Operand), operation.IsLifted, operation.IsChecked, operation.OperatorMethod,
                                                semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
@@ -2196,7 +2228,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             //done:
             //        Return result
 
-            var resultCaptureRegion = _currentRegion;
+            var resultCaptureRegion = CurrentRegionRequired;
 
             var done = new BasicBlockBuilder(BasicBlockKind.Block);
             var checkRight = new BasicBlockBuilder(BasicBlockKind.Block);
@@ -2271,14 +2303,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             EvalStackFrame frame = PushStackFrame();
 
-            condition = CreateConversion(Visit(left), booleanType);
+            condition = CreateConversion(VisitRequired(left), booleanType);
 
             ConditionalBranch(condition, jumpIfTrue: isAndAlso, checkRight);
             _currentBasicBlock = null;
 
             PopStackFrameAndLeaveRegion(frame);
 
-            var resultCaptureRegion = _currentRegion;
+            var resultCaptureRegion = CurrentRegionRequired;
 
             int resultId = GetNextCaptureId(resultCaptureRegion);
             ConstantValue constantValue = ConstantValue.Create(!isAndAlso);
@@ -2289,7 +2321,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             frame = PushStackFrame();
 
-            condition = CreateConversion(Visit(right), booleanType);
+            condition = CreateConversion(VisitRequired(right), booleanType);
 
             AddStatement(new FlowCaptureOperation(resultId, binOp.Syntax, condition));
 
@@ -2315,7 +2347,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             SpillEvalStack();
             Debug.Assert(binOp.Type is not null);
 
-            var resultCaptureRegion = _currentRegion;
+            var resultCaptureRegion = CurrentRegionRequired;
 
             INamedTypeSymbol booleanType = _compilation.GetSpecialType(SpecialType.System_Boolean);
             IOperation left = binOp.LeftOperand;
@@ -2383,7 +2415,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             EvalStackFrame frame = PushStackFrame();
             PushOperand(OperationCloner.CloneOperation(capturedLeft));
-            IOperation visitedRight = Visit(right);
+            IOperation visitedRight = VisitRequired(right);
             AddStatement(new FlowCaptureOperation(resultId, binOp.Syntax,
                                          new BinaryOperation(isAndAlso ? BinaryOperatorKind.And : BinaryOperatorKind.Or,
                                                                       PopOperand(),
@@ -2411,7 +2443,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             SpillEvalStack();
 
-            var resultCaptureRegion = _currentRegion;
+            var resultCaptureRegion = CurrentRegionRequired;
 
             INamedTypeSymbol booleanType = _compilation.GetSpecialType(SpecialType.System_Boolean);
             bool isLifted = binOp.IsLifted;
@@ -2467,7 +2499,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             EvalStackFrame frame = PushStackFrame();
             PushOperand(OperationCloner.CloneOperation(capturedLeft));
-            IOperation visitedRight = Visit(right);
+            IOperation visitedRight = VisitRequired(right);
 
             AddStatement(new FlowCaptureOperation(resultId, binOp.Syntax,
                                          new BinaryOperation(isAndAlso ? BinaryOperatorKind.And : BinaryOperatorKind.Or,
@@ -2516,7 +2548,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             VisitConditionalBranch(condition.LeftOperand, ref lazyFallThrough, stopSense);
 
-            var resultCaptureRegion = _currentRegion;
+            var resultCaptureRegion = CurrentRegionRequired;
             int captureId = captureIdForResult ?? GetNextCaptureId(resultCaptureRegion);
 
             IOperation resultFromRight = VisitConditionalExpression(condition.RightOperand, sense, captureId, fallToTrueOpt, fallToFalseOpt);
@@ -2574,7 +2606,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 }
             }
 
-            condition = Visit(condition);
+            condition = VisitRequired(condition);
             if (!sense)
             {
                 return lastUnary != null
@@ -2598,11 +2630,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                    ITypeSymbolHelpers.IsBooleanType(binOp.RightOperand.Type);
         }
 
-        private void VisitConditionalBranch(IOperation condition, ref BasicBlockBuilder? dest, bool jumpIfTrue)
+        private void VisitConditionalBranch(IOperation condition, [NotNull] ref BasicBlockBuilder? dest, bool jumpIfTrue)
         {
             SpillEvalStack();
 #if DEBUG
-            RegionBuilder current = _currentRegion;
+            RegionBuilder? current = _currentRegion;
 #endif
             VisitConditionalBranchCore(condition, ref dest, jumpIfTrue);
 #if DEBUG
@@ -2613,7 +2645,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// This function does not change the current region. The stack should be spilled before calling it.
         /// </summary>
-        private void VisitConditionalBranchCore(IOperation condition, ref BasicBlockBuilder? dest, bool jumpIfTrue)
+        private void VisitConditionalBranchCore(IOperation condition, [NotNull] ref BasicBlockBuilder? dest, bool jumpIfTrue)
         {
 oneMoreTime:
             Debug.Assert(_startSpillingAt == _evalStack.Count);
@@ -2744,7 +2776,7 @@ oneMoreTime:
                     {
                         EvalStackFrame frame = PushStackFrame();
 
-                        condition = Visit(condition);
+                        condition = VisitRequired(condition);
                         dest = dest ?? new BasicBlockBuilder(BasicBlockKind.Block);
                         ConditionalBranch(condition, jumpIfTrue, dest);
                         _currentBasicBlock = null;
@@ -2762,6 +2794,7 @@ oneMoreTime:
             Debug.Assert(previous.BranchValue == null);
             Debug.Assert(!previous.HasCondition);
             Debug.Assert(condition != null);
+            Debug.Assert(branch.Destination != null);
             Operation.SetParentOperation(condition, null);
             branch.Destination.AddPredecessor(previous);
             previous.BranchValue = condition;
@@ -2782,7 +2815,7 @@ oneMoreTime:
             SyntaxNode valueSyntax = operationValue.Syntax;
             ITypeSymbol? valueTypeOpt = operationValue.Type;
 
-            PushOperand(Visit(operationValue));
+            PushOperand(VisitRequired(operationValue));
             SpillEvalStack();
             IOperation testExpression = PopOperand();
 
@@ -2839,7 +2872,7 @@ oneMoreTime:
             var conversion = operation.WhenNull as IConversionOperation;
             bool alternativeThrows = conversion?.Operand.Kind == OperationKind.Throw;
 
-            RegionBuilder resultCaptureRegion = _currentRegion;
+            RegionBuilder resultCaptureRegion = CurrentRegionRequired;
 
             EvalStackFrame frame = PushStackFrame();
 
@@ -2899,11 +2932,11 @@ oneMoreTime:
             bool isStatement = _currentStatement == operation || operation.Parent.Kind == OperationKind.ExpressionStatement;
             Debug.Assert(captureIdForResult == null || !isStatement);
 
-            RegionBuilder resultCaptureRegion = _currentRegion;
+            RegionBuilder resultCaptureRegion = CurrentRegionRequired;
 
             EvalStackFrame frame = PushStackFrame();
 
-            PushOperand(Visit(operation.Target));
+            PushOperand(VisitRequired(operation.Target));
             SpillEvalStack();
             IOperation locationCapture = PopOperand();
 
@@ -2911,6 +2944,7 @@ oneMoreTime:
             // the null case
             EvalStackFrame valueFrame = PushStackFrame();
             SpillEvalStack();
+            Debug.Assert(valueFrame.RegionBuilderOpt != null);
             int valueCaptureId = GetNextCaptureId(valueFrame.RegionBuilderOpt);
             AddStatement(new FlowCaptureOperation(valueCaptureId, locationCapture.Syntax, locationCapture));
             IOperation valueCapture = GetCaptureReference(valueCaptureId, locationCapture);
@@ -2920,8 +2954,7 @@ oneMoreTime:
 
             int resultCaptureId = isStatement ? -1 : captureIdForResult ?? GetNextCaptureId(resultCaptureRegion);
 
-            Debug.Assert(operation.Target == null || operation.Target.Type != null);
-            if (operation.Target?.Type!.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
+            if (operation.Target?.Type?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
                 ((INamedTypeSymbol)operation.Target.Type!).TypeArguments[0].Equals(operation.Type))
             {
                 nullableValueTypeReturn();
@@ -2973,6 +3006,7 @@ oneMoreTime:
                 {
                     intermediateFrame = PushStackFrame();
                     SpillEvalStack();
+                    Debug.Assert(intermediateFrame.RegionBuilderOpt != null);
                     intermediateResult = GetNextCaptureId(intermediateFrame.RegionBuilderOpt);
                     AddStatement(
                         new FlowCaptureOperation(intermediateResult,
@@ -2987,6 +3021,7 @@ oneMoreTime:
 
                 if (!isStatement)
                 {
+                    Debug.Assert(intermediateFrame != null);
                     _currentBasicBlock = null;
                     AddStatement(
                         new FlowCaptureOperation(resultCaptureId,
@@ -3004,9 +3039,10 @@ oneMoreTime:
                 EvalStackFrame whenNullFrame = PushStackFrame();
                 SpillEvalStack();
 
-                IOperation whenNullValue = Visit(operation.Value);
+                IOperation whenNullValue = VisitRequired(operation.Value);
                 if (!isStatement)
                 {
+                    Debug.Assert(whenNullFrame.RegionBuilderOpt != null);
                     int intermediateValueCaptureId = GetNextCaptureId(whenNullFrame.RegionBuilderOpt);
                     AddStatement(new FlowCaptureOperation(intermediateValueCaptureId, whenNullValue.Syntax, whenNullValue));
                     whenNullValue = GetCaptureReference(intermediateValueCaptureId, whenNullValue);
@@ -3055,7 +3091,7 @@ oneMoreTime:
                 // packing will take care of removing the empty region.
                 EvalStackFrame whenNullFrame = PushStackFrame();
 
-                IOperation whenNullValue = Visit(operation.Value);
+                IOperation whenNullValue = VisitRequired(operation.Value);
                 IOperation whenNullAssignment = new SimpleAssignmentOperation(isRef: false, OperationCloner.CloneOperation(locationCapture), whenNullValue, semanticModel: null,
                     operation.Syntax, operation.Type, constantValue: operation.GetConstantValue(), isImplicit: true);
 
@@ -3071,26 +3107,25 @@ oneMoreTime:
                 PopStackFrameAndLeaveRegion(whenNullFrame);
             }
         }
-#nullable disable
 
         private static BasicBlockBuilder.Branch RegularBranch(BasicBlockBuilder destination)
         {
             return new BasicBlockBuilder.Branch() { Destination = destination, Kind = ControlFlowBranchSemantics.Regular };
         }
 
-        private static IOperation MakeInvalidOperation(ITypeSymbol type, IOperation child)
+        private static IOperation MakeInvalidOperation(ITypeSymbol? type, IOperation child)
         {
             return new InvalidOperation(ImmutableArray.Create<IOperation>(child),
                                         semanticModel: null, child.Syntax, type,
                                         constantValue: null, isImplicit: true);
         }
 
-        private static IOperation MakeInvalidOperation(SyntaxNode syntax, ITypeSymbol type, IOperation child1, IOperation child2)
+        private static IOperation MakeInvalidOperation(SyntaxNode syntax, ITypeSymbol? type, IOperation child1, IOperation child2)
         {
             return MakeInvalidOperation(syntax, type, ImmutableArray.Create<IOperation>(child1, child2));
         }
 
-        private static IOperation MakeInvalidOperation(SyntaxNode syntax, ITypeSymbol type, ImmutableArray<IOperation> children)
+        private static IOperation MakeInvalidOperation(SyntaxNode syntax, ITypeSymbol? type, ImmutableArray<IOperation> children)
         {
             return new InvalidOperation(children,
                                         semanticModel: null, syntax, type,
@@ -3105,7 +3140,7 @@ oneMoreTime:
         private static IsNullOperation MakeIsNullOperation(IOperation operand, ITypeSymbol booleanType)
         {
             Debug.Assert(ITypeSymbolHelpers.IsBooleanType(booleanType));
-            ConstantValue constantValue = operand.GetConstantValue() is { IsNull: var isNull }
+            ConstantValue? constantValue = operand.GetConstantValue() is { IsNull: var isNull }
                 ? ConstantValue.Create(isNull)
                 : null;
             return new IsNullOperation(operand.Syntax, operand,
@@ -3113,7 +3148,6 @@ oneMoreTime:
                                        constantValue);
         }
 
-#nullable enable
         private IOperation? TryCallNullableMember(IOperation value, SpecialMember nullableMember)
         {
             Debug.Assert(nullableMember == SpecialMember.System_Nullable_T_GetValueOrDefault ||
@@ -3155,7 +3189,7 @@ oneMoreTime:
         {
             SpillEvalStack();
 
-            RegionBuilder resultCaptureRegion = _currentRegion;
+            RegionBuilder resultCaptureRegion = CurrentRegionRequired;
 
             // Avoid creation of default values and FlowCapture for conditional access on a statement level.
             bool isOnStatementLevel = _currentStatement == operation || (_currentStatement == operation.Parent && _currentStatement?.Kind == OperationKind.ExpressionStatement);
@@ -3191,7 +3225,7 @@ oneMoreTime:
                 SyntaxNode testExpressionSyntax = testExpression.Syntax;
                 ITypeSymbol? testExpressionType = testExpression.Type;
 
-                PushOperand(Visit(testExpression));
+                PushOperand(VisitRequired(testExpression));
                 SpillEvalStack();
                 IOperation spilledTestExpression = PopOperand();
                 PopStackFrame(frames.Pop());
@@ -3229,7 +3263,7 @@ oneMoreTime:
                 Debug.Assert(frames.Count == 0);
                 frames.Free();
 
-                IOperation result = Visit(currentConditionalAccess.WhenNotNull);
+                IOperation result = VisitRequired(currentConditionalAccess.WhenNotNull);
                 Debug.Assert(_currentConditionalAccessInstance == null);
                 _currentConditionalAccessInstance = null;
 
@@ -3255,14 +3289,14 @@ oneMoreTime:
 
                 if (ITypeSymbolHelpers.IsNullableType(operation.Type) && !ITypeSymbolHelpers.IsNullableType(currentConditionalAccess.WhenNotNull.Type))
                 {
-                    IOperation access = Visit(currentConditionalAccess.WhenNotNull);
+                    IOperation access = VisitRequired(currentConditionalAccess.WhenNotNull);
                     AddStatement(new FlowCaptureOperation(resultCaptureId, currentConditionalAccess.WhenNotNull.Syntax,
                         MakeNullable(access, operation.Type)));
                 }
                 else
                 {
                     CaptureResultIfNotAlready(currentConditionalAccess.WhenNotNull.Syntax, resultCaptureId,
-                                              Visit(currentConditionalAccess.WhenNotNull, resultCaptureId));
+                                              VisitRequired(currentConditionalAccess.WhenNotNull, resultCaptureId));
                 }
 
                 PopStackFrame(frame);
@@ -3309,7 +3343,7 @@ oneMoreTime:
         {
             StartVisitingStatement(operation);
 
-            IOperation underlying = Visit(operation.Operation);
+            IOperation? underlying = Visit(operation.Operation);
 
             if (underlying == null)
             {
@@ -3429,7 +3463,7 @@ oneMoreTime:
                 EnterRegion(new RegionBuilder(ControlFlowRegionKind.Try));
             }
 
-            Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.Try);
+            Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.Try);
             VisitStatement(operation.Body);
             UnconditionalBranch(afterTryCatchFinally);
 
@@ -3462,6 +3496,7 @@ oneMoreTime:
                         continueDispatchBlock.FallThrough.Kind = ControlFlowBranchSemantics.StructuredExceptionHandling;
                         LeaveRegion();
 
+                        Debug.Assert(!filterRegion.IsEmpty);
                         Debug.Assert(filterRegion.LastBlock.FallThrough.Destination == null);
                         Debug.Assert(!filterRegion.FirstBlock.HasPredecessors);
                     }
@@ -3482,18 +3517,19 @@ oneMoreTime:
 
                     LeaveRegion();
 
+                    Debug.Assert(!handlerRegion.IsEmpty);
                     if (haveFilter)
                     {
-                        Debug.Assert(_currentRegion == filterAndHandlerRegion);
+                        Debug.Assert(CurrentRegionRequired == filterAndHandlerRegion);
                         LeaveRegion();
 #if DEBUG
-                        Debug.Assert(filterAndHandlerRegion.Regions[0].LastBlock.FallThrough.Destination == null);
+                        Debug.Assert(filterAndHandlerRegion.Regions![0].LastBlock!.FallThrough.Destination == null);
                         if (handlerRegion.FirstBlock.HasPredecessors)
                         {
                             var predecessors = ArrayBuilder<BasicBlockBuilder>.GetInstance();
                             handlerRegion.FirstBlock.GetPredecessors(predecessors);
-                            Debug.Assert(predecessors.All(p => filterAndHandlerRegion.Regions[0].FirstBlock.Ordinal <= p.Ordinal &&
-                                                          filterAndHandlerRegion.Regions[0].LastBlock.Ordinal >= p.Ordinal));
+                            Debug.Assert(predecessors.All(p => filterAndHandlerRegion.Regions[0].FirstBlock!.Ordinal <= p.Ordinal &&
+                                                          filterAndHandlerRegion.Regions[0].LastBlock!.Ordinal >= p.Ordinal));
                             predecessors.Free();
                         }
 #endif
@@ -3504,13 +3540,13 @@ oneMoreTime:
                     }
                 }
 
-                Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.TryAndCatch);
+                Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.TryAndCatch);
                 LeaveRegion();
             }
 
             if (haveFinally)
             {
-                Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.Try);
+                Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.Try);
                 LeaveRegion();
 
                 var finallyRegion = new RegionBuilder(ControlFlowRegionKind.Finally);
@@ -3523,12 +3559,13 @@ oneMoreTime:
                 LeaveRegion();
                 Debug.Assert(_currentRegion == tryAndFinallyRegion);
                 LeaveRegion();
+                Debug.Assert(!finallyRegion.IsEmpty);
                 Debug.Assert(finallyRegion.LastBlock.FallThrough.Destination == null);
                 Debug.Assert(!finallyRegion.FirstBlock.HasPredecessors);
             }
 
             AppendNewBlock(afterTryCatchFinally, linkToPrevious: false);
-            Debug.Assert(tryAndFinallyRegion?.Regions[1].LastBlock.FallThrough.Destination == null);
+            Debug.Assert(tryAndFinallyRegion?.Regions![1].LastBlock!.FallThrough.Destination == null);
 
             return FinishVisitingStatement(operation);
         }
@@ -3552,7 +3589,7 @@ oneMoreTime:
                 }
                 else
                 {
-                    exceptionTarget = Visit(exceptionDeclarationOrExpression);
+                    exceptionTarget = VisitRequired(exceptionDeclarationOrExpression);
                 }
 
                 if (exceptionTarget != null)
@@ -3578,7 +3615,7 @@ oneMoreTime:
         public override IOperation? VisitReturn(IReturnOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
-            IOperation returnedValue = Visit(operation.ReturnedValue);
+            IOperation? returnedValue = Visit(operation.ReturnedValue);
 
             switch (operation.Kind)
             {
@@ -3646,22 +3683,20 @@ oneMoreTime:
             _labeledBlocks.Add(labelOpt, labeledBlock);
             return labeledBlock;
         }
-#nullable disable
 
-        public override IOperation VisitBranch(IBranchOperation operation, int? captureIdForResult)
+        public override IOperation? VisitBranch(IBranchOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
             UnconditionalBranch(GetLabeledOrNewBlock(operation.Target));
             return FinishVisitingStatement(operation);
         }
 
-        public override IOperation VisitEmpty(IEmptyOperation operation, int? captureIdForResult)
+        public override IOperation? VisitEmpty(IEmptyOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
             return FinishVisitingStatement(operation);
         }
 
-#nullable enable
         public override IOperation? VisitThrow(IThrowOperation operation, int? captureIdForResult)
         {
             bool isStatement = (_currentStatement == operation);
@@ -3685,9 +3720,8 @@ oneMoreTime:
                 return new NoneOperation(children: ImmutableArray<IOperation>.Empty, semanticModel: null, operation.Syntax, constantValue: null, isImplicit: true, type: null);
             }
         }
-#nullable disable
 
-        private void LinkThrowStatement(IOperation exception)
+        private void LinkThrowStatement(IOperation? exception)
         {
             BasicBlockBuilder current = CurrentBasicBlock;
             Debug.Assert(current.BranchValue == null);
@@ -3698,7 +3732,6 @@ oneMoreTime:
             current.FallThrough.Kind = exception == null ? ControlFlowBranchSemantics.Rethrow : ControlFlowBranchSemantics.Throw;
         }
 
-#nullable enable
         public override IOperation? VisitUsing(IUsingOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
@@ -3737,7 +3770,7 @@ oneMoreTime:
                 Debug.Assert(resources.Kind != OperationKind.VariableDeclarator);
 
                 EvalStackFrame frame = PushStackFrame();
-                IOperation resource = Visit(resources);
+                IOperation resource = VisitRequired(resources);
 
                 if (shouldConvertToIDisposableBeforeTry(resource))
                 {
@@ -3824,14 +3857,14 @@ oneMoreTime:
 
                 processQueue(resourceQueueOpt);
 
-                Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.Try);
+                Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.Try);
                 UnconditionalBranch(afterTryFinally);
 
                 LeaveRegion();
 
                 AddDisposingFinally(resource, knownToImplementIDisposable: true, iDisposable, isAsynchronous);
 
-                Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.TryAndFinally);
+                Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.TryAndFinally);
                 LeaveRegion();
 
                 if (resourceRegion != null)
@@ -3846,7 +3879,7 @@ oneMoreTime:
 
         private void AddDisposingFinally(IOperation resource, bool knownToImplementIDisposable, ITypeSymbol iDisposable, bool isAsynchronous)
         {
-            Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.TryAndFinally);
+            Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.TryAndFinally);
 
             var endOfFinally = new BasicBlockBuilder(BasicBlockKind.Block);
             endOfFinally.FallThrough.Kind = ControlFlowBranchSemantics.StructuredExceptionHandling;
@@ -3969,7 +4002,7 @@ oneMoreTime:
             EnterRegion(lockRegion);
 
             EvalStackFrame frame = PushStackFrame();
-            IOperation lockedValue = Visit(operation.LockedValue);
+            IOperation lockedValue = VisitRequired(operation.LockedValue);
 
             if (!objectType.Equals(lockedValue.Type))
             {
@@ -4048,7 +4081,7 @@ oneMoreTime:
 
             VisitStatement(operation.Body);
 
-            Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.Try);
+            Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.Try);
             UnconditionalBranch(afterTryFinally);
 
             LeaveRegion();
@@ -4096,7 +4129,7 @@ oneMoreTime:
             AppendNewBlock(endOfFinally);
 
             LeaveRegion();
-            Debug.Assert(_currentRegion.Kind == ControlFlowRegionKind.TryAndFinally);
+            Debug.Assert(CurrentRegionRequired.Kind == ControlFlowRegionKind.TryAndFinally);
             LeaveRegion();
 
             LeaveRegionsUpTo(lockRegion);
@@ -4242,7 +4275,7 @@ oneMoreTime:
                 else
                 {
                     // This must be an error case
-                    AddStatement(MakeInvalidOperation(type: null, Visit(operation.Collection)));
+                    AddStatement(MakeInvalidOperation(type: null, VisitRequired(operation.Collection)));
                     result = new InvalidOperation(ImmutableArray<IOperation>.Empty, semanticModel: null, operation.Collection.Syntax,
                                                   type: null, constantValue: null, isImplicit: true);
                 }
@@ -4321,7 +4354,7 @@ oneMoreTime:
                                                                      isImplicit: true);
                     default:
                         return new SimpleAssignmentOperation(isRef: false, // In C# this is an error case and VB doesn't support ref locals
-                            Visit(operation.LoopControlVariable),
+                            VisitRequired(operation.LoopControlVariable),
                             current, semanticModel: null, operation.LoopControlVariable.Syntax,
                             operation.LoopControlVariable.Type,
                             constantValue: null, isImplicit: true);
@@ -4417,7 +4450,7 @@ oneMoreTime:
 
                 if (method is null)
                 {
-                    var builder = ArrayBuilder<IOperation?>.GetInstance(--parametersCount, fillWithValue: null);
+                    var builder = ArrayBuilder<IOperation>.GetInstance(--parametersCount, fillWithValue: null!);
                     builder[--parametersCount] = loopObjectReference;
                     do
                     {
@@ -4425,6 +4458,7 @@ oneMoreTime:
                     }
                     while (parametersCount != 0);
 
+                    Debug.Assert(builder.All(o => o != null));
                     return MakeInvalidOperation(operation.LimitValue.Syntax, booleanType, builder.ToImmutableAndFree());
                 }
                 else
@@ -4467,7 +4501,7 @@ oneMoreTime:
                 EvalStackFrame frame = PushStackFrame();
 
                 PushOperand(visitLoopControlVariableReference(forceImplicit: false));
-                PushOperand(Visit(operation.InitialValue));
+                PushOperand(VisitRequired(operation.InitialValue));
 
                 if (isObjectLoop)
                 {
@@ -4493,8 +4527,8 @@ oneMoreTime:
                     // }
                     // exit:
 
-                    PushOperand(Visit(operation.LimitValue));
-                    PushOperand(Visit(operation.StepValue));
+                    PushOperand(VisitRequired(operation.LimitValue));
+                    PushOperand(VisitRequired(operation.StepValue));
 
                     IOperation condition = tryCallObjectForLoopControlHelper(operation.LoopControlVariable.Syntax,
                                                                              WellKnownMember.Microsoft_VisualBasic_CompilerServices_ObjectFlowControl_ForLoopControl__ForLoopInitObj);
@@ -4505,7 +4539,7 @@ oneMoreTime:
                 else
                 {
                     SpillEvalStack();
-                    RegionBuilder currentRegion = _currentRegion;
+                    RegionBuilder currentRegion = CurrentRegionRequired;
 
                     limitValueId = GetNextCaptureId(loopRegion);
                     VisitAndCapture(operation.LimitValue, limitValueId);
@@ -4524,15 +4558,15 @@ oneMoreTime:
                         _forToLoopBinaryOperatorLeftOperand = GetCaptureReference(stepValueId, operation.StepValue);
                         _forToLoopBinaryOperatorRightOperand = GetCaptureReference(stepValueId, operation.StepValue);
 
-                        IOperation subtraction = Visit(userDefinedInfo.Subtraction.Value);
+                        IOperation subtraction = VisitRequired(userDefinedInfo.Subtraction);
 
                         _forToLoopBinaryOperatorLeftOperand = stepValue;
                         _forToLoopBinaryOperatorRightOperand = subtraction;
 
                         int positiveFlagId = GetNextCaptureId(loopRegion);
-                        VisitAndCapture(userDefinedInfo.GreaterThanOrEqual.Value, positiveFlagId);
+                        VisitAndCapture(userDefinedInfo.GreaterThanOrEqual, positiveFlagId);
 
-                        positiveFlag = GetCaptureReference(positiveFlagId, userDefinedInfo.GreaterThanOrEqual.Value);
+                        positiveFlag = GetCaptureReference(positiveFlagId, userDefinedInfo.GreaterThanOrEqual);
 
                         _forToLoopBinaryOperatorLeftOperand = null;
                         _forToLoopBinaryOperatorRightOperand = null;
@@ -4679,7 +4713,7 @@ oneMoreTime:
                     _forToLoopBinaryOperatorLeftOperand = controlVariableReferenceForCondition;
                     _forToLoopBinaryOperatorRightOperand = GetCaptureReference(limitValueId, operation.LimitValue);
 
-                    VisitConditionalBranch(userDefinedInfo.LessThanOrEqual.Value, ref @break, jumpIfTrue: false);
+                    VisitConditionalBranch(userDefinedInfo.LessThanOrEqual, ref @break, jumpIfTrue: false);
                     UnconditionalBranch(bodyBlock);
 
                     AppendNewBlock(notPositive);
@@ -4687,7 +4721,7 @@ oneMoreTime:
                     _forToLoopBinaryOperatorLeftOperand = OperationCloner.CloneOperation(_forToLoopBinaryOperatorLeftOperand);
                     _forToLoopBinaryOperatorRightOperand = OperationCloner.CloneOperation(_forToLoopBinaryOperatorRightOperand);
 
-                    VisitConditionalBranch(userDefinedInfo.GreaterThanOrEqual.Value, ref @break, jumpIfTrue: false);
+                    VisitConditionalBranch(userDefinedInfo.GreaterThanOrEqual, ref @break, jumpIfTrue: false);
                     UnconditionalBranch(bodyBlock);
 
                     PopStackFrameAndLeaveRegion(frame);
@@ -4915,7 +4949,7 @@ oneMoreTime:
                     _forToLoopBinaryOperatorLeftOperand = visitLoopControlVariableReference(forceImplicit: true); // Yes we are going to evaluate it again
                     _forToLoopBinaryOperatorRightOperand = GetCaptureReference(stepValueId, operation.StepValue);
 
-                    IOperation increment = Visit(userDefinedInfo.Addition.Value);
+                    IOperation increment = VisitRequired(userDefinedInfo.Addition);
 
                     _forToLoopBinaryOperatorLeftOperand = null;
                     _forToLoopBinaryOperatorRightOperand = null;
@@ -5018,6 +5052,7 @@ oneMoreTime:
 
                     if (isNullable)
                     {
+                        Debug.Assert(controlVariableReferenceForAssignment.Type != null);
                         increment = MakeNullable(increment, controlVariableReferenceForAssignment.Type);
                     }
 
@@ -5050,7 +5085,7 @@ oneMoreTime:
                     default:
                         Debug.Assert(!_forceImplicit);
                         _forceImplicit = forceImplicit;
-                        IOperation result = Visit(operation.LoopControlVariable);
+                        IOperation result = VisitRequired(operation.LoopControlVariable);
                         _forceImplicit = false;
                         return result;
                 }
@@ -5066,10 +5101,10 @@ oneMoreTime:
         {
             SpillEvalStack();
 
-            IOperation previousAggregationGroup = _currentAggregationGroup;
+            IOperation? previousAggregationGroup = _currentAggregationGroup;
             _currentAggregationGroup = VisitAndCapture(operation.Group);
 
-            IOperation result = Visit(operation.Aggregation);
+            IOperation result = VisitRequired(operation.Aggregation);
 
             _currentAggregationGroup = previousAggregationGroup;
             return result;
@@ -5172,7 +5207,7 @@ oneMoreTime:
 
                             EvalStackFrame frame = PushStackFrame();
                             PushOperand(OperationCloner.CloneOperation(switchValue));
-                            IOperation rightOperand = Visit(compareWith);
+                            IOperation rightOperand = VisitRequired(compareWith);
                             IOperation leftOperand = PopOperand();
 
                             if (isLifted)
@@ -5181,11 +5216,13 @@ oneMoreTime:
                                 {
                                     if (leftOperand.Type != null)
                                     {
+                                        Debug.Assert(compareWith.Type != null);
                                         leftOperand = MakeNullable(leftOperand, compareWith.Type);
                                     }
                                 }
                                 else if (!rightIsNullable && rightOperand.Type != null)
                                 {
+                                    Debug.Assert(operation.Value.Type != null);
                                     rightOperand = MakeNullable(rightOperand, operation.Value.Type);
                                 }
                             }
@@ -5218,7 +5255,7 @@ oneMoreTime:
 
                             EvalStackFrame frame = PushStackFrame();
                             PushOperand(OperationCloner.CloneOperation(switchValue));
-                            var pattern = (IPatternOperation)Visit(patternClause.Pattern);
+                            var pattern = (IPatternOperation)VisitRequired(patternClause.Pattern);
                             condition = new IsPatternOperation(PopOperand(), pattern, semanticModel: null,
                                                                patternClause.Pattern.Syntax, booleanType, isImplicit: true);
                             ConditionalBranch(condition, jumpIfTrue: false, nextCase);
@@ -5271,7 +5308,6 @@ oneMoreTime:
                 }
             }
         }
-#nullable disable
 
         private IOperation MakeNullable(IOperation operand, ITypeSymbol type)
         {
@@ -5311,7 +5347,7 @@ oneMoreTime:
             throw ExceptionUtilities.Unreachable;
         }
 
-        public override IOperation VisitEnd(IEndOperation operation, int? captureIdForResult)
+        public override IOperation? VisitEnd(IEndOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
             BasicBlockBuilder current = CurrentBasicBlock;
@@ -5324,7 +5360,6 @@ oneMoreTime:
             return FinishVisitingStatement(operation);
         }
 
-#nullable enable
         public override IOperation? VisitForLoop(IForLoopOperation operation, int? captureIdForResult)
         {
             StartVisitingStatement(operation);
@@ -5400,9 +5435,8 @@ oneMoreTime:
             LeaveRegion();
             return FinishVisitingStatement(operation);
         }
-#nullable disable
 
-        public override IOperation VisitVariableDeclarationGroup(IVariableDeclarationGroupOperation operation, int? captureIdForResult)
+        public override IOperation? VisitVariableDeclarationGroup(IVariableDeclarationGroupOperation operation, int? captureIdForResult)
         {
             // Anything that has a declaration group (such as for loops) needs to handle them directly itself,
             // this should only be encountered by the visitor for declaration statements.
@@ -5430,7 +5464,6 @@ oneMoreTime:
             }
         }
 
-#nullable enable
         private void HandleVariableDeclarator(IVariableDeclarationOperation declaration, IVariableDeclaratorOperation declarator)
         {
             if (declarator.Initializer == null && declaration.Initializer == null)
@@ -5466,7 +5499,7 @@ oneMoreTime:
 
             if (declaration.Initializer != null)
             {
-                IOperation operationInitializer = Visit(declaration.Initializer.Value);
+                IOperation operationInitializer = VisitRequired(declaration.Initializer.Value);
                 assignmentSyntax = declaration.Syntax;
                 if (initializer != null)
                 {
@@ -5486,7 +5519,7 @@ oneMoreTime:
             Debug.Assert(initializer != null && assignmentSyntax != null);
 
             // If we have an afterInitialization, then we must have static local and an initializer to ensure we don't create empty regions that can't be cleaned up.
-            Debug.Assert(afterInitialization == null || localSymbol.IsStatic);
+            Debug.Assert((afterInitialization, localSymbol.IsStatic) is (null, false) or (not null, true));
 
             // We can't use the IdentifierToken as the syntax for the local reference, so we use the
             // entire declarator as the node
@@ -5499,7 +5532,7 @@ oneMoreTime:
             if (localSymbol.IsStatic)
             {
                 LeaveRegion();
-                AppendNewBlock(afterInitialization);
+                AppendNewBlock(afterInitialization!);
             }
         }
 
@@ -5555,7 +5588,7 @@ oneMoreTime:
         {
             if (instance != null)
             {
-                PushOperand(Visit(instance));
+                PushOperand(VisitRequired(instance));
             }
 
             ImmutableArray<IArgumentOperation> visitedArguments = VisitArguments(arguments);
@@ -5676,7 +5709,7 @@ oneMoreTime:
                 if (!pushSuccess)
                 {
                     // Error case. We don't try any error recovery here, just return whatever the default visit would.
-                    result = Visit(assignmentOperation);
+                    result = VisitRequired(assignmentOperation);
                 }
                 else
                 {
@@ -5684,7 +5717,7 @@ oneMoreTime:
                     // After that has been pushed, we visit the value of the assignment, to ensure that the instance is captured if
                     // needed. Finally, we reassemble the target, which will pull the potentially captured instance from the stack
                     // and reassemble the member reference from the parts.
-                    IOperation right = Visit(assignmentOperation.Value);
+                    IOperation right = VisitRequired(assignmentOperation.Value);
                     IOperation left = popTarget(assignmentOperation.Target);
 
                     result = new SimpleAssignmentOperation(assignmentOperation.IsRef, left, right, semanticModel: null, assignmentOperation.Syntax,
@@ -5736,7 +5769,7 @@ oneMoreTime:
 
                 EvalStackFrame frame = PushStackFrame();
                 bool pushSuccess = tryPushTarget(memberInitializer.InitializedMember);
-                IOperation instance = pushSuccess ? popTarget(memberInitializer.InitializedMember) : Visit(memberInitializer.InitializedMember);
+                IOperation instance = pushSuccess ? popTarget(memberInitializer.InitializedMember) : VisitRequired(memberInitializer.InitializedMember);
                 visitInitializer(memberInitializer.Initializer, instance);
                 PopStackFrameAndLeaveRegion(frame);
             }
@@ -5762,7 +5795,7 @@ oneMoreTime:
                         // the value has been evaluated. So we assemble the reference after visiting the value.
                         if (!memberReference.Member.IsStatic && memberReference.Instance != null)
                         {
-                            PushOperand(Visit(memberReference.Instance));
+                            PushOperand(VisitRequired(memberReference.Instance));
                         }
                         return true;
 
@@ -5770,21 +5803,21 @@ oneMoreTime:
                         var arrayReference = (IArrayElementReferenceOperation)instance;
                         VisitAndPushArray(arrayReference.Indices);
                         SpillEvalStack();
-                        PushOperand(Visit(arrayReference.ArrayReference));
+                        PushOperand(VisitRequired(arrayReference.ArrayReference));
                         return true;
 
                     case OperationKind.DynamicIndexerAccess:
                         var dynamicIndexer = (IDynamicIndexerAccessOperation)instance;
                         VisitAndPushArray(dynamicIndexer.Arguments);
                         SpillEvalStack();
-                        PushOperand(Visit(dynamicIndexer.Operation));
+                        PushOperand(VisitRequired(dynamicIndexer.Operation));
                         return true;
 
                     case OperationKind.DynamicMemberReference:
                         var dynamicReference = (IDynamicMemberReferenceOperation)instance;
                         if (dynamicReference.Instance != null)
                         {
-                            PushOperand(Visit(dynamicReference.Instance));
+                            PushOperand(VisitRequired(dynamicReference.Instance));
                         }
                         return true;
 
@@ -5909,7 +5942,7 @@ oneMoreTime:
 
             IOperation visitAndCaptureInitializer(IPropertySymbol initializedProperty, IOperation initializer)
             {
-                PushOperand(Visit(initializer));
+                PushOperand(VisitRequired(initializer));
                 SpillEvalStack();
                 IOperation captured = PeekOperand(); // Keep it on the stack so that we know it is still used.
 
@@ -5927,10 +5960,11 @@ oneMoreTime:
         {
             StartVisitingStatement(operation);
 
-            RegionBuilder owner = _currentRegion;
+            RegionBuilder owner = CurrentRegionRequired;
 
             while (owner.IsStackSpillRegion)
             {
+                Debug.Assert(owner.Enclosing != null);
                 owner = owner.Enclosing;
             }
 
@@ -5974,7 +6008,7 @@ oneMoreTime:
             //  In future, based on the customer feedback, we can consider switching to approach #2 and lower the initializer into assignment(s).
             EvalStackFrame frame = PushStackFrame();
             VisitAndPushArray(operation.DimensionSizes);
-            var visitedInitializer = (IArrayInitializerOperation)Visit(operation.Initializer);
+            var visitedInitializer = (IArrayInitializerOperation?)Visit(operation.Initializer);
             ImmutableArray<IOperation> visitedDimensions = PopArray(operation.DimensionSizes);
             PopStackFrame(frame);
             return new ArrayCreationOperation(visitedDimensions, visitedInitializer, semanticModel: null,
@@ -5998,7 +6032,7 @@ oneMoreTime:
                     }
                     else
                     {
-                        PushOperand(Visit(elementValue));
+                        PushOperand(VisitRequired(elementValue));
                     }
                 }
             }
@@ -6060,12 +6094,12 @@ oneMoreTime:
                 var instance = ((IDynamicMemberReferenceOperation)operation.Operation).Instance;
                 if (instance != null)
                 {
-                    PushOperand(Visit(instance));
+                    PushOperand(VisitRequired(instance));
                 }
             }
             else
             {
-                PushOperand(Visit(operation.Operation));
+                PushOperand(VisitRequired(operation.Operation));
             }
 
             ImmutableArray<IOperation> rewrittenArguments = VisitArray(operation.Arguments);
@@ -6090,7 +6124,7 @@ oneMoreTime:
 
         public override IOperation VisitDynamicIndexerAccess(IDynamicIndexerAccessOperation operation, int? captureIdForResult)
         {
-            PushOperand(Visit(operation.Operation));
+            PushOperand(VisitRequired(operation.Operation));
 
             ImmutableArray<IOperation> rewrittenArguments = VisitArray(operation.Arguments);
             IOperation rewrittenOperation = PopOperand();
@@ -6110,7 +6144,6 @@ oneMoreTime:
             (IOperation visitedTarget, IOperation visitedValue) = VisitPreservingTupleOperations(operation.Target, operation.Value);
             return new DeconstructionAssignmentOperation(visitedTarget, visitedValue, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
-#nullable disable
 
         /// <summary>
         /// Recursively push nexted values onto the stack for visiting
@@ -6128,11 +6161,10 @@ oneMoreTime:
             }
             else
             {
-                PushOperand(Visit(value));
+                PushOperand(VisitRequired(value));
             }
         }
 
-#nullable enable
         /// <summary>
         /// Recursively pop nested tuple values off the stack after visiting
         /// </summary>
@@ -6179,7 +6211,7 @@ oneMoreTime:
             // the tuple that's been captured, it's the operands to the tuple.
             EvalStackFrame frame = PushStackFrame();
             PushTargetAndUnwrapTupleIfNecessary(left);
-            IOperation visitedRight = Visit(right);
+            IOperation visitedRight = VisitRequired(right);
             IOperation visitedLeft = PopTargetAndWrapTupleIfNecessary(left);
             PopStackFrame(frame);
             return (visitedLeft, visitedRight);
@@ -6226,11 +6258,11 @@ oneMoreTime:
                 if (element.Kind == OperationKind.Interpolation)
                 {
                     var interpolation = (IInterpolationOperation)element;
-                    PushOperand(Visit(interpolation.Expression));
+                    PushOperand(VisitRequired(interpolation.Expression));
 
                     if (interpolation.Alignment != null)
                     {
-                        PushOperand(Visit(interpolation.Alignment));
+                        PushOperand(VisitRequired(interpolation.Alignment));
                     }
                 }
             }
@@ -6365,13 +6397,12 @@ oneMoreTime:
 
         public override IOperation VisitParenthesized(IParenthesizedOperation operation, int? captureIdForResult)
         {
-            return new ParenthesizedOperation(Visit(operation.Operand), semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new ParenthesizedOperation(VisitRequired(operation.Operand), semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
-#nullable enable
         public override IOperation VisitAwait(IAwaitOperation operation, int? captureIdForResult)
         {
-            return new AwaitOperation(Visit(operation.Operation), semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
+            return new AwaitOperation(VisitRequired(operation.Operation), semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
         public override IOperation VisitSizeOf(ISizeOfOperation operation, int? captureIdForResult)
@@ -6386,7 +6417,7 @@ oneMoreTime:
 
         public override IOperation VisitIsType(IIsTypeOperation operation, int? captureIdForResult)
         {
-            return new IsTypeOperation(Visit(operation.ValueOperand), operation.TypeOperand, operation.IsNegated, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
+            return new IsTypeOperation(VisitRequired(operation.ValueOperand), operation.TypeOperand, operation.IsNegated, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
         public override IOperation? VisitParameterInitializer(IParameterInitializerOperation operation, int? captureIdForResult)
@@ -6464,7 +6495,7 @@ oneMoreTime:
             EnterRegion(new RegionBuilder(ControlFlowRegionKind.LocalLifetime, locals: initializer.Locals));
 
             EvalStackFrame frame = PushStackFrame();
-            var assignment = new SimpleAssignmentOperation(isRef: false, rewrittenTarget, Visit(initializer.Value), semanticModel: null,
+            var assignment = new SimpleAssignmentOperation(isRef: false, rewrittenTarget, VisitRequired(initializer.Value), semanticModel: null,
                 initializer.Syntax, rewrittenTarget.Type, constantValue: null, isImplicit: true);
             AddStatement(assignment);
             PopStackFrameAndLeaveRegion(frame);
@@ -6486,10 +6517,10 @@ oneMoreTime:
                 var eventReferenceInstance = eventReference.Event.IsStatic ? null : eventReference.Instance;
                 if (eventReferenceInstance != null)
                 {
-                    PushOperand(Visit(eventReferenceInstance));
+                    PushOperand(VisitRequired(eventReferenceInstance));
                 }
 
-                visitedHandler = Visit(operation.HandlerValue);
+                visitedHandler = VisitRequired(operation.HandlerValue);
 
                 IOperation? visitedInstance = eventReferenceInstance == null ? null : PopOperand();
                 visitedEventReference = new EventReferenceOperation(eventReference.Event, visitedInstance,
@@ -6499,8 +6530,8 @@ oneMoreTime:
             {
                 Debug.Assert(operation.EventReference != null);
 
-                PushOperand(Visit(operation.EventReference));
-                visitedHandler = Visit(operation.HandlerValue);
+                PushOperand(VisitRequired(operation.EventReference));
+                visitedHandler = VisitRequired(operation.HandlerValue);
                 visitedEventReference = PopOperand();
             }
 
@@ -6538,7 +6569,7 @@ oneMoreTime:
             var instance = operation.EventReference.Event.IsStatic ? null : operation.EventReference.Instance;
             if (instance != null)
             {
-                PushOperand(Visit(instance));
+                PushOperand(VisitRequired(instance));
             }
 
             ImmutableArray<IArgumentOperation> visitedArguments = VisitArguments(operation.Arguments);
@@ -6553,12 +6584,12 @@ oneMoreTime:
 
         public override IOperation VisitAddressOf(IAddressOfOperation operation, int? captureIdForResult)
         {
-            return new AddressOfOperation(Visit(operation.Reference), semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
+            return new AddressOfOperation(VisitRequired(operation.Reference), semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
         public override IOperation VisitIncrementOrDecrement(IIncrementOrDecrementOperation operation, int? captureIdForResult)
         {
-            return new IncrementOrDecrementOperation(operation.IsPostfix, operation.IsLifted, operation.IsChecked, Visit(operation.Target), operation.OperatorMethod,
+            return new IncrementOrDecrementOperation(operation.IsPostfix, operation.IsLifted, operation.IsChecked, VisitRequired(operation.Target), operation.OperatorMethod,
                                                      operation.Kind, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
@@ -6566,14 +6597,12 @@ oneMoreTime:
         {
             return new DiscardOperation(operation.DiscardSymbol, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
-#nullable disable
 
         public override IOperation VisitDiscardPattern(IDiscardPatternOperation pat, int? captureIdForResult)
         {
             return new DiscardPatternOperation(pat.InputType, pat.NarrowedType, semanticModel: null, pat.Syntax, IsImplicit(pat));
         }
 
-#nullable enable
         public override IOperation VisitOmittedArgument(IOmittedArgumentOperation operation, int? captureIdForResult)
         {
             return new OmittedArgumentOperation(semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
@@ -6613,10 +6642,9 @@ oneMoreTime:
             return new PlaceholderOperation(operation.PlaceholderKind, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
-#nullable enable
         public override IOperation VisitConversion(IConversionOperation operation, int? captureIdForResult)
         {
-            return new ConversionOperation(Visit(operation.Operand), ((ConversionOperation)operation).ConversionConvertible, operation.IsTryCast, operation.IsChecked, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new ConversionOperation(VisitRequired(operation.Operand), ((ConversionOperation)operation).ConversionConvertible, operation.IsTryCast, operation.IsChecked, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
         public override IOperation VisitDefaultValue(IDefaultValueOperation operation, int? captureIdForResult)
@@ -6627,14 +6655,13 @@ oneMoreTime:
         public override IOperation VisitIsPattern(IIsPatternOperation operation, int? captureIdForResult)
         {
             EvalStackFrame frame = PushStackFrame();
-            PushOperand(Visit(operation.Value));
-            var visitedPattern = (IPatternOperation)Visit(operation.Pattern);
+            PushOperand(VisitRequired(operation.Value));
+            var visitedPattern = (IPatternOperation)VisitRequired(operation.Pattern);
             IOperation visitedValue = PopOperand();
             PopStackFrame(frame);
             return new IsPatternOperation(visitedValue, visitedPattern, semanticModel: null,
                                           operation.Syntax, operation.Type, IsImplicit(operation));
         }
-#nullable disable
 
         public override IOperation VisitInvalid(IInvalidOperation operation, int? captureIdForResult)
         {
@@ -6655,7 +6682,7 @@ oneMoreTime:
 
                 foreach (var argument in children)
                 {
-                    PushOperand(Visit(argument));
+                    PushOperand(VisitRequired(argument));
                 }
 
                 for (int i = children.Count - 1; i >= 0; i--)
@@ -6700,7 +6727,6 @@ oneMoreTime:
             }
         }
 
-#nullable enable
         public override IOperation? VisitReDim(IReDimOperation operation, int? argument)
         {
             StartVisitingStatement(operation);
@@ -6725,7 +6751,7 @@ oneMoreTime:
 
             IReDimClauseOperation visitReDimClause(IReDimClauseOperation clause)
             {
-                PushOperand(Visit(clause.Operand));
+                PushOperand(VisitRequired(clause.Operand));
                 var visitedDimensionSizes = VisitArray(clause.DimensionSizes);
                 var visitedOperand = PopOperand();
                 return new ReDimClauseOperation(visitedOperand, visitedDimensionSizes, semanticModel: null, clause.Syntax, IsImplicit(clause));
@@ -6739,12 +6765,12 @@ oneMoreTime:
 
         public override IOperation VisitTranslatedQuery(ITranslatedQueryOperation operation, int? captureIdForResult)
         {
-            return new TranslatedQueryOperation(Visit(operation.Operation), semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
+            return new TranslatedQueryOperation(VisitRequired(operation.Operation), semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
         public override IOperation VisitConstantPattern(IConstantPatternOperation operation, int? captureIdForResult)
         {
-            return new ConstantPatternOperation(Visit(operation.Value), operation.InputType, operation.NarrowedType, semanticModel: null,
+            return new ConstantPatternOperation(VisitRequired(operation.Value), operation.InputType, operation.NarrowedType, semanticModel: null,
                 syntax: operation.Syntax, isImplicit: IsImplicit(operation));
         }
 
@@ -6752,7 +6778,7 @@ oneMoreTime:
         {
             return new RelationalPatternOperation(
                 operatorKind: operation.OperatorKind,
-                value: Visit(operation.Value),
+                value: VisitRequired(operation.Value),
                 inputType: operation.InputType,
                 narrowedType: operation.NarrowedType,
                 semanticModel: null,
@@ -6764,8 +6790,8 @@ oneMoreTime:
         {
             return new BinaryPatternOperation(
                 operatorKind: operation.OperatorKind,
-                leftPattern: (IPatternOperation)Visit(operation.LeftPattern),
-                rightPattern: (IPatternOperation)Visit(operation.RightPattern),
+                leftPattern: (IPatternOperation)VisitRequired(operation.LeftPattern),
+                rightPattern: (IPatternOperation)VisitRequired(operation.RightPattern),
                 inputType: operation.InputType,
                 narrowedType: operation.NarrowedType,
                 semanticModel: null,
@@ -6776,7 +6802,7 @@ oneMoreTime:
         public override IOperation VisitNegatedPattern(INegatedPatternOperation operation, int? argument)
         {
             return new NegatedPatternOperation(
-                pattern: (IPatternOperation)Visit(operation.Pattern),
+                pattern: (IPatternOperation)VisitRequired(operation.Pattern),
                 inputType: operation.InputType,
                 narrowedType: operation.NarrowedType,
                 semanticModel: null,
@@ -6813,8 +6839,8 @@ oneMoreTime:
             return new RecursivePatternOperation(
                 operation.MatchedType,
                 operation.DeconstructSymbol,
-                operation.DeconstructionSubpatterns.SelectAsArray(p => (IPatternOperation)Visit(p)),
-                operation.PropertySubpatterns.SelectAsArray(p => (IPropertySubpatternOperation)Visit(p)),
+                operation.DeconstructionSubpatterns.SelectAsArray((p, @this) => (IPatternOperation)@this.VisitRequired(p), this),
+                operation.PropertySubpatterns.SelectAsArray((p, @this) => (IPropertySubpatternOperation)@this.VisitRequired(p), this),
                 operation.DeclaredSymbol,
                 operation.InputType,
                 operation.NarrowedType,
@@ -6826,8 +6852,8 @@ oneMoreTime:
         public override IOperation VisitPropertySubpattern(IPropertySubpatternOperation operation, int? argument)
         {
             return new PropertySubpatternOperation(
-                Visit(operation.Member),
-                (IPatternOperation)Visit(operation.Pattern),
+                VisitRequired(operation.Member),
+                (IPatternOperation)VisitRequired(operation.Pattern),
                 semanticModel: null,
                 syntax: operation.Syntax,
                 isImplicit: IsImplicit(operation));
@@ -6835,7 +6861,7 @@ oneMoreTime:
 
         public override IOperation VisitDelegateCreation(IDelegateCreationOperation operation, int? captureIdForResult)
         {
-            return new DelegateCreationOperation(Visit(operation.Target), semanticModel: null,
+            return new DelegateCreationOperation(VisitRequired(operation.Target), semanticModel: null,
                 operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
@@ -6843,7 +6869,7 @@ oneMoreTime:
         {
             if (operation.LeftOperand is object)
             {
-                PushOperand(Visit(operation.LeftOperand));
+                PushOperand(VisitRequired(operation.LeftOperand));
             }
 
             IOperation? visitedRightOperand = null;
@@ -6882,7 +6908,7 @@ oneMoreTime:
 
             INamedTypeSymbol booleanType = _compilation.GetSpecialType(SpecialType.System_Boolean);
             SpillEvalStack();
-            RegionBuilder resultCaptureRegion = _currentRegion;
+            RegionBuilder resultCaptureRegion = CurrentRegionRequired;
             int captureOutput = captureIdForResult ?? GetNextCaptureId(resultCaptureRegion);
             var capturedInput = VisitAndCapture(operation.Value);
             var afterSwitch = new BasicBlockBuilder(BasicBlockKind.Block);
@@ -6897,7 +6923,7 @@ oneMoreTime:
                 // GotoIfFalse (captureInput is pat1) label;
                 {
                     EvalStackFrame frame = PushStackFrame();
-                    var visitedPattern = (IPatternOperation)Visit(arm.Pattern);
+                    var visitedPattern = (IPatternOperation)VisitRequired(arm.Pattern);
                     var patternTest = new IsPatternOperation(
                         OperationCloner.CloneOperation(capturedInput), visitedPattern, semanticModel: null,
                         arm.Syntax, booleanType, IsImplicit(arm));
@@ -6951,7 +6977,7 @@ oneMoreTime:
 
         private void VisitUsingVariableDeclarationOperation(IUsingDeclarationOperation operation, ImmutableArray<IOperation> statements)
         {
-            IOperation saveCurrentStatement = _currentStatement;
+            IOperation? saveCurrentStatement = _currentStatement;
             _currentStatement = operation;
             StartVisitingStatement(operation);
 
@@ -6972,16 +6998,34 @@ oneMoreTime:
             FinishVisitingStatement(operation);
             _currentStatement = saveCurrentStatement;
         }
-#nullable disable
 
-        public IOperation Visit(IOperation operation)
+        public IOperation? Visit(IOperation? operation)
         {
             // We should never be revisiting nodes we've already visited, and we don't set SemanticModel in this builder.
-            Debug.Assert(operation == null || ((Operation)operation).OwningSemanticModel.Compilation == _compilation);
+            Debug.Assert(operation == null || ((Operation)operation).OwningSemanticModel!.Compilation == _compilation);
             return Visit(operation, argument: null);
         }
 
-        public override IOperation Visit(IOperation operation, int? argument)
+        [return: NotNullIfNotNull("operation")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IOperation? VisitRequired(IOperation? operation, int? argument = null)
+        {
+            Debug.Assert(operation == null || ((Operation)operation).OwningSemanticModel!.Compilation == _compilation);
+            var result = Visit(operation, argument);
+            Debug.Assert((result == null) == (operation == null));
+            return result;
+        }
+
+        [return: NotNullIfNotNull("operation")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IOperation? BaseVisitRequired(IOperation? operation, int? argument)
+        {
+            var result = base.Visit(operation, argument);
+            Debug.Assert((result == null) == (operation == null));
+            return result;
+        }
+
+        public override IOperation? Visit(IOperation? operation, int? argument)
         {
             if (operation == null)
             {
@@ -7007,12 +7051,11 @@ oneMoreTime:
             throw ExceptionUtilities.Unreachable;
         }
 
-#nullable enable
         public override IOperation VisitWith(IWithOperation operation, int? argument)
         {
             EvalStackFrame frame = PushStackFrame();
             // Initializer is removed from the tree and turned into a series of statements that assign to the cloned instance
-            IOperation visitedInstance = Visit(operation.Operand);
+            IOperation visitedInstance = VisitRequired(operation.Operand);
 
             IOperation cloned = operation.CloneMethod is null
                 ? MakeInvalidOperation(visitedInstance.Type, visitedInstance)

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphExtensions.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
@@ -14,7 +13,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// Gets or creates a control flow graph for the given <paramref name="localFunction"/> defined in
         /// the given <paramref name="controlFlowGraph"/> or any of it's parent control flow graphs.
         /// </summary>
-        public static ControlFlowGraph GetLocalFunctionControlFlowGraphInScope([DisallowNull] this ControlFlowGraph? controlFlowGraph, IMethodSymbol localFunction, CancellationToken cancellationToken = default)
+        public static ControlFlowGraph GetLocalFunctionControlFlowGraphInScope(this ControlFlowGraph controlFlowGraph, IMethodSymbol localFunction, CancellationToken cancellationToken = default)
         {
             if (controlFlowGraph == null)
             {
@@ -26,14 +25,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 throw new ArgumentNullException(nameof(localFunction));
             }
 
+            ControlFlowGraph? currentGraph = controlFlowGraph;
             do
             {
-                if (controlFlowGraph.TryGetLocalFunctionControlFlowGraph(localFunction, cancellationToken, out ControlFlowGraph? localFunctionControlFlowGraph))
+                if (currentGraph.TryGetLocalFunctionControlFlowGraph(localFunction, cancellationToken, out ControlFlowGraph? localFunctionControlFlowGraph))
                 {
                     return localFunctionControlFlowGraph;
                 }
             }
-            while ((controlFlowGraph = controlFlowGraph.Parent) != null);
+            while ((currentGraph = currentGraph.Parent) != null);
 
             throw new ArgumentOutOfRangeException(nameof(localFunction));
         }
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// Gets or creates a control flow graph for the given <paramref name="anonymousFunction"/> defined in
         /// the given <paramref name="controlFlowGraph"/> or any of it's parent control flow graphs.
         /// </summary>
-        public static ControlFlowGraph GetAnonymousFunctionControlFlowGraphInScope([DisallowNull] this ControlFlowGraph? controlFlowGraph, IFlowAnonymousFunctionOperation anonymousFunction, CancellationToken cancellationToken = default)
+        public static ControlFlowGraph GetAnonymousFunctionControlFlowGraphInScope(this ControlFlowGraph controlFlowGraph, IFlowAnonymousFunctionOperation anonymousFunction, CancellationToken cancellationToken = default)
         {
             if (controlFlowGraph == null)
             {
@@ -54,14 +54,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 throw new ArgumentNullException(nameof(anonymousFunction));
             }
 
+            ControlFlowGraph? currentGraph = controlFlowGraph;
             do
             {
-                if (controlFlowGraph.TryGetAnonymousFunctionControlFlowGraph(anonymousFunction, cancellationToken, out ControlFlowGraph? localFunctionControlFlowGraph))
+                if (currentGraph.TryGetAnonymousFunctionControlFlowGraph(anonymousFunction, cancellationToken, out ControlFlowGraph? localFunctionControlFlowGraph))
                 {
                     return localFunctionControlFlowGraph;
                 }
             }
-            while ((controlFlowGraph = controlFlowGraph.Parent) != null);
+            while ((currentGraph = currentGraph.Parent) != null);
 
             throw new ArgumentOutOfRangeException(nameof(anonymousFunction));
         }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphExtensions.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphExtensions.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
@@ -15,7 +14,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// Gets or creates a control flow graph for the given <paramref name="localFunction"/> defined in
         /// the given <paramref name="controlFlowGraph"/> or any of it's parent control flow graphs.
         /// </summary>
-        public static ControlFlowGraph GetLocalFunctionControlFlowGraphInScope(this ControlFlowGraph controlFlowGraph, IMethodSymbol localFunction, CancellationToken cancellationToken = default)
+        public static ControlFlowGraph GetLocalFunctionControlFlowGraphInScope([DisallowNull] this ControlFlowGraph? controlFlowGraph, IMethodSymbol localFunction, CancellationToken cancellationToken = default)
         {
             if (controlFlowGraph == null)
             {
@@ -29,7 +28,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             do
             {
-                if (controlFlowGraph.TryGetLocalFunctionControlFlowGraph(localFunction, cancellationToken, out ControlFlowGraph localFunctionControlFlowGraph))
+                if (controlFlowGraph.TryGetLocalFunctionControlFlowGraph(localFunction, cancellationToken, out ControlFlowGraph? localFunctionControlFlowGraph))
                 {
                     return localFunctionControlFlowGraph;
                 }
@@ -43,7 +42,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// Gets or creates a control flow graph for the given <paramref name="anonymousFunction"/> defined in
         /// the given <paramref name="controlFlowGraph"/> or any of it's parent control flow graphs.
         /// </summary>
-        public static ControlFlowGraph GetAnonymousFunctionControlFlowGraphInScope(this ControlFlowGraph controlFlowGraph, IFlowAnonymousFunctionOperation anonymousFunction, CancellationToken cancellationToken = default)
+        public static ControlFlowGraph GetAnonymousFunctionControlFlowGraphInScope([DisallowNull] this ControlFlowGraph? controlFlowGraph, IFlowAnonymousFunctionOperation anonymousFunction, CancellationToken cancellationToken = default)
         {
             if (controlFlowGraph == null)
             {
@@ -57,7 +56,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             do
             {
-                if (controlFlowGraph.TryGetAnonymousFunctionControlFlowGraph(anonymousFunction, cancellationToken, out ControlFlowGraph localFunctionControlFlowGraph))
+                if (controlFlowGraph.TryGetAnonymousFunctionControlFlowGraph(anonymousFunction, cancellationToken, out ControlFlowGraph? localFunctionControlFlowGraph))
                 {
                     return localFunctionControlFlowGraph;
                 }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowRegion.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowRegion.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
@@ -25,13 +22,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Enclosing region. Null for <see cref="ControlFlowRegionKind.Root"/>
         /// </summary>
-        public ControlFlowRegion EnclosingRegion { get; private set; }
+        public ControlFlowRegion? EnclosingRegion { get; private set; }
 
         /// <summary>
         /// Target exception type for <see cref="ControlFlowRegionKind.Filter"/>, <see cref="ControlFlowRegionKind.Catch"/>, 
         /// <see cref="ControlFlowRegionKind.FilterAndHandler "/>
         /// </summary>
-        public ITypeSymbol ExceptionType { get; }
+        public ITypeSymbol? ExceptionType { get; }
 
         /// <summary>
         /// Ordinal (<see cref="BasicBlock.Ordinal"/>) of the first <see cref="BasicBlock"/> within the region. 
@@ -68,8 +65,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                         ImmutableArray<ILocalSymbol> locals,
                         ImmutableArray<IMethodSymbol> methods,
                         ImmutableArray<CaptureId> captureIds,
-                        ITypeSymbol exceptionType,
-                        ControlFlowRegion enclosingRegion)
+                        ITypeSymbol? exceptionType,
+                        ControlFlowRegion? enclosingRegion)
         {
             Debug.Assert(firstBlockOrdinal >= 0);
             Debug.Assert(lastBlockOrdinal >= firstBlockOrdinal);

--- a/src/Compilers/Core/Portable/Operations/ControlFlowRegionKind.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowRegionKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis

--- a/src/Compilers/Core/Portable/Operations/IConvertibleConversion.cs
+++ b/src/Compilers/Core/Portable/Operations/IConvertibleConversion.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     internal interface IConvertibleConversion

--- a/src/Compilers/Core/Portable/Operations/InstanceReferenceKind.cs
+++ b/src/Compilers/Core/Portable/Operations/InstanceReferenceKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/Loops/ForEachLoopOperationInfo.cs
+++ b/src/Compilers/Core/Portable/Operations/Loops/ForEachLoopOperationInfo.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Operations

--- a/src/Compilers/Core/Portable/Operations/Loops/ForToLoopOperationInfo.cs
+++ b/src/Compilers/Core/Portable/Operations/Loops/ForToLoopOperationInfo.cs
@@ -2,21 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Operations
 {
     internal class ForToLoopOperationUserDefinedInfo
     {
-        public readonly Lazy<IBinaryOperation> Addition;
-        public readonly Lazy<IBinaryOperation> Subtraction;
-        public readonly Lazy<IOperation> LessThanOrEqual;
-        public readonly Lazy<IOperation> GreaterThanOrEqual;
+        public readonly IBinaryOperation Addition;
+        public readonly IBinaryOperation Subtraction;
+        public readonly IOperation LessThanOrEqual;
+        public readonly IOperation GreaterThanOrEqual;
 
-        public ForToLoopOperationUserDefinedInfo(Lazy<IBinaryOperation> addition, Lazy<IBinaryOperation> subtraction, Lazy<IOperation> lessThanOrEqual, Lazy<IOperation> greaterThanOrEqual)
+        public ForToLoopOperationUserDefinedInfo(IBinaryOperation addition, IBinaryOperation subtraction, IOperation lessThanOrEqual, IOperation greaterThanOrEqual)
         {
             Addition = addition;
             Subtraction = subtraction;

--- a/src/Compilers/Core/Portable/Operations/Loops/LoopKind.cs
+++ b/src/Compilers/Core/Portable/Operations/Loops/LoopKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Operations/OperationExtensions.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -61,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Returns all the descendant operations of the given <paramref name="operation"/> in evaluation order.
         /// </summary>
         /// <param name="operation">Operation whose descendants are to be fetched.</param>
-        public static IEnumerable<IOperation> Descendants(this IOperation operation)
+        public static IEnumerable<IOperation> Descendants(this IOperation? operation)
         {
             return Descendants(operation, includeSelf: false);
         }
@@ -70,12 +68,12 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Returns all the descendant operations of the given <paramref name="operation"/> including the given <paramref name="operation"/> in evaluation order.
         /// </summary>
         /// <param name="operation">Operation whose descendants are to be fetched.</param>
-        public static IEnumerable<IOperation> DescendantsAndSelf(this IOperation operation)
+        public static IEnumerable<IOperation> DescendantsAndSelf(this IOperation? operation)
         {
             return Descendants(operation, includeSelf: true);
         }
 
-        private static IEnumerable<IOperation> Descendants(IOperation operation, bool includeSelf)
+        private static IEnumerable<IOperation> Descendants(IOperation? operation, bool includeSelf)
         {
             if (operation == null)
             {
@@ -164,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// if the single variable initializer is null.
         /// </summary>
         /// <param name="declarationOperation">Single variable declaration to retrieve initializer for.</param>
-        public static IVariableInitializerOperation GetVariableInitializer(this IVariableDeclaratorOperation declarationOperation)
+        public static IVariableInitializerOperation? GetVariableInitializer(this IVariableDeclaratorOperation declarationOperation)
         {
             if (declarationOperation == null)
             {
@@ -179,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         /// <param name="dynamicOperation">Dynamic or late bound operation.</param>
         /// <param name="index">Argument index.</param>
-        public static string GetArgumentName(this IDynamicInvocationOperation dynamicOperation, int index)
+        public static string? GetArgumentName(this IDynamicInvocationOperation dynamicOperation, int index)
         {
             if (dynamicOperation == null)
             {
@@ -194,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         /// <param name="dynamicOperation">Dynamic or late bound operation.</param>
         /// <param name="index">Argument index.</param>
-        public static string GetArgumentName(this IDynamicIndexerAccessOperation dynamicOperation, int index)
+        public static string? GetArgumentName(this IDynamicIndexerAccessOperation dynamicOperation, int index)
         {
             if (dynamicOperation == null)
             {
@@ -209,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         /// <param name="dynamicOperation">Dynamic or late bound operation.</param>
         /// <param name="index">Argument index.</param>
-        public static string GetArgumentName(this IDynamicObjectCreationOperation dynamicOperation, int index)
+        public static string? GetArgumentName(this IDynamicObjectCreationOperation dynamicOperation, int index)
         {
             if (dynamicOperation == null)
             {
@@ -224,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         /// <param name="dynamicOperation">Dynamic or late bound operation.</param>
         /// <param name="index">Argument index.</param>
-        internal static string GetArgumentName(this HasDynamicArgumentsExpression dynamicOperation, int index)
+        internal static string? GetArgumentName(this HasDynamicArgumentsExpression dynamicOperation, int index)
         {
             if (dynamicOperation.Arguments.IsDefaultOrEmpty)
             {
@@ -342,7 +340,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <returns>The corresponding operation or <c>null</c> in case not found (e.g. no loop or switch syntax, or the branch is not a break or continue)</returns>
         /// <exception cref="ArgumentNullException"><paramref name="operation"/> is null</exception>
         /// <exception cref="InvalidOperationException">The operation is a part of Control Flow Graph</exception>
-        public static IOperation GetCorrespondingOperation(this IBranchOperation operation)
+        public static IOperation? GetCorrespondingOperation(this IBranchOperation operation)
         {
             if (operation == null)
             {
@@ -379,11 +377,9 @@ namespace Microsoft.CodeAnalysis.Operations
             return null;
         }
 
-#nullable enable
         internal static ConstantValue? GetConstantValue(this IOperation operation)
         {
             return ((Operation)operation).OperationConstantValue;
         }
-#nullable disable
     }
 }

--- a/src/Compilers/Core/Portable/Operations/OperationNodes.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationNodes.cs
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
     internal sealed partial class IsNullOperation
     {
-        public IsNullOperation(SyntaxNode syntax, IOperation operand, ITypeSymbol type, ConstantValue constantValue) :
+        public IsNullOperation(SyntaxNode syntax, IOperation operand, ITypeSymbol type, ConstantValue? constantValue) :
             this(operand, semanticModel: null, syntax: syntax, type: type, constantValue: constantValue, isImplicit: true)
         {
             Debug.Assert(operand != null);

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>
@@ -34,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public abstract partial class OperationVisitor<TArgument, TResult>
     {
         // Make public after review: https://github.com/dotnet/roslyn/issues/21281
-        internal virtual TResult VisitFixed(IFixedOperation operation, TArgument argument) =>
+        internal virtual TResult? VisitFixed(IFixedOperation operation, TArgument argument) =>
             // https://github.com/dotnet/roslyn/issues/21281
             //return DefaultVisit(operation, argument);
             VisitNoneOperation(operation, argument);

--- a/src/Compilers/Core/Portable/Operations/OperationWalker.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationWalker.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Operations
@@ -29,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Visit(operation);
         }
 
-        public override void Visit(IOperation operation)
+        public override void Visit(IOperation? operation)
         {
             if (operation != null)
             {

--- a/src/Compilers/Core/Portable/Operations/PlaceholderKind.cs
+++ b/src/Compilers/Core/Portable/Operations/PlaceholderKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     internal enum PlaceholderKind

--- a/src/Compilers/Core/Portable/Operations/UnaryOperatorKind.cs
+++ b/src/Compilers/Core/Portable/Operations/UnaryOperatorKind.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -578,10 +578,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             if (userDefinedInfo != null)
             {
-                _ = userDefinedInfo.Addition.Value;
-                _ = userDefinedInfo.Subtraction.Value;
-                _ = userDefinedInfo.LessThanOrEqual.Value;
-                _ = userDefinedInfo.GreaterThanOrEqual.Value;
+                _ = userDefinedInfo.Addition;
+                _ = userDefinedInfo.Subtraction;
+                _ = userDefinedInfo.LessThanOrEqual;
+                _ = userDefinedInfo.GreaterThanOrEqual;
             }
         }
 

--- a/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
+++ b/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
@@ -275,10 +275,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             if (userDefinedInfo != null)
             {
-                VerifySubTree(userDefinedInfo.Addition.Value);
-                VerifySubTree(userDefinedInfo.Subtraction.Value);
-                VerifySubTree(userDefinedInfo.LessThanOrEqual.Value);
-                VerifySubTree(userDefinedInfo.GreaterThanOrEqual.Value);
+                VerifySubTree(userDefinedInfo.Addition);
+                VerifySubTree(userDefinedInfo.Subtraction);
+                VerifySubTree(userDefinedInfo.LessThanOrEqual);
+                VerifySubTree(userDefinedInfo.GreaterThanOrEqual);
             }
 
             IEnumerable<IOperation> children;

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1170,12 +1170,10 @@ Namespace Microsoft.CodeAnalysis.Operations
             If operatorsOpt IsNot Nothing Then
                 RecordParent(operatorsOpt.LeftOperandPlaceholder, boundForToStatement)
                 RecordParent(operatorsOpt.RightOperandPlaceholder, boundForToStatement)
-                userDefinedInfo = New ForToLoopOperationUserDefinedInfo(New Lazy(Of IBinaryOperation)(Function() DirectCast(Operation.SetParentOperation(Create(operatorsOpt.Addition), Nothing),
-                                                                                                                            IBinaryOperation)),
-                                                                        New Lazy(Of IBinaryOperation)(Function() DirectCast(Operation.SetParentOperation(Create(operatorsOpt.Subtraction), Nothing),
-                                                                                                                            IBinaryOperation)),
-                                                                        New Lazy(Of IOperation)(Function() Operation.SetParentOperation(Create(operatorsOpt.LessThanOrEqual), Nothing)),
-                                                                        New Lazy(Of IOperation)(Function() Operation.SetParentOperation(Create(operatorsOpt.GreaterThanOrEqual), Nothing)))
+                userDefinedInfo = New ForToLoopOperationUserDefinedInfo(DirectCast(Operation.SetParentOperation(Create(operatorsOpt.Addition), Nothing), IBinaryOperation),
+                                                                        DirectCast(Operation.SetParentOperation(Create(operatorsOpt.Subtraction), Nothing), IBinaryOperation),
+                                                                        Operation.SetParentOperation(Create(operatorsOpt.LessThanOrEqual), Nothing),
+                                                                        Operation.SetParentOperation(Create(operatorsOpt.GreaterThanOrEqual), Nothing))
             End If
 
             Return New ForToLoopOperation(loopControlVariable, initialValue, limitValue, stepValue, boundForToStatement.Checked, nextVariables, (loopObj, userDefinedInfo),

--- a/src/Features/Core/Portable/InlineMethod/AbstractInlineMethodRefactoringProvider.InlineContext.cs
+++ b/src/Features/Core/Portable/InlineMethod/AbstractInlineMethodRefactoringProvider.InlineContext.cs
@@ -400,17 +400,19 @@ namespace Microsoft.CodeAnalysis.InlineMethod
             {
                 var visitor = new LocalVariableDeclarationVisitor(cancellationToken);
                 var operation = semanticModel.GetOperation(methodDeclarationSyntax, cancellationToken);
-                if (operation != null)
-                {
-                    visitor.Visit(operation);
-                }
+                visitor.Visit(operation);
 
                 return visitor._allSymbols.ToImmutableHashSet();
             }
 
-            public override void Visit(IOperation operation)
+            public override void Visit(IOperation? operation)
             {
                 _cancellationToken.ThrowIfCancellationRequested();
+                if (operation == null)
+                {
+                    return;
+                }
+
                 if (operation is IVariableDeclaratorOperation variableDeclarationOperation)
                 {
                     _allSymbols.Add(variableDeclarationOperation.Symbol);


### PR DESCRIPTION
This fully enables nullable for the operation and CFG factories, the rest of the CFG public API, miscellaneous files in the Operations folders. In the CFG, I had to introduce a new `VisitRequired` intermediate method in the control flow factory for when visiting a child node should return a node that is not null, and replace a number of uses with it. The CFG nullability conditions, in particularly, are quite complicated, so this is a large PR to go through. Apologies in advance.