### PR TITLE
[LSP] Allow rename to potentially rename the file

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -33,42 +33,42 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public async Task<WorkspaceEdit?> HandleRequestAsync(RenameParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var document = context.Document;
-            if (document != null)
+            if (document == null)
             {
-                var oldSolution = document.Project.Solution;
-                var renameService = document.Project.LanguageServices.GetRequiredService<IEditorInlineRenameService>();
-                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
-
-                var renameInfo = await renameService.GetRenameInfoAsync(document, position, cancellationToken).ConfigureAwait(false);
-                if (!renameInfo.CanRename)
-                {
-                    return null;
-                }
-
-                var renameLocationSet = await renameInfo.FindRenameLocationsAsync(oldSolution.Workspace.Options, cancellationToken).ConfigureAwait(false);
-                var renameReplacementInfo = await renameLocationSet.GetReplacementsAsync(request.NewName, oldSolution.Workspace.Options, cancellationToken).ConfigureAwait(false);
-
-                var renamedSolution = renameReplacementInfo.NewSolution;
-                var solutionChanges = renamedSolution.GetChanges(oldSolution);
-
-                // Linked files can correspond to multiple roslyn documents each with changes.  Merge the changes in the linked files so that all linked documents have the same text.
-                // Then we can just take the text changes from the first document to avoid returning duplicate edits.
-                renamedSolution = await renamedSolution.WithMergedLinkedFileChangesAsync(oldSolution, solutionChanges, cancellationToken: cancellationToken).ConfigureAwait(false);
-                solutionChanges = renamedSolution.GetChanges(oldSolution);
-                var changedDocuments = solutionChanges
-                    .GetProjectChanges()
-                    .SelectMany(p => p.GetChangedDocuments(onlyGetDocumentsWithTextChanges: true))
-                    .GroupBy(docId => renamedSolution.GetRequiredDocument(docId).FilePath, StringComparer.OrdinalIgnoreCase).Select(group => group.First());
-
-                var textDiffService = renamedSolution.Workspace.Services.GetRequiredService<IDocumentTextDifferencingService>();
-
-                var documentEdits = await ProtocolConversions.ChangedDocumentsToTextDocumentEditsAsync(changedDocuments, renamedSolution.GetRequiredDocument, oldSolution.GetRequiredDocument,
-                    textDiffService, cancellationToken).ConfigureAwait(false);
-
-                return new WorkspaceEdit { DocumentChanges = documentEdits };
+                return null;
             }
 
-            return null;
+            var oldSolution = document.Project.Solution;
+            var renameService = document.Project.LanguageServices.GetRequiredService<IEditorInlineRenameService>();
+            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+
+            var renameInfo = await renameService.GetRenameInfoAsync(document, position, cancellationToken).ConfigureAwait(false);
+            if (!renameInfo.CanRename)
+            {
+                return null;
+            }
+
+            var renameLocationSet = await renameInfo.FindRenameLocationsAsync(oldSolution.Workspace.Options, cancellationToken).ConfigureAwait(false);
+            var renameReplacementInfo = await renameLocationSet.GetReplacementsAsync(request.NewName, oldSolution.Workspace.Options, cancellationToken).ConfigureAwait(false);
+
+            var renamedSolution = renameReplacementInfo.NewSolution;
+            var solutionChanges = renamedSolution.GetChanges(oldSolution);
+
+            // Linked files can correspond to multiple roslyn documents each with changes.  Merge the changes in the linked files so that all linked documents have the same text.
+            // Then we can just take the text changes from the first document to avoid returning duplicate edits.
+            renamedSolution = await renamedSolution.WithMergedLinkedFileChangesAsync(oldSolution, solutionChanges, cancellationToken: cancellationToken).ConfigureAwait(false);
+            solutionChanges = renamedSolution.GetChanges(oldSolution);
+            var changedDocuments = solutionChanges
+                .GetProjectChanges()
+                .SelectMany(p => p.GetChangedDocuments(onlyGetDocumentsWithTextChanges: true))
+                .GroupBy(docId => renamedSolution.GetRequiredDocument(docId).FilePath, StringComparer.OrdinalIgnoreCase).Select(group => group.First());
+
+            var textDiffService = renamedSolution.Workspace.Services.GetRequiredService<IDocumentTextDifferencingService>();
+
+            var documentEdits = await ProtocolConversions.ChangedDocumentsToTextDocumentEditsAsync(changedDocuments, renamedSolution.GetRequiredDocument, oldSolution.GetRequiredDocument,
+                textDiffService, cancellationToken).ConfigureAwait(false);
+
+            return new WorkspaceEdit { DocumentChanges = documentEdits };
         }
     }
 }


### PR DESCRIPTION
- The first commit in this PR is inverting an if-statement for easier readability. The second commit contains the actual changes.

- Since there are no user options yet in LSP, this PR emulates the default rename behavior in Roslyn: renaming a class whose name matches the file name will rename the file. If a file already exists with the new name, a unique name will be generated.

- This PR should probably wait to merge until https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1245594 on the Liveshare/LSP side is resolved, as I don't think having a save dialog pop up is ideal behavior here. I believe Liveshare/LSP may also be applying the edits in an inconsistent order, resulting in differing rename results each time.