### PR TITLE
Turn off text sync for Xaml

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
@@ -51,7 +51,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 OnAutoInsertProvider = new DocumentOnAutoInsertOptions { TriggerCharacters = new[] { "=", "/", ">" } },
                 TextDocumentSync = new TextDocumentSyncOptions
                 {
-                    Change = TextDocumentSyncKind.None
+                    Change = TextDocumentSyncKind.None,
+                    OpenClose = false
                 },
                 SupportsDiagnosticRequests = true,
             };


### PR DESCRIPTION
By default `ServerCapabilities` [opts in to didOpen and didClose](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient?path=%2Fsrc%2Fproduct%2FRemoteLanguage.Protocol%2FServerCapabilities.cs&version=GBdevelop&line=30&lineEnd=31&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) only, so when Changes are turned off, all LSP requests will be operating on stale data (that is, the document state when it was opened, without any edits having been applied).

I'm assuming since Xaml sets `Changes` to `None` that they don't want text sync, so its better to turn it off completely. This will save a little bit of memory because we won't store document state, and means LSP requests will operate on the real workspace, which I'm guessing is what is desired here.

FYI @mgoertz-msft @LinglingTong 
If you _do_ want text sync turned on, let me know, its just as easy as changing these values. Apologies for not spotting this on the pull diagnostic PR, I only discovered these odd defaults today.