### PR TITLE
Expose IPropertySymbol.BackingField and IEventSymbol.BackingField

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/EventSymbol.cs
@@ -62,6 +62,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             }
         }
 
+        IFieldSymbol? IEventSymbol.BackingField
+        {
+            get
+            {
+                return _underlying.AssociatedField.GetPublicSymbol();
+            }
+        }
+
         IEventSymbol IEventSymbol.OriginalDefinition
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/PropertySymbol.cs
@@ -58,6 +58,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             get { return _underlying.SetMethod.GetPublicSymbol(); }
         }
 
+        IFieldSymbol IPropertySymbol.BackingField
+        {
+            get { return (_underlying as SourcePropertySymbolBase)?.BackingField.GetPublicSymbol(); }
+        }
+
         IPropertySymbol IPropertySymbol.OriginalDefinition
         {
             get

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -360,6 +360,8 @@ class C
             Assert.Equal(MethodKind.PropertySet, setterSymbol.MethodKind);
             Assert.Equal(propertySymbol.SetMethod, setterSymbol);
             Assert.Equal("void C.this[System.Int32 x, System.Int32 y].set", setterSymbol.ToTestDisplayString());
+
+            Assert.Null(propertySymbol.BackingField);
         }
 
         [Fact]
@@ -389,6 +391,7 @@ class C
             Assert.Equal(2, accessorList.Count);
             Assert.Same(eventSymbol.AddMethod, model.GetDeclaredSymbol(accessorList[0]));
             Assert.Same(eventSymbol.RemoveMethod, model.GetDeclaredSymbol(accessorList[1]));
