### PR TITLE
Consolidate implementation of Equals that considers/doesn’t consider TypeCompareKind for VB type symbols.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.vb
@@ -82,6 +82,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Sub
 
         Public Overloads Function Equals(other As AnonymousTypeDescriptor) As Boolean Implements IEquatable(Of AnonymousTypeDescriptor).Equals
+            Return Equals(other, TypeCompareKind.ConsiderEverything)
+        End Function
+
+        Public Overloads Function Equals(other As AnonymousTypeDescriptor, compareKind As TypeCompareKind) As Boolean
             ' Comparing keys ensures field count, field names and keyness are equal
             If Not Me.Key.Equals(other.Key) Then
                 Return False
@@ -92,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim count As Integer = myFields.Length
             Dim otherFields As ImmutableArray(Of AnonymousTypeField) = other.Fields
             For i = 0 To count - 1
-                If Not myFields(i).Type.Equals(otherFields(i).Type) Then
+                If Not myFields(i).Type.Equals(otherFields(i).Type, compareKind) Then
                     Return False
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.vb
@@ -45,32 +45,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return New AnonymousDelegatePublicSymbol(Me, delegateDescriptor)
         End Function
 
-        ''' <summary>
-        ''' Compares anonymous types
-        ''' </summary>
-        Public Shared Function IsSameType(left As TypeSymbol, right As TypeSymbol, compareKind As TypeCompareKind) As Boolean
-
-            If left.TypeKind <> right.TypeKind Then
-                Return False
-            End If
-
-            Dim leftDescr = DirectCast(left, AnonymousTypeOrDelegatePublicSymbol).TypeDescriptor
-            Dim rightDescr = DirectCast(right, AnonymousTypeOrDelegatePublicSymbol).TypeDescriptor
-
-            If leftDescr.Key <> rightDescr.Key Then
-                Return False
-            End If
-
-            Dim count As Integer = leftDescr.Fields.Length
-            Debug.Assert(count = rightDescr.Fields.Length)
-            For i = 0 To count - 1
-                If Not leftDescr.Fields(i).Type.IsSameType(rightDescr.Fields(i).Type, compareKind) Then
-                    Return False
-                End If
-            Next
-            Return True
-        End Function
-
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousDelegate_TypePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousDelegate_TypePublicSymbol.vb
@@ -166,18 +166,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Public Overrides Function Equals(obj As Object) As Boolean
-                If Me Is obj Then
-                    Return True
-                End If
-                Dim other = TryCast(obj, AnonymousDelegatePublicSymbol)
-                Return other IsNot Nothing AndAlso Me.TypeDescriptor.Equals(other.TypeDescriptor)
-            End Function
-
-            Public Overrides Function GetHashCode() As Integer
-                Return Me.TypeDescriptor.GetHashCode()
-            End Function
-
         End Class
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
@@ -17,7 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Protected Sub New(manager As AnonymousTypeManager, typeDescr As AnonymousTypeDescriptor)
                 typeDescr.AssertGood()
-                Debug.Assert(TypeKind = TypeKind.Class OrElse TypeKind = TypeKind.Delegate)
+                Debug.Assert((TypeKind = TypeKind.Class AndAlso TypeOf Me Is AnonymousTypePublicSymbol) OrElse
+                             (TypeKind = TypeKind.Delegate AndAlso TypeOf Me Is AnonymousDelegatePublicSymbol))
 
                 Me.Manager = manager
                 Me.TypeDescriptor = typeDescr
@@ -310,6 +311,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
                 Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+            End Function
+
+            Public NotOverridable Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+                Return Equals(TryCast(other, AnonymousTypeOrDelegatePublicSymbol), comparison)
+            End Function
+
+            Public Overloads Function Equals(other As AnonymousTypeOrDelegatePublicSymbol, comparison As TypeCompareKind) As Boolean
+                If Me Is other Then
+                    Return True
+                End If
+
+                Return other IsNot Nothing AndAlso Me.TypeKind = other.TypeKind AndAlso Me.TypeDescriptor.Equals(other.TypeDescriptor, comparison)
+            End Function
+
+            Public NotOverridable Overrides Function GetHashCode() As Integer
+                Return Hash.Combine(Me.TypeDescriptor.GetHashCode(), TypeKind)
             End Function
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType_TypePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType_TypePublicSymbol.vb
@@ -187,18 +187,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Me.Manager.ConstructAnonymousTypeImplementationSymbol(Me)
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
-                If Me Is obj Then
-                    Return True
-                End If
-                Dim other = TryCast(obj, AnonymousTypePublicSymbol)
-                Return other IsNot Nothing AndAlso Me.TypeDescriptor.Equals(other.TypeDescriptor)
-            End Function
-
-            Public Overrides Function GetHashCode() As Integer
-                Return Me.TypeDescriptor.GetHashCode()
-            End Function
-
             Public Overrides ReadOnly Property DeclaringSyntaxReferences As ImmutableArray(Of SyntaxReference)
                 Get
                     Return GetDeclaringSyntaxReferenceHelper(Of AnonymousObjectCreationExpressionSyntax)(Me.Locations)

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousDelegate_TemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousDelegate_TemplateSymbol.vb
@@ -221,7 +221,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Manager.GetHashCode()
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
+            Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
                 If obj Is Me Then
                     Return True
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTypeParameterSymbol.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
     Partial Friend NotInheritable Class AnonymousTypeManager
 
-        Private Class AnonymousTypeOrDelegateTypeParameterSymbol
+        Private NotInheritable Class AnonymousTypeOrDelegateTypeParameterSymbol
             Inherits TypeParameterSymbol
 
             Private ReadOnly _container As AnonymousTypeOrDelegateTemplateSymbol
@@ -108,6 +108,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Friend Overrides Sub EnsureAllConstraintsAreResolved()
             End Sub
 
+            Public Overrides Function GetHashCode() As Integer
+                Return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Me)
+            End Function
+
+            Public Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+                Return other Is Me
+            End Function
         End Class
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -315,20 +315,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend MustOverride Overrides Function InternalSubstituteTypeParameters(substitution As TypeSubstitution) As TypeWithModifiers
 
-        Public Overrides Function Equals(obj As Object) As Boolean
-            Return IsSameType(obj, TypeCompareKind.ConsiderEverything)
+        Public NotOverridable Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            Return Equals(TryCast(other, ArrayTypeSymbol), comparison)
         End Function
 
-        Friend Function IsSameType(obj As Object, compareKind As TypeCompareKind) As Boolean
-            Debug.Assert((compareKind And Not (TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds Or TypeCompareKind.IgnoreTupleNames)) = 0)
-
-            If (Me Is obj) Then
+        Public Overloads Function Equals(other As ArrayTypeSymbol, compareKind As TypeCompareKind) As Boolean
+            If (Me Is other) Then
                 Return True
             End If
 
-            Dim other = TryCast(obj, ArrayTypeSymbol)
-
-            If (other Is Nothing OrElse Not other.HasSameShapeAs(Me) OrElse Not other.ElementType.IsSameType(ElementType, compareKind)) Then
+            If other Is Nothing OrElse Not other.HasSameShapeAs(Me) OrElse Not other.ElementType.Equals(ElementType, compareKind) Then
                 Return False
             End If
 
@@ -348,7 +344,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return True
         End Function
 
-        Public Overrides Function GetHashCode() As Integer
+        Public NotOverridable Overrides Function GetHashCode() As Integer
             ' Following the C# implementation to avoid recursion
             ' We don't want to blow the stack if we have a type like T[][][][][][][][]....[][],
             ' so we do not recurse until we have a non-array. Rather, hash all the ranks together

--- a/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
@@ -387,7 +387,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Overrides Function Equals(obj As Object) As Boolean
+        Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
             Return Me Is obj
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ExtendedErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ExtendedErrorTypeSymbol.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' An error type symbol with name and diagnostic. More info can be added in the future.
     ''' </summary>
     ''' <remarks></remarks>
-    Friend Class ExtendedErrorTypeSymbol
+    Friend NotInheritable Class ExtendedErrorTypeSymbol
         Inherits InstanceErrorTypeSymbol
 
         Private ReadOnly _diagnosticInfo As DiagnosticInfo
@@ -146,10 +146,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Overrides Function Equals(obj As Object) As Boolean
-            If (Me Is obj) Then
-                Return True
-            End If
+        Protected Overrides Function SpecializedEquals(obj As InstanceErrorTypeSymbol) As Boolean
+            Debug.Assert(obj IsNot Me)
 
             '' Error type symbols representing errors that have been reported compare based on the full
             '' name of the potential type they are representing.  If not reported, subclasses of ErrorTypeSymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/IndexedTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/IndexedTypeParameterSymbol.vb
@@ -95,9 +95,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        ' These object are unique (per index).
-        Public Overrides Function Equals(obj As Object) As Boolean
-            Return Me Is obj
+        ' These objects are unique (per index).
+        Public Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            Return Me Is other
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/InstanceErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/InstanceErrorTypeSymbol.vb
@@ -137,6 +137,45 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Public MustOverride Overrides Function GetHashCode() As Integer
+
+        Public NotOverridable Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            If other Is Me Then
+                Return True
+            End If
+
+            If other Is Nothing Then
+                Return False
+            End If
+
+            Dim otherInstance = TryCast(other, InstanceErrorTypeSymbol)
+
+            If otherInstance Is Nothing AndAlso (comparison And TypeCompareKind.AllIgnoreOptionsForVB) = 0 Then
+                Return False
+            End If
+
+            Dim otherTuple = TryCast(other, TupleTypeSymbol)
+            If otherTuple IsNot Nothing Then
+                Return otherTuple.Equals(Me, comparison)
+            End If
+
+            If otherInstance IsNot Nothing Then
+                Return SpecializedEquals(otherInstance)
+            End If
+
+            Debug.Assert((comparison And TypeCompareKind.AllIgnoreOptionsForVB) <> 0)
+
+            If Not Me.Equals(other.OriginalDefinition) Then
+                Return False
+            End If
+
+            ' Delegate comparison to the other type to ensure symmetry
+            Debug.Assert(TypeOf other Is SubstitutedErrorType)
+            Return other.Equals(Me, comparison)
+        End Function
+
+        Protected MustOverride Function SpecializedEquals(other As InstanceErrorTypeSymbol) As Boolean
+
         Private NotInheritable Class ErrorTypeParameterSymbol
             Inherits TypeParameterSymbol
 
@@ -222,7 +261,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Hash.Combine(_container.GetHashCode(), _ordinal)
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
+            Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
                 If obj Is Nothing Then
                     Return False
                 End If
@@ -233,7 +272,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 Dim other = TryCast(obj, ErrorTypeParameterSymbol)
 
-                Return other IsNot Nothing AndAlso other._ordinal = Me._ordinal AndAlso other._container.Equals(Me._container)
+                Return other IsNot Nothing AndAlso other._ordinal = Me._ordinal AndAlso other._container.Equals(Me._container, comparison)
             End Function
 
             Friend Overrides Sub EnsureAllConstraintsAreResolved()

--- a/src/Compilers/VisualBasic/Portable/Symbols/InstanceTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/InstanceTypeSymbol.vb
@@ -128,6 +128,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Public Overrides Function GetHashCode() As Integer
+            Return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Me)
+        End Function
+
+        Public Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            If other Is Me Then
+                Return True
+            End If
+
+            If other Is Nothing OrElse (comparison And TypeCompareKind.AllIgnoreOptionsForVB) = 0 Then
+                Return False
+            End If
+
+            Dim otherTuple = TryCast(other, TupleTypeSymbol)
+            If otherTuple IsNot Nothing Then
+                Return otherTuple.Equals(Me, comparison)
+            End If
+
+            If other.OriginalDefinition IsNot Me Then
+                Return False
+            End If
+
+            ' Delegate comparison to the other type to ensure symmetry
+            Debug.Assert(TypeOf other Is SubstitutedNamedType)
+            Return other.Equals(Me, comparison)
+        End Function
+
 #Region "Use-Site Diagnostics"
 
         Protected Function CalculateUseSiteErrorInfo() As DiagnosticInfo

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
     ''' </summary>
     ''' <remarks></remarks>
     Friend NotInheritable Class PETypeParameterSymbol
-        Inherits TypeParameterSymbol
+        Inherits SubstitutableTypeParameterSymbol
 
         Private ReadOnly _containingSymbol As Symbol ' Could be PENamedType or a PEMethod
         Private ReadOnly _handle As GenericParameterHandle

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingMetadataTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingMetadataTypeSymbol.vb
@@ -189,14 +189,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Public Overrides Function GetHashCode() As Integer
+            Public NotOverridable Overrides Function GetHashCode() As Integer
                 Return Hash.Combine(_containingModule, Hash.Combine(MetadataName, Hash.Combine(_namespaceName, Arity)))
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
-                If Me Is obj Then
-                    Return True
-                End If
+            Protected NotOverridable Overrides Function SpecializedEquals(obj As InstanceErrorTypeSymbol) As Boolean
+                Debug.Assert(obj IsNot Me)
 
                 Dim other = TryCast(obj, TopLevel)
 
@@ -251,7 +249,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' Represents nested missing type.
         ''' </summary>
