### PR TITLE
Don't offer use-compound-assignment with implicit object creation.

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundAssignmentTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -783,6 +781,26 @@ struct InsertionPoint
     InsertionPoint Up()
     {
         return new InsertionPoint
+        {
+            level [||]= level - 1,
+        };
+    }
+}");
+        }
+
+        [WorkItem(49294, "https://github.com/dotnet/roslyn/issues/49294")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestNotOnImplicitObjectInitializer()
+        {
+            await TestMissingAsync(
+@"
+struct InsertionPoint
+{
+    int level;
+    
+    InsertionPoint Up()
+    {
+        return new()
         {
             level [||]= level - 1,
         };

--- a/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundAssignmentTests.cs
@@ -808,6 +808,24 @@ struct InsertionPoint
 }");
         }
 
+        [WorkItem(49294, "https://github.com/dotnet/roslyn/issues/49294")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestNotOnRecord()
+        {
+            await TestMissingAsync(
+@"
+record InsertionPoint(int level)
+{
+    InsertionPoint Up()
+    {
+        return this with
+        {
+            level [||]= level - 1,
+        };
+    }
+}");
+        }
+
         [WorkItem(38137, "https://github.com/dotnet/roslyn/issues/38137")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
         public async Task TestParenthesizedExpression()

--- a/src/Analyzers/Core/Analyzers/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -111,8 +111,10 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
             }
 
             // Don't offer if this is `x = x + 1` inside an obj initializer like:
-            // `new Point { x = x + 1 }`
-            if (_syntaxFacts.IsObjectInitializerNamedAssignmentIdentifier(assignmentLeft))
+            // `new Point { x = x + 1 }` or
+            // `new () { x = x + 1 }` or
+            // `p with { x = x + 1 }`
+            if (_syntaxFacts.IsMemberInitializerNamedAssignmentIdentifier(assignmentLeft))
             {
                 return;
             }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2413,7 +2413,7 @@ index: 1);
 
         private async Task TestWithAllCodeStyleOff(
             string initialMarkup, string expectedMarkup,
-            ParseOptions parseOptions = null, int index = 0)
+            ParseOptions? parseOptions = null, int index = 0)
         {
             await TestAsync(
                 initialMarkup, expectedMarkup, parseOptions,

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -1882,6 +1880,94 @@ class C
     {
         var t = new Tweet();
         var t1 = new Tweet
+        {
+            {|Conflict:Tweet|} = t.GetTweet()
+        };
+    }
+}");
+        }
+
+        [WorkItem(45171, "https://github.com/dotnet/roslyn/issues/45171")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestReferenceInImplicitObjectInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class Tweet
+{
+    public string [||]Tweet { get; }
+}
+
+class C
+{
+    void Main()
+    {
+        var t = new Tweet();
+        Tweet t1 = new()
+        {
+            Tweet = t.Tweet
+        };
+    }
+}",
+@"public class Tweet
+{
+    private readonly string tweet;
+
+    public string GetTweet()
+    {
+        return tweet;
+    }
+}
+
+class C
+{
+    void Main()
+    {
+        var t = new Tweet();
+        Tweet t1 = new()
+        {
+            {|Conflict:Tweet|} = t.GetTweet()
+        };
+    }
+}");
+        }
+
+        [WorkItem(45171, "https://github.com/dotnet/roslyn/issues/45171")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestReferenceInWithInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class Tweet
+{
+    public string [||]Tweet { get; }
+}
+
+class C
+{
+    void Main()
+    {
+        var t = new Tweet();
+        var t1 = t with
+        {
+            Tweet = t.Tweet
+        };
+    }
+}",
+@"public class Tweet
+{
+    private readonly string tweet;
+
+    public string GetTweet()
+    {
+        return tweet;
+    }
+}
+
+class C
+{
+    void Main()
+    {
+        var t = new Tweet();
+        var t1 = t with
         {
             {|Conflict:Tweet|} = t.GetTweet()
         };

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateVariable
         {
         }
 
-        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+        internal override (DiagnosticAnalyzer?, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (null, new CSharpGenerateVariableCodeFixProvider());
 
         private readonly CodeStyleOption2<bool> onWithInfo = new CodeStyleOption2<bool>(true, NotificationOption2.Suggestion);

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -3511,6 +3509,36 @@ class Bar
     void goo()
     {
         var c = new Goo { Gibberish = 24 };
+    }
+}");
+        }
+
+        [WorkItem(49294, "https://github.com/dotnet/roslyn/issues/49294")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestPropertyInWithInitializer()
+        {
+            await TestInRegularAndScriptAsync(
+@"record Goo
+{
+}
+
+class Bar
+{
+    void goo(Goo g)
+    {
+        var c = g with { [|Gibberish|] = 24 };
+    }
+}",
+@"record Goo
+{
+    public int Gibberish { get; internal set; }
+}
+
+class Bar
+{
+    void goo(Goo g)
+    {
+        var c = g with { Gibberish = 24 };
     }
 }");
         }

--- a/src/Features/Core/Portable/GenerateMember/AbstractGenerateMemberService.cs
+++ b/src/Features/Core/Portable/GenerateMember/AbstractGenerateMemberService.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember
                 return;
             }
 
-            if (syntaxFacts.IsObjectInitializerNamedAssignmentIdentifier(
+            if (syntaxFacts.IsMemberInitializerNamedAssignmentIdentifier(
                     expression, out var initializedObject))
             {
                 typeToGenerateIn = semanticModel.GetTypeInfo(initializedObject, cancellationToken).Type as INamedTypeSymbol;

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 IsInConstructor = DetermineIsInConstructor(semanticDocument, simpleName);
                 IsInMemberContext =
                     simpleName != SimpleNameOrMemberAccessExpressionOpt ||
-                    syntaxFacts.IsObjectInitializerNamedAssignmentIdentifier(SimpleNameOrMemberAccessExpressionOpt);
+                    syntaxFacts.IsMemberInitializerNamedAssignmentIdentifier(SimpleNameOrMemberAccessExpressionOpt);
 
                 ContainingMethod = semanticModel.GetEnclosingSymbol<IMethodSymbol>(IdentifierToken.SpanStart, cancellationToken);
 

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                         editor.ReplaceNode(parent, parent.WithAdditionalAnnotations(
                             ConflictAnnotation.Create(FeaturesResources.Property_referenced_implicitly)));
                     }
-                    else if (syntaxFacts.IsObjectInitializerNamedAssignmentIdentifier(parent))
+                    else if (syntaxFacts.IsMemberInitializerNamedAssignmentIdentifier(parent))
                     {
                         editor.ReplaceNode(parent, parent.WithAdditionalAnnotations(
                             ConflictAnnotation.Create(FeaturesResources.Property_reference_cannot_be_updated)));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -667,27 +667,35 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsPropertyPatternClause(SyntaxNode node)
             => node.Kind() == SyntaxKind.PropertyPatternClause;
 
-        public bool IsObjectInitializerNamedAssignmentIdentifier([NotNullWhen(true)] SyntaxNode? node)
-            => IsObjectInitializerNamedAssignmentIdentifier(node, out _);
+        public bool IsMemberInitializerNamedAssignmentIdentifier([NotNullWhen(true)] SyntaxNode? node)
+            => IsMemberInitializerNamedAssignmentIdentifier(node, out _);
 
-        public bool IsObjectInitializerNamedAssignmentIdentifier(
+        public bool IsMemberInitializerNamedAssignmentIdentifier(
             [NotNullWhen(true)] SyntaxNode? node, [NotNullWhen(true)] out SyntaxNode? initializedInstance)
         {
             initializedInstance = null;
             if (node is IdentifierNameSyntax identifier &&
-                identifier.IsLeftSideOfAssignExpression() &&
-                identifier.Parent.IsParentKind(SyntaxKind.ObjectInitializerExpression))
+                identifier.IsLeftSideOfAssignExpression())
             {
-                var objectInitializer = identifier.Parent.GetRequiredParent();
-                if (objectInitializer.Parent is BaseObjectCreationExpressionSyntax)
+                if (identifier.Parent.IsParentKind(SyntaxKind.WithInitializerExpression))
                 {
-                    initializedInstance = objectInitializer.Parent;
+                    var withInitializer = identifier.Parent.GetRequiredParent();
+                    initializedInstance = withInitializer.GetRequiredParent();
                     return true;
                 }
-                else if (objectInitializer.IsParentKind(SyntaxKind.SimpleAssignmentExpression, out AssignmentExpressionSyntax? assignment))
+                else if (identifier.Parent.IsParentKind(SyntaxKind.ObjectInitializerExpression))
                 {
-                    initializedInstance = assignment.Left;
-                    return true;
+                    var objectInitializer = identifier.Parent.GetRequiredParent();
+                    if (objectInitializer.Parent is BaseObjectCreationExpressionSyntax)
+                    {
+                        initializedInstance = objectInitializer.Parent;
+                        return true;
+                    }
+                    else if (objectInitializer.IsParentKind(SyntaxKind.SimpleAssignmentExpression, out AssignmentExpressionSyntax? assignment))
+                    {
+                        initializedInstance = assignment.Left;
+                        return true;
+                    }
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -678,10 +678,10 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
                 identifier.IsLeftSideOfAssignExpression() &&
                 identifier.Parent.IsParentKind(SyntaxKind.ObjectInitializerExpression))
             {
-                var objectInitializer = identifier.Parent.Parent;
-                if (objectInitializer.IsParentKind(SyntaxKind.ObjectCreationExpression))
+                var objectInitializer = identifier.Parent.GetRequiredParent();
+                if (objectInitializer.Parent is BaseObjectCreationExpressionSyntax)
                 {
-                    initializedInstance = objectInitializer.Parent!;
+                    initializedInstance = objectInitializer.Parent;
                     return true;
                 }
                 else if (objectInitializer.IsParentKind(SyntaxKind.SimpleAssignmentExpression, out AssignmentExpressionSyntax? assignment))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
@@ -18,6 +18,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static class SyntaxNodeExtensions
     {
+        public static SyntaxNode GetRequiredParent(this SyntaxNode node)
+            => node.Parent ?? throw new InvalidOperationException("Node's parent was null");
+
         public static IEnumerable<SyntaxNodeOrToken> DepthFirstTraversal(this SyntaxNode node)
             => SyntaxNodeOrTokenExtensions.DepthFirstTraversal(node);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -275,8 +275,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         SyntaxList<SyntaxNode> GetAttributeLists(SyntaxNode? node);
 
         bool IsAttributeNamedArgumentIdentifier([NotNullWhen(true)] SyntaxNode? node);
-        bool IsObjectInitializerNamedAssignmentIdentifier([NotNullWhen(true)] SyntaxNode? node);
-        bool IsObjectInitializerNamedAssignmentIdentifier([NotNullWhen(true)] SyntaxNode? node, [NotNullWhen(true)] out SyntaxNode? initializedInstance);
+        bool IsMemberInitializerNamedAssignmentIdentifier([NotNullWhen(true)] SyntaxNode? node);
+        bool IsMemberInitializerNamedAssignmentIdentifier([NotNullWhen(true)] SyntaxNode? node, [NotNullWhen(true)] out SyntaxNode? initializedInstance);
 
         bool IsDirective([NotNullWhen(true)] SyntaxNode? node);
         bool IsStatement([NotNullWhen(true)] SyntaxNode? node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -685,14 +685,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return node.FindTokenOnRightOfPosition(position, includeSkipped, includeDirectives, includeDocumentationComments)
         End Function
 
-        Public Function IsObjectInitializerNamedAssignmentIdentifier(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsObjectInitializerNamedAssignmentIdentifier
+        Public Function IsMemberInitializerNamedAssignmentIdentifier(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsMemberInitializerNamedAssignmentIdentifier
             Dim unused As SyntaxNode = Nothing
-            Return IsObjectInitializerNamedAssignmentIdentifier(node, unused)
+            Return IsMemberInitializerNamedAssignmentIdentifier(node, unused)
         End Function
 
-        Public Function IsObjectInitializerNamedAssignmentIdentifier(
+        Public Function IsMemberInitializerNamedAssignmentIdentifier(
                 node As SyntaxNode,
-                ByRef initializedInstance As SyntaxNode) As Boolean Implements ISyntaxFacts.IsObjectInitializerNamedAssignmentIdentifier
+                ByRef initializedInstance As SyntaxNode) As Boolean Implements ISyntaxFacts.IsMemberInitializerNamedAssignmentIdentifier
 
             Dim identifier = TryCast(node, IdentifierNameSyntax)
             If identifier?.IsChildNode(Of NamedFieldInitializerSyntax)(Function(n) n.Name) Then


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49294