### PR TITLE
Remove unwanted DataContract attribute

### DIFF
--- a/src/Compilers/Core/Portable/Text/TextChange.cs
+++ b/src/Compilers/Core/Portable/Text/TextChange.cs
@@ -15,7 +15,6 @@ namespace Microsoft.CodeAnalysis.Text
     /// <summary>
     /// Describes a single change when a particular span is replaced with a new text.
     /// </summary>
-    [DataContract]
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public readonly struct TextChange : IEquatable<TextChange>
     {

--- a/src/Compilers/Core/Portable/Text/TextChange.cs
+++ b/src/Compilers/Core/Portable/Text/TextChange.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.Serialization;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text


### PR DESCRIPTION
Fixes a VS test break related to external users serializing instances of our types.

Have verified the fix locally, but still running automated validation over at https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/288168