-        Friend Class Nested
+        Friend NotInheritable Class Nested
             Inherits MissingMetadataTypeSymbol
 
             Private ReadOnly _containingType As NamedTypeSymbol
@@ -259,6 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Public Sub New(containingType As NamedTypeSymbol, name As String, arity As Integer, mangleName As Boolean)
                 MyBase.New(name, arity, mangleName)
                 Debug.Assert(containingType IsNot Nothing)
+                Debug.Assert(containingType.IsDefinition)
 
                 _containingType = containingType
             End Sub
@@ -290,10 +289,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Hash.Combine(_containingType, Hash.Combine(MetadataName, Arity))
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
-                If Me Is obj Then
-                    Return True
-                End If
+            Protected Overrides Function SpecializedEquals(obj As InstanceErrorTypeSymbol) As Boolean
+                Debug.Assert(Me IsNot obj)
 
                 Dim other = TryCast(obj, Nested)
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' a NoPia embedded type symbol that was attempted to be substituted with canonical type, 
     ''' but the canonical type was ambiguous.
     ''' </summary>
-    Friend Class NoPiaAmbiguousCanonicalTypeSymbol
+    Friend NotInheritable Class NoPiaAmbiguousCanonicalTypeSymbol
         Inherits ErrorTypeSymbol
 
         Private ReadOnly _embeddingAssembly As AssemblySymbol
