### PR TITLE
Use deterministic metadata names for emitted anonymous type fields.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType_PropertyBackingFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType_PropertyBackingFieldSymbol.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Get
                     ' To be sure that when we emitting the name, it's 
                     ' casing is in sync with that of the property
-                    Return "$" & Me._propertyOrEvent.Name
+                    Return "$" & Me._propertyOrEvent.MetadataName
                 End Get
             End Property
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesEmittedSymbolsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesEmittedSymbolsTests.vb
@@ -306,30 +306,31 @@ End Module
         End Sub
 
         <Fact>
+        <WorkItem(48417, "https://github.com/dotnet/roslyn/issues/48417")>
         Public Sub CheckPropertyFieldAndAccessorsNamesTest()
             Dim compilationDef =
     <compilation name="CheckPropertyFieldAndAccessorsNamesTest">
         <file name="b.vb">
 Module ModuleB
     Sub Test1(x As Integer)
-        Dim v1 As Object = New With { .aa = 1 }.aa
-        Dim v2 As Object = New With { Key .AA = "a" }.aa
+        Dim v1 As Object = New With { .aab = 1 }.aab
+        Dim v2 As Object = New With { Key .AAB = "a" }.aab
     End Sub
 End Module
         </file>
         <file name="a.vb">
 Module ModuleA
     Sub Test1(x As Integer)
-        Dim v1 As Object = New With { .Aa = 1 }.aa
-        Dim v2 As Object = New With { Key .aA = "A" }.aa
+        Dim v1 As Object = New With { .Aab = 1 }.aab
+        Dim v2 As Object = New With { Key .aAB = "A" }.aab
     End Sub
 End Module
         </file>
         <file name="c.vb">
 Module ModuleC
     Sub Test1(x As Integer)
-        Dim v1 As Object = New With { .AA = 1 }.aa
-        Dim v2 As Object = New With { Key .aa = "A" }.aa
+        Dim v1 As Object = New With { .AAb = 1 }.aab
+        Dim v2 As Object = New With { Key .aaB = "A" }.aab
     End Sub
 End Module
         </file>
@@ -339,14 +340,15 @@ End Module
             For i = 0 To 50
                 CompileAndVerify(compilationDef,
                                  references:={SystemCoreRef},
+                                 options:=TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
                                  symbolValidator:=Sub(m As ModuleSymbol)
                                                       Dim type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_0`1")
                                                       Assert.NotNull(type)
-                                                      CheckPropertyAccessorsAndField(m, type, "aa", type.TypeParameters(0), False)
+                                                      CheckPropertyAccessorsAndField(m, type, "aab", type.TypeParameters(0), False)
 
                                                       type = m.ContainingAssembly.GetTypeByMetadataName("VB$AnonymousType_1`1")
                                                       Assert.NotNull(type)
-                                                      CheckPropertyAccessorsAndField(m, type, "AA", type.TypeParameters(0), True)
+                                                      CheckPropertyAccessorsAndField(m, type, "AAB", type.TypeParameters(0), True)
                                                   End Sub)
             Next
         End Sub
@@ -647,8 +649,7 @@ End Module
 #Region "Utils"
 
         Private Shared Sub CheckPropertyAccessorsAndField(m As ModuleSymbol, type As NamedTypeSymbol, propName As String, propType As TypeSymbol, isKey As Boolean)
-            Dim prop = DirectCast(type.GetMember(propName), PropertySymbol)
-            Assert.NotNull(prop)
+            Dim prop = type.GetMembers().OfType(Of PropertySymbol)().Single()
             Assert.Equal(propType, prop.Type)
             Assert.Equal(propName, prop.Name)
             Assert.Equal(propName, prop.MetadataName)
@@ -682,7 +683,11 @@ End Module
                 Assert.Null(prop.SetMethod)
             End If
 
-            Assert.Equal(0, type.GetMembers("$" & propName).Length)
+            Dim field = type.GetMembers().OfType(Of FieldSymbol)().Single()
+            Assert.Equal(propType, field.Type)
+            Assert.Equal("$" & propName, field.Name)
+            Assert.Equal("$" & propName, field.MetadataName)
+            Assert.Equal(Accessibility.Private, field.DeclaredAccessibility)
         End Sub
 
         Private Shared Sub CheckMethod(m As ModuleSymbol, method As MethodSymbol,


### PR DESCRIPTION
Fixes #48417.