### PR TITLE
Editor config block comment header

### DIFF
--- a/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
+++ b/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
@@ -28,6 +28,10 @@ file_header_template = \nCopyright (c) SomeCorp. All rights reserved.\n\nLicense
 file_header_template = //\n// Copyright (c) SomeCorp. All rights reserved.\n//\n// Licensed under the ??? license. See LICENSE file in the project root for full license information.\n//
 ";
 
+        private const string TestSettingsWithMultiLineComment = @"
+[*.cs]
+file_header_template = /************************************************\n*                                               *\n* Copyright (c) SomeCorp. All rights reserved.  *\n*                                               *\n* Licensed under the ??? license.               *\n*                                               *\n************************************************/
+";
         /// <summary>
         /// Verifies that the analyzer will not report a diagnostic when the file header is not configured.
         /// </summary>
@@ -628,6 +632,37 @@ namespace Bar
                 TestCode = testCode,
                 FixedCode = fixedCode,
                 EditorConfig = TestSettingsWithSingleLineComment,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNoFileHeaderWithMultiLineCommentsInEditorConfig()
+        {
+            var newLine = "\r\n";
+            var testCode = @"[||]
+namespace Bar
+{
+}
+";
+            var fixedCode =
+"/************************************************" + newLine +
+"*                                               *" + newLine +
+"* Copyright (c) SomeCorp. All rights reserved.  *" + newLine +
+"*                                               *" + newLine +
+"* Licensed under the ??? license.               *" + newLine +
+"*                                               *" + newLine +
+"************************************************/" + @"
+
+namespace Bar
+{
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                FixedCode = fixedCode,
+                EditorConfig = TestSettingsWithMultiLineComment,
             }.RunAsync();
         }
     }

--- a/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
+++ b/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
@@ -25,7 +25,7 @@ file_header_template = \nCopyright (c) SomeCorp. All rights reserved.\n\nLicense
 
         private const string TestSettingsWithSingleLineComment = @"
 [*.cs]
-file_header_template = //\n// Copyright (c) SomeCorp. All rights reserved.\n//\n// Licensed under the ??? license. See LICENSE file in the project root for full license information.\n
+file_header_template = //\n// Copyright (c) SomeCorp. All rights reserved.\n//\n// Licensed under the ??? license. See LICENSE file in the project root for full license information.\n//
 ";
 
         /// <summary>
@@ -635,6 +635,7 @@ namespace Bar
                     },
                 },
                 EditorConfig = TestSettingsWithSingleLineComment,
+                CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
             }.RunAsync();
         }
     }

--- a/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
+++ b/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
@@ -625,17 +625,9 @@ namespace Bar
 
             await new VerifyCS.Test
             {
-                TestState = { Sources = { testCode } },
-                FixedState = {
-                    Sources = { fixedCode },
-                    ExpectedDiagnostics =
-                    {
-                        // /0/Test0.cs(1,1): hidden IDE0073: Header mismatch.
-                        new DiagnosticResult("IDE0073", DiagnosticSeverity.Hidden).WithSpan(1,1,1,3),
-                    },
-                },
+                TestCode = testCode,
+                FixedCode = fixedCode,
                 EditorConfig = TestSettingsWithSingleLineComment,
-                CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
             }.RunAsync();
         }
     }

--- a/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
+++ b/src/Analyzers/CSharp/Tests/FileHeaders/FileHeaderTests.cs
@@ -30,8 +30,15 @@ file_header_template = //\n// Copyright (c) SomeCorp. All rights reserved.\n//\n
 
         private const string TestSettingsWithMultiLineComment = @"
 [*.cs]
-file_header_template = /************************************************\n*                                               *\n* Copyright (c) SomeCorp. All rights reserved.  *\n*                                               *\n* Licensed under the ??? license.               *\n*                                               *\n************************************************/
-";
+file_header_template = " +
+@"/************************************************\n" +
+@"*                                               *\n" +
+@"* Copyright (c) SomeCorp. All rights reserved.  *\n" +
+@"*                                               *\n" +
+@"* Licensed under the ??? license.               *\n" +
+@"*                                               *\n" +
+@"************************************************/";
+
         /// <summary>
         /// Verifies that the analyzer will not report a diagnostic when the file header is not configured.
         /// </summary>

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -63,7 +63,10 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             }
 
             var expectedFileHeader = fileHeaderTemplate.Replace("{fileName}", Path.GetFileName(tree.FilePath));
