### PR TITLE
Ignore tuple names when comparing symbols

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -11,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseImplicitObjectCreation
 {
@@ -112,8 +111,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseImplicitObjectCreation
             if (leftType.IsErrorType() || rightType.IsErrorType())
                 return;
 
-            if (!leftType.Equals(rightType, SymbolEqualityComparer.Default))
+            // The default SymbolEquivalenceComparer will ignore tuple name differences, which is advantageous here
+            if (!SymbolEquivalenceComparer.Instance.Equals(leftType, rightType))
+            {
                 return;
+            }
 
             context.ReportDiagnostic(DiagnosticHelper.Create(
                 Descriptor,

--- a/src/Analyzers/CSharp/Tests/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.UseImplicitObjectCreation;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseImplicitObjectCreationTests
@@ -589,6 +590,78 @@ class C
     {
         C c2 = new();
     });
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [WorkItem(49291, "https://github.com/dotnet/roslyn/issues/49291")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitObjectCreation)]
+        public async Task TestListOfTuplesWithLabels()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System.Collections.Generic;
+class C
+{
+    List<(int SomeName, int SomeOtherName, int YetAnotherName)> list = new [|List<(int SomeName, int SomeOtherName, int YetAnotherName)>|]();
+}",
+                FixedCode = @"
+using System.Collections.Generic;
+class C
+{
+    List<(int SomeName, int SomeOtherName, int YetAnotherName)> list = new();
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [WorkItem(49291, "https://github.com/dotnet/roslyn/issues/49291")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitObjectCreation)]
+        public async Task TestListOfTuplesWithoutLabels()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System.Collections.Generic;
+class C
+{
+    List<(int SomeName, int SomeOtherName, int YetAnotherName)> list = new [|List<(int, int, int)>|]();
+}",
+                FixedCode = @"
+using System.Collections.Generic;
+class C
+{
+    List<(int SomeName, int SomeOtherName, int YetAnotherName)> list = new();
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [WorkItem(49291, "https://github.com/dotnet/roslyn/issues/49291")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitObjectCreation)]
+        public async Task TestListOfTuplesWithoutLabelsAsLocal()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System.Collections.Generic;
+class C
+{
+    void M()
+    {
+        List<(int SomeName, int SomeOtherName, int YetAnotherName)> list = new [|List<(int, int, int)>|]();
+    }
+}",
+                FixedCode = @"
+using System.Collections.Generic;
+class C
+{
+    void M()
+    {
+        List<(int SomeName, int SomeOtherName, int YetAnotherName)> list = new();
+    }
 }",
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
             }.RunAsync();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49291