### PR TITLE
[LSP] Fix FAR namespace bug + re-enable FAR tests

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -109,6 +109,11 @@ namespace Roslyn.Test.Utilities
             }
         }
 
+        protected class OrderLocations : Comparer<LSP.Location>
+        {
+            public override int Compare(LSP.Location x, LSP.Location y) => CompareLocations(x, y);
+        }
+
         protected virtual TestComposition Composition => s_composition;
 
         /// <summary>
@@ -141,13 +146,13 @@ namespace Roslyn.Test.Utilities
             var orderedExpectedLocations = expectedLocations.OrderBy(CompareLocations);
 
             AssertJsonEquals(orderedExpectedLocations, orderedActualLocations);
+        }
 
-            static int CompareLocations(LSP.Location l1, LSP.Location l2)
-            {
-                var compareDocument = l1.Uri.OriginalString.CompareTo(l2.Uri.OriginalString);
-                var compareRange = CompareRange(l1.Range, l2.Range);
-                return compareDocument != 0 ? compareDocument : compareRange;
-            }
+        protected static int CompareLocations(LSP.Location l1, LSP.Location l2)
+        {
+            var compareDocument = l1.Uri.OriginalString.CompareTo(l2.Uri.OriginalString);
+            var compareRange = CompareRange(l1.Range, l2.Range);
+            return compareDocument != 0 ? compareDocument : compareRange;
         }
 
         protected static int CompareRange(LSP.Range r1, LSP.Range r2)

