### PR TITLE
Small nullability fixes

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -115,6 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Visit(node.IterationVariableType);
                 Visit(node.AwaitOpt);
+                Visit(node.EnumeratorInfoOpt?.DisposeAwaitableInfo);
                 Visit(node.Expression);
                 // https://github.com/dotnet/roslyn/issues/35010: handle the deconstruction
                 //this.Visit(node.DeconstructionOpt);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8587,19 +8587,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (node.EnumeratorInfoOpt is { NeedsDisposal: true, DisposeAwaitableInfo: BoundAwaitableInfo awaitDisposalInfo })
                 {
                     var disposalPlaceholder = awaitDisposalInfo.AwaitableInstancePlaceholder;
-                    if (disposalPlaceholder is not null && node.EnumeratorInfoOpt.DisposeMethod is not null) // no statically known Dispose method if doing a runtime check
+                    bool addedPlaceholder = false;
+                    if (node.EnumeratorInfoOpt.DisposeMethod is not null) // no statically known Dispose method if doing a runtime check
                     {
+                        Debug.Assert(disposalPlaceholder is not null);
                         var disposeAsyncMethod = (MethodSymbol)AsMemberOfType(reinferredGetEnumeratorMethod.ReturnType, node.EnumeratorInfoOpt.DisposeMethod);
                         EnsureAwaitablePlaceholdersInitialized();
                         var result = new VisitResult(GetReturnTypeWithState(disposeAsyncMethod), disposeAsyncMethod.ReturnTypeWithAnnotations);
                         _awaitablePlaceholdersOpt.Add(disposalPlaceholder, (disposalPlaceholder, result));
+                        addedPlaceholder = true;
                     }
 
                     Visit(awaitDisposalInfo);
 
-                    if (disposalPlaceholder is not null)
+                    if (addedPlaceholder)
                     {
-                        _awaitablePlaceholdersOpt!.Remove(disposalPlaceholder);
+                        _awaitablePlaceholdersOpt!.Remove(disposalPlaceholder!);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9543,7 +9543,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        [MemberNotNull("_awaitablePlaceholdersOpt")]
+        [MemberNotNull(nameof(_awaitablePlaceholdersOpt))]
         private void EnsureAwaitablePlaceholdersInitialized()
         {
             _awaitablePlaceholdersOpt ??= PooledDictionary<BoundAwaitableValuePlaceholder, (BoundExpression AwaitableExpression, VisitResult Result)>.GetInstance();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5329,11 +5329,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Note: for lambda arguments, they will be converted in the context/state we saved for that argument
                         if (conversion is { Kind: ConversionKind.ImplicitUserDefined })
                         {
-                            var argumentResultType = result.RValueType.Type;
-                            Debug.Assert(argumentResultType is not null);
+                            var argumentResultType = resultType.Type;
                             conversion = GenerateConversion(_conversions, argumentNoConversion, argumentResultType, parameterType.Type, fromExplicitCast: false, extensionMethodThisArgument: false);
                             if (!conversion.Exists && !argumentNoConversion.IsSuppressed)
                             {
+                                Debug.Assert(argumentResultType is not null);
                                 ReportNullabilityMismatchInArgument(argumentNoConversion.Syntax, argumentResultType, parameter, parameterType.Type, forOutput: false);
                             }
                         }
@@ -6399,17 +6399,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (targetSlot > 0)
             {
                 TrackNullableStateForAssignment(value, symbol!.GetTypeOrReturnType(), targetSlot, valueType, valueSlot);
-            }
-        }
-
-        private void TrackNullableStateOfNullableValue(BoundExpression node, BoundExpression operand, TypeSymbol convertedType, TypeWithAnnotations underlyingType)
-        {
-            int valueSlot = MakeSlot(operand);
-            if (valueSlot > 0)
-            {
-                int containingSlot = GetOrCreatePlaceholderSlot(node);
-                Debug.Assert(containingSlot > 0);
-                TrackNullableStateOfNullableValue(containingSlot, convertedType, operand, underlyingType.ToTypeWithState(), valueSlot);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5327,17 +5327,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case RefKind.In:
                     {
                         // Note: for lambda arguments, they will be converted in the context/state we saved for that argument
-                        if (conversion is { Kind: ConversionKind.ImplicitUserDefined })
-                        {
-                            var argumentResultType = resultType.Type;
-                            conversion = GenerateConversion(_conversions, argumentNoConversion, argumentResultType, parameterType.Type, fromExplicitCast: false, extensionMethodThisArgument: false);
-                            if (!conversion.Exists && !argumentNoConversion.IsSuppressed)
-                            {
-                                Debug.Assert(argumentResultType is not null);
-                                ReportNullabilityMismatchInArgument(argumentNoConversion.Syntax, argumentResultType, parameter, parameterType.Type, forOutput: false);
-                            }
-                        }
-
                         var stateAfterConversion = VisitConversion(
                             conversionOpt: conversionOpt,
                             conversionOperand: argumentNoConversion,
@@ -7061,6 +7050,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(conversion.Kind == ConversionKind.ExplicitUserDefined || conversion.Kind == ConversionKind.ImplicitUserDefined);
 
             TypeSymbol targetType = targetTypeWithNullability.Type;
+
+            if (parameterOpt is not null)
+            {
+                conversion = GenerateConversion(_conversions, conversionOperand, operandType.Type, targetTypeWithNullability.Type, fromExplicitCast: false, extensionMethodThisArgument: false);
+                if (!conversion.Exists && !conversionOperand.IsSuppressed)
+                {
+                    Debug.Assert(operandType.Type is not null);
+                    ReportNullabilityMismatchInArgument(conversionOperand.Syntax, operandType.Type, parameterOpt, targetTypeWithNullability.Type, forOutput: false);
+                }
+            }
 
             // cf. Binder.CreateUserDefinedConversion
             if (!conversion.IsValid)


### PR DESCRIPTION
Extracting some nullability fixes from my PR on type substitution (https://github.com/dotnet/roslyn/pull/48694).

- Fixes https://github.com/dotnet/roslyn/issues/29898 (we should re-infer user-defined conversion operators on arguments)
- Fixes an issue with `async foreach` analysis