### PR TITLE
Collect nfw information for a crash we're seeing.

### DIFF
--- a/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelReuse/AbstractSemanticModelReuseLanguageService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelReuse
                 try
                 {
                     throw new InvalidOperationException(
-                        $@"Syntax trees should have been equivalent.
+                        $@"Syntax trees should have had top-level equivalency.
 ---
 {previousSyntaxTree.GetText(cancellationToken)}
 ---


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49413

This changes us from a hard crash when we run into something unexpected into a soft watson where we log the information and then fallback to safe, but less fast, codepath.