### PR TITLE
Remove unnecessary ArrayBuilder in MakeCallWithNoExplicitArgument

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -480,12 +480,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var expanded = method.HasParamsParameter();
 
             var argsToParams = default(ImmutableArray<int>);
-            var refKindsBuilder = ArrayBuilder<RefKind>.GetInstance();
             binder.BindDefaultArguments(
                 syntax,
                 method.Parameters,
                 argsBuilder,
-                refKindsBuilder,
+                argumentRefKindsBuilder: null,
                 ref argsToParams,
                 out var defaultArguments,
                 expanded,
@@ -496,7 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenReceiver: receiver,
                 method: method,
                 rewrittenArguments: argsBuilder.ToImmutableAndFree(),
-                argumentRefKindsOpt: refKindsBuilder.ToImmutableOrNull(),
+                argumentRefKindsOpt: default,
                 expanded,
                 invokedAsExtensionMethod: method.IsExtensionMethod,
                 argsToParamsOpt: argsToParams,


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/49186#discussion_r523443366