### PR TITLE
Avoid optimizing away temporary for 'is not' pattern

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -52,47 +52,53 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Note that these labels are for the convenience of the compilation of patterns, and are not necessarily emitted into the lowered code.
             LabelSymbol whenTrueLabel = new GeneratedLabelSymbol("isPatternSuccess");
             LabelSymbol whenFalseLabel = new GeneratedLabelSymbol("isPatternFailure");
+
+            bool negated = pattern.IsNegated(out var innerPattern);
             BoundDecisionDag decisionDag = DecisionDagBuilder.CreateDecisionDagForIsPattern(
-                this.Compilation, pattern.Syntax, expression, pattern, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, diagnostics);
-            if (!hasErrors && !decisionDag.ReachableLabels.Contains(whenTrueLabel))
+                this.Compilation, pattern.Syntax, expression, innerPattern, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, diagnostics);
+
+            if (!hasErrors && getConstantResult(decisionDag, negated, whenTrueLabel, whenFalseLabel) is { } constantResult)
             {
-                diagnostics.Add(ErrorCode.ERR_IsPatternImpossible, node.Location, expression.Type);
-                hasErrors = true;
-            }
-            else if (!hasErrors && !decisionDag.ReachableLabels.Contains(whenFalseLabel))
-            {
-                switch (pattern)
+                if (constantResult)
                 {
-                    case BoundConstantPattern _:
-                    case BoundITuplePattern _:
-                        // these patterns can fail in practice
-                        throw ExceptionUtilities.Unreachable;
-                    case BoundRelationalPattern _:
-                    case BoundTypePattern _:
-                    case BoundNegatedPattern _:
-                    case BoundBinaryPattern _:
-                        diagnostics.Add(ErrorCode.WRN_IsPatternAlways, node.Location, expression.Type);
-                        break;
-                    case BoundDiscardPattern _:
-                        // we do not give a warning on this because it is an existing scenario, and it should
-                        // have been obvious in source that it would always match.
-                        break;
-                    case BoundDeclarationPattern _:
-                    case BoundRecursivePattern _:
-                        // We do not give a warning on these because people do this to give a name to a value
-                        break;
+                    diagnostics.Add(ErrorCode.ERR_IsPatternImpossible, node.Location, expression.Type);
+                    hasErrors = true;
+                }
+                else
+                {
+                    switch (pattern)
+                    {
+                        case BoundConstantPattern _:
+                        case BoundITuplePattern _:
+                            // these patterns can fail in practice
+                            throw ExceptionUtilities.Unreachable;
+                        case BoundRelationalPattern _:
+                        case BoundTypePattern _:
+                        case BoundNegatedPattern _:
+                        case BoundBinaryPattern _:
+                            diagnostics.Add(ErrorCode.WRN_IsPatternAlways, node.Location, expression.Type);
+                            break;
+                        case BoundDiscardPattern _:
+                            // we do not give a warning on this because it is an existing scenario, and it should
+                            // have been obvious in source that it would always match.
+                            break;
+                        case BoundDeclarationPattern _:
+                        case BoundRecursivePattern _:
+                            // We do not give a warning on these because people do this to give a name to a value
+                            break;
+                    }
                 }
             }
             else if (expression.ConstantValue != null)
             {
                 decisionDag = decisionDag.SimplifyDecisionDagIfConstantInput(expression);
-                if (!hasErrors)
+                if (!hasErrors && getConstantResult(decisionDag, negated, whenTrueLabel, whenFalseLabel) is { } simplifiedResult)
                 {
-                    if (!decisionDag.ReachableLabels.Contains(whenTrueLabel))
+                    if (simplifiedResult)
                     {
                         diagnostics.Add(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, node.Location);
                     }
-                    else if (!decisionDag.ReachableLabels.Contains(whenFalseLabel))
+                    else
                     {
                         switch (pattern)
                         {
@@ -113,6 +119,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return new BoundIsPatternExpression(
                 node, expression, pattern, decisionDag, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, boolType, hasErrors);
+
+            static bool? getConstantResult(BoundDecisionDag decisionDag, bool negated, LabelSymbol whenTrueLabel, LabelSymbol whenFalseLabel)
+            {
+                if (!decisionDag.ReachableLabels.Contains(whenTrueLabel))
+                {
+                    return !negated;
+                }
+                else if (!decisionDag.ReachableLabels.Contains(whenFalseLabel))
+                {
+                    return negated;
+                }
+                return null;
+            }
         }
 
         private BoundExpression BindSwitchExpression(SwitchExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -117,6 +117,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            // decisionDag, whenTrueLabel, and whenFalseLabel represent the decision DAG and
+            // branch labels for the original pattern rather than the inner pattern.
             return new BoundIsPatternExpression(
                 node, expression, pattern, decisionDag, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, boolType, hasErrors);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -117,8 +117,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // decisionDag, whenTrueLabel, and whenFalseLabel represent the decision DAG and
-            // branch labels for the original pattern rather than the inner pattern.
+            // decisionDag, whenTrueLabel, and whenFalseLabel represent the decision DAG for the inner pattern,
+            // after removing any outer 'not's, so consumers will need to compensate for negated patterns.
             return new BoundIsPatternExpression(
                 node, expression, pattern, decisionDag, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, boolType, hasErrors);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!hasErrors && getConstantResult(decisionDag, negated, whenTrueLabel, whenFalseLabel) is { } constantResult)
             {
-                if (constantResult)
+                if (!constantResult)
                 {
                     diagnostics.Add(ErrorCode.ERR_IsPatternImpossible, node.Location, expression.Type);
                     hasErrors = true;
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 decisionDag = decisionDag.SimplifyDecisionDagIfConstantInput(expression);
                 if (!hasErrors && getConstantResult(decisionDag, negated, whenTrueLabel, whenFalseLabel) is { } simplifiedResult)
                 {
-                    if (simplifiedResult)
+                    if (!simplifiedResult)
                     {
                         diagnostics.Add(ErrorCode.WRN_GivenExpressionNeverMatchesPattern, node.Location);
                     }
@@ -126,11 +126,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (!decisionDag.ReachableLabels.Contains(whenTrueLabel))
                 {
-                    return !negated;
+                    return negated;
                 }
                 else if (!decisionDag.ReachableLabels.Contains(whenFalseLabel))
                 {
-                    return negated;
+                    return !negated;
                 }
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // decisionDag, whenTrueLabel, and whenFalseLabel represent the decision DAG for the inner pattern,
             // after removing any outer 'not's, so consumers will need to compensate for negated patterns.
             return new BoundIsPatternExpression(
-                node, expression, pattern, decisionDag, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, boolType, hasErrors);
+                node, expression, pattern, negated, decisionDag, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, boolType, hasErrors);
 
             static bool? getConstantResult(BoundDecisionDag decisionDag, bool negated, LabelSymbol whenTrueLabel, LabelSymbol whenFalseLabel)
             {

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -1446,6 +1446,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return $"t{tempIdentifier(a)}={a.Kind}({tempName(a.Input)} as {a.Type})";
                         case BoundDagFieldEvaluation e:
                             return $"t{tempIdentifier(e)}={e.Kind}({tempName(e.Input)}.{e.Field.Name})";
+                        case BoundDagPropertyEvaluation e:
+                            return $"t{tempIdentifier(e)}={e.Kind}({tempName(e.Input)}.{e.Property.Name})";
                         case BoundDagEvaluation e:
                             return $"t{tempIdentifier(e)}={e.Kind}({tempName(e.Input)})";
                         case BoundDagTypeTest b:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         break;
                     case BoundLeafDecisionDagNode node:
-                        result.AppendLine($"  Case: " + node.Syntax);
+                        result.AppendLine($"  Case: {node.Label.Name}" + node.Syntax);
                         break;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(state);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2022,9 +2022,9 @@
     <Field Name="Format" Type="BoundLiteral?"/>
   </Node>
   
-    <!-- An 'is' pattern. The fields represent the complete pattern, including any 'not'.
-         For assignment in negated patterns (such as lowering and definite assignment of 'is not Type t'),
-         that requires assigning at WhenFalseLabel rather than WhenTrueLabel. -->
+    <!-- An 'is pattern'. The fields DecisionDag, WhenTrueLabel, and WhenFalseLabel represent the inner pattern
+         after removing any outer 'not's, so consumers (such as lowering and definite assignment of the local in
+         'is not Type t') will need to compensate for negated patterns. -->
   <Node Name="BoundIsPatternExpression" Base="BoundExpression">
     <Field Name="Expression" Type="BoundExpression" Null="disallow"/>
     <Field Name="Pattern" Type="BoundPattern" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2022,6 +2022,9 @@
     <Field Name="Format" Type="BoundLiteral?"/>
   </Node>
   
+    <!-- An 'is' pattern. The fields represent the complete pattern, including any 'not'.
+         For assignment in negated patterns (such as lowering and definite assignment of 'is not Type t'),
+         that requires assigning at WhenFalseLabel rather than WhenTrueLabel. -->
   <Node Name="BoundIsPatternExpression" Base="BoundExpression">
     <Field Name="Expression" Type="BoundExpression" Null="disallow"/>
     <Field Name="Pattern" Type="BoundPattern" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2024,7 +2024,8 @@
   
     <!-- An 'is pattern'. The fields DecisionDag, WhenTrueLabel, and WhenFalseLabel represent the inner pattern
          after removing any outer 'not's, so consumers (such as lowering and definite assignment of the local in
-         'is not Type t') will need to compensate for negated patterns. -->
+         'is not Type t') will need to compensate for negated patterns. IsNegated is set if Pattern is the negated
+         form of the inner pattern represented by DecisionDag. -->
   <Node Name="BoundIsPatternExpression" Base="BoundExpression">
     <Field Name="Expression" Type="BoundExpression" Null="disallow"/>
     <Field Name="Pattern" Type="BoundPattern" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2028,6 +2028,7 @@
   <Node Name="BoundIsPatternExpression" Base="BoundExpression">
     <Field Name="Expression" Type="BoundExpression" Null="disallow"/>
     <Field Name="Pattern" Type="BoundPattern" Null="disallow"/>
+    <Field Name="IsNegated" Type="bool"/>
     <Field Name="DecisionDag" Type="BoundDecisionDag" Null="disallow" SkipInVisitor="true"/>
     <Field Name="WhenTrueLabel" Type="LabelSymbol" Null="disallow"/>
     <Field Name="WhenFalseLabel" Type="LabelSymbol" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundPattern.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundPattern.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class BoundPattern
+    {
+        internal bool IsNegated(out BoundPattern innerPattern)
+        {
+            innerPattern = this;
+            bool negated = false;
+            while (innerPattern is BoundNegatedPattern negatedPattern)
+            {
+                negated = !negated;
+                innerPattern = negatedPattern.Negated;
+            }
+            return negated;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundPattern.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundPattern.cs
@@ -6,6 +6,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class BoundPattern
     {
+        /// <summary>
+        /// Sets <paramref name="innerPattern"/> to the inner pattern after stripping off outer
+        /// <see cref="BoundNegatedPattern"/>s, and returns true if the original pattern is a
+        /// negated form of the inner pattern.
+        /// </summary>
         internal bool IsNegated(out BoundPattern innerPattern)
         {
             innerPattern = this;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -962,13 +962,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!IsConditionalState);
             VisitRvalue(node.Expression);
 
-            var pattern = node.Pattern;
-            bool negated = false;
-            while (pattern is BoundNegatedPattern n)
-            {
-                negated = !negated;
-                pattern = n.Negated;
-            }
+            bool negated = node.Pattern.IsNegated(out var pattern);
 
             VisitPattern(pattern);
             var reachableLabels = node.DecisionDag.ReachableLabels;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -963,6 +963,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitRvalue(node.Expression);
 
             bool negated = node.Pattern.IsNegated(out var pattern);
+            Debug.Assert(negated == node.IsNegated);
 
             VisitPattern(pattern);
             var reachableLabels = node.DecisionDag.ReachableLabels;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -685,9 +685,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             LearnFromAnyNullPatterns(node.Expression, node.Pattern);
             VisitPatternForRewriting(node.Pattern);
             var expressionState = VisitRvalueWithState(node.Expression);
+            bool negated = node.Pattern.IsNegated(out _);
             var labelStateMap = LearnFromDecisionDag(node.Syntax, node.DecisionDag, node.Expression, expressionState, ref this.State);
-            var trueState = labelStateMap.TryGetValue(node.WhenTrueLabel, out var s1) ? s1.state : UnreachableState();
-            var falseState = labelStateMap.TryGetValue(node.WhenFalseLabel, out var s2) ? s2.state : UnreachableState();
+            var trueState = labelStateMap.TryGetValue(negated ? node.WhenFalseLabel : node.WhenTrueLabel, out var s1) ? s1.state : UnreachableState();
+            var falseState = labelStateMap.TryGetValue(negated ? node.WhenTrueLabel : node.WhenFalseLabel, out var s2) ? s2.state : UnreachableState();
             labelStateMap.Free();
             SetConditionalState(trueState, falseState);
             SetNotNullResult(node);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -685,10 +685,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             LearnFromAnyNullPatterns(node.Expression, node.Pattern);
             VisitPatternForRewriting(node.Pattern);
             var expressionState = VisitRvalueWithState(node.Expression);
-            bool negated = node.Pattern.IsNegated(out _);
             var labelStateMap = LearnFromDecisionDag(node.Syntax, node.DecisionDag, node.Expression, expressionState, ref this.State);
-            var trueState = labelStateMap.TryGetValue(negated ? node.WhenFalseLabel : node.WhenTrueLabel, out var s1) ? s1.state : UnreachableState();
-            var falseState = labelStateMap.TryGetValue(negated ? node.WhenTrueLabel : node.WhenFalseLabel, out var s2) ? s2.state : UnreachableState();
+            var trueState = labelStateMap.TryGetValue(node.IsNegated ? node.WhenFalseLabel : node.WhenTrueLabel, out var s1) ? s1.state : UnreachableState();
+            var falseState = labelStateMap.TryGetValue(node.IsNegated ? node.WhenTrueLabel : node.WhenFalseLabel, out var s2) ? s2.state : UnreachableState();
             labelStateMap.Free();
             SetConditionalState(trueState, falseState);
             SetNotNullResult(node);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -7223,7 +7223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundIsPatternExpression : BoundExpression
     {
-        public BoundIsPatternExpression(SyntaxNode syntax, BoundExpression expression, BoundPattern pattern, BoundDecisionDag decisionDag, LabelSymbol whenTrueLabel, LabelSymbol whenFalseLabel, TypeSymbol? type, bool hasErrors = false)
+        public BoundIsPatternExpression(SyntaxNode syntax, BoundExpression expression, BoundPattern pattern, bool isNegated, BoundDecisionDag decisionDag, LabelSymbol whenTrueLabel, LabelSymbol whenFalseLabel, TypeSymbol? type, bool hasErrors = false)
             : base(BoundKind.IsPatternExpression, syntax, type, hasErrors || expression.HasErrors() || pattern.HasErrors() || decisionDag.HasErrors())
         {
 
@@ -7235,6 +7235,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.Expression = expression;
             this.Pattern = pattern;
+            this.IsNegated = isNegated;
             this.DecisionDag = decisionDag;
             this.WhenTrueLabel = whenTrueLabel;
             this.WhenFalseLabel = whenFalseLabel;
@@ -7245,6 +7246,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundPattern Pattern { get; }
 
+        public bool IsNegated { get; }
+
         public BoundDecisionDag DecisionDag { get; }
 
         public LabelSymbol WhenTrueLabel { get; }
@@ -7253,11 +7256,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitIsPatternExpression(this);
 
-        public BoundIsPatternExpression Update(BoundExpression expression, BoundPattern pattern, BoundDecisionDag decisionDag, LabelSymbol whenTrueLabel, LabelSymbol whenFalseLabel, TypeSymbol? type)
+        public BoundIsPatternExpression Update(BoundExpression expression, BoundPattern pattern, bool isNegated, BoundDecisionDag decisionDag, LabelSymbol whenTrueLabel, LabelSymbol whenFalseLabel, TypeSymbol? type)
         {
-            if (expression != this.Expression || pattern != this.Pattern || decisionDag != this.DecisionDag || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(whenTrueLabel, this.WhenTrueLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(whenFalseLabel, this.WhenFalseLabel) || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (expression != this.Expression || pattern != this.Pattern || isNegated != this.IsNegated || decisionDag != this.DecisionDag || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(whenTrueLabel, this.WhenTrueLabel) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(whenFalseLabel, this.WhenFalseLabel) || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundIsPatternExpression(this.Syntax, expression, pattern, decisionDag, whenTrueLabel, whenFalseLabel, type, this.HasErrors);
+                var result = new BoundIsPatternExpression(this.Syntax, expression, pattern, isNegated, decisionDag, whenTrueLabel, whenFalseLabel, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -10754,7 +10757,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundDecisionDag decisionDag = node.DecisionDag;
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, type);
+            return node.Update(expression, pattern, node.IsNegated, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, type);
         }
         public override BoundNode? VisitConstantPattern(BoundConstantPattern node)
         {
@@ -13039,12 +13042,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, infoAndType.Type);
+                updatedNode = node.Update(expression, pattern, node.IsNegated, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, node.Type);
+                updatedNode = node.Update(expression, pattern, node.IsNegated, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, node.Type);
             }
             return updatedNode;
         }
@@ -14932,6 +14935,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             new TreeDumperNode("expression", null, new TreeDumperNode[] { Visit(node.Expression, null) }),
             new TreeDumperNode("pattern", null, new TreeDumperNode[] { Visit(node.Pattern, null) }),
+            new TreeDumperNode("isNegated", node.IsNegated, null),
             new TreeDumperNode("decisionDag", null, new TreeDumperNode[] { Visit(node.DecisionDag, null) }),
             new TreeDumperNode("whenTrueLabel", node.WhenTrueLabel, null),
             new TreeDumperNode("whenFalseLabel", node.WhenFalseLabel, null),

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
@@ -408,7 +408,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(loweredInput.Type is { });
 
                 // We share input variables if there is no when clause (because a when clause might mutate them).
-                bool anyWhenClause = decisionDag.TopologicallySortedNodes.Any(node => isWhenClause(node));
+                bool anyWhenClause =
+                    decisionDag.TopologicallySortedNodes
+                    .Any(node => node is BoundWhenDecisionDagNode { WhenExpression: { ConstantValue: null } });
 
                 var inputDagTemp = BoundDagTemp.ForOriginalInput(loweredInput);
                 if ((loweredInput.Kind == BoundKind.Local || loweredInput.Kind == BoundKind.Parameter)
@@ -469,9 +471,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 Debug.Assert(savedInputExpression != null);
                 return decisionDag;
-
-                static bool isWhenClause(BoundDecisionDagNode node) =>
-                    node is BoundWhenDecisionDagNode { WhenExpression: { ConstantValue: null } };
 
                 static bool usesOriginalInput(BoundDecisionDagNode node)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
@@ -413,8 +413,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var inputDagTemp = BoundDagTemp.ForOriginalInput(loweredInput);
                 if ((loweredInput.Kind == BoundKind.Local || loweredInput.Kind == BoundKind.Parameter)
                     && loweredInput.GetRefKind() == RefKind.None &&
-                    !anyWhenClause &&
-                    !decisionDag.TopologicallySortedNodes.Any(node => isNotClause(node)))
+                    !anyWhenClause)
                 {
                     // If we're switching on a local variable and there is no when clause,
                     // we assume the value of the local variable does not change during the execution of the
@@ -473,9 +472,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 static bool isWhenClause(BoundDecisionDagNode node) =>
                     node is BoundWhenDecisionDagNode { WhenExpression: { ConstantValue: null } };
-
-                static bool isNotClause(BoundDecisionDagNode node) =>
-                    node is BoundTestDecisionDagNode { WhenFalse: BoundWhenDecisionDagNode { } };
 
                 static bool usesOriginalInput(BoundDecisionDagNode node)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -14,32 +14,38 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
         {
+            bool negated = node.Pattern.IsNegated(out _);
+            BoundExpression result;
+
             if (canProduceLinearSequence(node.DecisionDag.RootNode, whenTrueLabel: node.WhenTrueLabel, whenFalseLabel: node.WhenFalseLabel))
             {
                 // If we can build a linear test sequence `(e1 && e2 && e3)` for the dag, do so.
                 var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
-                BoundExpression result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, whenTrueLabel: node.WhenTrueLabel, whenFalseLabel: node.WhenFalseLabel);
+                result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, whenTrueLabel: node.WhenTrueLabel, whenFalseLabel: node.WhenFalseLabel);
                 isPatternRewriter.Free();
-                return result;
             }
             else if (canProduceLinearSequence(node.DecisionDag.RootNode, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel))
             {
                 // If we can build a linear test sequence with the whenTrue and whenFalse labels swapped, then negate the
                 // result.  This would typically arise when the source contains `e is not pattern`.
+                negated = !negated;
                 var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
-                BoundExpression result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
-                result = this._factory.Not(result);
+                result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
                 isPatternRewriter.Free();
-                return result;
             }
             else
             {
                 // We need to lower a generalized dag, so we produce a label for the true and false branches and assign to a temporary containing the result.
                 var isPatternRewriter = new IsPatternExpressionGeneralLocalRewriter(node.Syntax, this);
-                BoundExpression result = isPatternRewriter.LowerGeneralIsPattern(node);
+                result = isPatternRewriter.LowerGeneralIsPattern(node);
                 isPatternRewriter.Free();
-                return result;
             }
+
+            if (negated)
+            {
+                result = this._factory.Not(result);
+            }
+            return result;
 
             // Can the given decision dag node, and its successors, be generated as a sequence of
             // linear tests with a single "golden" path to the try label and all other paths leading

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
         {
-            bool negated = node.Pattern.IsNegated(out _);
+            bool negated = node.IsNegated;
             BoundExpression result;
 
             if (canProduceLinearSequence(node.DecisionDag.RootNode, whenTrueLabel: node.WhenTrueLabel, whenFalseLabel: node.WhenFalseLabel))

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -1158,35 +1158,38 @@ public class C {
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("C.M",
 @"{
-  // Code size       82 (0x52)
+  // Code size       84 (0x54)
   .maxstack  3
-  .locals init (string V_0) //name
+  .locals init (string V_0, //name
+                Person V_1)
   IL_0000:  ldarg.1
-  IL_0001:  brfalse.s  IL_0051
-  IL_0003:  ldarg.1
-  IL_0004:  callvirt   ""string Person.Name.get""
-  IL_0009:  stloc.0
-  IL_000a:  ldloc.0
-  IL_000b:  ldstr      ""Bill""
-  IL_0010:  call       ""bool string.op_Equality(string, string)""
-  IL_0015:  brtrue.s   IL_0026
-  IL_0017:  ldloc.0
-  IL_0018:  ldstr      ""Bob""
-  IL_001d:  call       ""bool string.op_Equality(string, string)""
-  IL_0022:  brtrue.s   IL_0031
-  IL_0024:  br.s       IL_003c
-  IL_0026:  ldstr      ""Hey Bill!""
-  IL_002b:  call       ""void System.Console.WriteLine(string)""
-  IL_0030:  ret
-  IL_0031:  ldstr      ""Hey Bob!""
-  IL_0036:  call       ""void System.Console.WriteLine(string)""
-  IL_003b:  ret
-  IL_003c:  ldstr      ""Hello ""
-  IL_0041:  ldloc.0
-  IL_0042:  ldstr      ""!""
-  IL_0047:  call       ""string string.Concat(string, string, string)""
-  IL_004c:  call       ""void System.Console.WriteLine(string)""
-  IL_0051:  ret
+  IL_0001:  stloc.1
+  IL_0002:  ldloc.1
+  IL_0003:  brfalse.s  IL_0053
+  IL_0005:  ldloc.1
+  IL_0006:  callvirt   ""string Person.Name.get""
+  IL_000b:  stloc.0
+  IL_000c:  ldloc.0
+  IL_000d:  ldstr      ""Bill""
+  IL_0012:  call       ""bool string.op_Equality(string, string)""
+  IL_0017:  brtrue.s   IL_0028
+  IL_0019:  ldloc.0
+  IL_001a:  ldstr      ""Bob""
+  IL_001f:  call       ""bool string.op_Equality(string, string)""
+  IL_0024:  brtrue.s   IL_0033
+  IL_0026:  br.s       IL_003e
+  IL_0028:  ldstr      ""Hey Bill!""
+  IL_002d:  call       ""void System.Console.WriteLine(string)""
+  IL_0032:  ret
+  IL_0033:  ldstr      ""Hey Bob!""
+  IL_0038:  call       ""void System.Console.WriteLine(string)""
+  IL_003d:  ret
+  IL_003e:  ldstr      ""Hello ""
+  IL_0043:  ldloc.0
+  IL_0044:  ldstr      ""!""
+  IL_0049:  call       ""string string.Concat(string, string, string)""
+  IL_004e:  call       ""void System.Console.WriteLine(string)""
+  IL_0053:  ret
 }");
         }
 
@@ -1217,32 +1220,35 @@ public class C {
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("C.M",
 @"{
-  // Code size       64 (0x40)
+  // Code size       66 (0x42)
   .maxstack  3
   .locals init (string V_0, //name
-                string V_1) //name
+                string V_1, //name
+                Person V_2)
   IL_0000:  ldarg.1
-  IL_0001:  brfalse.s  IL_003f
-  IL_0003:  ldarg.1
-  IL_0004:  callvirt   ""string Person.Name.get""
-  IL_0009:  stloc.0
-  IL_000a:  ldarg.1
-  IL_000b:  ldfld      ""int Person.Age""
-  IL_0010:  brtrue.s   IL_0028
-  IL_0012:  ldstr      ""Hello baby ""
-  IL_0017:  ldloc.0
-  IL_0018:  ldstr      ""!""
-  IL_001d:  call       ""string string.Concat(string, string, string)""
-  IL_0022:  call       ""void System.Console.WriteLine(string)""
-  IL_0027:  ret
-  IL_0028:  ldloc.0
-  IL_0029:  stloc.1
-  IL_002a:  ldstr      ""Hello ""
-  IL_002f:  ldloc.1
-  IL_0030:  ldstr      ""!""
-  IL_0035:  call       ""string string.Concat(string, string, string)""
-  IL_003a:  call       ""void System.Console.WriteLine(string)""
-  IL_003f:  ret
+  IL_0001:  stloc.2
+  IL_0002:  ldloc.2
+  IL_0003:  brfalse.s  IL_0041
+  IL_0005:  ldloc.2
+  IL_0006:  callvirt   ""string Person.Name.get""
+  IL_000b:  stloc.0
+  IL_000c:  ldloc.2
+  IL_000d:  ldfld      ""int Person.Age""
+  IL_0012:  brtrue.s   IL_002a
+  IL_0014:  ldstr      ""Hello baby ""
+  IL_0019:  ldloc.0
+  IL_001a:  ldstr      ""!""
+  IL_001f:  call       ""string string.Concat(string, string, string)""
+  IL_0024:  call       ""void System.Console.WriteLine(string)""
+  IL_0029:  ret
+  IL_002a:  ldloc.0
+  IL_002b:  stloc.1
+  IL_002c:  ldstr      ""Hello ""
+  IL_0031:  ldloc.1
+  IL_0032:  ldstr      ""!""
+  IL_0037:  call       ""string string.Concat(string, string, string)""
+  IL_003c:  call       ""void System.Console.WriteLine(string)""
+  IL_0041:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -1158,38 +1158,35 @@ public class C {
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("C.M",
 @"{
-  // Code size       84 (0x54)
+  // Code size       82 (0x52)
   .maxstack  3
-  .locals init (string V_0, //name
-                Person V_1)
+  .locals init (string V_0) //name
   IL_0000:  ldarg.1
-  IL_0001:  stloc.1
-  IL_0002:  ldloc.1
-  IL_0003:  brfalse.s  IL_0053
-  IL_0005:  ldloc.1
-  IL_0006:  callvirt   ""string Person.Name.get""
-  IL_000b:  stloc.0
-  IL_000c:  ldloc.0
-  IL_000d:  ldstr      ""Bill""
-  IL_0012:  call       ""bool string.op_Equality(string, string)""
-  IL_0017:  brtrue.s   IL_0028
-  IL_0019:  ldloc.0
-  IL_001a:  ldstr      ""Bob""
-  IL_001f:  call       ""bool string.op_Equality(string, string)""
-  IL_0024:  brtrue.s   IL_0033
-  IL_0026:  br.s       IL_003e
-  IL_0028:  ldstr      ""Hey Bill!""
-  IL_002d:  call       ""void System.Console.WriteLine(string)""
-  IL_0032:  ret
-  IL_0033:  ldstr      ""Hey Bob!""
-  IL_0038:  call       ""void System.Console.WriteLine(string)""
-  IL_003d:  ret
-  IL_003e:  ldstr      ""Hello ""
-  IL_0043:  ldloc.0
-  IL_0044:  ldstr      ""!""
-  IL_0049:  call       ""string string.Concat(string, string, string)""
-  IL_004e:  call       ""void System.Console.WriteLine(string)""
-  IL_0053:  ret
+  IL_0001:  brfalse.s  IL_0051
+  IL_0003:  ldarg.1
+  IL_0004:  callvirt   ""string Person.Name.get""
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  ldstr      ""Bill""
+  IL_0010:  call       ""bool string.op_Equality(string, string)""
+  IL_0015:  brtrue.s   IL_0026
+  IL_0017:  ldloc.0
+  IL_0018:  ldstr      ""Bob""
+  IL_001d:  call       ""bool string.op_Equality(string, string)""
+  IL_0022:  brtrue.s   IL_0031
+  IL_0024:  br.s       IL_003c
+  IL_0026:  ldstr      ""Hey Bill!""
+  IL_002b:  call       ""void System.Console.WriteLine(string)""
+  IL_0030:  ret
+  IL_0031:  ldstr      ""Hey Bob!""
+  IL_0036:  call       ""void System.Console.WriteLine(string)""
+  IL_003b:  ret
+  IL_003c:  ldstr      ""Hello ""
+  IL_0041:  ldloc.0
+  IL_0042:  ldstr      ""!""
+  IL_0047:  call       ""string string.Concat(string, string, string)""
+  IL_004c:  call       ""void System.Console.WriteLine(string)""
+  IL_0051:  ret
 }");
         }
 
@@ -1220,35 +1217,32 @@ public class C {
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("C.M",
 @"{
-  // Code size       66 (0x42)
+  // Code size       64 (0x40)
   .maxstack  3
   .locals init (string V_0, //name
-                string V_1, //name
-                Person V_2)
+                string V_1) //name
   IL_0000:  ldarg.1
-  IL_0001:  stloc.2
-  IL_0002:  ldloc.2
-  IL_0003:  brfalse.s  IL_0041
-  IL_0005:  ldloc.2
-  IL_0006:  callvirt   ""string Person.Name.get""
-  IL_000b:  stloc.0
-  IL_000c:  ldloc.2
-  IL_000d:  ldfld      ""int Person.Age""
-  IL_0012:  brtrue.s   IL_002a
-  IL_0014:  ldstr      ""Hello baby ""
-  IL_0019:  ldloc.0
-  IL_001a:  ldstr      ""!""
-  IL_001f:  call       ""string string.Concat(string, string, string)""
-  IL_0024:  call       ""void System.Console.WriteLine(string)""
-  IL_0029:  ret
-  IL_002a:  ldloc.0
-  IL_002b:  stloc.1
-  IL_002c:  ldstr      ""Hello ""
-  IL_0031:  ldloc.1
-  IL_0032:  ldstr      ""!""
-  IL_0037:  call       ""string string.Concat(string, string, string)""
-  IL_003c:  call       ""void System.Console.WriteLine(string)""
-  IL_0041:  ret
+  IL_0001:  brfalse.s  IL_003f
+  IL_0003:  ldarg.1
+  IL_0004:  callvirt   ""string Person.Name.get""
+  IL_0009:  stloc.0
+  IL_000a:  ldarg.1
+  IL_000b:  ldfld      ""int Person.Age""
+  IL_0010:  brtrue.s   IL_0028
+  IL_0012:  ldstr      ""Hello baby ""
+  IL_0017:  ldloc.0
+  IL_0018:  ldstr      ""!""
+  IL_001d:  call       ""string string.Concat(string, string, string)""
+  IL_0022:  call       ""void System.Console.WriteLine(string)""
+  IL_0027:  ret
+  IL_0028:  ldloc.0
+  IL_0029:  stloc.1
+  IL_002a:  ldstr      ""Hello ""
+  IL_002f:  ldloc.1
+  IL_0030:  ldstr      ""!""
+  IL_0035:  call       ""string string.Concat(string, string, string)""
+  IL_003a:  call       ""void System.Console.WriteLine(string)""
+  IL_003f:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -6409,7 +6409,7 @@ class Program
         }
 
         [Fact, WorkItem(20103, "https://github.com/dotnet/roslyn/issues/20103")]
-        public void TestNullInInPattern()
+        public void TestNullInIsPattern()
         {
             var source =
 @"using System;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -6236,6 +6236,7 @@ class C
         [InlineData("c is not (not not C c1)")]
         [InlineData("c is not not (not C c1)")]
         [InlineData("c is not { } c1")]
+        [InlineData("!(c is not not { } c1)")]
         public void IsNot_08(string pattern)
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -6150,6 +6150,332 @@ class C
         }
 
         [Fact]
+        public void IsNot_06()
+        {
+            var source =
+@"using static System.Console;
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        M1(c);
+        M2(c);
+    }
+    static void M1(object o)
+    {
+        if (!(o is C c1)) return;
+        WriteLine(c1.F);
+    }
+    static void M2(object o)
+    {
+        if (o is not C c1) return;
+        WriteLine(c1.F);
+    }
+    int F = 42;
+}";
+            var comp = CreateCompilation(source);
+            var verifier = CompileAndVerify(source, expectedOutput:
+@"42
+42");
+            var expectedIL =
+@"{
+  // Code size       23 (0x17)
+  .maxstack  1
+  .locals init (C V_0) //c1
+  IL_0000:  ldarg.0
+  IL_0001:  isinst     ""C""
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  brtrue.s   IL_000b
+  IL_000a:  ret
+  IL_000b:  ldloc.0
+  IL_000c:  ldfld      ""int C.F""
+  IL_0011:  call       ""void System.Console.WriteLine(int)""
+  IL_0016:  ret
+}";
+            verifier.VerifyIL("C.M1", expectedIL);
+            verifier.VerifyIL("C.M2", expectedIL);
+        }
+
+        [Fact]
+        [WorkItem(49262, "https://github.com/dotnet/roslyn/issues/49262")]
+        public void IsNot_07()
+        {
+            var source =
+@"using static System.Console;
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        M1(c);
+        M2(c);
+    }
+    static void M1(C c)
+    {
+        if (!(c is C c1)) return;
+        WriteLine(c1.F);
+    }
+    static void M2(C c)
+    {
+        if (c is not C c1) return;
+        WriteLine(c1.F);
+    }
+    int F = 42;
+}";
+            var comp = CreateCompilation(source);
+            var verifier = CompileAndVerify(source, expectedOutput:
+@"42
+42");
+            verifier.VerifyIL("C.M1",
+@"{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (C V_0) //c1
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0007
+  IL_0003:  ldarg.0
+  IL_0004:  stloc.0
+  IL_0005:  br.s       IL_0008
+  IL_0007:  ret
+  IL_0008:  ldloc.0
+  IL_0009:  ldfld      ""int C.F""
+  IL_000e:  call       ""void System.Console.WriteLine(int)""
+  IL_0013:  ret
+}");
+            verifier.VerifyIL("C.M2",
+@"{
+  // Code size       18 (0x12)
+  .maxstack  1
+  .locals init (C V_0) //c1
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  brtrue.s   IL_0006
+  IL_0005:  ret
+  IL_0006:  ldloc.0
+  IL_0007:  ldfld      ""int C.F""
+  IL_000c:  call       ""void System.Console.WriteLine(int)""
+  IL_0011:  ret
+}");
+        }
+
+        [Fact]
+        [WorkItem(49262, "https://github.com/dotnet/roslyn/issues/49262")]
+        public void IsNot_08()
+        {
+            var source =
+@"using static System.Console;
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        M1(c);
+        M2(c);
+    }
+    static void M1(C c)
+    {
+        if (!(c is { } c1)) return;
+        WriteLine(c1.F);
+    }
+    static void M2(C c)
+    {
+        if (c is not { } c1) return;
+        WriteLine(c1.F);
+    }
+    int F = 42;
+}";
+            var comp = CreateCompilation(source);
+            var verifier = CompileAndVerify(source, expectedOutput:
+@"42
+42");
+            verifier.VerifyIL("C.M1",
+@"{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (C V_0) //c1
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0007
+  IL_0003:  ldarg.0
+  IL_0004:  stloc.0
+  IL_0005:  br.s       IL_0008
+  IL_0007:  ret
+  IL_0008:  ldloc.0
+  IL_0009:  ldfld      ""int C.F""
+  IL_000e:  call       ""void System.Console.WriteLine(int)""
+  IL_0013:  ret
+}");
+            verifier.VerifyIL("C.M2",
+@"{
+  // Code size       18 (0x12)
+  .maxstack  1
+  .locals init (C V_0) //c1
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  brtrue.s   IL_0006
+  IL_0005:  ret
+  IL_0006:  ldloc.0
+  IL_0007:  ldfld      ""int C.F""
+  IL_000c:  call       ""void System.Console.WriteLine(int)""
+  IL_0011:  ret
+}");
+        }
+
+        [Fact]
+        [WorkItem(49262, "https://github.com/dotnet/roslyn/issues/49262")]
+        public void IsNot_09()
+        {
+            var source =
+@"using static System.Console;
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        M1(c);
+        M2(c);
+    }
+    static void M1(C c)
+    {
+        if (!(c is { F: 42 } c1)) return;
+        WriteLine(c1.F);
+    }
+    static void M2(C c)
+    {
+        if (c is not { F: 42 } c1) return;
+        WriteLine(c1.F);
+    }
+    int F = 42;
+}";
+            var comp = CreateCompilation(source);
+            var verifier = CompileAndVerify(source, expectedOutput:
+@"42
+42");
+            verifier.VerifyIL("C.M1",
+@"{
+  // Code size       30 (0x1e)
+  .maxstack  2
+  .locals init (C V_0) //c1
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0011
+  IL_0003:  ldarg.0
+  IL_0004:  ldfld      ""int C.F""
+  IL_0009:  ldc.i4.s   42
+  IL_000b:  bne.un.s   IL_0011
+  IL_000d:  ldarg.0
+  IL_000e:  stloc.0
+  IL_000f:  br.s       IL_0012
+  IL_0011:  ret
+  IL_0012:  ldloc.0
+  IL_0013:  ldfld      ""int C.F""
+  IL_0018:  call       ""void System.Console.WriteLine(int)""
+  IL_001d:  ret
+}");
+            verifier.VerifyIL("C.M2",
+@"{
+  // Code size       28 (0x1c)
+  .maxstack  2
+  .locals init (C V_0) //c1
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  brfalse.s  IL_000f
+  IL_0005:  ldloc.0
+  IL_0006:  ldfld      ""int C.F""
+  IL_000b:  ldc.i4.s   42
+  IL_000d:  beq.s      IL_0010
+  IL_000f:  ret
+  IL_0010:  ldloc.0
+  IL_0011:  ldfld      ""int C.F""
+  IL_0016:  call       ""void System.Console.WriteLine(int)""
+  IL_001b:  ret
+}");
+        }
+
+        [Fact]
+        [WorkItem(49262, "https://github.com/dotnet/roslyn/issues/49262")]
+        public void IsNot_10()
+        {
+            var source =
+@"using static System.Console;
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        M1(c);
+        M2(c);
+    }
+    static void M1(C c)
+    {
+        if (!(c is { F: var f } c1)) return;
+        WriteLine(f);
+        WriteLine(c1.F);
+    }
+    static void M2(C c)
+    {
+        if (c is not { F: var f } c1) return;
+        WriteLine(f);
+        WriteLine(c1.F);
+    }
+    object F = 42;
+}";
+            var comp = CreateCompilation(source);
+            var verifier = CompileAndVerify(source, expectedOutput:
+@"42
+42
+42
+42");
+            verifier.VerifyIL("C.M1",
+@"{
+  // Code size       33 (0x21)
+  .maxstack  1
+  .locals init (C V_0, //c1
+                object V_1) //f
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_000e
+  IL_0003:  ldarg.0
+  IL_0004:  ldfld      ""object C.F""
+  IL_0009:  stloc.1
+  IL_000a:  ldarg.0
+  IL_000b:  stloc.0
+  IL_000c:  br.s       IL_000f
+  IL_000e:  ret
+  IL_000f:  ldloc.1
+  IL_0010:  call       ""void System.Console.WriteLine(object)""
+  IL_0015:  ldloc.0
+  IL_0016:  ldfld      ""object C.F""
+  IL_001b:  call       ""void System.Console.WriteLine(object)""
+  IL_0020:  ret
+}");
+            verifier.VerifyIL("C.M2",
+@"{
+  // Code size       33 (0x21)
+  .maxstack  1
+  .locals init (C V_0, //c1
+                object V_1) //f
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  brfalse.s  IL_000e
+  IL_0005:  ldloc.0
+  IL_0006:  ldfld      ""object C.F""
+  IL_000b:  stloc.1
+  IL_000c:  br.s       IL_000f
+  IL_000e:  ret
+  IL_000f:  ldloc.1
+  IL_0010:  call       ""void System.Console.WriteLine(object)""
+  IL_0015:  ldloc.0
+  IL_0016:  ldfld      ""object C.F""
+  IL_001b:  call       ""void System.Console.WriteLine(object)""
+  IL_0020:  ret
+}");
+        }
+
+        [Fact]
         public void NonexhaustiveEnumDiagnostic_10()
         {
             var source =


### PR DESCRIPTION
Pattern matching was optimizing away the temporary for the pattern input `c` in `c is not C c1`. That temporary would be reused by the pattern variable `c1`, but if optimized away, the temporary for the pattern variable is only assigned in the success case (when `c is not C`, where the variable is not needed) rather than the failure case (when `c is C`).

Fixes #49262