### PR TITLE
[LSP] Better error logging and nicer shutdown

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -383,7 +383,7 @@ namespace Roslyn.Test.Utilities
         {
             var workspace = (TestWorkspace)solution.Workspace;
             var solutionProvider = workspace.ExportProvider.GetExportedValue<ILspSolutionProvider>();
-            return new RequestExecutionQueue(solutionProvider);
+            return new RequestExecutionQueue(solutionProvider, "Tests");
         }
 
         private static string GetDocumentFilePathFromName(string documentName)

--- a/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/AbstractRequestHandlerProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             var handler = (IRequestHandler<RequestType, ResponseType>?)handlerEntry.Value;
             Contract.ThrowIfNull(handler, string.Format("Request handler not found for method {0}", methodName));
 
-            return queue.ExecuteAsync(mutatesSolutionState, handler, request, clientCapabilities, clientName, cancellationToken);
+            return queue.ExecuteAsync(mutatesSolutionState, handler, request, clientCapabilities, clientName, methodName, cancellationToken);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
@@ -16,10 +16,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly struct QueueItem
         {
             /// <summary>
-            /// Processes the queued request, and signals back to the called whether the handler ran to completion.
+            /// Processes the queued request. Exceptions that occur will be sent back to the requesting client, then re-thrown
             /// </summary>
-            /// <remarks>A return value of true does not imply that the request was handled successfully, only that no exception was thrown and the task wasn't cancelled.</remarks>
-            public readonly Func<RequestContext, CancellationToken, Task<bool>> CallbackAsync;
+            public readonly Func<RequestContext, CancellationToken, Task> CallbackAsync;
 
             /// <inheritdoc cref="ExportLspMethodAttribute.MutatesSolutionState" />
             public readonly bool MutatesSolutionState;
@@ -40,7 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             /// </summary>
             public readonly CancellationToken CancellationToken;
 
-            public QueueItem(bool mutatesSolutionState, ClientCapabilities clientCapabilities, string? clientName, TextDocumentIdentifier? textDocument, Func<RequestContext, CancellationToken, Task<bool>> callbackAsync, CancellationToken cancellationToken)
+            public QueueItem(bool mutatesSolutionState, ClientCapabilities clientCapabilities, string? clientName, TextDocumentIdentifier? textDocument, Func<RequestContext, CancellationToken, Task> callbackAsync, CancellationToken cancellationToken)
             {
                 MutatesSolutionState = mutatesSolutionState;
                 ClientCapabilities = clientCapabilities;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// </para>
     /// <para>
     /// Regardless of whether a request is mutating or not, or blocking or not, is an implementation detail of this class
-    /// and any consumers observing the results of the task returned from <see cref="ExecuteAsync{TRequestType, TResponseType}(bool, IRequestHandler{TRequestType, TResponseType}, TRequestType, ClientCapabilities, string?, CancellationToken)"/>
+    /// and any consumers observing the results of the task returned from <see cref="ExecuteAsync{TRequestType, TResponseType}(bool, IRequestHandler{TRequestType, TResponseType}, TRequestType, ClientCapabilities, string?, string, CancellationToken)"/>
     /// will see the results of the handling of the request, whenever it occurred.
     /// </para>
     /// <para>
@@ -109,6 +109,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// <param name="request">The request to handle.</param>
         /// <param name="clientCapabilities">The client capabilities.</param>
         /// <param name="clientName">The client name.</param>
+        /// <param name="methodName">The name of the LSP method.</param>
         /// <param name="requestCancellationToken">A cancellation token that will cancel the handing of this request.
         /// The request could also be cancelled by the queue shutting down.</param>
         /// <returns>A task that can be awaited to observe the results of the handing of this request.</returns>
@@ -118,6 +119,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             TRequestType request,
             ClientCapabilities clientCapabilities,
             string? clientName,
+            string methodName,
             CancellationToken requestCancellationToken) where TRequestType : class
         {
             // Create a task completion source that will represent the processing of this request to the caller
@@ -152,7 +154,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         completion.SetException(exception);
 
                         // Also allow the exception to flow back to the request queue to handle as appropriate
-                        throw;
+                        throw new InvalidOperationException($"Error handling '{methodName}' request: {exception.Message}", exception);
                     }
                 }, requestCancellationToken);
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.DocumentChanges
 
         private static Task<Solution> GetLSPSolution(Handler.RequestExecutionQueue queue, Uri uri)
         {
-            return queue.ExecuteAsync(false, new GetLSPSolutionHandler(), uri, new ClientCapabilities(), null, CancellationToken.None);
+            return queue.ExecuteAsync(false, new GetLSPSolutionHandler(), uri, new ClientCapabilities(), null, "test/getLSPSolution", CancellationToken.None);
         }
 
         private class GetLSPSolutionHandler : IRequestHandler<Uri, Solution>

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractInProcLanguageClient.cs
@@ -87,9 +87,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         /// </summary>
         protected internal abstract VSServerCapabilities GetCapabilities();
 
