### PR TITLE
Resolve follow-up comments in PR "Create default arguments during binding"

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1186,7 +1186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression defaultValue;
             if (callerSourceLocation is object && parameter.IsCallerLineNumber)
             {
-                int line = GetCallerLocation(syntax).SourceTree.GetDisplayLineNumber(callerSourceLocation.SourceSpan);
+                int line = callerSourceLocation.SourceTree.GetDisplayLineNumber(callerSourceLocation.SourceSpan);
                 defaultValue = new BoundLiteral(syntax, ConstantValue.Create(line), Compilation.GetSpecialType(SpecialType.System_Int32)) { WasCompilerGenerated = true };
             }
             else if (callerSourceLocation is object && parameter.IsCallerFilePath)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -224,17 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Debug.Assert(completedOnThisThread);
                 }
 
-#if DEBUG
-                // If we accidentally access DefaultSyntaxValue in a reentrant manner, and we use a cancellation token
-                // that never expires, then the failure mode will be to spin wait forever.
-                // For debug purposes let's instead use a token which expires after a modest amount of time
-                // to wait for the default syntax value to be available.
-                var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                var token = cts.Token;
-#else
-                var token = CancellationToken.None;
-#endif
-                state.SpinWaitComplete(CompletionPart.EndDefaultSyntaxValue, token);
+                state.SpinWaitComplete(CompletionPart.EndDefaultSyntaxValue, default(CancellationToken));
                 return _lazyDefaultSyntaxValue;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // that never expires, then the failure mode will be to spin wait forever.
                 // For debug purposes let's instead use a token which expires after a modest amount of time
                 // to wait for the default syntax value to be available.
-                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
                 var token = cts.Token;
 #else
                 var token = CancellationToken.None;


### PR DESCRIPTION
Closes #49559

> Feel like `ForceComplete` should change to assert that this part has completed. That is the pattern we usually have elsewhere.

I wasn't sure how to resolve this comment, so will just push another commit once we've gotten that figured out. /cc @jaredpar