### PR TITLE
Add source generator support to the LSIF indexer

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -471,6 +471,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Edit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Test.Utilities", "src\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj", "{5D94ED65-EFA3-44EB-A5DA-62E85BAC9DD6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.TestSourceGenerator", "src\Workspaces\TestSourceGenerator\Microsoft.CodeAnalysis.TestSourceGenerator.csproj", "{21B50E65-D601-4D82-B98A-FFE6DE3B25DC}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
@@ -1230,6 +1232,10 @@ Global
 		{5D94ED65-EFA3-44EB-A5DA-62E85BAC9DD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D94ED65-EFA3-44EB-A5DA-62E85BAC9DD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D94ED65-EFA3-44EB-A5DA-62E85BAC9DD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21B50E65-D601-4D82-B98A-FFE6DE3B25DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21B50E65-D601-4D82-B98A-FFE6DE3B25DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21B50E65-D601-4D82-B98A-FFE6DE3B25DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21B50E65-D601-4D82-B98A-FFE6DE3B25DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1447,6 +1453,7 @@ Global
 		{9B25E472-DF94-4E24-9F5D-E487CE5A91FB} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{67F44564-759B-4643-BD86-407B010B0B74} = {EE97CB90-33BB-4F3A-9B3D-69375DEC6AC6}
 		{5D94ED65-EFA3-44EB-A5DA-62E85BAC9DD6} = {A41D1B99-F489-4C43-BBDF-96D61B19A6B9}
+		{21B50E65-D601-4D82-B98A-FFE6DE3B25DC} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
@@ -207,6 +208,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public new void OnParseOptionsChanged(ProjectId projectId, ParseOptions parseOptions)
             => base.OnParseOptionsChanged(projectId, parseOptions);
+
+        public new void OnAnalyzerReferenceAdded(ProjectId projectId, AnalyzerReference analyzerReference)
+            => base.OnAnalyzerReferenceAdded(projectId, analyzerReference);
 
         public void OnDocumentRemoved(DocumentId documentId, bool closeDocument = false)
         {

--- a/src/Features/Lsif/Generator/CompilerInvocation.cs
+++ b/src/Features/Lsif/Generator/CompilerInvocation.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Newtonsoft.Json;
@@ -76,6 +77,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             var commandLineParserService = languageServices.GetRequiredService<ICommandLineParserService>();
             var parsedCommandLine = commandLineParserService.Parse(splitCommandLine, Path.GetDirectoryName(invocationInfo.ProjectFilePath), isInteractive: false, sdkDirectory: null);
 
+            var analyzerLoader = new DefaultAnalyzerAssemblyLoader();
+
             var projectId = ProjectId.CreateNewId(invocationInfo.ProjectFilePath);
 
             var projectInfo = ProjectInfo.Create(
@@ -90,7 +93,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 parsedCommandLine.ParseOptions,
                 parsedCommandLine.SourceFiles.Select(s => CreateDocumentInfo(unmappedPath: s.Path)),
                 metadataReferences: parsedCommandLine.MetadataReferences.Select(r => MetadataReference.CreateFromFile(mapPath(r.Reference), r.Properties)),
-                additionalDocuments: parsedCommandLine.AdditionalFiles.Select(f => CreateDocumentInfo(unmappedPath: f.Path)))
+                additionalDocuments: parsedCommandLine.AdditionalFiles.Select(f => CreateDocumentInfo(unmappedPath: f.Path)),
+                analyzerReferences: parsedCommandLine.AnalyzerReferences.Select(r => new AnalyzerFileReference(r.FilePath, analyzerLoader)))
                 .WithAnalyzerConfigDocuments(parsedCommandLine.AnalyzerConfigPaths.Select(CreateDocumentInfo));
 
             workspace.AddProject(projectInfo);

--- a/src/Features/Lsif/Generator/Graph/LsifDocument.cs
+++ b/src/Features/Lsif/Generator/Graph/LsifDocument.cs
@@ -14,11 +14,20 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
         public Uri Uri { get; }
         public string LanguageId { get; }
 
-        public LsifDocument(Uri uri, string languageId, IdFactory idFactory)
+        /// <summary>
+        /// The base-64 encoded contents of the file.
+        /// </summary>
+        /// <remarks>
+        /// We only include this for generated files.
+        /// </remarks>
+        public string? Contents { get; }
+
+        public LsifDocument(Uri uri, string languageId, string? contents, IdFactory idFactory)
             : base(label: "document", idFactory)
         {
             this.Uri = uri;
             this.LanguageId = languageId;
+            this.Contents = contents;
         }
     }
 }