+            Assert.Null(eventSymbol.BackingField);
         }
 
         [WorkItem(543494, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543494")]
@@ -406,11 +409,13 @@ class C
             var typeDecl = (TypeDeclarationSyntax)root.Members[0];
             var eventDecl = (EventFieldDeclarationSyntax)typeDecl.Members[0];
             var model = compilation.GetSemanticModel(tree);
-            var eventSymbol = model.GetDeclaredSymbol(eventDecl.Declaration.Variables[0]);
+            var eventSymbol = (IEventSymbol)model.GetDeclaredSymbol(eventDecl.Declaration.Variables[0]);
             Assert.NotNull(eventSymbol);
             Assert.Null(model.GetDeclaredSymbol(eventDecl)); // the event decl may have multiple variable declarators, the result for GetDeclaredSymbol will always be null
             Assert.Equal("E", eventSymbol.Name);
             Assert.IsType<SourceFieldLikeEventSymbol>(eventSymbol.GetSymbol());
+            Assert.NotNull(eventSymbol.BackingField);
+            Assert.Equal(eventSymbol, eventSymbol.BackingField.AssociatedSymbol);
         }
 
         [WorkItem(543574, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543574")]
@@ -2883,6 +2888,8 @@ class C : I
             Assert.Equal("I.set_P", explicitPropertySetterSymbol.Name);
             Assert.Equal(1, explicitPropertySetterSymbol.ExplicitInterfaceImplementations.Length);
             Assert.Same(explicitPropertySymbol.SetMethod, explicitPropertySetterSymbol);
+
+            Assert.NotNull(explicitPropertySymbol.BackingField);
         }
 
         [WorkItem(527284, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527284")]

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
+Microsoft.CodeAnalysis.IPropertySymbol.BackingField.get -> Microsoft.CodeAnalysis.IFieldSymbol
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
+Microsoft.CodeAnalysis.IEventSymbol.BackingField.get -> Microsoft.CodeAnalysis.IFieldSymbol
 Microsoft.CodeAnalysis.IPropertySymbol.BackingField.get -> Microsoft.CodeAnalysis.IFieldSymbol
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind

--- a/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
@@ -47,6 +47,11 @@ namespace Microsoft.CodeAnalysis
         IMethodSymbol? RaiseMethod { get; }
 
         /// <summary>
+        /// The backing field of the event, or null if the event does not use a backing field.
+        /// </summary>
+        IFieldSymbol? BackingField { get; }
+
+        /// <summary>
         /// The original definition of the event. If the event is constructed from another
         /// symbol by type substitution, OriginalDefinition gets the original symbol, as it was 
         /// defined in source or metadata.

--- a/src/Compilers/Core/Portable/Symbols/IPropertySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IPropertySymbol.cs
@@ -77,6 +77,11 @@ namespace Microsoft.CodeAnalysis
         IMethodSymbol? SetMethod { get; }
 
         /// <summary>
+        /// The backing field of the property, or null if the property does not use a backing field.
+        /// </summary>
+        IFieldSymbol? BackingField { get; }
+
+        /// <summary>
         /// The original definition of the property. If the property is constructed from another
         /// symbol by type substitution, OriginalDefinition gets the original symbol, as it was 
         /// defined in source or metadata.

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -302,6 +302,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IEventSymbol_BackingField As IFieldSymbol Implements IEventSymbol.BackingField
+            Get
+                Return Me.AssociatedField
+            End Get
+        End Property
+
         Private ReadOnly Property IEventSymbol_OriginalDefinition As IEventSymbol Implements IEventSymbol.OriginalDefinition
             Get
                 Return Me.OriginalDefinition

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -503,6 +503,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IPropertySymbol_BackingField As IFieldSymbol Implements IPropertySymbol.BackingField
+            Get
+                Return Me.AssociatedField
+            End Get
+        End Property
+
         Private ReadOnly Property IPropertySymbol_ReturnsByRef As Boolean Implements IPropertySymbol.ReturnsByRef
             Get
                 Return Me.ReturnsByRef

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
@@ -1098,9 +1098,12 @@ End Class
 
             propertySymbol = GetPropertySymbol(compilation, bindings, "c.vb", "Property P As Integer", propertySyntax)
             Assert.NotNull(propertySymbol)
+            Assert.Null(propertySymbol.BackingField)
 
             propertySymbol = GetPropertySymbol(compilation, bindings, "c.vb", "Property Q As Object", propertySyntax)
             Assert.NotNull(propertySymbol)
+            Assert.NotNull(propertySymbol.BackingField)
+            Assert.Equal(propertySymbol, propertySymbol.BackingField.AssociatedSymbol)
 
             propertySymbol = GetPropertySymbol(compilation, bindings, "c.vb", "Property R(index As Integer)", propertySyntax)
             Assert.NotNull(propertySymbol)

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public IEventSymbol? OverriddenEvent => _symbol.OverriddenEvent;
             public IMethodSymbol? RaiseMethod => _symbol.RaiseMethod;
             public IMethodSymbol? RemoveMethod => _symbol.RemoveMethod;
+            public IFieldSymbol? BackingField => _symbol.BackingField;
             public ITypeSymbol Type => _symbol.Type;
             public NullableAnnotation NullableAnnotation => _symbol.NullableAnnotation;
         }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public IMethodSymbol SetMethod => _symbol.SetMethod;
 
+            public IFieldSymbol BackingField => _symbol.BackingField;
+
             public ITypeSymbol Type => _symbol.Type;
 
             public NullableAnnotation NullableAnnotation => _symbol.NullableAnnotation;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
@@ -62,5 +62,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public IEventSymbol? OverriddenEvent => null;
 
         public static ImmutableArray<CustomModifier> TypeCustomModifiers => ImmutableArray.Create<CustomModifier>();
+
+        public IFieldSymbol BackingField => null;
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
@@ -88,5 +88,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public ImmutableArray<CustomModifier> RefCustomModifiers => ImmutableArray<CustomModifier>.Empty;
 
         public ImmutableArray<CustomModifier> TypeCustomModifiers => ImmutableArray<CustomModifier>.Empty;
+
+        public IFieldSymbol BackingField => null;
     }
 }


### PR DESCRIPTION
Closes #40103 and closes #42355. Covers https://github.com/dotnet/roslyn/issues/46682 as well.

I considered adding commits demonstrating how useful this is to the IDE layer, particularly in places where features just assume there are no event backing fields to worry about. (Unlike property backing fields, event backing fields are no longer included in ISymbol.GetMembers since they were removed in 2011.) In case that could detract from the simplicity of the PR, I'd like to follow up with some IDE fixes after this PR merges.