### PR TITLE
Fix module-level SkipLocalsInit with top-level statements

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     return method.AreLocalsZeroed;
                 }
-                else if (ContainingType is SourceNamedTypeSymbol type)
+                else if (ContainingType is SourceMemberContainerTypeSymbol type)
                 {
                     return type.AreLocalsZeroed;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49434