@@ -60,10 +60,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return RuntimeHelpers.GetHashCode(Me)
         End Function
 
-        Public Overrides Function Equals(obj As Object) As Boolean
+        Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
             Return obj Is Me
         End Function
-
 
         Friend Overrides ReadOnly Property ErrorInfo As DiagnosticInfo
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' A NoPiaIllegalGenericInstantiationSymbol is a special kind of ErrorSymbol that represents
     ''' a generic type instantiation that cannot cross assembly boundaries according to NoPia rules.
     ''' </summary>
-    Friend Class NoPiaIllegalGenericInstantiationSymbol
+    Friend NotInheritable Class NoPiaIllegalGenericInstantiationSymbol
         Inherits ErrorTypeSymbol
 
         Private ReadOnly _underlyingSymbol As NamedTypeSymbol
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return RuntimeHelpers.GetHashCode(Me)
         End Function
 
-        Public Overrides Function Equals(obj As Object) As Boolean
+        Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
             Return obj Is Me
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' a NoPia embedded type symbol that was attempted to be substituted with canonical type, 
     ''' but the canonical type couldn't be found.
     ''' </summary>
-    Friend Class NoPiaMissingCanonicalTypeSymbol
+    Friend NotInheritable Class NoPiaMissingCanonicalTypeSymbol
         Inherits ErrorTypeSymbol ' TODO: Should probably inherit from MissingMetadataType.TopLevel, but review TypeOf checks for MissingMetadataType.
 
         Private ReadOnly _embeddingAssembly As AssemblySymbol
@@ -85,7 +85,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return RuntimeHelpers.GetHashCode(Me)
         End Function
 
-        Public Overrides Function Equals(obj As Object) As Boolean
+        Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
             Return obj Is Me
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/PointerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PointerTypeSymbol.vb
@@ -53,13 +53,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Hash.Combine(last, indirections)
         End Function
 
-        Public Overrides Function Equals(obj As Object) As Boolean
+        Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
             If Me Is obj Then
                 Return True
             End If
 
             Dim other = TryCast(obj, PointerTypeSymbol)
-            Return other IsNot Nothing AndAlso other._pointedAtType.Equals(_pointedAtType) AndAlso other._customModifiers.SequenceEqual(_customModifiers)
+            Return other IsNot Nothing AndAlso other._pointedAtType.Equals(_pointedAtType, comparison) AndAlso
+                   ((comparison And TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) <> 0 OrElse
+                    other._customModifiers.SequenceEqual(_customModifiers))
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
@@ -769,15 +769,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Hash.Combine(_ordinal.GetHashCode(), Me.ContainingSymbol.GetHashCode())
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
+            Public Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+                Return Equals(TryCast(other, ReducedTypeParameterSymbol), comparison)
+            End Function
 
-                If Me Is obj Then
+            Public Overloads Function Equals(other As ReducedTypeParameterSymbol, comparison As TypeCompareKind) As Boolean
+
+                If Me Is other Then
                     Return True
                 End If
 
-                Dim other = TryCast(obj, ReducedTypeParameterSymbol)
-
-                Return other IsNot Nothing AndAlso Me._ordinal = other._ordinal AndAlso Me.ContainingSymbol.Equals(other.ContainingSymbol)
+                Return other IsNot Nothing AndAlso Me._ordinal = other._ordinal AndAlso Me.ContainingSymbol.Equals(other.ContainingSymbol, comparison)
             End Function
 
         End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
     ''' It can retarget symbols for multiple assemblies at the same time.
     ''' </summary>
     Friend NotInheritable Class RetargetingTypeParameterSymbol
