### PR TITLE
Added support to normalize auto properties on a single line.

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private static bool IsAutoAccessorList(SyntaxToken token)
         {
-            if(token.Parent != null && token.Parent is AccessorListSyntax accessorList)
+            if (token.Parent is AccessorListSyntax accessorList)
             {
                 return accessorList.Accessors.All(a => a.Body == null);
             }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -284,22 +284,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private static bool IsAutoAccessorList(SyntaxToken token)
             => token.Parent is AccessorListSyntax accessorList &&
-               All(accessorList.Accessors, a => a.Body == null);
+                All(accessorList.Accessors, a => a.Body == null);
 
         private static bool IsAutoAccessorList(SyntaxNode? node)
-        {
-            if (node?.Parent is AccessorListSyntax accessorList)
-            {
-                return All(accessorList.Accessors, a => a.Body == null);
-            }
+            => node?.Parent is AccessorListSyntax accessorList &&
+                All(accessorList.Accessors, a => a.Body == null);
 
-            return false;
-        }
+        private static bool HasInitializer(BasePropertyDeclarationSyntax basePropertyDeclaration)
+            => (basePropertyDeclaration is PropertyDeclarationSyntax property && property.Initializer != null);
 
-        private static bool IsAccessorListFollowedByInitializer(SyntaxToken token) =>
-            token.Parent is AccessorListSyntax accessorList &&
-            accessorList.Parent is PropertyDeclarationSyntax propertyDeclarationSyntax &&
-                    propertyDeclarationSyntax.Initializer != null;
+        private static bool IsAccessorListFollowedByInitializer(SyntaxToken token)
+            => token.Parent is AccessorListSyntax accessorList &&
+                accessorList.Parent is BasePropertyDeclarationSyntax basePropertyDeclarationSyntax &&
+                HasInitializer(basePropertyDeclarationSyntax);
 
         private static int LineBreaksBeforeOpenBrace(SyntaxToken currentToken, SyntaxToken nextToken)
         {
@@ -414,9 +411,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return false;
             }
 
-            if (!next.IsKind(SyntaxKind.SemicolonToken) && (IsAutoAccessorList(next) || IsAutoAccessorList(next.Parent)))
+            if (IsAutoAccessorList(next) || IsAutoAccessorList(next.Parent))
             {
-                return true;
+                return !next.IsKind(SyntaxKind.SemicolonToken);
             }
 
             if (IsXmlTextToken(token.Kind()) || IsXmlTextToken(next.Kind()))

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 IsAccessorListWithoutAccessorsWithBlockBody(next.Parent.Parent))
             {
                 // when the accessors are formatted inline, the separator is needed
-                // unless there is a semicolon. For example: "{ get; set; }"
+                // unless there is a semicolon. For example: "{ get; set; }" 
                 return !next.IsKind(SyntaxKind.SemicolonToken);
             }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         }
 
         private static bool All<TNode>(SyntaxList<TNode> items, Func<TNode, bool> predicate)
-            where TNode: SyntaxNode
+            where TNode : SyntaxNode
         {
             bool result = true;
             for (int i = 0; i < items.Count; i++)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -283,14 +283,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         }
 
         private static bool IsAutoAccessorList(SyntaxToken token)
