### PR TITLE
AddSynthesizedRecordMembersIfNecessary - avoid touching members that are known to have no effect on the outcome of the function.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3034,7 +3034,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var members = ArrayBuilder<Symbol>.GetInstance(builder.NonTypeNonIndexerMembers.Count + 1);
             foreach (var member in builder.NonTypeNonIndexerMembers)
             {
-                switch(member)
+                switch (member)
                 {
                     case FieldSymbol:
                     case EventSymbol:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3034,6 +3034,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var members = ArrayBuilder<Symbol>.GetInstance(builder.NonTypeNonIndexerMembers.Count + 1);
             foreach (var member in builder.NonTypeNonIndexerMembers)
             {
+                switch(member)
+                {
+                    case FieldSymbol:
+                    case EventSymbol:
+                    case MethodSymbol { MethodKind: not (MethodKind.Ordinary or MethodKind.Constructor) }:
+                        continue;
+                }
+
                 if (!memberSignatures.ContainsKey(member))
                 {
                     memberSignatures.Add(member, member);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/RecordTests.cs
@@ -1566,5 +1566,71 @@ class C
   IL_001b:  ret
 }");
         }
+
+        [Fact]
+        [WorkItem(49286, "https://github.com/dotnet/roslyn/issues/49286")]
+        public void RecordWithEventImplicitlyImplementingAnInterface()
+        {
+            var src = @"
+using System;
+
+public interface I1
+{
+    event Action E1;
+}
+
+public record R1 : I1
+{
+    public event Action E1 {  add { } remove { } }
+}
+";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(49286, "https://github.com/dotnet/roslyn/issues/49286")]
+        public void RecordWithPropertyImplicitlyImplementingAnInterface()
+        {
+            var src = @"
+using System;
+
+public interface I1
+{
+    Action P1 { get; set; }
+}
+
+public record R1 : I1
+{
+    public Action P1 {  get; set; }
+}
+";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(49286, "https://github.com/dotnet/roslyn/issues/49286")]
+        public void RecordWithMethodImplicitlyImplementingAnInterface()
+        {
+            var src = @"
+using System;
+
+public interface I1
+{
+    Action M1();
+}
+
+public record R1 : I1
+{
+    public Action M1() => throw null;
+}
+";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
This avoids unnecessary work and fixes #49286.