-        Inherits TypeParameterSymbol
+        Inherits SubstitutableTypeParameterSymbol
 
         ''' <summary>
         ''' Owning RetargetingModuleSymbol.

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CrefTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CrefTypeParameterSymbol.vb
@@ -113,16 +113,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Overrides Function Equals(obj As Object) As Boolean
-            If obj Is Nothing Then
-                Return False
-            End If
+        Public Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            Return Equals(TryCast(other, CrefTypeParameterSymbol))
+        End Function
 
-            If Me Is obj Then
+        Public Overloads Function Equals(other As CrefTypeParameterSymbol) As Boolean
+            If Me Is other Then
                 Return True
             End If
 
-            Dim other = TryCast(obj, CrefTypeParameterSymbol)
             If other Is Nothing Then
                 Return False
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -511,7 +511,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return ReservedDispId.None
             End Function
 
-            Private Class SynthesizedComInterface
+            Private NotInheritable Class SynthesizedComInterface
                 Inherits NamedTypeSymbol
 
                 Private ReadOnly _comClass As SourceNamedTypeSymbol
@@ -520,6 +520,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Private ReadOnly _defaultMemberName As String
 
                 Public Sub New(comClass As SourceNamedTypeSymbol, interfaceMembers As ArrayBuilder(Of KeyValuePair(Of Symbol, Integer)))
+                    Debug.Assert(Not comClass.IsGenericType)
                     _comClass = comClass
                     _isEventInterface = False
 
@@ -638,6 +639,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     _members = members.ToImmutableAndFree()
                 End Sub
 
+                Public Overrides Function GetHashCode() As Integer
+                    Return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Me)
+                End Function
+
+                Public Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+                    Return Me Is other
+                End Function
+
                 Private Shared Function GetNextAvailableDispId(
                     usedDispIds As HashSet(Of Integer),
                     <[In], Out> ByRef nextDispId As Integer
@@ -752,7 +761,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End Get
                 End Property
 
-                Friend NotOverridable Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+                Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
                     Get
                         Return Nothing
                     End Get
@@ -938,17 +947,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End Get
                 End Property
 
-                Public NotOverridable Overrides Function GetTypeArgumentCustomModifiers(ordinal As Integer) As ImmutableArray(Of CustomModifier)
+                Public Overrides Function GetTypeArgumentCustomModifiers(ordinal As Integer) As ImmutableArray(Of CustomModifier)
                     Return GetEmptyTypeArgumentCustomModifiers(ordinal)
                 End Function
 
-                Friend NotOverridable Overrides ReadOnly Property HasTypeArgumentsCustomModifiers As Boolean
+                Friend Overrides ReadOnly Property HasTypeArgumentsCustomModifiers As Boolean
                     Get
                         Return False
                     End Get
                 End Property
 
-                Public Overrides ReadOnly Property TypeKind As TYPEKIND
+                Public Overrides ReadOnly Property TypeKind As TypeKind
                     Get
                         Return TypeKind.Interface
                     End Get
@@ -976,7 +985,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return ImmutableArray(Of VisualBasicAttributeData).Empty
                 End Function
 
-                Friend Overrides Sub AddSynthesizedAttributes(compilationState as ModuleCompilationState, ByRef attributes As ArrayBuilder(Of SynthesizedAttributeData))
+                Friend Overrides Sub AddSynthesizedAttributes(compilationState As ModuleCompilationState, ByRef attributes As ArrayBuilder(Of SynthesizedAttributeData))
                     MyBase.AddSynthesizedAttributes(compilationState, attributes)
 
                     Dim compilation As VisualBasicCompilation = _comClass.DeclaringCompilation
@@ -1017,7 +1026,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return Nothing
                 End Function
 
-                Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+                Friend Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
                     Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
                 End Function
             End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceTypeParameterSymbol.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' Represents a type parameter symbol defined in source.
     ''' </summary>
     Friend MustInherit Class SourceTypeParameterSymbol
-        Inherits TypeParameterSymbol
+        Inherits SubstitutableTypeParameterSymbol
 
         Private ReadOnly _ordinal As Integer ' 0 is first type parameter, etc.
         Private ReadOnly _name As String

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutableTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutableTypeParameterSymbol.vb
@@ -1,0 +1,45 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
+
+    ''' <summary>
+    ''' A SubstitutableTypeParameterSymbol represents a definition that is subject to alpha-renaming, 
+    ''' which results in <see cref="SubstitutedTypeParameterSymbol"/>.
+    ''' 
+    ''' The main purpose of this type is to share equality implementation that ensures symmetry
+    ''' across both of these types.
+    ''' </summary>
+    Friend MustInherit Class SubstitutableTypeParameterSymbol
+        Inherits TypeParameterSymbol
+
+        Public NotOverridable Overrides Function GetHashCode() As Integer
+            Return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Me)
+        End Function
+
+        Public NotOverridable Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            If other Is Me Then
+                Return True
+            End If
+
+            If other Is Nothing OrElse (comparison And TypeCompareKind.AllIgnoreOptionsForVB) = 0 Then
+                Return False
+            End If
+
+            If other.OriginalDefinition IsNot Me Then
+                Return False
+            End If
+
+            ' Delegate comparison to the other type to ensure symmetry
+            Debug.Assert(TypeOf other Is SubstitutedTypeParameterSymbol)
+            Return other.Equals(Me, comparison)
+        End Function
+
+        Public NotOverridable Overrides ReadOnly Property OriginalDefinition As TypeParameterSymbol
+            Get
+                Return Me
+            End Get
+        End Property
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
@@ -575,8 +575,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' alpha-renamed type parameters.
                 Debug.Assert(container.TypeSubstitution IsNot Nothing AndAlso
                              container.TypeSubstitution.TargetGenericDefinition Is originalDefinition.ContainingSymbol)