-        {
-            if (token.Parent is AccessorListSyntax accessorList)
-            {
-                return All(accessorList.Accessors, a => a.Body == null);
-            }
-
-            return false;
-        }
+            => token.Parent is AccessorListSyntax accessorList &&
+               All(accessorList.Accessors, a => a.Body == null);
 
         private static bool IsAutoAccessorList(SyntaxNode? node)
         {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private static bool IsAccessorListFollowedByInitializer(SyntaxToken token)
         {
-            if (token.Parent != null && token.Parent is AccessorListSyntax accessorList)
+            if (token.Parent is AccessorListSyntax accessorList)
             {
                 var declaration = accessorList.Parent;
                 if (declaration == null)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private static bool IsAutoAccessorList(SyntaxNode? node)
         {
-            if (node != null && node.Parent != null && node.Parent is AccessorListSyntax accessorList)
+            if (node?.Parent is AccessorListSyntax accessorList)
             {
                 return All(accessorList.Accessors, a => a.Body == null);
             }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -296,32 +296,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return false;
         }
 
-        private static bool IsAccessorListFollowedByInitializer(SyntaxToken token)
-        {
-            if (token.Parent is AccessorListSyntax accessorList)
-            {
-                var declaration = accessorList.Parent;
-                if (declaration == null)
-                {
-                    return false;
-                }
-
-                SyntaxNode? lastChild = null;
-                foreach (var item in declaration.ChildNodes())
-                {
-                    lastChild = item;
-                }
-
-                if (lastChild == null || lastChild == accessorList)
-                {
-                    return false;
-                }
-
-                return true;
-            }
-
-            return false;
-        }
+        private static bool IsAccessorListFollowedByInitializer(SyntaxToken token) =>
+            token.Parent is AccessorListSyntax accessorList &&
+            accessorList.Parent is PropertyDeclarationSyntax propertyDeclarationSyntax &&
+                    propertyDeclarationSyntax.Initializer != null;
 
         private static int LineBreaksBeforeOpenBrace(SyntaxToken currentToken, SyntaxToken nextToken)
         {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -275,13 +276,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             => node is AccessorListSyntax accessorList &&
                 accessorList.Accessors.All(a => a.Body == null);
 
-        private static bool HasInitializer(BasePropertyDeclarationSyntax basePropertyDeclaration)
-            => basePropertyDeclaration is PropertyDeclarationSyntax property && property.Initializer != null;
-
-        private static bool IsAccessorListFollowedByInitializer(SyntaxNode? node)
+        private static bool IsAccessorListFollowedByInitializer([NotNullWhen(true)] SyntaxNode? node)
             => node is AccessorListSyntax accessorList &&
-                accessorList.Parent is BasePropertyDeclarationSyntax basePropertyDeclarationSyntax &&
-                HasInitializer(basePropertyDeclarationSyntax);
+                node.Parent is PropertyDeclarationSyntax property &&
+                property.Initializer != null;
 
         private static int LineBreaksBeforeOpenBrace(SyntaxToken openBraceToken)
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 .NormalizeWhitespace();
 
             // no space between int and ?
-            Assert.Equal("class C\r\n{\r\n    int? P\r\n    {\r\n    }\r\n}", syntaxNode.ToFullString());
+            Assert.Equal("class C\r\n{\r\n    int? P { }\r\n}", syntaxNode.ToFullString());
         }
 
         [Fact]
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 .NormalizeWhitespace();
 
             // no space between DateTime and ?
-            Assert.Equal("class C\r\n{\r\n    DateTime? P\r\n    {\r\n    }\r\n}", syntaxNode.ToFullString());
+            Assert.Equal("class C\r\n{\r\n    DateTime? P { }\r\n}", syntaxNode.ToFullString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 "class x\r\n{\r\n  int _g;\r\n  int G\r\n  {\r\n    get\r\n    {\r\n      return _g;\r\n    }\r\n\r\n    init;\r\n  }\r\n\r\n  int H\r\n  {\r\n    get;\r\n    set\r\n    {\r\n      _g = 12;\r\n    }\r\n  }\r\n}");
 
             TestNormalizeDeclaration("class i1\r\n{\r\nint\r\np\r\n{\r\nget;\r\n}\r\n}", "class i1\r\n{\r\n  int p { get; }\r\n}");
-            TestNormalizeDeclaration("class i2\r\n{\r\nint\r\np\r\n{\r\nget=>1;\r\n}\r\n}", "class i2\r\n{\r\n  int p { get => 1; }\r\n}");
+            TestNormalizeDeclaration("class i2\r\n{\r\nint\r\np\r\n{\r\nget=>2;\r\n}\r\n}", "class i2\r\n{\r\n  int p { get => 2; }\r\n}");
             TestNormalizeDeclaration("class i2a\r\n{\r\nint _p;\r\nint\r\np\r\n{\r\nget=>\r\n_p;set\r\n=>_p\r\n=value\r\n;\r\n}\r\n}", "class i2a\r\n{\r\n  int _p;\r\n  int p { get => _p; set => _p = value; }\r\n}");
             TestNormalizeDeclaration("class i3\r\n{\r\nint\r\np\r\n{\r\nget{}\r\n}\r\n}", "class i3\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n  }\r\n}");
             TestNormalizeDeclaration("class i4\r\n{\r\nint\r\np\r\n{\r\nset;\r\n}\r\n}", "class i4\r\n{\r\n  int p { set; }\r\n}");

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -220,6 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             TestNormalizeDeclaration("class i1\r\n{\r\nint\r\np\r\n{\r\nget;\r\n}\r\n}", "class i1\r\n{\r\n  int p { get; }\r\n}");
             TestNormalizeDeclaration("class i2\r\n{\r\nint\r\np\r\n{\r\nget=>1;\r\n}\r\n}", "class i2\r\n{\r\n  int p { get => 1; }\r\n}");
+            TestNormalizeDeclaration("class i2a\r\n{\r\nint _p;\r\nint\r\np\r\n{\r\nget=>\r\n_p;set\r\n=>_p\r\n=value\r\n;\r\n}\r\n}", "class i2a\r\n{\r\n  int _p;\r\n  int p { get => _p; set => _p = value; }\r\n}");
             TestNormalizeDeclaration("class i3\r\n{\r\nint\r\np\r\n{\r\nget{}\r\n}\r\n}", "class i3\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n  }\r\n}");
             TestNormalizeDeclaration("class i4\r\n{\r\nint\r\np\r\n{\r\nset;\r\n}\r\n}", "class i4\r\n{\r\n  int p { set; }\r\n}");
             TestNormalizeDeclaration("class i5\r\n{\r\nint\r\np\r\n{\r\nset{}\r\n}\r\n}", "class i5\r\n{\r\n  int p\r\n  {\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
@@ -229,6 +230,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration("class i9\r\n{\r\nint\r\np\r\n{\r\nget=>1;\r\nset{z=1;}\r\n}\r\n}", "class i9\r\n{\r\n  int p\r\n  {\r\n    get => 1;\r\n    set\r\n    {\r\n      z = 1;\r\n    }\r\n  }\r\n}");
             TestNormalizeDeclaration("class ia\r\n{\r\nint\r\np\r\n{\r\nget{}\r\nset;\r\n}\r\n}", "class ia\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set;\r\n  }\r\n}");
             TestNormalizeDeclaration("class ib\r\n{\r\nint\r\np\r\n{\r\nget;\r\nset{}\r\n}\r\n}", "class ib\r\n{\r\n  int p\r\n  {\r\n    get;\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
+
+            // properties with initalizers
             TestNormalizeDeclaration("class i4\r\n{\r\nint\r\np\r\n{\r\nset;\r\n}=1;\r\n}", "class i4\r\n{\r\n  int p { set; } = 1;\r\n}");
             TestNormalizeDeclaration("class i5\r\n{\r\nint\r\np\r\n{\r\nset{}\r\n}=1;\r\n}", "class i5\r\n{\r\n  int p\r\n  {\r\n    set\r\n    {\r\n    }\r\n  } = 1;\r\n}");
             TestNormalizeDeclaration("class i6\r\n{\r\nint\r\np\r\n{\r\ninit;\r\n}=1;\r\n}", "class i6\r\n{\r\n  int p { init; } = 1;\r\n}");
@@ -251,6 +254,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration("class i9\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget=>1;\r\nset{z=1;}\r\n}\r\n}", "class i9\r\n{\r\n  int this[b c]\r\n  {\r\n    get => 1;\r\n    set\r\n    {\r\n      z = 1;\r\n    }\r\n  }\r\n}");
             TestNormalizeDeclaration("class ia\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget{}\r\nset;\r\n}\r\n}", "class ia\r\n{\r\n  int this[b c]\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set;\r\n  }\r\n}");
             TestNormalizeDeclaration("class ib\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget;\r\nset{}\r\n}\r\n}", "class ib\r\n{\r\n  int this[b c]\r\n  {\r\n    get;\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
+
+            // events
+            TestNormalizeDeclaration("class a\r\n{\r\npublic\r\nevent\r\nw\r\ne;\r\n}", "class a\r\n{\r\n  public event w e;\r\n}");
+            TestNormalizeDeclaration("abstract class b\r\n{\r\nevent\r\nw\r\ne\r\n;\r\n}", "abstract class b\r\n{\r\n  event w e;\r\n}");
+            TestNormalizeDeclaration("interface c1\r\n{\r\nevent\r\nw\r\ne\r\n;\r\n}", "interface c1\r\n{\r\n  event w e;\r\n}");
+            TestNormalizeDeclaration("interface c2 : c1\r\n{\r\nabstract\r\nevent\r\nw\r\nc1\r\n.\r\ne\r\n;\r\n}", "interface c2 : c1\r\n{\r\n  abstract event w c1.e;\r\n}");
+            TestNormalizeDeclaration("class d\r\n{\r\nevent w x;\r\nevent\r\nw\r\ne\r\n{\r\nadd\r\n=>\r\nx+=\r\nvalue;\r\nremove\r\n=>x\r\n-=\r\nvalue;\r\n}}", "class d\r\n{\r\n  event w x;\r\n  event w e { add => x += value; remove => x -= value; }\r\n}");
+            TestNormalizeDeclaration("class e\r\n{\r\nevent w e\r\n{\r\nadd{}\r\nremove{\r\n}\r\n}\r\n}", "class e\r\n{\r\n  event w e\r\n  {\r\n    add\r\n    {\r\n    }\r\n\r\n    remove\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class f\r\n{\r\nevent w x;\r\nevent w e\r\n{\r\nadd\r\n{\r\nx\r\n+=\r\nvalue;\r\n}\r\nremove\r\n{\r\nx\r\n-=\r\nvalue;\r\n}\r\n}\r\n}", "class f\r\n{\r\n  event w x;\r\n  event w e\r\n  {\r\n    add\r\n    {\r\n      x += value;\r\n    }\r\n\r\n    remove\r\n    {\r\n      x -= value;\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class g\r\n{\r\nextern\r\nevent\r\nw\r\ne\r\n=\r\nnull\r\n;\r\n}", "class g\r\n{\r\n  extern event w e = null;\r\n}");
+            TestNormalizeDeclaration("class h\r\n{\r\npublic event w e\r\n{\r\nadd\r\n=>\r\nc\r\n(\r\n);\r\nremove\r\n=>\r\nd(\r\n);\r\n}\r\n}", "class h\r\n{\r\n  public event w e { add => c(); remove => d(); }\r\n}");
+            TestNormalizeDeclaration("class i\r\n{\r\nevent w e\r\n{\r\nadd;\r\nremove;\r\n}\r\n}", "class i\r\n{\r\n  event w e { add; remove; }\r\n}");
 
             // fields
             TestNormalizeDeclaration("class a{b c;}", "class a\r\n{\r\n  b c;\r\n}");

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -215,7 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration("class a {\r\nint Q{get{return 0;}init{}}\r\nint R{get=>1;}\r\n}\r\n", "class a\r\n{\r\n  int Q\r\n  {\r\n    get\r\n    {\r\n      return 0;\r\n    }\r\n\r\n    init\r\n    {\r\n    }\r\n  }\r\n\r\n  int R { get => 1; }\r\n}");
             TestNormalizeDeclaration("class a {\r\nint R{get=>1;}\r\n}\r\n", "class a\r\n{\r\n  int R { get => 1; }\r\n}");
             TestNormalizeDeclaration("class a {\r\nint S=>2;\r\n}\r\n", "class a\r\n{\r\n  int S => 2;\r\n}");
-
+            TestNormalizeDeclaration("class x\r\n{\r\nint _g;\r\nint G\r\n{\r\nget\r\n{\r\nreturn\r\n_g;\r\n}\r\ninit;\r\n}\r\nint H\r\n{\r\nget;\r\nset\r\n{\r\n_g\r\n=\r\n12;\r\n}\r\n}\r\n}\r\n",
+                "class x\r\n{\r\n  int _g;\r\n  int G\r\n  {\r\n    get\r\n    {\r\n      return _g;\r\n    }\r\n\r\n    init;\r\n  }\r\n\r\n  int H\r\n  {\r\n    get;\r\n    set\r\n    {\r\n      _g = 12;\r\n    }\r\n  }\r\n}");
 
             // indexers
             TestNormalizeDeclaration("class a{b this[c d]{get;}}", "class a\r\n{\r\n  b this[c d] { get; }\r\n}");

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -207,10 +207,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration("class a{~a(){}}", "class a\r\n{\r\n  ~a()\r\n  {\r\n  }\r\n}");
 
             // properties
-            TestNormalizeDeclaration("class a{b c{get;}}", "class a\r\n{\r\n  b c\r\n  {\r\n    get;\r\n  }\r\n}");
+            TestNormalizeDeclaration("class a{b c{get;}}", "class a\r\n{\r\n  b c { get; }\r\n}");
+            TestNormalizeDeclaration("class a {\r\nint X{get;set;}= 2;\r\n}\r\n", "class a\r\n{\r\n  int X { get; set; } = 2;\r\n}");
+            TestNormalizeDeclaration("class a {\r\nint Y\r\n{get;\r\nset;\r\n}\r\n=99;\r\n}\r\n", "class a\r\n{\r\n  int Y { get; set; } = 99;\r\n}");
+            TestNormalizeDeclaration("class a {\r\nint Z{get;}\r\n}\r\n", "class a\r\n{\r\n  int Z { get; }\r\n}");
+            TestNormalizeDeclaration("class a {\r\nint T{get;init;}\r\nint R{get=>1;}\r\n}\r\n", "class a\r\n{\r\n  int T { get; init; }\r\n\r\n  int R { get => 1; }\r\n}");
+            TestNormalizeDeclaration("class a {\r\nint Q{get{return 0;}init{}}\r\nint R{get=>1;}\r\n}\r\n", "class a\r\n{\r\n  int Q\r\n  {\r\n    get\r\n    {\r\n      return 0;\r\n    }\r\n\r\n    init\r\n    {\r\n    }\r\n  }\r\n\r\n  int R { get => 1; }\r\n}");
+            TestNormalizeDeclaration("class a {\r\nint R{get=>1;}\r\n}\r\n", "class a\r\n{\r\n  int R { get => 1; }\r\n}");
+            TestNormalizeDeclaration("class a {\r\nint S=>2;\r\n}\r\n", "class a\r\n{\r\n  int S => 2;\r\n}");
+
 
             // indexers
-            TestNormalizeDeclaration("class a{b this[c d]{get;}}", "class a\r\n{\r\n  b this[c d]\r\n  {\r\n    get;\r\n  }\r\n}");
+            TestNormalizeDeclaration("class a{b this[c d]{get;}}", "class a\r\n{\r\n  b this[c d] { get; }\r\n}");
 
             // fields
             TestNormalizeDeclaration("class a{b c;}", "class a\r\n{\r\n  b c;\r\n}");

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -218,8 +218,39 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration("class x\r\n{\r\nint _g;\r\nint G\r\n{\r\nget\r\n{\r\nreturn\r\n_g;\r\n}\r\ninit;\r\n}\r\nint H\r\n{\r\nget;\r\nset\r\n{\r\n_g\r\n=\r\n12;\r\n}\r\n}\r\n}\r\n",
                 "class x\r\n{\r\n  int _g;\r\n  int G\r\n  {\r\n    get\r\n    {\r\n      return _g;\r\n    }\r\n\r\n    init;\r\n  }\r\n\r\n  int H\r\n  {\r\n    get;\r\n    set\r\n    {\r\n      _g = 12;\r\n    }\r\n  }\r\n}");
 
+            TestNormalizeDeclaration("class i1\r\n{\r\nint\r\np\r\n{\r\nget;\r\n}\r\n}", "class i1\r\n{\r\n  int p { get; }\r\n}");
+            TestNormalizeDeclaration("class i2\r\n{\r\nint\r\np\r\n{\r\nget=>1;\r\n}\r\n}", "class i2\r\n{\r\n  int p { get => 1; }\r\n}");
+            TestNormalizeDeclaration("class i3\r\n{\r\nint\r\np\r\n{\r\nget{}\r\n}\r\n}", "class i3\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i4\r\n{\r\nint\r\np\r\n{\r\nset;\r\n}\r\n}", "class i4\r\n{\r\n  int p { set; }\r\n}");
+            TestNormalizeDeclaration("class i5\r\n{\r\nint\r\np\r\n{\r\nset{}\r\n}\r\n}", "class i5\r\n{\r\n  int p\r\n  {\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i6\r\n{\r\nint\r\np\r\n{\r\ninit;\r\n}\r\n}", "class i6\r\n{\r\n  int p { init; }\r\n}");
+            TestNormalizeDeclaration("class i7\r\n{\r\nint\r\np\r\n{\r\ninit{}\r\n}\r\n}", "class i7\r\n{\r\n  int p\r\n  {\r\n    init\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i8\r\n{\r\nint\r\np\r\n{\r\nget{}\r\nset{}\r\n}\r\n}", "class i8\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i9\r\n{\r\nint\r\np\r\n{\r\nget=>1;\r\nset{z=1;}\r\n}\r\n}", "class i9\r\n{\r\n  int p\r\n  {\r\n    get => 1;\r\n    set\r\n    {\r\n      z = 1;\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class ia\r\n{\r\nint\r\np\r\n{\r\nget{}\r\nset;\r\n}\r\n}", "class ia\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set;\r\n  }\r\n}");
+            TestNormalizeDeclaration("class ib\r\n{\r\nint\r\np\r\n{\r\nget;\r\nset{}\r\n}\r\n}", "class ib\r\n{\r\n  int p\r\n  {\r\n    get;\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i4\r\n{\r\nint\r\np\r\n{\r\nset;\r\n}=1;\r\n}", "class i4\r\n{\r\n  int p { set; } = 1;\r\n}");
+            TestNormalizeDeclaration("class i5\r\n{\r\nint\r\np\r\n{\r\nset{}\r\n}=1;\r\n}", "class i5\r\n{\r\n  int p\r\n  {\r\n    set\r\n    {\r\n    }\r\n  } = 1;\r\n}");
+            TestNormalizeDeclaration("class i6\r\n{\r\nint\r\np\r\n{\r\ninit;\r\n}=1;\r\n}", "class i6\r\n{\r\n  int p { init; } = 1;\r\n}");
+            TestNormalizeDeclaration("class i7\r\n{\r\nint\r\np\r\n{\r\ninit{}\r\n}=1;\r\n}", "class i7\r\n{\r\n  int p\r\n  {\r\n    init\r\n    {\r\n    }\r\n  } = 1;\r\n}");
+            TestNormalizeDeclaration("class i8\r\n{\r\nint\r\np\r\n{\r\nget{}\r\nset{}\r\n}=1;\r\n}", "class i8\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set\r\n    {\r\n    }\r\n  } = 1;\r\n}");
+            TestNormalizeDeclaration("class i9\r\n{\r\nint\r\np\r\n{\r\nget=>1;\r\nset{z=1;}\r\n}=1;\r\n}", "class i9\r\n{\r\n  int p\r\n  {\r\n    get => 1;\r\n    set\r\n    {\r\n      z = 1;\r\n    }\r\n  } = 1;\r\n}");
+            TestNormalizeDeclaration("class ia\r\n{\r\nint\r\np\r\n{\r\nget{}\r\nset;\r\n}=1;\r\n}", "class ia\r\n{\r\n  int p\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set;\r\n  } = 1;\r\n}");
+            TestNormalizeDeclaration("class ib\r\n{\r\nint\r\np\r\n{\r\nget;\r\nset{}\r\n}=1;\r\n}", "class ib\r\n{\r\n  int p\r\n  {\r\n    get;\r\n    set\r\n    {\r\n    }\r\n  } = 1;\r\n}");
+
             // indexers
             TestNormalizeDeclaration("class a{b this[c d]{get;}}", "class a\r\n{\r\n  b this[c d] { get; }\r\n}");
+            TestNormalizeDeclaration("class i1\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget;\r\n}\r\n}", "class i1\r\n{\r\n  int this[b c] { get; }\r\n}");
+            TestNormalizeDeclaration("class i2\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget=>1;\r\n}\r\n}", "class i2\r\n{\r\n  int this[b c] { get => 1; }\r\n}");
+            TestNormalizeDeclaration("class i3\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget{}\r\n}\r\n}", "class i3\r\n{\r\n  int this[b c]\r\n  {\r\n    get\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i4\r\n{\r\nint\r\nthis[b c]\r\n{\r\nset;\r\n}\r\n}", "class i4\r\n{\r\n  int this[b c] { set; }\r\n}");
+            TestNormalizeDeclaration("class i5\r\n{\r\nint\r\nthis[b c]\r\n{\r\nset{}\r\n}\r\n}", "class i5\r\n{\r\n  int this[b c]\r\n  {\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i6\r\n{\r\nint\r\nthis[b c]\r\n{\r\ninit;\r\n}\r\n}", "class i6\r\n{\r\n  int this[b c] { init; }\r\n}");
+            TestNormalizeDeclaration("class i7\r\n{\r\nint\r\nthis[b c]\r\n{\r\ninit{}\r\n}\r\n}", "class i7\r\n{\r\n  int this[b c]\r\n  {\r\n    init\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i8\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget{}\r\nset{}\r\n}\r\n}", "class i8\r\n{\r\n  int this[b c]\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class i9\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget=>1;\r\nset{z=1;}\r\n}\r\n}", "class i9\r\n{\r\n  int this[b c]\r\n  {\r\n    get => 1;\r\n    set\r\n    {\r\n      z = 1;\r\n    }\r\n  }\r\n}");
+            TestNormalizeDeclaration("class ia\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget{}\r\nset;\r\n}\r\n}", "class ia\r\n{\r\n  int this[b c]\r\n  {\r\n    get\r\n    {\r\n    }\r\n\r\n    set;\r\n  }\r\n}");
+            TestNormalizeDeclaration("class ib\r\n{\r\nint\r\nthis[b c]\r\n{\r\nget;\r\nset{}\r\n}\r\n}", "class ib\r\n{\r\n  int this[b c]\r\n  {\r\n    get;\r\n    set\r\n    {\r\n    }\r\n  }\r\n}");
 
             // fields
             TestNormalizeDeclaration("class a{b c;}", "class a\r\n{\r\n  b c;\r\n}");

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -374,6 +374,16 @@ namespace Microsoft.CodeAnalysis
             return _node != null;
         }
 
+        internal bool All(Func<TNode, bool> predicate)
+        {
+            foreach (var item in this)
+            {
+                if (!predicate(item)) return false;
+            }
+
+            return true;
+        }
+
         // for debugging
         private TNode[] Nodes
         {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -378,7 +378,10 @@ namespace Microsoft.CodeAnalysis
         {
             foreach (var item in this)
             {
-                if (!predicate(item)) return false;
+                if (!predicate(item))
+                {
+                    return false;
+                }
             }
 
             return true;

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -979,15 +979,15 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
         {
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract | DeclarationModifiers.ReadOnly),
-                "abstract x p\r\n{\r\n    get;\r\n}");
+                "abstract x p { get; }");
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract | DeclarationModifiers.WriteOnly),
-                "abstract x p\r\n{\r\n    set;\r\n}");
+                "abstract x p { set; }");
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.ReadOnly),
-                "x p\r\n{\r\n    get;\r\n}");
+                "x p { get; }");
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.ReadOnly, getAccessorStatements: Array.Empty<SyntaxNode>()),
@@ -995,7 +995,7 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.WriteOnly),
-                "x p\r\n{\r\n    set;\r\n}");
+                "x p { set; }");
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.WriteOnly, setAccessorStatements: Array.Empty<SyntaxNode>()),
@@ -1003,7 +1003,7 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract),
-                "abstract x p\r\n{\r\n    get;\r\n    set;\r\n}");
+                "abstract x p { get; set; }");
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.ReadOnly, getAccessorStatements: new[] { Generator.IdentifierName("y") }),
@@ -1027,15 +1027,15 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
         {
             VerifySyntax<IndexerDeclarationSyntax>(
                 Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("z", Generator.IdentifierName("y")) }, Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract | DeclarationModifiers.ReadOnly),
