### PR TITLE
Fix the ability to expand the list of analyzers in a reference

### DIFF
--- a/src/EditorFeatures/TestUtilities/Diagnostics/TestAnalyzerReferenceByLanguage.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/TestAnalyzerReferenceByLanguage.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -14,10 +12,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         private readonly IReadOnlyDictionary<string, ImmutableArray<DiagnosticAnalyzer>> _analyzersMap;
 
-        public TestAnalyzerReferenceByLanguage(IReadOnlyDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzersMap)
-            => _analyzersMap = analyzersMap;
+        public TestAnalyzerReferenceByLanguage(IReadOnlyDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzersMap, string? fullPath = null)
+        {
+            _analyzersMap = analyzersMap;
+            FullPath = fullPath;
+        }
 
-        public override string FullPath => null;
+        public override string? FullPath { get; }
         public override string Display => nameof(TestAnalyzerReferenceByLanguage);
         public override object Id => Display;
 

--- a/src/VisualStudio/Core/Test/SolutionExplorer/CpsDiagnosticItemSourceTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/CpsDiagnosticItemSourceTests.vb
@@ -1,0 +1,51 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.Internal.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports Microsoft.VisualStudio.Shell
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
+    <UseExportProvider>
+    Public Class CpsDiagnosticItemSourceTests
+        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        Public Sub AnalyzerHasDiagnostics()
+            Dim workspaceXml =
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                    </Project>
+                </Workspace>
+
+            Using workspace = TestWorkspace.Create(workspaceXml)
+                Dim project = workspace.Projects.Single()
+
+                Dim analyzers = New Dictionary(Of String, ImmutableArray(Of DiagnosticAnalyzer))
+
+                ' The choice here of this analyzer to test with is arbitray -- there's nothing special about this
+                ' analyzer versus any other one.
+                analyzers.Add(LanguageNames.VisualBasic, ImmutableArray.Create(Of DiagnosticAnalyzer)(New Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty.VisualBasicUseAutoPropertyAnalyzer()))
+
+                Const analyzerPath = "C:\Analyzer.dll"
+                workspace.OnAnalyzerReferenceAdded(project.Id, New TestAnalyzerReferenceByLanguage(analyzers, analyzerPath))
+
+                Dim source As IAttachedCollectionSource = New CpsDiagnosticItemSource(
+                    workspace,
+                    project.FilePath,
+                    project.Id,
+                    New MockHierarchyItem() With {.CanonicalName = "\net472\analyzerdependency\" + analyzerPath},
+                    New FakeAnalyzersCommandHandler, workspace.GetService(Of IDiagnosticAnalyzerService))
+
+                Assert.True(source.HasItems)
+                Dim diagnostic = Assert.IsAssignableFrom(Of ITreeDisplayItem)(Assert.Single(source.Items))
+                Assert.Contains(IDEDiagnosticIds.UseAutoPropertyDiagnosticId, diagnostic.Text)
+            End Using
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
This was broken by 7fa2c964f8433b928c5ff966427ce3798724cdd2, where I asserted that GetDiagnosticItems was only called when we already knew we would have items. This was broken since right before we called the method the collection would get created, which changed the answer it would return. A small refactoring ensures we create the list and fill it in at once. This also makes it clear we aren't passing a non-trivial LINQ query across method boundaries anyways in a way that might result in multiple enumerations.

Fixes https://github.com/dotnet/roslyn/issues/49524