### PR TITLE
Set an encoding on source text

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
         public Task<object?> HandleRequestAsync(LSP.DidOpenTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
         {
             // Add the document and ensure the text we have matches whats on the client
-            var sourceText = SourceText.From(request.TextDocument.Text);
+            var sourceText = SourceText.From(request.TextDocument.Text, System.Text.Encoding.UTF8);
 
             context.StartTracking(request.TextDocument.Uri, sourceText);
 


### PR DESCRIPTION
Fixes [AB#1244286](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1244286) (or possibly, works around?)

The remote workspace caches solutions based on their checksum, and so LUT can sometimes see our LSP solutions if its text is the same as the workspace, but can't use them because LUT needs to do a build, and build can't work without an encoding.

This unblocks LUT by setting an encoding. I think something should change with OOP that makes this not necessary, but that's a longer term fix and this doesn't seem to cost anything.

FYI @shyamnamboodiripad @drognanar 