-                "abstract x this[y z]\r\n{\r\n    get;\r\n}");
+                "abstract x this[y z] { get; }");
 
             VerifySyntax<IndexerDeclarationSyntax>(
                 Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("z", Generator.IdentifierName("y")) }, Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract | DeclarationModifiers.WriteOnly),
-                "abstract x this[y z]\r\n{\r\n    set;\r\n}");
+                "abstract x this[y z] { set; }");
 
             VerifySyntax<IndexerDeclarationSyntax>(
                 Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("z", Generator.IdentifierName("y")) }, Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract),
-                "abstract x this[y z]\r\n{\r\n    get;\r\n    set;\r\n}");
+                "abstract x this[y z] { get; set; }");
 
             VerifySyntax<IndexerDeclarationSyntax>(
                 Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("z", Generator.IdentifierName("y")) }, Generator.IdentifierName("x"), modifiers: DeclarationModifiers.ReadOnly),
@@ -1091,11 +1091,11 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
         {
             VerifySyntax<EventDeclarationSyntax>(
                 Generator.CustomEventDeclaration("ep", Generator.IdentifierName("t"), modifiers: DeclarationModifiers.Abstract),
-                "abstract event t ep\r\n{\r\n    add;\r\n    remove;\r\n}");
+                "abstract event t ep { add; remove; }");
 
             VerifySyntax<EventDeclarationSyntax>(
                 Generator.CustomEventDeclaration("ep", Generator.IdentifierName("t"), accessibility: Accessibility.Public, modifiers: DeclarationModifiers.Abstract),
-                "public abstract event t ep\r\n{\r\n    add;\r\n    remove;\r\n}");
+                "public abstract event t ep { add; remove; }");
 
             VerifySyntax<EventDeclarationSyntax>(
                 Generator.CustomEventDeclaration("ep", Generator.IdentifierName("t")),
@@ -1308,19 +1308,19 @@ public interface IFace
 
             VerifySyntax<InterfaceDeclarationSyntax>(
                 Generator.InterfaceDeclaration("i", members: new[] { Generator.PropertyDeclaration("p", Generator.IdentifierName("t"), accessibility: Accessibility.Public, modifiers: DeclarationModifiers.Sealed) }),
-                "interface i\r\n{\r\n    t p\r\n    {\r\n        get;\r\n        set;\r\n    }\r\n}");
+                "interface i\r\n{\r\n    t p { get; set; }\r\n}");
 
             VerifySyntax<InterfaceDeclarationSyntax>(
                 Generator.InterfaceDeclaration("i", members: new[] { Generator.PropertyDeclaration("p", Generator.IdentifierName("t"), accessibility: Accessibility.Public, modifiers: DeclarationModifiers.ReadOnly) }),
-                "interface i\r\n{\r\n    t p\r\n    {\r\n        get;\r\n    }\r\n}");
+                "interface i\r\n{\r\n    t p { get; }\r\n}");
 
             VerifySyntax<InterfaceDeclarationSyntax>(
                 Generator.InterfaceDeclaration("i", members: new[] { Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("y", Generator.IdentifierName("x")) }, Generator.IdentifierName("t"), Accessibility.Public, DeclarationModifiers.Sealed) }),