--- a/src/Features/Lsif/GeneratorTest/CompilerInvocationTests.vb
+++ b/src/Features/Lsif/GeneratorTest/CompilerInvocationTests.vb
@@ -149,5 +149,22 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                 Assert.Equal(ReportDiagnostic.Warn, compilerInvocation.Compilation.Options.SpecificDiagnosticOptions("CA1001"))
             End Using
         End Function
+
+        <Fact>
+        Public Async Function TestSourceGeneratorOutputIncludedInCompilation() As Task
+            Dim sourceGeneratorLocation = GetType(TestSourceGenerator.HelloWorldGenerator).Assembly.Location
+
+            Dim compilerInvocation = Await Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.CompilerInvocation.CreateFromJsonAsync("
+                    {
+                        ""tool"": ""csc"",
+                        ""arguments"": ""/noconfig /analyzer:\""" + sourceGeneratorLocation.Replace("\", "\\") + "\""  /out:Output.dll"",
+                        ""projectFilePath"": ""F:\\Project.csproj"",
+                        ""sourceRootPath"": ""F:\\""
+                    }")
+
+            Dim generatedTree = Assert.Single(compilerInvocation.Compilation.SyntaxTrees)
+
+            Assert.EndsWith(TestSourceGenerator.HelloWorldGenerator.GeneratedClassName + ".cs", generatedTree.FilePath)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Lsif/GeneratorTest/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.vbproj
+++ b/src/Features/Lsif/GeneratorTest/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.vbproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\EditorFeatures\TestUtilities\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.csproj" />
+    <ProjectReference Include="..\..\..\Workspaces\TestSourceGenerator\Microsoft.CodeAnalysis.TestSourceGenerator.csproj" />
     <ProjectReference Include="..\Generator\Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj" />
 
     <!-- Below is the transitive closure of the project references above to placate BuildBoss. If changes are made above this line,

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -7,6 +7,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.TestSourceGenerator;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.LanguageServices;
 using Roslyn.Test.Utilities;
@@ -29,7 +30,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
             await base.InitializeAsync();
 
-            VisualStudio.SolutionExplorer.AddAnalyzerReference(typeof(IntegrationTestSourceGenerator).Assembly.Location, new ProjectUtils.Project(ProjectName));
+            VisualStudio.SolutionExplorer.AddAnalyzerReference(typeof(HelloWorldGenerator).Assembly.Location, new ProjectUtils.Project(ProjectName));
         }
 
         [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/47255"), Trait(Traits.Feature, Traits.Features.SourceGenerators)]
@@ -40,14 +41,14 @@ internal static class Program
 {
     public static void Main()
     {
-        Console.WriteLine(" + IntegrationTestSourceGenerator.GeneratedClassName + @".GetMessage());
+        Console.WriteLine(" + HelloWorldGenerator.GeneratedClassName + @".GetMessage());
     }
 }");
 
-            VisualStudio.Editor.PlaceCaret(IntegrationTestSourceGenerator.GeneratedClassName);
+            VisualStudio.Editor.PlaceCaret(HelloWorldGenerator.GeneratedClassName);
             VisualStudio.Editor.GoToDefinition();
-            Assert.Equal($"{IntegrationTestSourceGenerator.GeneratedClassName}.cs {ServicesVSResources.generated_suffix}", VisualStudio.Shell.GetActiveWindowCaption());
-            Assert.Equal(IntegrationTestSourceGenerator.GeneratedClassName, VisualStudio.Editor.GetSelectedText());
+            Assert.Equal($"{HelloWorldGenerator.GeneratedClassName}.cs {ServicesVSResources.generated_suffix}", VisualStudio.Shell.GetActiveWindowCaption());
+            Assert.Equal(HelloWorldGenerator.GeneratedClassName, VisualStudio.Editor.GetSelectedText());
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Microsoft.VisualStudio.LanguageServices.IntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Microsoft.VisualStudio.LanguageServices.IntegrationTests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\IntegrationService\Microsoft.VisualStudio.IntegrationTest.IntegrationService.csproj" />
     <ProjectReference Include="..\TestUtilities\Microsoft.VisualStudio.IntegrationTest.Utilities.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
+    <ProjectReference Include="..\..\..\Workspaces\TestSourceGenerator\Microsoft.CodeAnalysis.TestSourceGenerator.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -164,23 +161,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var compilationWithGenerator = await solution.GetRequiredProject(projectIdWithGenerator).GetRequiredCompilationAsync(CancellationToken.None);
 
             Assert.Same(compilationWithGenerator, compilationReference.Compilation);
-        }
-
-        private sealed class TestGeneratorReference : AnalyzerReference
-        {
-            private readonly ISourceGenerator _generator;
-
-            public TestGeneratorReference(ISourceGenerator generator)
-            {
-                _generator = generator;
-            }
-
-            public override string? FullPath => null;
-            public override object Id => this;
-
-            public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => ImmutableArray<DiagnosticAnalyzer>.Empty;
-            public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => ImmutableArray<DiagnosticAnalyzer>.Empty;
-            public override ImmutableArray<ISourceGenerator> GetGenerators(string language) => ImmutableArray.Create(_generator);
         }
 
         private sealed class GenerateFileForEachAdditionalFileWithContentsCommented : ISourceGenerator

--- a/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
+++ b/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Roslyn.Test.Utilities
+{
+    /// <summary>
+    /// A simple deriviation of <see cref="AnalyzerReference"/> that returns the source generator
+    /// passed, for ease in unit tests.
+    /// </summary>
+    public sealed class TestGeneratorReference : AnalyzerReference
+    {
+        private readonly ISourceGenerator _generator;
+
+        public TestGeneratorReference(ISourceGenerator generator)
+        {
+            _generator = generator;
+        }
+
+        public override string? FullPath => null;
+        public override object Id => this;
+
+        public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => ImmutableArray<DiagnosticAnalyzer>.Empty;
+        public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => ImmutableArray<DiagnosticAnalyzer>.Empty;
+        public override ImmutableArray<ISourceGenerator> GetGenerators(string language) => ImmutableArray.Create(_generator);
+    }
+}

--- a/src/Workspaces/TestSourceGenerator/HelloWorldGenerator.cs
+++ b/src/Workspaces/TestSourceGenerator/HelloWorldGenerator.cs
@@ -2,18 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Roslyn.VisualStudio.IntegrationTests
+namespace Microsoft.CodeAnalysis.TestSourceGenerator
 {
     [Generator]
-    internal sealed class IntegrationTestSourceGenerator : ISourceGenerator
+    public sealed class HelloWorldGenerator : ISourceGenerator
     {
-        public const string GeneratedClassName = nameof(IntegrationTestSourceGenerator) + "Output";
+        public const string GeneratedClassName = "HelloWorld";
 
         public void Initialize(GeneratorInitializationContext context)
         {

--- a/src/Workspaces/TestSourceGenerator/Microsoft.CodeAnalysis.TestSourceGenerator.csproj
+++ b/src/Workspaces/TestSourceGenerator/Microsoft.CodeAnalysis.TestSourceGenerator.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This adds support for running generators when the LSIF tool is invoked, and writes out contents for the generated files so further tools can process them.

The "interesting" bit of this PR is actually refactoring out a test source generator we had into a project of it's own. The compiler now requires that the assembly that contains the generator not be targeting the .NET Framework; since we have test projects that are currently targeting .NET Framework we can't put the generator in the unit test projects; even if we retarget the test projects we may still want to test on .NET Framework hosts since that's where our code is actually running in some scenarios. Right now the compiler has a similar need for such a project, so hopefully we'll move it further down and use it for that too. (FYI to @chsienki on this bit.)