-            if (!CompareCopyrightText(expectedFileHeader, fileHeader.CopyrightText))
+            if (!CompareCopyrightText(expectedFileHeader, fileHeader.CopyrightText) &&
+                // Compare the current fileHeader with the expected file header, assuming the expected file header is written as a comment
+                // e.g. file_header_template = /* Copyright */
+                !CompareCopyrightText(expectedFileHeader, root.GetText().GetSubText(fileHeader.GetHeaderLocation(tree).SourceSpan).ToString()))
             {
                 context.ReportDiagnostic(Diagnostic.Create(InvalidHeaderDescriptor, fileHeader.GetLocation(tree)));
                 return;

--- a/src/Analyzers/Core/Analyzers/FileHeaders/FileHeader.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/FileHeader.cs
@@ -17,6 +17,11 @@ namespace Microsoft.CodeAnalysis.FileHeaders
         private readonly int _fileHeaderStart;
 
         /// <summary>
+        /// The location in the source where the file header was expected to end.
+        /// </summary>
+        private readonly int _fileHeaderEnd;
+
+        /// <summary>
         /// The length of the prefix indicating the start of a comment. For example:
         /// <list type="bullet">
         ///   <item>
@@ -40,8 +45,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
         internal FileHeader(string copyrightText, int fileHeaderStart, int fileHeaderEnd, int commentPrefixLength)
             : this(fileHeaderStart, isMissing: false)
         {
-            // Currently unused
-            _ = fileHeaderEnd;
+            _fileHeaderEnd = fileHeaderEnd;
 
             CopyrightText = copyrightText;
             _commentPrefixLength = commentPrefixLength;
@@ -55,6 +59,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
         private FileHeader(int fileHeaderStart, bool isMissing)
         {
             _fileHeaderStart = fileHeaderStart;
+            _fileHeaderEnd = fileHeaderStart;
             _commentPrefixLength = 0;
 
             IsMissing = isMissing;
@@ -103,6 +108,21 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             }
 
             return Location.Create(syntaxTree, new TextSpan(_fileHeaderStart, _commentPrefixLength));
+        }
+
+        /// <summary>
+        /// Gets the location representing the file header.
+        /// </summary>
+        /// <param name="syntaxTree">The syntax tree to use for generating the location.</param>
+        /// <returns>The location representing the file header.</returns>
+        internal Location GetHeaderLocation(SyntaxTree syntaxTree)
+        {
+            if (IsMissing)
+            {
+                return Location.Create(syntaxTree, new TextSpan(_fileHeaderStart, 0));
+            }
+
+            return Location.Create(syntaxTree, TextSpan.FromBounds(_fileHeaderStart, _fileHeaderEnd));
         }
     }
 }

--- a/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
@@ -200,6 +200,12 @@ namespace Microsoft.CodeAnalysis.FileHeaders
 
         private static SyntaxTriviaList CreateNewHeader(ISyntaxFacts syntaxFacts, string prefixWithLeadingSpaces, string expectedFileHeader, string newLineText)
         {
+            var tryParseTemplate = syntaxFacts.ParseLeadingTrivia(expectedFileHeader.Replace("\r\n", newLineText).Replace("\n", newLineText));
+            if (tryParseTemplate.Any() && syntaxFacts.IsRegularComment(tryParseTemplate[0]) && tryParseTemplate.All(trivia => !trivia.ContainsDiagnostics))
+            {
+                return tryParseTemplate;
+            }
+
             var copyrightText = GetCopyrightText(prefixWithLeadingSpaces, expectedFileHeader, newLineText);
             var newHeader = copyrightText;
             return syntaxFacts.ParseLeadingTrivia(newHeader);


### PR DESCRIPTION
Fixes #47228
Related #33012

Missing:
* [ ] Tests for VB
* [ ] Tests for malformed code comments (editor config starts like a code comment, but parsing fails)