### PR TITLE
Split Document/Workspace handler into only handling open/closed documents respectively.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 {

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
@@ -62,16 +62,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             // Note: context.Document may be null in the case where the client is asking about a document that we have
             // since removed from the workspace.  In this case, we don't really have anything to process.
             // GetPreviousResults will be used to properly realize this and notify the client that the doc is gone.
-            return context.Document == null ? ImmutableArray<Document>.Empty : ImmutableArray.Create(context.Document);
+            //
+            // Only consider open documents here (and only closed ones in the WorkspacePullDiagnosticHandler).  Each
+            // handler treats those as separate worlds that they are responsible for.
+            return context.Document != null && context.IsTracking(context.Document.GetURI())
+                ? ImmutableArray.Create(context.Document)
+                : ImmutableArray<Document>.Empty;
         }
 
         protected override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
             RequestContext context, Document document, Option2<DiagnosticMode> diagnosticMode, CancellationToken cancellationToken)
         {
-            // We only support doc diagnostics for open files.
-            if (!context.IsTracking(document.GetURI()))
-                return SpecializedTasks.EmptyImmutableArray<DiagnosticData>();
-
             // For open documents, directly use the IDiagnosticAnalyzerService.  This will use the actual snapshots
             // we're passing in.  If information is already cached for that snapshot, it will be returned.  Otherwise,
             // it will be computed on demand.  Because it is always accurate as per this snapshot, all spans are correct

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
             var results = await RunGetDocumentPullDiagnosticsAsync(workspace, queue, server, document);
 
-            Assert.Empty(results.Single().Diagnostics);
+            Assert.Empty(results);
         }
 
         [Fact]


### PR DESCRIPTION
We cannot have both doc/workspace diagnostics handling the same files.  this is because the different systems don't necessary agree with each otehr, but the client requires them to be in agreement.  i.e. client calls between doc/workspace/doc/workspace for the same file and then expects things like "did not change" to have meaning.  but because one of these is immediate and one may be stale, we might have workspcae diags saying "nothing changed" while doc diagnostics disagrees.

The fix here is to keep these two spaces entirely separated.  If a file is open, doc diagnostics handles it entire.  If it is closed then workspace diags handles it.