### PR TITLE
Rewrite AnalyzeFileReference.GetSupportedLanguages without LINQ

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -243,12 +243,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static IEnumerable<string> GetSupportedLanguages(TypeDefinition typeDef, PEModule peModule, Type attributeType, AttributeLanguagesFunc languagesFunc)
         {
-            var attributeLanguagesList = from customAttrHandle in typeDef.GetCustomAttributes()
-                                         where peModule.IsTargetAttribute(customAttrHandle, attributeType.Namespace!, attributeType.Name, ctor: out _)
-                                         let attributeSupportedLanguages = languagesFunc(peModule, customAttrHandle)
-                                         where attributeSupportedLanguages != null
-                                         select attributeSupportedLanguages;
-            return attributeLanguagesList.SelectMany(x => x);
+            foreach (CustomAttributeHandle customAttrHandle in typeDef.GetCustomAttributes())
+            {
+                if (peModule.IsTargetAttribute(customAttrHandle, attributeType.Namespace!, attributeType.Name, ctor: out _))
+                {
+                    IEnumerable<string>? attributeSupportedLanguages = languagesFunc(peModule, customAttrHandle);
+                    if (attributeSupportedLanguages != null)
+                    {
+                        foreach (string item in attributeSupportedLanguages)
+                        {
+                            yield return item;
+                        }
+                    }
+                }
+            }
         }
 
         private static IEnumerable<string> GetDiagnosticsAnalyzerSupportedLanguages(PEModule peModule, CustomAttributeHandle customAttrHandle)


### PR DESCRIPTION
I did an allocation profile of csc.dll for building a simple "hello world" with the configuration `dotnet build` employs on a simple `dotnet new console` app.  There are ~194K allocations / ~19MB.  And ~30K / ~1MB of those are occurring unnecessarily because of use of LINQ in one function.  This just rewrites that function to not use LINQ.

Before:
![image](https://user-images.githubusercontent.com/2642209/99002430-63d90600-250a-11eb-905f-88a4e225230f.png)

After:
![image](https://user-images.githubusercontent.com/2642209/99002496-7e12e400-250a-11eb-91fa-f06d66010feb.png)

Contributes to https://github.com/dotnet/msbuild/issues/5876