--- a/src/Features/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +19,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.References
 {
     public class FindAllReferencesHandlerTests : AbstractLanguageServerProtocolTests
     {
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/43063")]
+        [WpfFact]
         public async Task TestFindAllReferencesAsync()
         {
             var markup =
@@ -45,15 +44,17 @@ class B
             var results = await RunFindAllReferencesAsync(workspace.CurrentSolution, locations["caret"].First());
             AssertLocationsEqual(locations["reference"], results.Select(result => result.Location));
 
-            Assert.Equal("A", results[0].ContainingType);
-            Assert.Equal("B", results[2].ContainingType);
-            Assert.Equal("M", results[1].ContainingMember);
-            Assert.Equal("M2", results[3].ContainingMember);
+            // Results are returned in a non-deterministic order, so we order them by location
+            var orderedResults = results.OrderBy(r => r.Location, new OrderLocations()).ToArray();
+            Assert.Equal("A", orderedResults[0].ContainingType);
+            Assert.Equal("B", orderedResults[2].ContainingType);
+            Assert.Equal("M", orderedResults[1].ContainingMember);
+            Assert.Equal("M2", orderedResults[3].ContainingMember);
 
             AssertValidDefinitionProperties(results, 0, Glyph.FieldPublic);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/43063")]
+        [WpfFact]
         public async Task TestFindAllReferencesAsync_Streaming()
         {
             var markup =
@@ -90,15 +91,17 @@ class B
 
             AssertLocationsEqual(locations["reference"], results.Select(result => result.Location));
 
-            Assert.Equal("A", results[0].ContainingType);
-            Assert.Equal("B", results[2].ContainingType);
-            Assert.Equal("M", results[1].ContainingMember);
-            Assert.Equal("M2", results[3].ContainingMember);
+            // Results are returned in a non-deterministic order, so we order them by location
+            var orderedResults = results.OrderBy(r => r.Location, new OrderLocations()).ToArray();
+            Assert.Equal("A", orderedResults[0].ContainingType);
+            Assert.Equal("B", orderedResults[2].ContainingType);
+            Assert.Equal("M", orderedResults[1].ContainingMember);
+            Assert.Equal("M2", orderedResults[3].ContainingMember);
 
             AssertValidDefinitionProperties(results, 0, Glyph.FieldPublic);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/43063")]
+        [WpfFact]
         public async Task TestFindAllReferencesAsync_Class()
         {
             var markup =
@@ -128,14 +131,17 @@ class B
             var actualText = string.Concat(textElement.Runs.Select(r => r.Text));
 
             Assert.Equal("class A", actualText);
-            Assert.Equal("B", results[1].ContainingType);
-            Assert.Equal("B", results[2].ContainingType);
-            Assert.Equal("M2", results[2].ContainingMember);
+
+            // Results are returned in a non-deterministic order, so we order them by location
+            var orderedResults = results.OrderBy(r => r.Location, new OrderLocations()).ToArray();
+            Assert.Equal("B", orderedResults[1].ContainingType);
+            Assert.Equal("B", orderedResults[2].ContainingType);
+            Assert.Equal("M2", orderedResults[2].ContainingMember);
 
             AssertValidDefinitionProperties(results, 0, Glyph.ClassInternal);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/43063")]
+        [WpfFact]
         public async Task TestFindAllReferencesAsync_MultipleDocuments()
         {
             var markups = new string[] {
@@ -162,10 +168,12 @@ class B
             var results = await RunFindAllReferencesAsync(workspace.CurrentSolution, locations["caret"].First());
             AssertLocationsEqual(locations["reference"], results.Select(result => result.Location));
 
-            Assert.Equal("A", results[0].ContainingType);
-            Assert.Equal("B", results[2].ContainingType);
-            Assert.Equal("M", results[1].ContainingMember);
-            Assert.Equal("M2", results[3].ContainingMember);
+            // Results are returned in a non-deterministic order, so we order them by location
+            var orderedResults = results.OrderBy(r => r.Location, new OrderLocations()).ToArray();
+            Assert.Equal("A", orderedResults[0].ContainingType);
+            Assert.Equal("B", orderedResults[2].ContainingType);
+            Assert.Equal("M", orderedResults[1].ContainingMember);
+            Assert.Equal("M2", orderedResults[3].ContainingMember);
 
             AssertValidDefinitionProperties(results, 0, Glyph.FieldPublic);
         }
@@ -184,7 +192,7 @@ class B
             Assert.Empty(results);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/43063")]
+        [WpfFact]
         public async Task TestFindAllReferencesMetadataDefinitionAsync()
         {
             var markup =
@@ -201,6 +209,34 @@ class A
 
             var results = await RunFindAllReferencesAsync(workspace.CurrentSolution, locations["caret"].First());
             Assert.NotNull(results[0].Location.Uri);
+        }
+
+        [WpfFact, WorkItem(1240061, "https://devdiv.visualstudio.com/DevDiv/_queries/edit/1240061/")]
+        public async Task TestFindAllReferencesAsync_Namespace()
+        {
+            var markup =
+@"namespace {|caret:|}{|reference:N|}
+{
+    class C
+    {
+        void M()
+        {
+            var x = new {|reference:N|}.C();
+        }
+    }
+}
+";
+            using var workspace = CreateTestWorkspace(markup, out var locations);
+
+            var results = await RunFindAllReferencesAsync(workspace.CurrentSolution, locations["caret"].First());
+
+            // Namespace definitions should not have a location
+            Assert.True(results.Any(r => r.DefinitionText != null && r.Location == null));
+
+            // Namespace references should have locations
+            Assert.True(results.Any(r => r.DefinitionText == null && r.Location != null));
+
+            AssertValidDefinitionProperties(results, 0, Glyph.Namespace);
         }
 
         private static LSP.ReferenceParams CreateReferenceParams(LSP.Location caret, IProgress<object> progress) =>

--- a/src/Features/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
@@ -211,7 +211,7 @@ class A
             Assert.NotNull(results[0].Location.Uri);
         }
 
-        [WpfFact, WorkItem(1240061, "https://devdiv.visualstudio.com/DevDiv/_queries/edit/1240061/")]
+        [WpfFact, WorkItem(1240061, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1240061/")]
         public async Task TestFindAllReferencesAsync_Namespace()
         {
             var markup =
@@ -233,7 +233,7 @@ class A
             // Namespace definitions should not have a location
             Assert.True(results.Any(r => r.DefinitionText != null && r.Location == null));
 
-            // Namespace references should have locations
+            // Namespace references should have a location
             Assert.True(results.Any(r => r.DefinitionText == null && r.Location != null));
 
             AssertValidDefinitionProperties(results, 0, Glyph.Namespace);


### PR DESCRIPTION
This PR:

1) Addresses the Roslyn side of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1240061/.
We previously ignored items that were missing locations and did not return them to LSP. However, namespace definitions do not have locations in Roslyn, so we now must consider these items.
LSP will have to respond to this change as they do nothing when location-less items are returned to them (filed https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1244900).

2) Fixes https://github.com/dotnet/roslyn/issues/43063
The tests were previously non-deterministic since we could not guarantee the order references were returned in, resulting in the occasional flaky test.
The references are now ordered by location and so should be deterministic.