### PR TITLE
Avoid creating dependent slots in NullableWalker (#48920)

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Force a variable to have a slot.  Returns -1 if the variable has an empty struct type.
         /// </summary>
-        protected virtual int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
+        protected virtual int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false, bool createIfMissing = true)
         {
             Debug.Assert(containingSlot >= 0);
             Debug.Assert(symbol != null);
@@ -141,6 +141,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Since analysis may proceed in multiple passes, it is possible the slot is already assigned.
             if (!_variableSlot.TryGetValue(identifier, out slot))
             {
+                if (!createIfMissing)
+                {
+                    return -1;
+                }
+
                 var variableType = symbol.GetTypeOrReturnType().Type;
                 if (!forceSlotEvenIfEmpty && IsEmptyStructType(variableType))
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1305,12 +1305,30 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private SharedWalkerState SaveSharedState() =>
-            new SharedWalkerState(
+#if DEBUG
+#if REPORT_MAX
+        private static (Symbol symbol, int slots) s_maxSlots;
+#endif
+#endif
+
+        private SharedWalkerState SaveSharedState()
+        {
+#if DEBUG
+#if REPORT_MAX
+            int slots = _variableSlot.Count;
+            if (slots > s_maxSlots.slots)
+            {
+                s_maxSlots = (_symbol, slots);
+                Debug.WriteLine("{0}: {1}", slots, _symbol);
+            }
+#endif
+#endif
+            return new SharedWalkerState(
                 _variableSlot.ToImmutableDictionary(),
                 ImmutableArray.Create(variableBySlot, start: 0, length: nextVariableSlot),
                 _variableTypes.ToImmutableDictionary(),
                 CurrentSymbol);
+        }
 
         private void TakeIncrementalSnapshot(BoundNode? node)
         {
@@ -1592,12 +1610,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
+        protected override int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false, bool createIfMissing = true)
         {
             if (containingSlot > 0 && !IsSlotMember(containingSlot, symbol))
                 return -1;
 
-            return base.GetOrCreateSlot(symbol, containingSlot, forceSlotEvenIfEmpty);
+            return base.GetOrCreateSlot(symbol, containingSlot, forceSlotEvenIfEmpty, createIfMissing);
         }
 
         private void VisitAndUnsplitAll<T>(ImmutableArray<T> nodes) where T : BoundNode
@@ -3915,7 +3933,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     member.RequiresInstanceReceiver() &&
                     (containingType is null || AccessCheck.IsSymbolAccessible(member, containingType, ref discardedUseSiteDiagnostics)))
                 {
-                    int childSlot = GetOrCreateSlot(member, slot, true);
+                    int childSlot = GetOrCreateSlot(member, slot, forceSlotEvenIfEmpty: true, createIfMissing: false);
                     if (childSlot > 0)
                     {
                         state[childSlot] = NullableFlowState.NotNull;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -2066,7 +2066,12 @@ class C
 }
 ");
             c.VerifyDiagnostics(
-                );
+                // (13,17): warning CS8602: Dereference of a possibly null reference.
+                //                 c.c.c.c.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.c.c").WithLocation(13, 17),
+                // (13,17): warning CS8602: Dereference of a possibly null reference.
+                //                 c.c.c.c.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.c.c.c").WithLocation(13, 17));
         }
 
         [Fact]


### PR DESCRIPTION
Port of https://github.com/dotnet/roslyn/pull/48920 to release/dev16.8

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1246011