-        public Task<Connection> ActivateAsync(CancellationToken token)
+        public async Task<Connection> ActivateAsync(CancellationToken token)
         {
-            Contract.ThrowIfTrue(_languageServer?.Running == true, "The language server has not yet shutdown.");
+            if (_languageServer is not null)
+            {
+                Contract.ThrowIfFalse(_languageServer.HasShutdownStarted, "The language server has not yet been asked to shutdown.");
+
+                await _languageServer.DisposeAsync().ConfigureAwait(false);
+            }
 
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
             _languageServer = new InProcLanguageServer(
@@ -103,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 _solutionProvider,
                 clientName: _diagnosticsClientName);
 
-            return Task.FromResult(new Connection(clientStream, clientStream));
+            return new Connection(clientStream, clientStream);
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Client;
@@ -31,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
     /// Defines the language server to be hooked up to an <see cref="ILanguageClient"/> using StreamJsonRpc.  This runs
     /// in proc as not all features provided by this server are available out of proc (e.g. some diagnostics).
     /// </summary>
-    internal class InProcLanguageServer
+    internal class InProcLanguageServer : IAsyncDisposable
     {
         /// <summary>
         /// Legacy support for LSP push diagnostics.
@@ -54,6 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 
         private VSClientCapabilities? _clientCapabilities;
         private bool _shuttingDown;
+        private Task? _errorShutdownTask;
 
         public InProcLanguageServer(
             AbstractInProcLanguageClient languageClient,
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 _diagnosticService.DiagnosticsUpdated += DiagnosticService_DiagnosticsUpdated;
         }
 
-        public bool Running => !_shuttingDown && !_jsonRpc.IsDisposed;
+        public bool HasShutdownStarted => _shuttingDown;
 
         /// <summary>
         /// Handle the LSP initialize request by storing the client capabilities and responding with the server
@@ -441,7 +441,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             };
 
             var asyncToken = _listener.BeginAsyncOperation(nameof(RequestExecutionQueue_Errored));
-            Task.Run(async () =>
+            _errorShutdownTask = Task.Run(async () =>
             {
                 await _jsonRpc.NotifyWithParameterObjectAsync(Methods.WindowLogMessageName, message).ConfigureAwait(false);
 
@@ -653,6 +653,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         {
             var linePositionSpan = DiagnosticData.GetLinePositionSpan(diagnosticDataLocation, text, useMapped: true);
             return ProtocolConversions.LinePositionToRange(linePositionSpan);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // if the server shut down due to error, we might not have finished cleaning up
+            if (_errorShutdownTask is not null)
+            {
+                await _errorShutdownTask.ConfigureAwait(false);
+            }
         }
 
         internal TestAccessor GetTestAccessor() => new(this);

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             _listener = listenerProvider.GetListener(FeatureAttribute.LanguageServer);
             _clientName = clientName;
 
-            _queue = new RequestExecutionQueue(solutionProvider);
+            _queue = new RequestExecutionQueue(solutionProvider, languageClient.Name);
             _queue.RequestServerShutdown += RequestExecutionQueue_Errored;
 
             // Dedupe on DocumentId.  If we hear about the same document multiple times, we only need to process that id once.

--- a/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
@@ -382,7 +382,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                 var solutionProvider = workspace.ExportProvider.GetExportedValue<ILspSolutionProvider>();
 
                 var languageServer = new InProcLanguageServer(
-                    languageClient: null!,
+                    languageClient: new TestLanguageClient(),
                     inputStream,
                     outputStream,
                     protocol,
@@ -565,6 +565,19 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                     return Task.CompletedTask;
                 }
             }
+        }
+
+        private class TestLanguageClient : AbstractInProcLanguageClient
+        {
+            public TestLanguageClient()
+                : base(null!, null!, null, null!, null!, null)
+            {
+            }
+
+            public override string Name => nameof(LspDiagnosticsTests);
+
+            protected internal override LSP.VSServerCapabilities GetCapabilities() => new();
+
         }
     }
 }


### PR DESCRIPTION
I never could get the server activation error to happen under the debugger, but I did see a case where the shutdown, which happens on a background task, hadn't finished by the time we started back up again, so this addresses that just in case. It also introduces better error reporting for LSP requests, rather than relying on the client.