-                Dim substitution = VisualBasic.Symbols.TypeSubstitution.CreateForAlphaRename(container.TypeSubstitution,
-                                                                         StaticCast(Of TypeParameterSymbol).From(newTypeParameters))
+                Dim substitution = VisualBasic.Symbols.TypeSubstitution.CreateForAlphaRename(container.TypeSubstitution, newTypeParameters)
                 Debug.Assert(substitution.TargetGenericDefinition Is originalDefinition)
 
                 ' Now create the symbol.

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -29,7 +29,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly _substitution As TypeSubstitution
 
         Private Sub New(substitution As TypeSubstitution)
-            Debug.Assert(substitution IsNot Nothing AndAlso substitution.TargetGenericDefinition.IsDefinition)
+            Debug.Assert(substitution IsNot Nothing)
+            Debug.Assert(substitution.TargetGenericDefinition.IsDefinition)
+            Debug.Assert(TypeOf substitution.TargetGenericDefinition Is InstanceTypeSymbol) ' Required to ensure symmetrical equality
             _substitution = substitution
         End Sub
 
@@ -491,30 +493,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Select
         End Function
 
-        Public Overrides Function GetHashCode() As Integer
-            Dim _hash As Integer = OriginalDefinition.GetHashCode()
+        Public NotOverridable Overrides Function GetHashCode() As Integer
+            Dim hash As Integer = OriginalDefinition.GetHashCode()
             If Me._substitution.WasConstructedForModifiers() Then
-                Return _hash
+                Return hash
             End If
 
-            _hash = Hash.Combine(ContainingType, _hash)
+            hash = Roslyn.Utilities.Hash.Combine(ContainingType, hash)
 
             ' There is a circularity problem here with alpha-renamed type parameters.
             ' Calculating GetHashCode for them calls back into container's GetHashCode.
-            ' Do not ask for hash code of type arguments here, derived classes 
-            ' override this function and do that when appropriate. 
-            Return _hash
+            If Me IsNot Me.ConstructedFrom Then
+                For Each typeArgument In TypeArgumentsNoUseSiteDiagnostics
+                    hash = Roslyn.Utilities.Hash.Combine(typeArgument, hash)
+                Next
+            End If
+
+            Return hash
         End Function
 
-        Public MustOverride Overrides Function Equals(obj As Object) As Boolean
-
-        ''' <summary>
-        ''' Compare SubstitutedNamedTypes with no regard to type arguments.
-        ''' </summary>
-        Private Function EqualsWithNoRegardToTypeArguments(Of T As SubstitutedNamedType)(other As T) As Boolean
+        Public NotOverridable Overrides Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            If other Is Me Then
+                Return True
+            End If
 
             If other Is Nothing Then
                 Return False
+            End If
+
+            If (comparison And TypeCompareKind.AllIgnoreOptionsForVB) = 0 AndAlso
+               Not Me.GetType().Equals(other.GetType()) Then
+                Return False
+            End If
+
+            Dim otherTuple = TryCast(other, TupleTypeSymbol)
+            If otherTuple IsNot Nothing Then
+                Return otherTuple.Equals(Me, comparison)
             End If
 
             If Not OriginalDefinition.Equals(other.OriginalDefinition) Then
@@ -524,14 +538,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim containingType = Me.ContainingType
 
             If containingType IsNot Nothing AndAlso
-                Not containingType.Equals(other.ContainingType) Then
+               Not containingType.Equals(other.ContainingType, comparison) Then
                 Return False
             End If
 
-            ' There is a circularity problem here with alpha-renamed type parameters.
-            ' Equals for them calls back into container's Equals.
-            ' Do not compare type arguments here, derived classes 
-            ' override Equals and do that when appropriate. 
+            Dim otherNamed = DirectCast(other, NamedTypeSymbol)
+
+            If Me Is Me.ConstructedFrom AndAlso otherNamed Is otherNamed.ConstructedFrom Then
+                ' No need to compare type arguments on those containers when they didn't add type arguments.
+                ' That would cause cycles because Equals for them calls back into container's Equals.
+                Return True
+            End If
+
+            Dim arguments = TypeArgumentsNoUseSiteDiagnostics
+            Dim otherArguments = otherNamed.TypeArgumentsNoUseSiteDiagnostics
+            Dim count As Integer = arguments.Length
+
+            For i As Integer = 0 To count - 1 Step 1
+                If Not arguments(i).Equals(otherArguments(i), comparison) Then
+                    Return False
+                End If
+            Next
+
+            If (comparison And TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) = 0 AndAlso
+               Not HasSameTypeArgumentCustomModifiers(Me, otherNamed) Then
+
+                Return False
+            End If
+
             Return True
         End Function
 
@@ -646,8 +680,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' alpha-renamed type parameters.
                 Debug.Assert(container.TypeSubstitution IsNot Nothing AndAlso
                              container.TypeSubstitution.TargetGenericDefinition Is fullInstanceType.ContainingSymbol)
-                Dim substitution = VisualBasic.Symbols.TypeSubstitution.CreateForAlphaRename(container.TypeSubstitution,
-                                                                         StaticCast(Of TypeParameterSymbol).From(newTypeParameters))
+                Dim substitution = VisualBasic.Symbols.TypeSubstitution.CreateForAlphaRename(container.TypeSubstitution, newTypeParameters)
                 Debug.Assert(substitution.TargetGenericDefinition Is fullInstanceType)
 
                 ' Now create the symbol.
@@ -789,14 +822,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 'End If
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
-                If Me Is obj Then
-                    Return True
-                End If
-
-                Return EqualsWithNoRegardToTypeArguments(TryCast(obj, SpecializedGenericType))
-            End Function
-
         End Class
 
         ''' <summary>
@@ -910,14 +935,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Me
             End Function
 