-                "interface i\r\n{\r\n    t this[x y]\r\n    {\r\n        get;\r\n        set;\r\n    }\r\n}");
+                "interface i\r\n{\r\n    t this[x y] { get; set; }\r\n}");
 
             VerifySyntax<InterfaceDeclarationSyntax>(
                 Generator.InterfaceDeclaration("i", members: new[] { Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("y", Generator.IdentifierName("x")) }, Generator.IdentifierName("t"), Accessibility.Public, DeclarationModifiers.ReadOnly) }),
-                "interface i\r\n{\r\n    t this[x y]\r\n    {\r\n        get;\r\n    }\r\n}");
+                "interface i\r\n{\r\n    t this[x y] { get; }\r\n}");
 
             VerifySyntax<InterfaceDeclarationSyntax>(
                 Generator.InterfaceDeclaration("i", members: new[] { Generator.CustomEventDeclaration("ep", Generator.IdentifierName("t"), accessibility: Accessibility.Public, modifiers: DeclarationModifiers.Static) }),
@@ -1332,7 +1332,7 @@ public interface IFace
 
             VerifySyntax<InterfaceDeclarationSyntax>(
                 Generator.InterfaceDeclaration("i", members: new[] { Generator.FieldDeclaration("f", Generator.IdentifierName("t"), accessibility: Accessibility.Public, modifiers: DeclarationModifiers.Sealed) }),
-                "interface i\r\n{\r\n    t f\r\n    {\r\n        get;\r\n        set;\r\n    }\r\n}");
+                "interface i\r\n{\r\n    t f { get; set; }\r\n}");
         }
 
         [Fact]
