### PR TITLE
Remove IOperation laziness from SemanticModel

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
@@ -90,24 +90,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (rootSyntax.Kind())
             {
                 case SyntaxKind.VariableDeclarator:
-                    rootSyntax = ((VariableDeclaratorSyntax)rootSyntax).Initializer.Value;
+                    rootSyntax = ((VariableDeclaratorSyntax)rootSyntax).Initializer;
                     break;
 
                 case SyntaxKind.Parameter:
-                    var paramDefault = ((ParameterSyntax)rootSyntax).Default;
-                    rootSyntax = (paramDefault == null) ? null : paramDefault.Value;
+                    rootSyntax = ((ParameterSyntax)rootSyntax).Default;
                     break;
 
                 case SyntaxKind.EqualsValueClause:
-                    rootSyntax = ((EqualsValueClauseSyntax)rootSyntax).Value;
+                    rootSyntax = ((EqualsValueClauseSyntax)rootSyntax);
                     break;
 
                 case SyntaxKind.EnumMemberDeclaration:
-                    rootSyntax = ((EnumMemberDeclarationSyntax)rootSyntax).EqualsValue.Value;
+                    rootSyntax = ((EnumMemberDeclarationSyntax)rootSyntax).EqualsValue;
                     break;
 
                 case SyntaxKind.PropertyDeclaration:
-                    rootSyntax = ((PropertyDeclarationSyntax)rootSyntax).Initializer.Value;
+                    rootSyntax = ((PropertyDeclarationSyntax)rootSyntax).Initializer;
                     break;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -5,15 +5,11 @@
 #nullable disable
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
@@ -29,10 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly Symbol _memberSymbol;
         private readonly CSharpSyntaxNode _root;
-        private readonly DiagnosticBag _ignoredDiagnostics = new DiagnosticBag();
-        private readonly ReaderWriterLockSlim _nodeMapLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+        private readonly DiagnosticBag _ignoredDiagnostics = new();
+        private readonly ReaderWriterLockSlim _nodeMapLock = new(LockRecursionPolicy.NoRecursion);
         // The bound nodes associated with a syntax node, from highest in the tree to lowest.
-        private readonly Dictionary<SyntaxNode, ImmutableArray<BoundNode>> _guardedNodeMap = new Dictionary<SyntaxNode, ImmutableArray<BoundNode>>();
+        private readonly Dictionary<SyntaxNode, ImmutableArray<BoundNode>> _guardedBoundNodeMap = new();
+        private readonly Dictionary<SyntaxNode, IOperation> _guardedIOperationNodeMap = new();
         private Dictionary<SyntaxNode, BoundStatement> _lazyGuardedSynthesizedStatementsMap;
         private NullableWalker.SnapshotManager _lazySnapshotManager;
         private ImmutableDictionary<Symbol, Symbol> _lazyRemappedSymbols;
@@ -1137,20 +1134,36 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal override IOperation GetOperationWorker(CSharpSyntaxNode node, CancellationToken cancellationToken)
+#nullable enable
+        internal override IOperation? GetOperationWorker(CSharpSyntaxNode node, CancellationToken cancellationToken)
         {
-            CSharpSyntaxNode bindingRoot = GetBindingRootOrInitializer(node);
-
-            IOperation statementOrRootOperation = GetStatementOrRootOperation(bindingRoot, cancellationToken);
-            if (statementOrRootOperation == null)
+            using (_nodeMapLock.DisposableRead())
             {
-                return null;
+                if (_guardedIOperationNodeMap.Count != 0)
+                {
+                    return guardedGetIOperation();
+                }
             }
 
-            // we might optimize it later
-            // https://github.com/dotnet/roslyn/issues/22180
-            return statementOrRootOperation.DescendantsAndSelf().FirstOrDefault(o => !o.IsImplicit && o.Syntax == node);
+            IOperation rootOperation = GetRootOperation();
+
+            using var _ = _nodeMapLock.DisposableWrite();
+
+            if (_guardedIOperationNodeMap.Count != 0)
+            {
+                return guardedGetIOperation();
+            }
+
+            OperationMapBuilder.Instance.Visit(rootOperation, _guardedIOperationNodeMap);
+            return guardedGetIOperation();
+
+            IOperation? guardedGetIOperation()
+            {
+                _nodeMapLock.AssertCanRead();
+                return _guardedIOperationNodeMap.TryGetValue(node, out var operation) ? operation : null;
+            }
         }
+#nullable disable
 
         private CSharpSyntaxNode GetBindingRootOrInitializer(CSharpSyntaxNode node)
         {
@@ -1191,23 +1204,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             return bindingRoot;
         }
 
-        private IOperation GetStatementOrRootOperation(CSharpSyntaxNode node, CancellationToken cancellationToken)
+#nullable enable
+        private IOperation GetRootOperation()
         {
-            Debug.Assert(node == GetBindingRootOrInitializer(node));
+            BoundNode highestBoundNode = GetBoundRoot();
+            Debug.Assert(highestBoundNode != null);
 
-            BoundNode highestBoundNode;
-            GetBoundNodes(node, out _, out _, out highestBoundNode, out _);
-
-            // decide whether we should use highest or lowest bound node here 
-            // https://github.com/dotnet/roslyn/issues/22179
-            BoundNode result = highestBoundNode;
+            if (highestBoundNode is BoundGlobalStatementInitializer { Statement: var innerStatement })
+            {
+                // We don't have an IOperation node for the top-level statement here.
+                highestBoundNode = innerStatement;
+            }
 
             // The CSharp operation factory assumes that UnboundLambda will be bound for error recovery and never be passed to the factory
             // as the start of a tree to get operations for. This is guaranteed by the builder that populates the node map, as it will call
             // UnboundLambda.BindForErrorRecovery() when it encounters an UnboundLambda node.
-            Debug.Assert(result?.Kind != BoundKind.UnboundLambda);
-            return _operationFactory.Value.Create(result);
+            Debug.Assert(highestBoundNode.Kind != BoundKind.UnboundLambda);
+            IOperation operation = _operationFactory.Value.Create(highestBoundNode);
+            Operation.SetParentOperation(operation, null);
+            return operation;
         }
+#nullable disable
 
         internal override SymbolInfo GetSymbolInfoWorker(CSharpSyntaxNode node, SymbolInfoOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -1438,7 +1455,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(_nodeMapLock.IsWriteLockHeld || _nodeMapLock.IsReadLockHeld);
             ImmutableArray<BoundNode> result;
-            return _guardedNodeMap.TryGetValue(node, out result) ? result : default(ImmutableArray<BoundNode>);
+            return _guardedBoundNodeMap.TryGetValue(node, out result) ? result : default(ImmutableArray<BoundNode>);
         }
 
         /// <summary>
@@ -1447,7 +1464,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal ImmutableArray<BoundNode> TestOnlyTryGetBoundNodesFromMap(CSharpSyntaxNode node)
         {
             ImmutableArray<BoundNode> result;
-            return _guardedNodeMap.TryGetValue(node, out result) ? result : default(ImmutableArray<BoundNode>);
+            return _guardedBoundNodeMap.TryGetValue(node, out result) ? result : default(ImmutableArray<BoundNode>);
         }
 
         // Adds every syntax/bound pair in a tree rooted at the given bound node to the map, and the
@@ -1460,19 +1477,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (bound != null)
             {
-                alreadyInTree = _guardedNodeMap.ContainsKey(bound.Syntax);
+                alreadyInTree = _guardedBoundNodeMap.ContainsKey(bound.Syntax);
             }
 
             // check if we already have node in the cache.
             // this may happen if we have races and in such case we are no longer interested in adding
             if (!alreadyInTree)
             {
-                NodeMapBuilder.AddToMap(bound, _guardedNodeMap, SyntaxTree);
-                Debug.Assert(syntax != _root || _guardedNodeMap.ContainsKey(bound.Syntax));
+                NodeMapBuilder.AddToMap(bound, _guardedBoundNodeMap, SyntaxTree);
+                Debug.Assert(syntax != _root || _guardedBoundNodeMap.ContainsKey(bound.Syntax));
             }
 
             ImmutableArray<BoundNode> result;
-            return _guardedNodeMap.TryGetValue(syntax, out result) ? result : default(ImmutableArray<BoundNode>);
+            return _guardedBoundNodeMap.TryGetValue(syntax, out result) ? result : default(ImmutableArray<BoundNode>);
         }
 
         protected void UnguardedAddBoundTreeForStandaloneSyntax(SyntaxNode syntax, BoundNode bound, NullableWalker.SnapshotManager manager = null, ImmutableDictionary<Symbol, Symbol> remappedSymbols = null)