-            Public Overrides Function Equals(obj As Object) As Boolean
-                If Me Is obj Then
-                    Return True
-                End If
-
-                Return EqualsWithNoRegardToTypeArguments(TryCast(obj, SpecializedNonGenericType))
-            End Function
-
         End Class
 
         ''' <summary>
@@ -981,56 +998,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Public Overrides Function Construct(typeArguments As ImmutableArray(Of TypeSymbol)) As NamedTypeSymbol
                 Throw New InvalidOperationException()
-            End Function
-
-            Public Overrides Function GetHashCode() As Integer
-                If Me._substitution.WasConstructedForModifiers() Then
-                    Return OriginalDefinition.GetHashCode()
-                End If
-
-                Dim _hash As Integer = MyBase.GetHashCode()
-
-                For Each typeArgument In TypeArgumentsNoUseSiteDiagnostics
-                    _hash = Hash.Combine(typeArgument, _hash)
-                Next
-
-                Return _hash
-            End Function
-
-            Public Overrides Function Equals(obj As Object) As Boolean
-                If Me Is obj Then
-                    Return True
-                End If
-
-                Dim other = TryCast(obj, ConstructedType)
-
-                If Not EqualsWithNoRegardToTypeArguments(other) Then
-                    Return False
-                End If
-
-                If _hasTypeArgumentsCustomModifiers <> other._hasTypeArgumentsCustomModifiers Then
-                    Return False
-                End If
-
-                Dim arguments = TypeArgumentsNoUseSiteDiagnostics
-                Dim otherArguments = other.TypeArgumentsNoUseSiteDiagnostics
-                Dim count As Integer = arguments.Length
-
-                For i As Integer = 0 To count - 1 Step 1
-                    If Not arguments(i).Equals(otherArguments(i)) Then
-                        Return False
-                    End If
-                Next
-
-                If _hasTypeArgumentsCustomModifiers Then
-                    For i As Integer = 0 To count - 1 Step 1
-                        If Not GetTypeArgumentCustomModifiers(i).SequenceEqual(other.GetTypeArgumentCustomModifiers(i)) Then
-                            Return False
-                        End If
-                    Next
-                End If
-
-                Return True
             End Function
 
             Friend NotOverridable Overrides Function GetUnificationUseSiteDiagnosticRecursive(owner As Symbol, ByRef checkedTypes As HashSet(Of TypeSymbol)) As DiagnosticInfo

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -771,18 +771,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Me.[Equals](TryCast(other, Symbol), equalityComparer.CompareKind)
         End Function
 
-        Overloads Function Equals(other As ISymbolInternal, compareKind As TypeCompareKind) As Boolean Implements ISymbolInternal.Equals
+        Private Overloads Function ISymbolInternal_Equals(other As ISymbolInternal, compareKind As TypeCompareKind) As Boolean Implements ISymbolInternal.Equals
             Return Me.Equals(TryCast(other, Symbol), compareKind)
         End Function
 
         ' By default we don't consider the compareKind. This can be overridden.
-        Public Overloads Function Equals(other As Symbol, compareKind As TypeCompareKind) As Boolean
+        Public Overridable Overloads Function Equals(other As Symbol, compareKind As TypeCompareKind) As Boolean
             Return Me.Equals(other)
         End Function
 
         ' By default, we do reference equality. This can be overridden.
         Public Overrides Function GetHashCode() As Integer
-            Return MyBase.GetHashCode()
+            Return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Me)
         End Function
 
         Public NotOverridable Overrides Function ToString() As String

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedClonedTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedClonedTypeParameterSymbol.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' Type parameter that represents another type parameter while being applied on a different symbol
     ''' </summary>
     Friend NotInheritable Class SynthesizedClonedTypeParameterSymbol
-        Inherits TypeParameterSymbol
+        Inherits SubstitutableTypeParameterSymbol
 
         Private ReadOnly _typeMapFactory As Func(Of Symbol, TypeSubstitution)
         Private ReadOnly _container As Symbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -343,6 +343,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(elementLocations.IsDefault OrElse elementLocations.Length = elementTypes.Length)
             Debug.Assert(elementNames.IsDefault OrElse elementNames.Length = elementTypes.Length)
             Debug.Assert(Not underlyingType.IsTupleType)
+            Debug.Assert(TypeOf underlyingType Is InstanceTypeSymbol OrElse
+                         TypeOf underlyingType Is InstanceErrorTypeSymbol OrElse
+                         TypeOf underlyingType Is SubstitutedNamedType OrElse
+                         TypeOf underlyingType Is SubstitutedErrorType) ' Required to ensure symmetrical equality
             Me._elementLocations = elementLocations
             Me._providedElementNames = elementNames
             Me._elementTypes = elementTypes
@@ -967,35 +971,45 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Me._underlyingType.GetAttributes()
         End Function
 