@@ -1527,19 +1527,19 @@ public interface IFace
                 Generator.AddAttributes(
                     Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), accessibility: Accessibility.NotApplicable, modifiers: DeclarationModifiers.Abstract),
                     Generator.Attribute("a")),
-                "[a]\r\nabstract x p\r\n{\r\n    get;\r\n    set;\r\n}");
+                "[a]\r\nabstract x p { get; set; }");
 
             VerifySyntax<IndexerDeclarationSyntax>(
                 Generator.AddAttributes(
                     Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("z", Generator.IdentifierName("y")) }, Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract),
                     Generator.Attribute("a")),
-                "[a]\r\nabstract x this[y z]\r\n{\r\n    get;\r\n    set;\r\n}");
+                "[a]\r\nabstract x this[y z] { get; set; }");
 
             VerifySyntax<EventDeclarationSyntax>(
                 Generator.AddAttributes(
                     Generator.CustomEventDeclaration("ep", Generator.IdentifierName("t"), modifiers: DeclarationModifiers.Abstract),
                     Generator.Attribute("a")),
-                "[a]\r\nabstract event t ep\r\n{\r\n    add;\r\n    remove;\r\n}");
+                "[a]\r\nabstract event t ep { add; remove; }");
 
             VerifySyntax<EventFieldDeclarationSyntax>(
                 Generator.AddAttributes(
@@ -2441,7 +2441,7 @@ public class C
         {
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.WithAccessorDeclarations(Generator.PropertyDeclaration("p", Generator.IdentifierName("x"))),
-                "x p\r\n{\r\n}");
+                "x p { }");
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.WithAccessorDeclarations(
@@ -2463,7 +2463,7 @@ public class C
 
             VerifySyntax<IndexerDeclarationSyntax>(
                 Generator.WithAccessorDeclarations(Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("p", Generator.IdentifierName("t")) }, Generator.IdentifierName("x"))),
-                "x this[t p]\r\n{\r\n}");
+                "x this[t p] { }");
 
             VerifySyntax<IndexerDeclarationSyntax>(
                 Generator.WithAccessorDeclarations(Generator.IndexerDeclaration(new[] { Generator.ParameterDeclaration("p", Generator.IdentifierName("t")) }, Generator.IdentifierName("x")),


### PR DESCRIPTION
The discussion started here: https://github.com/dotnet/roslyn/issues/49468

The work consisted in:
- Added support in the SyntaxNormalizer class for the auto-properties (the ones who have null Body property)
- Added more tests for properties including init accessor and initializers
- Fixed the two existing tests (property and indexer) to reflect the changes

The following comparisons shows the results of the actual tests, before and after this PR.

```
Before:
class a
{
  b c
  {
    get;
  }
}

After:
class a
{
  b c { get; }
}

```

```
Before:
class a
{
  int X
  {
    get;
    set;
  }

  = 2;
}

After:
class a
{
  int X { get; set; } = 2;
}
```

```
Before:
class a
{
  int Y
  {
    get;
    set;
  }

  = 99;
}

After:
class a
{
  int Y { get; set; } = 99;
}
```

```
Before:
class a
{
  int Z
  {
    get;
  }
}

After:
class a
{
  int Z { get; }
}

```

```
Before:
class a
{
  int T
  {
    get;
    init;
  }

  int R
  {
    get => 1;
  }
}

After:
class a
{
  int T { get; init; }

  int R { get => 1; }
}

```

```
Before:
class a
{
  int Q
  {
    get
    {
      return 0;
    }

    init
    {
    }
  }

  int R
  {
    get => 1;
  }
}

After:
class a
{
  int Q
  {
    get
    {
      return 0;
    }

    init
    {
    }
  }

  int R { get => 1; }
}

```

```
Before:
class a
{
  int R
  {
    get => 1;
  }
}

After:
class a
{
  int R { get => 1; }
}
```

```
Before:
class a
{
  int S => 2;
}

After:
class a
{
  int S => 2;
}
```

```
Before:
class a
{
  b this[c d]
  {
    get;
  }
}

After:
class a
{
  b this[c d] { get; }
}


```