@@ -1492,7 +1509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // this may happen if we have races and in such case we are no longer interested in adding
             if (bound != null)
             {
-                alreadyInTree = _guardedNodeMap.ContainsKey(bound.Syntax);
+                alreadyInTree = _guardedBoundNodeMap.ContainsKey(bound.Syntax);
             }
 
             if (!alreadyInTree)
@@ -1503,13 +1520,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // If syntax is a statement, we need to add all its children.
                     // Node cache assumes that if statement is cached, then all 
                     // its children are cached too.
-                    NodeMapBuilder.AddToMap(bound, _guardedNodeMap, SyntaxTree);
-                    Debug.Assert(syntax != _root || _guardedNodeMap.ContainsKey(bound.Syntax));
+                    NodeMapBuilder.AddToMap(bound, _guardedBoundNodeMap, SyntaxTree);
+                    Debug.Assert(syntax != _root || _guardedBoundNodeMap.ContainsKey(bound.Syntax));
                 }
                 else
                 {
                     // expressions can be added individually.
-                    NodeMapBuilder.AddToMap(bound, _guardedNodeMap, SyntaxTree, syntax);
+                    NodeMapBuilder.AddToMap(bound, _guardedBoundNodeMap, SyntaxTree, syntax);
                 }
 
                 Debug.Assert((manager is null && (!Compilation.NullableSemanticAnalysisEnabled || syntax != Root || syntax is TypeSyntax ||
@@ -1939,11 +1956,11 @@ done:
             // is in the map, as there are some models for which there is no BoundNode for the
             // Root elements (such as fields, where the root is a VariableDeclarator but the
             // first BoundNode corresponds to the underlying EqualsValueSyntax of the initializer)
-            if (_guardedNodeMap.Count > 0)
+            if (_guardedBoundNodeMap.Count > 0)
             {
                 Debug.Assert(!Compilation.NullableSemanticAnalysisEnabled ||
-                             _guardedNodeMap.ContainsKey(bindableRoot) ||
-                             _guardedNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax));
+                             _guardedBoundNodeMap.ContainsKey(bindableRoot) ||
+                             _guardedBoundNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax));
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -179,14 +179,12 @@ namespace Microsoft.CodeAnalysis.Operations
         internal IOperation CreateMemberInitializerInitializedMember(BoundNode initializedMember)
         {
 
-            switch (initializedMember.Kind)
+            switch (initializedMember)
             {
-                case BoundKind.ObjectInitializerMember:
-                    return _nodeMap.GetOrAdd(initializedMember, key =>
-                        CreateBoundObjectInitializerMemberOperation((BoundObjectInitializerMember)key, isObjectOrCollectionInitializer: true));
-                case BoundKind.DynamicObjectInitializerMember:
-                    return _nodeMap.GetOrAdd(initializedMember, key =>
-                        CreateBoundDynamicObjectInitializerMemberOperation((BoundDynamicObjectInitializerMember)key));
+                case BoundObjectInitializerMember objectInitializer:
+                    return CreateBoundObjectInitializerMemberOperation(objectInitializer, isObjectOrCollectionInitializer: true);
+                case BoundDynamicObjectInitializerMember dynamicInitializer:
+                    return CreateBoundDynamicObjectInitializerMemberOperation(dynamicInitializer);
                 default:
                     return Create(initializedMember);
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -3514,6 +3514,37 @@ class C
             var x1Decl = GetOutVarDeclaration(tree, "x1");
             var x1Ref = GetReference(tree, "x1");
             VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+            model.VerifyOperationTree(initializer, @"
+IInvocationOperation ( C..ctor(System.Boolean b)) (OperationKind.Invocation, Type: System.Void) (Syntax: ':base(TakeO ... && x1 >= 5)')
+  Instance Receiver: 
+    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: ':base(TakeO ... && x1 >= 5)')
+  Arguments(1):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: b) (OperationKind.Argument, Type: null) (Syntax: 'TakeOutPara ...  && x1 >= 5')
+        IBinaryOperation (BinaryOperatorKind.ConditionalAnd) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'TakeOutPara ...  && x1 >= 5')
+          Left: 
+            IInvocationOperation (System.Boolean D.TakeOutParam(System.Int32 y, out System.Int32 x)) (OperationKind.Invocation, Type: System.Boolean) (Syntax: 'TakeOutPara ... out int x1)')
+              Instance Receiver: 
+                null
+              Arguments(2):
+                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: y) (OperationKind.Argument, Type: null) (Syntax: 'o')
+                    IParameterReferenceOperation: o (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'o')
+                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument, Type: null) (Syntax: 'out int x1')
+                    IDeclarationExpressionOperation (OperationKind.DeclarationExpression, Type: System.Int32) (Syntax: 'int x1')
+                      ILocalReferenceOperation: x1 (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'x1')
+                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+          Right: 
+            IBinaryOperation (BinaryOperatorKind.GreaterThanOrEqual) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x1 >= 5')
+              Left: 
+                ILocalReferenceOperation: x1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'x1')
+              Right: 
+                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5) (Syntax: '5')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -3515,35 +3515,42 @@ class C
             var x1Ref = GetReference(tree, "x1");
             VerifyModelForOutVar(model, x1Decl, x1Ref);
 