-        Public Overrides Function Equals(obj As Object) As Boolean
+        Public Overrides Function Equals(obj As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            If obj Is Me Then
+                Return True
+            End If
+
+            If obj Is Nothing Then
+                Return False
+            End If
+
             Dim otherTuple = TryCast(obj, TupleTypeSymbol)
-            If otherTuple Is Nothing Then
+
+            If otherTuple Is Nothing AndAlso (comparison And TypeCompareKind.IgnoreTupleNames) = 0 Then
                 Return False
             End If
 
-            Dim otherUnderlying = otherTuple.TupleUnderlyingType
-            If (Not TypeSymbol.Equals(Me.TupleUnderlyingType, otherUnderlying, TypeCompareKind.ConsiderEverything)) Then
+            If Not Me.TupleUnderlyingType.Equals(obj.GetTupleUnderlyingTypeOrSelf(), comparison) Then
                 Return False
             End If
 
-            Dim myNames = Me.TupleElementNames
-            Dim otherNames = otherTuple.TupleElementNames
+            If (comparison And TypeCompareKind.IgnoreTupleNames) = 0 Then
+                Dim myNames = Me.TupleElementNames
+                Dim otherNames = otherTuple.TupleElementNames
 
-            If myNames.IsDefault Then
-                Return otherNames.IsDefault
-            End If
+                If myNames.IsDefault Then
+                    Return otherNames.IsDefault
+                End If
 
-            If otherNames.IsDefault Then
-                Return False
-            End If
-
-            Debug.Assert(myNames.Length = otherNames.Length)
-
-            For i As Integer = 0 To myNames.Length - 1
-                If Not IdentifierComparison.Equals(myNames(i), otherNames(i)) Then
+                If otherNames.IsDefault Then
                     Return False
                 End If
-            Next
+
+                Debug.Assert(myNames.Length = otherNames.Length)
+
+                For i As Integer = 0 To myNames.Length - 1
+                    If Not IdentifierComparison.Equals(myNames(i), otherNames(i)) Then
+                        Return False
+                    End If
+                Next
+            End If
 
             Return True
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
@@ -585,7 +585,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <param name="alphaRenamedTypeParameters">Alpha-renamed type parameters.</param>
         Public Shared Function CreateForAlphaRename(
             parent As TypeSubstitution,
-            alphaRenamedTypeParameters As ImmutableArray(Of TypeParameterSymbol)
+            alphaRenamedTypeParameters As ImmutableArray(Of SubstitutedTypeParameterSymbol)
         ) As TypeSubstitution
             Debug.Assert(parent IsNot Nothing)
             Debug.Assert(Not alphaRenamedTypeParameters.IsEmpty)
@@ -609,7 +609,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim pairs(typeParametersDefinitions.Length - 1) As KeyValuePair(Of TypeParameterSymbol, TypeWithModifiers)
 
             For i As Integer = 0 To typeParametersDefinitions.Length - 1 Step 1
-                Debug.Assert(Not alphaRenamedTypeParameters(i).Equals(typeParametersDefinitions(i)))
+                Debug.Assert(Not TypeOf typeParametersDefinitions(i) Is SubstitutedTypeParameterSymbol)
                 Debug.Assert(alphaRenamedTypeParameters(i).OriginalDefinition Is typeParametersDefinitions(i))
                 pairs(i) = New KeyValuePair(Of TypeParameterSymbol, TypeWithModifiers)(typeParametersDefinitions(i), New TypeWithModifiers(alphaRenamedTypeParameters(i)))
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -332,12 +332,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Operator
 
         Public Overloads Shared Function Equals(left As TypeSymbol, right As TypeSymbol, comparison As TypeCompareKind) As Boolean
-            ' VB doesn't support any nullable annotations, but it is desirable at the top level to allow them to be provided
-            ' as a comparison option so that a user doesn't need to distinguish between VB and C# symbols.
-            ' We explicitly strip out the nullable ignore options here so that later assertions and code don't have to consider them 
-            comparison = comparison And Not TypeCompareKind.AllNullableIgnoreOptions
-            Return left.IsSameType(right, comparison)
+            Return If(left?.Equals(right, comparison), right Is Nothing)
         End Function
+
+        Public NotOverridable Overrides Function Equals(obj As Object) As Boolean
+            Return Equals(TryCast(obj, TypeSymbol), TypeCompareKind.ConsiderEverything)
+        End Function
+
+        Public NotOverridable Overrides Function Equals(other As Symbol, compareKind As TypeCompareKind) As Boolean
+            Return Equals(TryCast(other, TypeSymbol), compareKind)
+        End Function
+
+
+        Public MustOverride Overrides Function GetHashCode() As Integer
+
+        Public MustOverride Overloads Function Equals(other As TypeSymbol, comparison As TypeCompareKind) As Boolean
 
         ''' <summary>
         ''' Lookup an immediately nested type referenced from metadata, names should be

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -243,105 +243,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         <Extension()>
         Friend Function IsSameType(t1 As TypeSymbol, t2 As TypeSymbol, compareKind As TypeCompareKind) As Boolean
-            Debug.Assert((compareKind And Not (TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds Or TypeCompareKind.IgnoreTupleNames)) = 0)
-
-            If t1 Is t2 Then
-                Return True
-            ElseIf t1 Is Nothing OrElse t2 Is Nothing Then
-                Return False
-            End If
-
-            If compareKind = TypeCompareKind.ConsiderEverything Then
-                Return t1.Equals(t2)
-            End If
-
-            Dim kind = t1.Kind
-
-            If kind <> t2.Kind Then
-                Return False
-            End If
-
-            ' Custom modifiers can be inside arrays, pointers and generic instantiations (VB doesn't support pointers)
-            If kind = SymbolKind.ArrayType Then
-                Dim array1 = DirectCast(t1, ArrayTypeSymbol)
-                Dim array2 = DirectCast(t2, ArrayTypeSymbol)
-
-                Return array1.IsSameType(array2, compareKind)
-            ElseIf t1.IsAnonymousType AndAlso t2.IsAnonymousType Then
-                Return AnonymousTypeManager.IsSameType(t1, t2, compareKind)
-
-            ElseIf kind = SymbolKind.NamedType OrElse kind = SymbolKind.ErrorType Then
-                If t1.IsTupleType OrElse t2.IsTupleType Then
-                    If t1.GetTupleUnderlyingTypeOrSelf().IsSameType(t2.GetTupleUnderlyingTypeOrSelf(), compareKind) Then
-                        If (compareKind And TypeCompareKind.IgnoreTupleNames) = 0 Then
-                            If Not t1.IsTupleType OrElse Not t2.IsTupleType OrElse Not HasSameTupleNames(t1, t2) Then
-                                Return False
-                            End If
-                        End If
-                        Return True
-                    Else
-                        Return False
-                    End If
-                End If
-
-                Dim t1IsDefinition = t1.IsDefinition
-                Dim t2IsDefinition = t2.IsDefinition
-
-                If Not (t1IsDefinition AndAlso t2IsDefinition) Then ' This is a generic instantiation case
-
-                    If Not t1.OriginalDefinition.Equals(t2.OriginalDefinition) Then
-                        Return False ' different definition
-                    End If
-
-                    ' Compare arguments for this type and all containing types
-                    Dim container1 As NamedTypeSymbol = DirectCast(t1, NamedTypeSymbol)
-                    Dim container2 As NamedTypeSymbol = DirectCast(t2, NamedTypeSymbol)
-
-                    Do
-
-                        If Not (container1 Is container1.ConstructedFrom AndAlso container2 Is container2.ConstructedFrom) Then
-                            ' No need to compare type arguments on those containers when they didn't add type arguments (that would cause cycles)
-
-                            If (compareKind And Global.Microsoft.CodeAnalysis.TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) = 0 AndAlso
-                                Not HasSameTypeArgumentCustomModifiers(container1, container2) Then
-
-                                Return False
-                            End If
-
-                            Dim args1 As ImmutableArray(Of TypeSymbol) = container1.TypeArgumentsNoUseSiteDiagnostics
-                            Dim args2 As ImmutableArray(Of TypeSymbol) = container2.TypeArgumentsNoUseSiteDiagnostics
-
-                            For i As Integer = 0 To args1.Length - 1 Step 1
-                                If Not args1(i).IsSameType(args2(i), compareKind) Then
-                                    Return False
-                                End If
-                            Next
-                        End If
-
-                        container1 = container1.ContainingType
-                        container2 = container2.ContainingType
-
-                        If container1 Is Nothing OrElse
-                           container1 Is container2 Then ' Shortcut
-                            Exit Do
-                        End If
-
-                    Loop
-
-                    Return True
-                End If
-            ElseIf kind = SymbolKind.TypeParameter Then
-                If Not t1.OriginalDefinition.Equals(t2.OriginalDefinition) Then
-                    Return False ' different definition
-                End If
-
-                Return t1.ContainingType.IsSameType(t2.ContainingType, compareKind)
-            End If
-
-            Return t1.Equals(t2)
+            Return TypeSymbol.Equals(t1, t2, compareKind)
         End Function
 
