### PR TITLE
Changes around usage of Nullable.GetValueOrDefault API on conditional access

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -406,8 +406,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                         // Let's use a trick. To make sure the kind is the same, make sure
                         // base type is the same.
-                        SpecialType baseSpecialType = (candidate.BaseTypeNoUseSiteDiagnostics?.SpecialType).GetValueOrDefault();
-                        if (baseSpecialType == SpecialType.None || baseSpecialType != (baseType?.SpecialType).GetValueOrDefault())
+                        SpecialType baseSpecialType = (candidate.BaseTypeNoUseSiteDiagnostics?.SpecialType ?? SpecialType.None);
+                        if (baseSpecialType == SpecialType.None || baseSpecialType != (baseType?.SpecialType ?? SpecialType.None))
                         {
                             continue;
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/Symbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             foreach (var typeArg in typeArguments)
             {
                 var type = typeArg.EnsureCSharpSymbolOrNull(nameof(typeArguments));
-                builder.Add(TypeWithAnnotations.Create(type, (typeArg?.NullableAnnotation.ToInternalAnnotation()).GetValueOrDefault()));
+                builder.Add(TypeWithAnnotations.Create(type, (typeArg?.NullableAnnotation.ToInternalAnnotation() ?? NullableAnnotation.NotAnnotated)));
             }
 
             return builder.ToImmutableAndFree();

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -906,7 +906,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If symbol.Kind <> SymbolKind.Property AndAlso
                Compilation.SourceModule IsNot symbol.ContainingModule AndAlso
-               (symbol.ContainingType?.IsInterface).GetValueOrDefault() AndAlso
+               If(symbol.ContainingType?.IsInterface, False) AndAlso
                Not Compilation.Assembly.RuntimeSupportsDefaultInterfaceImplementation Then
 
                 If Not symbol.IsShared AndAlso

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundCall.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundCall.vb
@@ -94,7 +94,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' Null DefaultArguments doesn't indicate that Arguments is non-null, but if DefaultArguments is non-null we must have some arguments.
             Debug.Assert(DefaultArguments.IsNull OrElse Not Arguments.IsEmpty)
 
-            If isLifted.GetValueOrDefault AndAlso Not Method.ReturnType.IsNullableType() Then
+            If isLifted.GetValueOrDefault() AndAlso Not Method.ReturnType.IsNullableType() Then
                 Debug.Assert(OverloadResolution.CanLiftType(Method.ReturnType) AndAlso
                              Type.IsNullableType() AndAlso
                              Type.GetNullableUnderlyingType().IsSameTypeIgnoringAll(Method.ReturnType))

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
@@ -173,6 +173,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If IsConversionFromUnderlyingToNullable(conversion) Then
                         Return conversion.Operand
                     End If
+
+                Case Else
+                    Debug.Assert(Not HasValue(expr))
+
+                    If Not _inExpressionLambda AndAlso expr.Type.IsNullableOfBoolean() Then
+
+                        Dim whenNotNull As BoundExpression = Nothing
+                        Dim whenNull As BoundExpression = Nothing
+                        If IsConditionalAccess(expr, whenNotNull, whenNull) AndAlso HasNoValue(whenNull) Then
+                            Debug.Assert(Not HasNoValue(whenNotNull))
+                            Return UpdateConditionalAccess(expr,
+                                                           NullableValueOrDefault(whenNotNull),
+                                                           New BoundLiteral(expr.Syntax, ConstantValue.False, expr.Type.GetNullableUnderlyingType()))
+                        End If
+                    End If
             End Select
 
             Dim getValueOrDefaultMethod = GetNullableMethod(expr.Syntax, expr.Type, SpecialMember.System_Nullable_T_GetValueOrDefault)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperators.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperators.vb
@@ -32,17 +32,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return New BoundLiteral(node.Syntax, ConstantValue.False, node.Type)
             End If
 
-            Dim whenNotNull As BoundExpression = Nothing
-            Dim whenNull As BoundExpression = Nothing
-            If IsConditionalAccess(operand, whenNotNull, whenNull) Then
-                If HasNoValue(whenNull) Then
-                    Debug.Assert(Not HasNoValue(whenNotNull))
-                    Return UpdateConditionalAccess(operand,
-                                              NullableValueOrDefault(whenNotNull),
-                                              New BoundLiteral(node.Syntax, ConstantValue.False, node.Type))
-                End If
-            End If
-
             Return NullableValueOrDefault(operand)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1227,7 +1227,7 @@ Namespace Microsoft.CodeAnalysis.Operations
 
         Friend Function CreateBoundCatchBlockExceptionDeclarationOrExpression(boundCatchBlock As BoundCatchBlock) As IOperation
             If boundCatchBlock.LocalOpt IsNot Nothing AndAlso
-                        (boundCatchBlock.ExceptionSourceOpt?.Kind = BoundKind.Local).GetValueOrDefault() AndAlso
+                        If(boundCatchBlock.ExceptionSourceOpt?.Kind = BoundKind.Local, False) AndAlso
                         boundCatchBlock.LocalOpt Is DirectCast(boundCatchBlock.ExceptionSourceOpt, BoundLocal).LocalSymbol Then
                 Return New VariableDeclaratorOperation(boundCatchBlock.LocalOpt, initializer:=Nothing, ignoredArguments:=ImmutableArray(Of IOperation).Empty, semanticModel:=_semanticModel, syntax:=boundCatchBlock.ExceptionSourceOpt.Syntax, type:=Nothing, constantValue:=Nothing, isImplicit:=False)
             Else

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_QueryLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_QueryLambdaRewriter.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             End Function
 
             Public Overrides Function VisitParameter(node As BoundParameter) As BoundNode
-                If (node.ParameterSymbol?.ContainingSymbol.IsQueryLambdaMethod).GetValueOrDefault() AndAlso Not _uniqueNodes.Add(node) Then
+                If If(node.ParameterSymbol?.ContainingSymbol.IsQueryLambdaMethod, False) AndAlso Not _uniqueNodes.Add(node) Then
                     Dim wasCompilerGenerated As Boolean = node.WasCompilerGenerated
                     node = New BoundParameter(node.Syntax, node.ParameterSymbol, node.IsLValue, node.SuppressVirtualCalls, node.Type, node.HasErrors)
                     If wasCompilerGenerated Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -361,8 +361,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
                         ' Let's use a trick. To make sure the kind is the same, make sure
                         ' base type is the same.
-                        Dim baseSpecialType As SpecialType = (candidate.BaseTypeNoUseSiteDiagnostics?.SpecialType).GetValueOrDefault()
-                        If baseSpecialType = SpecialType.None OrElse baseSpecialType <> (baseType?.SpecialType).GetValueOrDefault() Then
+                        Dim baseSpecialType As SpecialType = If(candidate.BaseTypeNoUseSiteDiagnostics?.SpecialType, SpecialType.None)
+                        If baseSpecialType = SpecialType.None OrElse baseSpecialType <> If(baseType?.SpecialType, SpecialType.None) Then
                             Continue For
                         End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1299,8 +1299,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ' Should this be optimized for perf (caching for VT<0> to VT<7>, etc.)?
             If Not IsUnboundGenericType AndAlso
-                (ContainingSymbol?.Kind = SymbolKind.Namespace).GetValueOrDefault() AndAlso
-                (ContainingNamespace.ContainingNamespace?.IsGlobalNamespace).GetValueOrDefault() AndAlso
+                If(ContainingSymbol?.Kind = SymbolKind.Namespace, False) AndAlso
+                If(ContainingNamespace.ContainingNamespace?.IsGlobalNamespace, False) AndAlso
                 Name = TupleTypeSymbol.TupleTypeName AndAlso
                 ContainingNamespace.Name = MetadataHelpers.SystemString Then
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -107,7 +107,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 If Me.ContainingSymbol.IsImplicitlyDeclared Then
 
-                    If (TryCast(Me.ContainingSymbol, MethodSymbol)?.MethodKind = MethodKind.DelegateInvoke).GetValueOrDefault() AndAlso
+                    If If(TryCast(Me.ContainingSymbol, MethodSymbol)?.MethodKind = MethodKind.DelegateInvoke, False) AndAlso
                        Not Me.ContainingType.AssociatedSymbol?.IsImplicitlyDeclared Then
                         Return False
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
@@ -438,7 +438,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         <Extension>
         Friend Function ContainingNonLambdaMember(member As Symbol) As Symbol
-            While (member?.Kind = SymbolKind.Method).GetValueOrDefault() AndAlso DirectCast(member, MethodSymbol).MethodKind = MethodKind.AnonymousFunction
+            While If(member?.Kind = SymbolKind.Method, False) AndAlso DirectCast(member, MethodSymbol).MethodKind = MethodKind.AnonymousFunction
                 member = member.ContainingSymbol
             End While
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenNullable.vb
@@ -6806,5 +6806,465 @@ End Module
 
         End Class
 
+        <Fact()>
+        Public Sub BooleanExpression_31()
+            Dim verifier = CompileAndVerify(
+                <compilation>
+                    <file name="a.vb"><![CDATA[
+Option Explicit On
+
+Module Module1
+
+    Sub Main()
+    End Sub
+
+    Function Test1() As Integer
+        If GetC()?.F Then
+            Return 2
+        Else
+            Return 3
+        End If
+    End Function
+
+    Function GetC() As C
+        Return Nothing
+    End Function
+
+End Module
+
+Class C
+    Public F As Boolean
+End Class
+                    ]]></file>
+                </compilation>)
+
+            verifier.VerifyIL("Module1.Test1",
+            <![CDATA[
+{
+  // Code size       27 (0x1b)
+  .maxstack  2
+  .locals init (Integer V_0) //Test1
+  IL_0000:  call       "Function Module1.GetC() As C"
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_000c
+  IL_0008:  pop
+  IL_0009:  ldc.i4.0
+  IL_000a:  br.s       IL_0011
+  IL_000c:  ldfld      "C.F As Boolean"
+  IL_0011:  brfalse.s  IL_0017
+  IL_0013:  ldc.i4.2
+  IL_0014:  stloc.0
+  IL_0015:  br.s       IL_0019
+  IL_0017:  ldc.i4.3
+  IL_0018:  stloc.0
+  IL_0019:  ldloc.0
+  IL_001a:  ret
+}
+                ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub BooleanExpression_32()
+            Dim verifier = CompileAndVerify(
+                <compilation>
+                    <file name="a.vb"><![CDATA[
+Option Explicit On
+
+Module Module1
+
+    Sub Main()
+    End Sub
+
+    Function Test1() As Integer
+        If GetBool1() AndAlso GetC()?.F Then
+            Return 2
+        Else
+            Return 3
+        End If
+    End Function
+
+    Function GetBool1() As Boolean
+        Return Nothing
+    End Function
+
+    Function GetC() As C
+        Return Nothing
+    End Function
+
+End Module
+
+Class C
+    Public F As Boolean
+End Class
+                    ]]></file>
+                </compilation>)
+
+            verifier.VerifyIL("Module1.Test1",
+            <![CDATA[
+{
+  // Code size       34 (0x22)
+  .maxstack  2
+  .locals init (Integer V_0) //Test1
+  IL_0000:  call       "Function Module1.GetBool1() As Boolean"
+  IL_0005:  brfalse.s  IL_001e
+  IL_0007:  call       "Function Module1.GetC() As C"
+  IL_000c:  dup
+  IL_000d:  brtrue.s   IL_0013
+  IL_000f:  pop
+  IL_0010:  ldc.i4.0
+  IL_0011:  br.s       IL_0018
+  IL_0013:  ldfld      "C.F As Boolean"
+  IL_0018:  brfalse.s  IL_001e
+  IL_001a:  ldc.i4.2
+  IL_001b:  stloc.0
+  IL_001c:  br.s       IL_0020
+  IL_001e:  ldc.i4.3
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  ret
+}
+                ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub BooleanExpression_33()
+            Dim verifier = CompileAndVerify(
+                <compilation>
+                    <file name="a.vb"><![CDATA[
+Option Explicit On
+
+Module Module1
+
+    Sub Main()
+    End Sub
+
+    Function Test1() As Integer
+        If GetC()?.F OrElse GetBool1() Then
+            Return 2
+        Else
+            Return 3
+        End If
+    End Function
+
+    Function GetBool1() As Boolean
+        Return Nothing
+    End Function
+
+    Function GetC() As C
+        Return Nothing
+    End Function
+
+End Module
+
+Class C
+    Public F As Boolean
+End Class
+                    ]]></file>
+                </compilation>)
+
+            verifier.VerifyIL("Module1.Test1",
+            <![CDATA[
+{
+  // Code size       34 (0x22)
+  .maxstack  2
+  .locals init (Integer V_0) //Test1
+  IL_0000:  call       "Function Module1.GetC() As C"
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_000c
+  IL_0008:  pop
+  IL_0009:  ldc.i4.0
+  IL_000a:  br.s       IL_0011
+  IL_000c:  ldfld      "C.F As Boolean"
+  IL_0011:  brtrue.s   IL_001a
+  IL_0013:  call       "Function Module1.GetBool1() As Boolean"
+  IL_0018:  brfalse.s  IL_001e
+  IL_001a:  ldc.i4.2
+  IL_001b:  stloc.0
+  IL_001c:  br.s       IL_0020
+  IL_001e:  ldc.i4.3
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  ret
+}
+                ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub BooleanExpression_34()
+            Dim verifier = CompileAndVerify(
+                <compilation>
+                    <file name="a.vb"><![CDATA[
+Option Explicit On
+
+Module Module1
+
+    Sub Main()
+    End Sub
+
+    Function Test1() As Integer
+        If GetBool1() AndAlso GetC()?.F OrElse GetBool2() Then
+            Return 2
+        Else
+            Return 3
+        End If
+    End Function
+
+    Function GetBool1() As Boolean
+        Return Nothing
+    End Function
+
+    Function GetBool2() As Boolean
+        Return Nothing
+    End Function
+
+    Function GetC() As C
+        Return Nothing
+    End Function
+
+End Module
+
+Class C
+    Public F As Boolean
+End Class
+                    ]]></file>
+                </compilation>)
+
+            verifier.VerifyIL("Module1.Test1",
+            <![CDATA[
+{
+  // Code size       41 (0x29)
+  .maxstack  2
+  .locals init (Integer V_0) //Test1
+  IL_0000:  call       "Function Module1.GetBool1() As Boolean"
+  IL_0005:  brfalse.s  IL_001a
+  IL_0007:  call       "Function Module1.GetC() As C"
+  IL_000c:  dup
+  IL_000d:  brtrue.s   IL_0013
+  IL_000f:  pop
+  IL_0010:  ldc.i4.0
+  IL_0011:  br.s       IL_0018
+  IL_0013:  ldfld      "C.F As Boolean"
+  IL_0018:  brtrue.s   IL_0021
+  IL_001a:  call       "Function Module1.GetBool2() As Boolean"
+  IL_001f:  brfalse.s  IL_0025
+  IL_0021:  ldc.i4.2
+  IL_0022:  stloc.0
+  IL_0023:  br.s       IL_0027
+  IL_0025:  ldc.i4.3
+  IL_0026:  stloc.0
+  IL_0027:  ldloc.0
+  IL_0028:  ret
+}
+                ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub BooleanExpression_35()
+            Dim verifier = CompileAndVerify(
+                <compilation>
+                    <file name="a.vb"><![CDATA[
+Option Explicit On
+
+Module Module1
+
+    Sub Main()
+    End Sub
+
+    Function Test1() As Integer
+        If GetNullable() AndAlso GetC()?.F Then
+            Return 2
+        Else
+            Return 3
+        End If
+    End Function
+
+    Function GetNullable() As Boolean?
+        Return Nothing
+    End Function
+
+    Function GetC() As C
+        Return Nothing
+    End Function
+
+End Module
+
+Class C
+    Public F As Boolean
+End Class
+                    ]]></file>
+                </compilation>)
+
+            verifier.VerifyIL("Module1.Test1",
+            <![CDATA[
+{
+  // Code size       60 (0x3c)
+  .maxstack  2
+  .locals init (Integer V_0, //Test1
+                Boolean? V_1)
+  IL_0000:  call       "Function Module1.GetNullable() As Boolean?"
+  IL_0005:  stloc.1
+  IL_0006:  ldloca.s   V_1
+  IL_0008:  call       "Function Boolean?.get_HasValue() As Boolean"
+  IL_000d:  brfalse.s  IL_0018
+  IL_000f:  ldloca.s   V_1
+  IL_0011:  call       "Function Boolean?.GetValueOrDefault() As Boolean"
+  IL_0016:  brfalse.s  IL_0038
+  IL_0018:  call       "Function Module1.GetC() As C"
+  IL_001d:  dup
+  IL_001e:  brtrue.s   IL_0024
+  IL_0020:  pop
+  IL_0021:  ldc.i4.0
+  IL_0022:  br.s       IL_0029
+  IL_0024:  ldfld      "C.F As Boolean"
+  IL_0029:  brfalse.s  IL_0038
+  IL_002b:  ldloca.s   V_1
+  IL_002d:  call       "Function Boolean?.get_HasValue() As Boolean"
+  IL_0032:  brfalse.s  IL_0038
+  IL_0034:  ldc.i4.2
+  IL_0035:  stloc.0
+  IL_0036:  br.s       IL_003a
+  IL_0038:  ldc.i4.3
+  IL_0039:  stloc.0
+  IL_003a:  ldloc.0
+  IL_003b:  ret
+}
+                ]]>)
+        End Sub
+
+        <Fact()>
+        <WorkItem(38306, "https://github.com/dotnet/roslyn/issues/38306")>
+        Public Sub BooleanExpression_36()
+            Dim verifier = CompileAndVerify(
+                <compilation>
+                    <file name="a.vb"><![CDATA[
+Option Explicit On
+
+Module Module1
+
+    Sub Main()
+    End Sub
+
+    Function Test1() As Integer
+        If (GetC()?.F).GetValueOrDefault() AndAlso GetBool1() Then
+            Return 2
+        Else
+            Return 3
+        End If
+    End Function
+
+    Function GetBool1() As Boolean
+        Return Nothing
+    End Function
+
+    Function GetC() As C
+        Return Nothing
+    End Function
+
+End Module
+
+Class C
+    Public F As Boolean
+End Class
+                    ]]></file>
+                </compilation>)
+
+            verifier.VerifyIL("Module1.Test1",
+            <![CDATA[
+{
+  // Code size       55 (0x37)
+  .maxstack  2
+  .locals init (Integer V_0, //Test1
+                Boolean? V_1)
+  IL_0000:  call       "Function Module1.GetC() As C"
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_0014
+  IL_0008:  pop
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  initobj    "Boolean?"
+  IL_0011:  ldloc.1
+  IL_0012:  br.s       IL_001e
+  IL_0014:  ldfld      "C.F As Boolean"
+  IL_0019:  newobj     "Sub Boolean?..ctor(Boolean)"
+  IL_001e:  stloc.1
+  IL_001f:  ldloca.s   V_1
+  IL_0021:  call       "Function Boolean?.GetValueOrDefault() As Boolean"
+  IL_0026:  brfalse.s  IL_0033
+  IL_0028:  call       "Function Module1.GetBool1() As Boolean"
+  IL_002d:  brfalse.s  IL_0033
+  IL_002f:  ldc.i4.2
+  IL_0030:  stloc.0
+  IL_0031:  br.s       IL_0035
+  IL_0033:  ldc.i4.3
+  IL_0034:  stloc.0
+  IL_0035:  ldloc.0
+  IL_0036:  ret
+}
+                ]]>)
+        End Sub
+
+        <Fact()>
+        <WorkItem(38306, "https://github.com/dotnet/roslyn/issues/38306")>
+        Public Sub BooleanExpression_37()
+            Dim verifier = CompileAndVerify(
+                <compilation>
+                    <file name="a.vb"><![CDATA[
+Option Explicit On
+
+Module Module1
+
+    Sub Main()
+    End Sub
+
+    Function Test1() As Integer
+        If If(GetC()?.F, False) AndAlso GetBool1() Then
+            Return 2
+        Else
+            Return 3
+        End If
+    End Function
+
+    Function GetBool1() As Boolean
+        Return Nothing
+    End Function
+
+    Function GetC() As C
+        Return Nothing
+    End Function
+
+End Module
+
+Class C
+    Public F As Boolean
+End Class
+                    ]]></file>
+                </compilation>)
+
+            verifier.VerifyIL("Module1.Test1",
+            <![CDATA[
+{
+  // Code size       34 (0x22)
+  .maxstack  2
+  .locals init (Integer V_0) //Test1
+  IL_0000:  call       "Function Module1.GetC() As C"
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_000c
+  IL_0008:  pop
+  IL_0009:  ldc.i4.0
+  IL_000a:  br.s       IL_0011
+  IL_000c:  ldfld      "C.F As Boolean"
+  IL_0011:  brfalse.s  IL_001e
+  IL_0013:  call       "Function Module1.GetBool1() As Boolean"
+  IL_0018:  brfalse.s  IL_001e
+  IL_001a:  ldc.i4.2
+  IL_001b:  stloc.0
+  IL_001c:  br.s       IL_0020
+  IL_001e:  ldc.i4.3
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  ret
+}
+                ]]>)
+        End Sub
+
     End Class
 End Namespace

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                     _addNullCheckOptionValue = addNullChecksOption.Value;
                 }
 
-                var addNullChecks = (addNullChecksOption?.Value).GetValueOrDefault();
+                var addNullChecks = (addNullChecksOption?.Value ?? false);
                 var state = await State.TryGenerateAsync(
                     _service, _document, _textSpan, _containingType,
                     result.Members, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
@@ -82,8 +82,8 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                     _generateOperatorsOptionValue = generateOperatorsOption.Value;
                 }
 
-                var implementIEquatable = (implementIEqutableOption?.Value).GetValueOrDefault();
-                var generatorOperators = (generateOperatorsOption?.Value).GetValueOrDefault();
+                var implementIEquatable = (implementIEqutableOption?.Value ?? false);
+                var generatorOperators = (generateOperatorsOption?.Value ?? false);
 
                 var action = new GenerateEqualsAndGetHashCodeAction(
                     _document, _typeDeclaration, _containingType, result.Members,

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -195,7 +195,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             End If
 
             ' use FormattableString if conversion between String And FormattableString
-            If (info.Type?.SpecialType = SpecialType.System_String).GetValueOrDefault() AndAlso
+            If If(info.Type?.SpecialType = SpecialType.System_String, False) AndAlso
                info.ConvertedType?.IsFormattableString() Then
 
                 Return info.ConvertedType

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
@@ -595,8 +595,8 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
                 Return False
             End If
 
-            Dim match = (TryCast(container, MethodBlockBaseSyntax)?.EndBlockStatement.EndKeyword = nextToken).GetValueOrDefault() OrElse
-                        (TryCast(container, MultiLineLambdaExpressionSyntax)?.EndSubOrFunctionStatement.EndKeyword = nextToken).GetValueOrDefault()
+            Dim match = If(TryCast(container, MethodBlockBaseSyntax)?.EndBlockStatement.EndKeyword = nextToken, False) OrElse
+                        If(TryCast(container, MultiLineLambdaExpressionSyntax)?.EndSubOrFunctionStatement.EndKeyword = nextToken, False)
 
             If Not match Then
                 Return False

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Utilities/CastAnalyzer.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Utilities/CastAnalyzer.vb
@@ -225,7 +225,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
             ' A casts to object can always be removed from an expression inside of an interpolation, since it'll be converted to object
             ' in order to call string.Format(...) anyway.
-            If (castType?.SpecialType = SpecialType.System_Object).GetValueOrDefault() AndAlso
+            If If(castType?.SpecialType = SpecialType.System_Object, False) AndAlso
                 _castNode.WalkUpParentheses().IsParentKind(SyntaxKind.Interpolation) Then
                 Return True
             End If

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -121,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
 
                 Dim symbols = Me._model.GetSymbolInfo(expression, _cancellationToken).GetAllSymbols()
                 Return symbols.Any() AndAlso symbols.All(
-                    Function(s) (TryCast(s, IMethodSymbol)?.MethodKind).GetValueOrDefault() = MethodKind.Ordinary)
+                    Function(s) If(TryCast(s, IMethodSymbol)?.MethodKind = MethodKind.Ordinary, False))
             End Function
 
             Private Function IsDelegateType(expression As ExpressionSyntax) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Simplifiers/NameSimplifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Simplifiers/NameSimplifier.vb
@@ -433,7 +433,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification.Simplifiers
             If name.IsKind(SyntaxKind.GenericName) Then
                 If (name.IsParentKind(SyntaxKind.CrefReference)) OrElse ' cref="Nullable(Of T)"
                    (name.IsParentKind(SyntaxKind.QualifiedName) AndAlso name.Parent?.IsParentKind(SyntaxKind.CrefReference)) OrElse ' cref="System.Nullable(Of T)"
-                   (name.IsParentKind(SyntaxKind.QualifiedName) AndAlso (name.Parent?.IsParentKind(SyntaxKind.QualifiedName)).GetValueOrDefault() AndAlso name.Parent.Parent?.IsParentKind(SyntaxKind.CrefReference)) Then  ' cref="System.Nullable(Of T).Value"
+                   (name.IsParentKind(SyntaxKind.QualifiedName) AndAlso If(name.Parent?.IsParentKind(SyntaxKind.QualifiedName), False) AndAlso name.Parent.Parent?.IsParentKind(SyntaxKind.CrefReference)) Then  ' cref="System.Nullable(Of T).Value"
                     ' Unfortunately, unlike in corresponding C# case, we need syntax based checking to detect these cases because of bugs in the VB SemanticModel.
                     ' See https://github.com/dotnet/roslyn/issues/2196, https://github.com/dotnet/roslyn/issues/2197
                     Return False


### PR DESCRIPTION
- In product code, when the access part yields non-nullable value, use coalesce expression instead.
- In VB lowering, use coalesce expression instead of synthesized Nullable.GetValueOrDefault call under the same conditions when result is also Boolean.

Related to #38306.