-            model.VerifyOperationTree(initializer, @"
-IInvocationOperation ( C..ctor(System.Boolean b)) (OperationKind.Invocation, Type: System.Void) (Syntax: ':base(TakeO ... && x1 >= 5)')
-  Instance Receiver: 
-    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: ':base(TakeO ... && x1 >= 5)')
-  Arguments(1):
-      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: b) (OperationKind.Argument, Type: null) (Syntax: 'TakeOutPara ...  && x1 >= 5')
-        IBinaryOperation (BinaryOperatorKind.ConditionalAnd) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'TakeOutPara ...  && x1 >= 5')
-          Left: 
-            IInvocationOperation (System.Boolean D.TakeOutParam(System.Int32 y, out System.Int32 x)) (OperationKind.Invocation, Type: System.Boolean) (Syntax: 'TakeOutPara ... out int x1)')
-              Instance Receiver: 
-                null
-              Arguments(2):
-                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: y) (OperationKind.Argument, Type: null) (Syntax: 'o')
-                    IParameterReferenceOperation: o (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'o')
-                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                  IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument, Type: null) (Syntax: 'out int x1')
-                    IDeclarationExpressionOperation (OperationKind.DeclarationExpression, Type: System.Int32) (Syntax: 'int x1')
-                      ILocalReferenceOperation: x1 (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'x1')
-                    InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                    OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-          Right: 
-            IBinaryOperation (BinaryOperatorKind.GreaterThanOrEqual) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x1 >= 5')
-              Left: 
-                ILocalReferenceOperation: x1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'x1')
-              Right: 
-                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5) (Syntax: '5')
-        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+            var initializerOperation = model.GetOperation(initializer);
+
+            Assert.Null(initializerOperation.Parent.Parent.Parent);
+            VerifyOperationTree(compilation, initializerOperation.Parent.Parent, @"
+IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: ':base(TakeO ... && x1 >= 5)')
+  Expression: 
+    IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '(TakeOutPar ... && x1 >= 5)')
+      Children(1):
+          IInvocationOperation ( C..ctor(System.Boolean b)) (OperationKind.Invocation, Type: System.Void) (Syntax: ':base(TakeO ... && x1 >= 5)')
+            Instance Receiver: 
+              IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: ':base(TakeO ... && x1 >= 5)')
+            Arguments(1):
+                IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: b) (OperationKind.Argument, Type: null) (Syntax: 'TakeOutPara ...  && x1 >= 5')
+                  IBinaryOperation (BinaryOperatorKind.ConditionalAnd) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'TakeOutPara ...  && x1 >= 5')
+                    Left: 
+                      IInvocationOperation (System.Boolean D.TakeOutParam(System.Int32 y, out System.Int32 x)) (OperationKind.Invocation, Type: System.Boolean) (Syntax: 'TakeOutPara ... out int x1)')
+                        Instance Receiver: 
+                          null
+                        Arguments(2):
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: y) (OperationKind.Argument, Type: null) (Syntax: 'o')
+                              IParameterReferenceOperation: o (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'o')
+                              InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                              OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument, Type: null) (Syntax: 'out int x1')
+                              IDeclarationExpressionOperation (OperationKind.DeclarationExpression, Type: System.Int32) (Syntax: 'int x1')
+                                ILocalReferenceOperation: x1 (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'x1')
+                              InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                              OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                    Right: 
+                      IBinaryOperation (BinaryOperatorKind.GreaterThanOrEqual) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x1 >= 5')
+                        Left: 
+                          ILocalReferenceOperation: x1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'x1')
+                        Right: 
+                          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5) (Syntax: '5')
+                  InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                  OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
 ");
         }
 

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6982,12 +6982,7 @@ oneMoreTime:
             StartVisitingStatement(operation);
 
             // a using statement introduces a 'logical' block after declaration, we synthesize one here in order to analyze it like a regular using 