-        Private Function HasSameTypeArgumentCustomModifiers(type1 As NamedTypeSymbol, type2 As NamedTypeSymbol) As Boolean
+        Friend Function HasSameTypeArgumentCustomModifiers(type1 As NamedTypeSymbol, type2 As NamedTypeSymbol) As Boolean
             Dim hasMods1 = type1.HasTypeArgumentsCustomModifiers()
             Dim hasMods2 = type2.HasTypeArgumentsCustomModifiers()
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -23181,8 +23181,18 @@ End Class"
 
                 Case TupleUnderlyingTypeValue.Distinct
                     Assert.NotEqual(type, underlyingType)
-                    Assert.False(type.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions))
+                    Assert.NotEqual(underlyingType, type)
+
+                    Assert.True(type.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions))
+                    Assert.True(underlyingType.Equals(type, TypeCompareKind.AllIgnoreOptions))
                     Assert.False(type.Equals(underlyingType, TypeCompareKind.ConsiderEverything))
+                    Assert.False(underlyingType.Equals(type, TypeCompareKind.ConsiderEverything))
+
+                    Assert.True(DirectCast(type, Symbol).Equals(underlyingType, TypeCompareKind.AllIgnoreOptions))
+                    Assert.True(DirectCast(underlyingType, Symbol).Equals(type, TypeCompareKind.AllIgnoreOptions))
+                    Assert.False(DirectCast(type, Symbol).Equals(underlyingType, TypeCompareKind.ConsiderEverything))
+                    Assert.False(DirectCast(underlyingType, Symbol).Equals(type, TypeCompareKind.ConsiderEverything))
+
                     VerifyPublicType(underlyingType, expectedValue:=TupleUnderlyingTypeValue.Nothing)
 
                 Case Else

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -3943,11 +3943,28 @@ BC31091: Import of type 'C(Of ).D(Of )' from assembly or module 'TypeSymbolGetHa
             AssertHashCodesMatch(definition, t1)
         End Sub
 
-        Private Shared Sub AssertHashCodesMatch(c As TypeSymbol, c2 As TypeSymbol)
+        Private Shared Sub AssertHashCodesMatch(c As NamedTypeSymbol, c2 As NamedTypeSymbol)
             Assert.False(c.IsSameType(c2, TypeCompareKind.ConsiderEverything))
             Assert.True(c.IsSameType(c2, (TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds Or TypeCompareKind.IgnoreTupleNames)))
+            Assert.False(c2.IsSameType(c, TypeCompareKind.ConsiderEverything))
+            Assert.True(c2.IsSameType(c, (TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds Or TypeCompareKind.IgnoreTupleNames)))
 
             Assert.Equal(c2.GetHashCode(), c.GetHashCode())
+
+            If c.Arity <> 0 Then
+                Dim ctp = c.TypeParameters(0)
+                Dim ctp2 = c2.TypeParameters(0)
+
+                If ctp IsNot ctp2 Then
+                    Assert.False(ctp.IsSameType(ctp2, TypeCompareKind.ConsiderEverything))
+                    Assert.True(ctp.IsSameType(ctp2, (TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds Or TypeCompareKind.IgnoreTupleNames)))
+
+                    Assert.False(ctp2.IsSameType(ctp, TypeCompareKind.ConsiderEverything))
+                    Assert.True(ctp2.IsSameType(ctp, (TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds Or TypeCompareKind.IgnoreTupleNames)))
+
+                    Assert.Equal(ctp2.GetHashCode(), ctp.GetHashCode())
+                End If
+            End If
         End Sub
     End Class
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.vb
@@ -8,7 +8,7 @@ Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     Friend NotInheritable Class EETypeParameterSymbol
-        Inherits TypeParameterSymbol
+        Inherits SubstitutableTypeParameterSymbol
 
         Private ReadOnly _container As Symbol
         Private ReadOnly _sourceTypeParameterSymbol As TypeParameterSymbol

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     ''' A simple type parameter with no constraints.
     ''' </summary>
     Friend NotInheritable Class SimpleTypeParameterSymbol
-        Inherits TypeParameterSymbol
+        Inherits SubstitutableTypeParameterSymbol
 
         Private ReadOnly _container As Symbol
         Private ReadOnly _ordinal As Integer


### PR DESCRIPTION
Closes #14336