### PR TITLE
Reuse LSP solutions if they don't need re-forking

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var lspSolution = GetLSPSolution(workspaceSolution);
 
-                        // If we got a document id back, we pull it out of our updated solution so the handler is operating on the latest
+            // If we got a document id back, we pull it out of our updated solution so the handler is operating on the latest
             // document text. If document id is null here, this will just return null
             var document = lspSolution.GetDocument(documentId);
 

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 workspaceSolution != cacheInfo.workspaceSolution)
             {
                 var lspSolution = GetSolutionWithReplacedDocuments(workspaceSolution);
-                                _lspSolutionCache[workspace] = (workspaceSolution, lspSolution);
+                _lspSolutionCache[workspace] = (workspaceSolution, lspSolution);
 
                 return lspSolution;
             }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// <para>
     /// This class acheives this by distinguishing between mutating and non-mutating requests, and ensuring that
     /// when a mutating request comes in, its processing blocks all subsequent requests. As each request comes in
-    /// it is added to a queue, and a queue item will not be retreived while a mutating request is running. Before
+    /// it is added to a queue, and a queue item will not be retrieved while a mutating request is running. Before
     /// any request is handled the solution state is created by merging workspace solution state, which could have
     /// changes from non-LSP means (eg, adding a project reference), with the current "mutated" state.
     /// When a non-mutating work item is retrieved from the queue, it is given the current solution state, but then
@@ -55,6 +55,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly CancellationTokenSource _cancelSource;
         private readonly DocumentChangeTracker _documentChangeTracker;
 
+        // These two dictionaries are used to cache our forked LSP solution so we don't have to
+        // recompute it for each request. We don't need to worry about threading because they are only
+        // used when preparing to handle a request, which happens in a single thread in the ProcessQueueAsync
+        // method.
         private readonly Dictionary<Workspace, Solution> _lastWorkspaceSolution = new();
         private readonly Dictionary<Workspace, Solution> _lastLSPSolution = new();
 
@@ -184,16 +188,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         // Mutating requests block other requests from starting to ensure an up to date snapshot is used.
                         var ranToCompletion = await work.CallbackAsync(context, cancellationToken).ConfigureAwait(false);
 
-                        if (ranToCompletion)
-                        {
-                            // We've had a successfully mutating request, so clear out our saved state to ensure its recalculated
-                            _lastLSPSolution.Remove(context.Solution.Workspace);
-                        }
-                        else
+                        // Now that we've mutated our solution, clear out our saved state to ensure it gets recalculated
+                        _lastLSPSolution.Remove(context.Solution.Workspace);
+
+                        if (!ranToCompletion)
                         {
                             // If the handling of the request failed, the exception will bubble back up to the caller, and we
                             // request shutdown because we're in an invalid state
-                            OnRequestServerShutdown($"An error occured processing a mutating request and the solution is in an invalid state. Check LSP client logs for any error information.");
+                            OnRequestServerShutdown($"An error occurred processing a mutating request and the solution is in an invalid state. Check LSP client logs for any error information.");
                             break;
                         }
                     }
@@ -213,7 +215,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
-                OnRequestServerShutdown($"Error occured processing queue: {e.Message}.");
+                OnRequestServerShutdown($"Error occurred processing queue: {e.Message}.");
             }
         }
 
@@ -264,6 +266,25 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // solution
             var (documentId, workspaceSolution) = _solutionProvider.GetDocumentAndSolution(queueItem.TextDocument, queueItem.ClientName);
 
+            var lspSolution = GetLSPSolution(workspaceSolution);
+
+                        // If we got a document id back, we pull it out of our updated solution so the handler is operating on the latest
+            // document text. If document id is null here, this will just return null
+            var document = lspSolution.GetDocument(documentId);
+
+            var trackerToUse = queueItem.MutatesSolutionState
+                ? (IDocumentChangeTracker)_documentChangeTracker
+                : new NonMutatingDocumentChangeTracker(_documentChangeTracker);
+
+            return new RequestContext(lspSolution, queueItem.ClientCapabilities, queueItem.ClientName, document, trackerToUse);
+        }
+
+        /// <summary>
+        /// Gets the "LSP view of the world", either by forking the workspace solution and updating the documents we track
+        /// or by simply returning our cached solution if it is still valid.
+        /// </summary>
+        private Solution GetLSPSolution(Solution workspaceSolution)
+        {
             var workspace = workspaceSolution.Workspace;
 
             var recalculateSolution = false;
@@ -294,18 +315,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 lspSolution = _lastLSPSolution[workspace];
             }
 
-            // If we got a document id back, we pull it out of our updated solution so the handler is operating on the latest
-            // document text. If document id is null here, this will just return null
-            var document = lspSolution.GetDocument(documentId);
-
-            // Logically, if a mutating request fails we don't want to take its mutations, so giving it the "real"
-            // tracker is a bad idea, but since we tear down the queue for any error anyway, the document tracker
-            // will be emptied and no future requests will be handled, so we don't need to do anything special here.
-            var trackerToUse = queueItem.MutatesSolutionState
-                ? (IDocumentChangeTracker)_documentChangeTracker
-                : new NonMutatingDocumentChangeTracker(_documentChangeTracker);
-
-            return new RequestContext(lspSolution, queueItem.ClientCapabilities, queueItem.ClientName, document, trackerToUse);
+            return lspSolution;
         }
 
         /// <summary>

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/MutatingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/MutatingRequestHandler.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             var response = new TestResponse
             {
                 Solution = context.Solution,
-                RequestOrder = request.RequestOrder,
                 StartTime = DateTime.UtcNow
             };
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/NonMutatingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/NonMutatingRequestHandler.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             var response = new TestResponse();
 
             response.Solution = context.Solution;