-            BlockOperation logicalBlock = new BlockOperation(
-                operations: statements,
-                locals: ImmutableArray<ILocalSymbol>.Empty,
-                ((Operation)operation).OwningSemanticModel,
-                operation.Syntax,
-                isImplicit: true);
+            BlockOperation logicalBlock = BlockOperation.CreateTemporaryBlock(statements, ((Operation)operation).OwningSemanticModel!, operation.Syntax);
 
             HandleUsingOperationParts(
                 resources: operation.DeclarationGroup,

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -142,7 +142,9 @@ namespace Microsoft.CodeAnalysis
         [return: NotNullIfNotNull("operation")]
         public static T? SetParentOperation<T>(T? operation, IOperation? parent) where T : IOperation
         {
-            // explicit cast is not allowed, so using "as" instead
+            // For simplicity of implementation of derived types, we handle `null` children, as some children
+            // are optional.
+            Debug.Assert(operation == null || ((Operation)(IOperation)operation)._parentDoNotAccessDirectly == s_unset);
             (operation as Operation)?.SetParentOperation(parent);
             return operation;
         }
@@ -158,17 +160,6 @@ namespace Microsoft.CodeAnalysis
 
             foreach (var operation in operations)
             {
-                if ((operation as Operation)?._parentDoNotAccessDirectly != s_unset)
-                {
-#if DEBUG
-                    VerifyParentOperation(parent, operation);
-                    continue;
-#else
-                    break;
-#endif
-                }
-
-                // go through slowest path
                 SetParentOperation(operation, parent);
             }
 

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -129,15 +129,12 @@ namespace Microsoft.CodeAnalysis
 
         protected void SetParentOperation(IOperation? parent)
         {
-            Debug.Assert(Volatile.Read(ref _parentDoNotAccessDirectly) == s_unset);
-            var result = Interlocked.CompareExchange(ref _parentDoNotAccessDirectly, parent, s_unset);
+            Debug.Assert(_parentDoNotAccessDirectly == s_unset);
+            Debug.Assert(parent != s_unset);
+            _parentDoNotAccessDirectly = parent;
 
             // tree must belong to same semantic model if parent is given
-            Debug.Assert(parent == null || ((Operation)parent).OwningSemanticModel == OwningSemanticModel ||
-                ((Operation)parent).OwningSemanticModel == null || OwningSemanticModel == null);
-
-            // make sure given parent and one we already have is same if we have one already
-            Debug.Assert(result == s_unset || result == parent);
+            Debug.Assert(parent == null || ((Operation)parent).OwningSemanticModel == OwningSemanticModel);
         }
 
         [return: NotNullIfNotNull("operation")]

--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -129,6 +129,7 @@ namespace Microsoft.CodeAnalysis
 
         protected void SetParentOperation(IOperation? parent)
         {
+            Debug.Assert(Volatile.Read(ref _parentDoNotAccessDirectly) == s_unset);
             var result = Interlocked.CompareExchange(ref _parentDoNotAccessDirectly, parent, s_unset);
 
             // tree must belong to same semantic model if parent is given
@@ -144,7 +145,6 @@ namespace Microsoft.CodeAnalysis
         {
             // For simplicity of implementation of derived types, we handle `null` children, as some children
             // are optional.
-            Debug.Assert(operation == null || ((Operation)(IOperation)operation)._parentDoNotAccessDirectly == s_unset);
             (operation as Operation)?.SetParentOperation(parent);
             return operation;
         }

--- a/src/Compilers/Core/Portable/Operations/OperationMapBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationMapBuilder.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed class OperationMapBuilder : OperationWalker<Dictionary<SyntaxNode, IOperation>>
+    {
+        internal static readonly OperationMapBuilder Instance = new OperationMapBuilder();
+
+        private OperationMapBuilder() { }
+
+        public override object? Visit(IOperation? operation, Dictionary<SyntaxNode, IOperation> argument)
+        {
+            if (operation == null)
+            {
+                return null;
+            }
+
+            RecordOperation(operation, argument);
+
+            return base.Visit(operation, argument);
+        }
+
+        public override object? VisitBinaryOperator([DisallowNull] IBinaryOperation? operation, Dictionary<SyntaxNode, IOperation> argument)
+        {
+            // In order to handle very large nested operators, we implement manual iteration here. Our operations are not order sensitive,
+            // so we don't need to maintain a stack, just iterate through every level. Visit above will have already recorded the given operation.
+            Debug.Assert(argument.ContainsKey(operation.Syntax) || operation.IsImplicit);
+            do
+            {
+                Visit(operation.RightOperand, argument);
+                if (operation.LeftOperand is IBinaryOperation nested)
+                {
+                    operation = nested;
+                    RecordOperation(operation, argument);
+                }
+                else
+                {
+                    Visit(operation.LeftOperand, argument);
+                    break;
+                }
+            } while (true);
+
+            return null;
+        }
+
+        private static void RecordOperation(IOperation operation, Dictionary<SyntaxNode, IOperation> argument)
+        {
+            if (!operation.IsImplicit)
+            {
+                // IOperation invariant is that all there is at most 1 non-implicit node per syntax node.
+                argument.Add(operation.Syntax, operation);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Operations/OperationNodes.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationNodes.cs
@@ -363,4 +363,20 @@ namespace Microsoft.CodeAnalysis.Operations
         {
         }
     }
+
+    internal sealed partial class BlockOperation
+    {
+        public static BlockOperation CreateTemporaryBlock(ImmutableArray<IOperation> statements, SemanticModel semanticModel, SyntaxNode syntax)
+            => new(statements, semanticModel, syntax);
+
+        private BlockOperation(ImmutableArray<IOperation> statements, SemanticModel semanticModel, SyntaxNode syntax)
+            : base(semanticModel, syntax, isImplicit: true)
+        {
+            // Intentionally skipping SetParentOperation: this is used by CreateTemporaryBlock for the purposes of the
+            // control flow factory, to temporarily create a new block for use in emulating the "block" a using variable
+            // declaration introduces.
+            Operations = statements;
+            Locals = ImmutableArray<ILocalSymbol>.Empty;
+        }
+    }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,11 +1,15 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
+Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
+Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Compare(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> int
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Equals(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> bool
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGenerators(string language) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGeneratorsForAllLanguages() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>
+override Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.DefaultVisit(Microsoft.CodeAnalysis.IOperation operation, TArgument argument) -> object
+override Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.Visit(Microsoft.CodeAnalysis.IOperation operation, TArgument argument) -> object
 virtual Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetGenerators(string language) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>
 virtual Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetGeneratorsForAllLanguages() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>

--- a/src/Compilers/Test/Core/CommonTestBase.cs
+++ b/src/Compilers/Test/Core/CommonTestBase.cs
@@ -485,9 +485,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 // check parent property returns same parent we gathered by walking down operation tree
                 Assert.Equal(child.Parent, parent);
 
-                // check SearchparentOperation return same parent
-                Assert.Equal(((Operation)child).SearchParentOperation(), parent);
-
                 if (parent == null)
                 {
                     // this is root of operation tree

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -874,7 +874,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Operation.SetParentOperation(rootOperation, Nothing)
-                OperationMapBuilder.Instance.Visit(rootOperation, _guardedIOperationNodeMap)
+                OperationMapBuilder.AddToMap(rootOperation, _guardedIOperationNodeMap)
 
                 Return If(_guardedIOperationNodeMap.TryGetValue(node, result), result, Nothing)
             Finally

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -850,30 +850,36 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function GetOperationWorker(node As VisualBasicSyntaxNode, cancellationToken As CancellationToken) As IOperation
-            ' see whether we can bind smaller scope than GetBindingRoot to make perf better
-            ' https://github.com/dotnet/roslyn/issues/22176
-            Dim bindingRoot = DirectCast(GetBindingRoot(node), VisualBasicSyntaxNode)
 
-            Dim statementOrRootOperation As IOperation = GetStatementOrRootOperation(bindingRoot, cancellationToken)
-            If statementOrRootOperation Is Nothing Then
-                Return Nothing
-            End If
+            Dim result As IOperation = Nothing
+            Try
+                _rwLock.EnterReadLock()
 
-            ' we might optimize it later
-            ' https://github.com/dotnet/roslyn/issues/22180
-            Return statementOrRootOperation.DescendantsAndSelf().FirstOrDefault(Function(o) Not o.IsImplicit AndAlso o.Syntax Is node)
-        End Function
+                If _guardedIOperationNodeMap.Count > 0 Then
+                    Return If(_guardedIOperationNodeMap.TryGetValue(node, result), result, Nothing)
+                End If
+            Finally
+                _rwLock.ExitReadLock()
+            End Try
 
-        Private Function GetStatementOrRootOperation(node As VisualBasicSyntaxNode, cancellationToken As CancellationToken) As IOperation
-            Debug.Assert(node Is GetBindingRoot(node))
+            Dim rootNode As BoundNode = GetBoundRoot()
+            Dim rootOperation As IOperation = _operationFactory.Value.Create(rootNode)
 
-            Dim summary As BoundNodeSummary = GetBoundNodeSummary(node)
 
-            ' decide whether we should use highest or lowest bound node here 
-            ' https://github.com/dotnet/roslyn/issues/22179
-            Dim result As BoundNode = summary.HighestBoundNode
+            Try
+                _rwLock.EnterWriteLock()
 
-            Return _operationFactory.Value.Create(result)
+                If _guardedIOperationNodeMap.Count > 0 Then
+                    Return If(_guardedIOperationNodeMap.TryGetValue(node, result), result, Nothing)
+                End If
+
+                Operation.SetParentOperation(rootOperation, Nothing)
+                OperationMapBuilder.Instance.Visit(rootOperation, _guardedIOperationNodeMap)
+
+                Return If(_guardedIOperationNodeMap.TryGetValue(node, result), result, Nothing)
+            Finally
+                _rwLock.ExitWriteLock()
+            End Try
         End Function
 
         Friend Overrides Function GetExpressionTypeInfo(node As ExpressionSyntax, Optional cancellationToken As CancellationToken = Nothing) As VisualBasicTypeInfo
@@ -1133,7 +1139,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Sub CacheBoundNodes(boundNode As BoundNode, Optional thisSyntaxNodeOnly As SyntaxNode = Nothing)
             _rwLock.EnterWriteLock()
             Try
-                SemanticModelMapsBuilder.GuardedCacheBoundNodes(boundNode, Me, Me._guardedNodeMap, thisSyntaxNodeOnly)
+                SemanticModelMapsBuilder.GuardedCacheBoundNodes(boundNode, Me, Me._guardedBoundNodeMap, thisSyntaxNodeOnly)
             Finally
                 _rwLock.ExitWriteLock()
             End Try
@@ -1214,7 +1220,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         '' map, so that we can answer GetEnclosingBinder questions.
 
         ' The bound nodes associated with syntaxnode, from highest in the tree to lowest.
-        Private ReadOnly _guardedNodeMap As New SmallDictionary(Of SyntaxNode, ImmutableArray(Of BoundNode))(ReferenceEqualityComparer.Instance)
+        Private ReadOnly _guardedBoundNodeMap As New SmallDictionary(Of SyntaxNode, ImmutableArray(Of BoundNode))(ReferenceEqualityComparer.Instance)
+        Private ReadOnly _guardedIOperationNodeMap As New Dictionary(Of SyntaxNode, IOperation)
 
         Private ReadOnly _guardedQueryBindersMap As New Dictionary(Of SyntaxNode, ImmutableArray(Of Binder))()
         Private ReadOnly _guardedAnonymousTypeBinderMap As New Dictionary(Of FieldInitializerSyntax, Binder.AnonymousTypeFieldInitializerBinder)()
@@ -1246,7 +1253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function GuardedGetBoundNodesFromMap(node As SyntaxNode) As ImmutableArray(Of BoundNode)
             Debug.Assert(_rwLock.IsReadLockHeld OrElse _rwLock.IsWriteLockHeld)
             Dim result As ImmutableArray(Of BoundNode) = Nothing
-            Return If(Me._guardedNodeMap.TryGetValue(node, result), result, Nothing)
+            Return If(Me._guardedBoundNodeMap.TryGetValue(node, result), result, Nothing)
         End Function
 
         ''' <summary>
@@ -1895,7 +1902,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If bound.IsDefault Then
                         ' Bind the node and cache any associated bound nodes we find.
                         Dim boundNode = Me.Bind(binder, node, Me._guardedDiagnostics)
-                        SemanticModelMapsBuilder.GuardedCacheBoundNodes(boundNode, Me, _guardedNodeMap, node)
+                        SemanticModelMapsBuilder.GuardedCacheBoundNodes(boundNode, Me, _guardedBoundNodeMap, node)
                     End If
 
                     bound = GuardedGetBoundNodesFromMap(node)
@@ -1940,7 +1947,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Sub GuardedIncrementalBind(bindingRoot As SyntaxNode, enclosingBinder As Binder)
             Debug.Assert(_rwLock.IsWriteLockHeld)
 
-            If _guardedNodeMap.ContainsKey(bindingRoot) Then
+            If _guardedBoundNodeMap.ContainsKey(bindingRoot) Then
                 ' We've already bound this. No need to bind it again (saves a bit of 
                 ' work below).
                 Return
@@ -1955,9 +1962,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return
             End If
 
-            SemanticModelMapsBuilder.GuardedCacheBoundNodes(boundRoot, Me, _guardedNodeMap)
+            SemanticModelMapsBuilder.GuardedCacheBoundNodes(boundRoot, Me, _guardedBoundNodeMap)
 
-            If Not _guardedNodeMap.ContainsKey(bindingRoot) Then
+            If Not _guardedBoundNodeMap.ContainsKey(bindingRoot) Then
                 ' Generally 'bindingRoot' is supposed to be found in node map at this point,
                 ' but it will not happen in some scenarios such as for field or property 
                 ' initializers, let's add it to prevent re-binding 
@@ -1968,7 +1975,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                              bindingRoot.Kind = SyntaxKind.EnumMemberDeclaration OrElse
                              bindingRoot Is Me.Root AndAlso Me.IsSpeculativeSemanticModel)
 
-                _guardedNodeMap.Add(bindingRoot, ImmutableArray.Create(Of BoundNode)(boundRoot))
+                _guardedBoundNodeMap.Add(bindingRoot, ImmutableArray.Create(Of BoundNode)(boundRoot))
             End If
         End Sub
 


### PR DESCRIPTION
Previously, a `ConcurrentDictionary`s existed on the operation factories, maintaining a `BoundNode`->`Operation` mapping that was responsible for ensuring that all returned nodes are the same. I've removed this cache, and rewritten how the semantic models fetch operations. Now, they get the bound node for the root of the semantic model, and get the operation it. They then build a cache from `SyntaxNode`->explicit `Operation`, which can be quickly queried by future calls to `GetOperation`. As part of this, I added a new public `OperationWalker<TArgument>` type, which walks an operation tree given an argument, and is used for sharing instances of the cache populater. Commit 1 enables C#, commit 2 enables VB.