### PR TITLE
Ignore explicit interface implementation in naming style

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/NamingStyle/CSharpNamingStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NamingStyle/CSharpNamingStyleDiagnosticAnalyzer.cs
@@ -24,20 +24,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.NamingStyles
                 SyntaxKind.Parameter,
                 SyntaxKind.TypeParameter);
 
-        // Parameters of positional record declarations should be ignored because they also
-        // considered properties, and that naming style makes more sense
         protected override bool ShouldIgnore(ISymbol symbol)
-            => (symbol.IsKind(SymbolKind.Parameter)
-            && IsParameterOfRecordDeclaration(symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()))
-            || !symbol.CanBeReferencedByName;
-
-        private static bool IsParameterOfRecordDeclaration(SyntaxNode? node)
-            => node is ParameterSyntax
-            {
-                Parent: ParameterListSyntax
+        {
+            if (symbol.IsKind(SymbolKind.Parameter)
+                && symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is ParameterSyntax
                 {
-                    Parent: RecordDeclarationSyntax
-                }
-            };
+                    Parent: ParameterListSyntax
+                    {
+                        Parent: RecordDeclarationSyntax
+                    }
+                })
+            {
+                // Parameters of positional record declarations should be ignored because they also
+                // considered properties, and that naming style makes more sense
+                return true;
+            }
+
+            if (!symbol.CanBeReferencedByName)
+            {
+                // Explicit interface implementation falls into here, as they don't own their names
+                // Two symbols are involved here, and symbol.ExplicitInterfaceImplementations only applies for one
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/NamingStyle/CSharpNamingStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NamingStyle/CSharpNamingStyleDiagnosticAnalyzer.cs
@@ -27,8 +27,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.NamingStyles
         // Parameters of positional record declarations should be ignored because they also
         // considered properties, and that naming style makes more sense
         protected override bool ShouldIgnore(ISymbol symbol)
-            => symbol.IsKind(SymbolKind.Parameter)
-            && IsParameterOfRecordDeclaration(symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax());
+            => (symbol.IsKind(SymbolKind.Parameter)
+            && IsParameterOfRecordDeclaration(symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()))
+            || !symbol.CanBeReferencedByName;
 
         private static bool IsParameterOfRecordDeclaration(SyntaxNode? node)
             => node is ParameterSyntax

--- a/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
+++ b/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
@@ -1365,5 +1365,22 @@ $@"class C
     }}
 }}", new TestParameters(options: s_options.LocalNamesAreCamelCase));
         }
+
+        [Fact]
+        [WorkItem(49535, "https://github.com/dotnet/roslyn/issues/49535")]
+        public async Task TestGlobalDirectiveAsync()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+interface I
+{
+    int X { get; }
+}
+
+class C : I
+{
+    int [|global::I.X|] => 0;
+}", new TestParameters(options: s_options.PropertyNamesArePascalCase));
+        }
     }
 }


### PR DESCRIPTION
Fixes #49535

The diagnostic triggers for `C.X`, which is not marked with interface implementation in `ISymbol`. `C.I.X` is the one marked with interface implementation.

I believe just ignoring everything cannot be referenced by name should be correct.