-            response.RequestOrder = request.RequestOrder;
             response.StartTime = DateTime.UtcNow;
 
             await Task.Delay(Delay, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -227,10 +227,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             var clientCapabilities = new LSP.ClientCapabilities();
 
             var waitables = new List<Task<TestResponse>>();
-            var order = 1;
             foreach (var request in requests)
             {
-                request.RequestOrder = order++;
                 waitables.Add(languageServer.ExecuteRequestAsync<TestRequest, TestResponse>(queue, request.MethodName, request, clientCapabilities, null, CancellationToken.None));
             }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -147,8 +147,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             var queue = CreateRequestQueue(workspace.CurrentSolution);
             var languageServer = GetLanguageServer(workspace.CurrentSolution);
 
-            UpdateSolutionProvider(workspace, workspace.CurrentSolution);
-
             var expectedSolution = workspace.CurrentSolution;
 
             // solution should be the same because no mutations have happened

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -183,6 +183,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             solution = await GetLSPSolution(NonMutatingRequestHandler.MethodName);
             Assert.Equal(expectedSolution, solution);
 
+            return;
+
             async Task<Solution> GetLSPSolution(string methodName)
             {
                 var request = new TestRequest(methodName);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -4,15 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -141,6 +137,71 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             await Assert.ThrowsAsync<TaskCanceledException>(() => Task.WhenAll(waitables.Skip(1)));
 
             Assert.All(waitables.Skip(1), w => Assert.True(w.IsCanceled));
+        }
+
+        [Fact]
+        public async Task NonMutatingRequestsOperateOnTheSameSolutionAfterMutation()
+        {
+            using var workspace = CreateTestWorkspace("class C { {|caret:|} }", out var locations);
+
+            var queue = CreateRequestQueue(workspace.CurrentSolution);
+            var languageServer = GetLanguageServer(workspace.CurrentSolution);
+
+            UpdateSolutionProvider(workspace, workspace.CurrentSolution);
+
+            var expectedSolution = workspace.CurrentSolution;
+
+            // solution should be the same because no mutations have happened
+            var solution = await GetLSPSolution(NonMutatingRequestHandler.MethodName);
+            Assert.Equal(expectedSolution, solution);
+
+            // Open a document, to get a forked solution
+            await ExecuteDidOpen();
+
+            // solution should be different because there has been a mutation
+            solution = await GetLSPSolution(NonMutatingRequestHandler.MethodName);
+            Assert.NotEqual(expectedSolution, solution);
+
+            expectedSolution = solution;
+
+            // solution should be the same because no mutations have happened
+            solution = await GetLSPSolution(NonMutatingRequestHandler.MethodName);
+            Assert.Equal(expectedSolution, solution);
+
+            // Apply some random change to the workspace that the LSP server doesn't "see"
+            workspace.SetCurrentSolution(s => s.WithProjectName(s.Projects.First().Id, "NewName"), WorkspaceChangeKind.ProjectChanged);
+
+            expectedSolution = workspace.CurrentSolution;
+
+            // solution should be different because there has been a workspace change
+            solution = await GetLSPSolution(NonMutatingRequestHandler.MethodName);
+            Assert.NotEqual(expectedSolution, solution);
+
+            expectedSolution = solution;
+
+            // solution should be the same because no mutations have happened
+            solution = await GetLSPSolution(NonMutatingRequestHandler.MethodName);
+            Assert.Equal(expectedSolution, solution);
+
+            async Task<Solution> GetLSPSolution(string methodName)
+            {
+                var request = new TestRequest(methodName);
+                var response = await languageServer.ExecuteRequestAsync<TestRequest, TestResponse>(queue, request.MethodName, request, new LSP.ClientCapabilities(), null, CancellationToken.None);
+                return response.Solution;
+            }
+
+            async Task ExecuteDidOpen()
+            {
+                var didOpenParams = new LSP.DidOpenTextDocumentParams
+                {
+                    TextDocument = new LSP.TextDocumentItem
+                    {
+                        Uri = locations["caret"].First().Uri,
+                        Text = "// hi there"
+                    }
+                };
+                await languageServer.ExecuteRequestAsync<LSP.DidOpenTextDocumentParams, object>(queue, Methods.TextDocumentDidOpenName, didOpenParams, new LSP.ClientCapabilities(), null, CancellationToken.None);
+            }
         }
 
         private async Task<TestResponse[]> TestAsync(TestRequest[] requests)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/TestRequest.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/TestRequest.cs
@@ -7,7 +7,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
     internal class TestRequest
     {
         public string MethodName { get; }
-        public int RequestOrder { get; set; }
 
         public TestRequest(string methodName)
         {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/TestResponse.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/TestResponse.cs
@@ -8,7 +8,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 {
     internal class TestResponse
     {
-        public int RequestOrder { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
 


### PR DESCRIPTION
This is a speed improvement to https://github.com/dotnet/roslyn/pull/49256 in advance of a larger change to make LSP servers per-workspace.

Just putting this up now, because I doubt I'll get the bigger change up before next week.