### PR TITLE
Avoid duplicate GetHashCode() values in TokenMap (#48897)

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -346,5 +346,32 @@ class Program
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
         }
+
+        [Fact]
+        [WorkItem(48886, "https://github.com/dotnet/roslyn/issues/48886")]
+        public void ArrayInitializationAnonymousTypes()
+        {
+            const int nTypes = 250;
+            const int nItemsPerType = 1000;
+
+            var builder = new StringBuilder();
+            for (int i = 0; i < nTypes; i++)
+            {
+                builder.AppendLine($"class C{i}");
+                builder.AppendLine("{");
+                builder.AppendLine("    static object[] F = new[]");
+                builder.AppendLine("    {");
+                for (int j = 0; j < nItemsPerType; j++)
+                {
+                    builder.AppendLine($"        new {{ Id = {j} }},");
+                }
+                builder.AppendLine("    };");
+                builder.AppendLine("}");
+            }
+
+            var source = builder.ToString();
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
     }
 }

--- a/src/Compilers/Core/Portable/IReferenceOrISignature.cs
+++ b/src/Compilers/Core/Portable/IReferenceOrISignature.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis
 
         public override bool Equals(object? obj) => false;
 
-        public override int GetHashCode() => _item.GetHashCode();
+        public override int GetHashCode() => RuntimeHelpers.GetHashCode(_item);
 
         public override string ToString() => _item.ToString() ?? "null";
     }


### PR DESCRIPTION
Port https://github.com/dotnet/roslyn/pull/48897 to release/dev16.8.

Fixes https://github.com/dotnet/efcore/issues/23291.