### PR TITLE
Enable caching of semantic models during generator runs

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverState.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal GeneratorDriverState(ParseOptions parseOptions,
                                       AnalyzerConfigOptionsProvider optionsProvider,
+                                      CachingSemanticModelProvider modelProvider,
                                       ImmutableArray<ISourceGenerator> generators,
                                       ImmutableArray<AdditionalText> additionalTexts,
                                       ImmutableArray<GeneratorState> generatorStates,
@@ -26,6 +27,7 @@ namespace Microsoft.CodeAnalysis
             Edits = edits;
             ParseOptions = parseOptions;
             OptionsProvider = optionsProvider;
+            ModelProvider = modelProvider;
             EditsFailed = editsFailed;
 
             Debug.Assert(Generators.Length == GeneratorStates.Length);
@@ -74,6 +76,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal readonly ParseOptions ParseOptions;
 
+        internal readonly CachingSemanticModelProvider ModelProvider;
+
         internal GeneratorDriverState With(
             ImmutableArray<ISourceGenerator>? generators = null,
             ImmutableArray<GeneratorState>? generatorStates = null,
@@ -84,6 +88,7 @@ namespace Microsoft.CodeAnalysis
             return new GeneratorDriverState(
                 this.ParseOptions,
                 this.OptionsProvider,
+                this.ModelProvider,
                 generators ?? this.Generators,
                 additionalTexts ?? this.AdditionalTexts,
                 generatorStates ?? this.GeneratorStates,


### PR DESCRIPTION
Use a `CachingSemanticModelProvider` during generator runs to improve performance by sharing identical semantic models rather than recreating them. We clear the cache at the end of each run (the models won't be useful after generation as we'll have changed the compilation they came from).

Note: the cache is a strongly referenced cache, so if a generator asked for every semantic model in a compilation we could run into memory issues. However this reduces the theoretical maximum memory usage by semantic models from unbounded today (a generator can just keep requesting them and getting new ones) to `O(SemanticModelCount)`.

If we get data suggesting memory pressure issues in the future we can tune the cache to use a MRU model or weak references.

Fixes  #49289