### PR TITLE
Fix implementations of GetDocument(SyntaxTree)

### DIFF
--- a/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
@@ -1,0 +1,36 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
+    <[UseExportProvider]>
+    Public Class SourceGeneratorTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Public Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameColorColorCaseWithGeneratedClassName(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+public class RegularClass
+{
+    public GeneratedClass [|$$GeneratedClass|];
+}
+                            </Document>
+                            <DocumentFromSourceGenerator>
+public class GeneratedClass
+{
+}
+                            </DocumentFromSourceGenerator>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="A")
+
+            End Using
+        End Sub
+    End Class
+End Namespace

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -69,6 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private const string AllowUnsafeAttributeName = "AllowUnsafe";
         private const string OutputKindName = "OutputKind";
         private const string NullableAttributeName = "Nullable";
+        private const string DocumentFromSourceGenerator = "DocumentFromSourceGenerator";
 
         /// <summary>
         /// Creates a single buffer in a workspace.

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -30,6 +30,7 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
+using Roslyn.Test.Utilities.TestGenerators;
 using Roslyn.Utilities;
 using Xunit;
 
@@ -964,6 +965,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                         ImmutableArray<DiagnosticAnalyzer>.Empty,
                         display: (string)analyzer.Attribute(AnalyzerDisplayAttributeName),
                         fullPath: (string)analyzer.Attribute(AnalyzerFullPathAttributeName)));
+            }
+
+            foreach (var fileToGenerate in projectElement.Elements(DocumentFromSourceGenerator))
+            {
+                analyzers.Add(new TestGeneratorReference(new SingleFileTestGenerator(fileToGenerate.Value)));
             }
 
             return analyzers;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis
 
             // Trickier case now: it's possible we generated this, but we don't actually have the SourceGeneratedDocument for it, so let's go
             // try to fetch the state.
-            var documentState = _solution.State.TryGetSourceGeneratedDocumentForAlreadyGeneratedId(documentId);
+            var documentState = _solution.State.TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentId);
 
             if (documentState == null)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -1029,7 +1029,7 @@ namespace Microsoft.CodeAnalysis
                 return compilationInfo.GeneratedDocuments;
             }
 
-            public SourceGeneratedDocumentState? TryGetSourceGeneratedDocumentForAlreadyGeneratedId(DocumentId documentId)
+            public SourceGeneratedDocumentState? TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(DocumentId documentId)
             {
                 var state = ReadState();
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -359,22 +359,39 @@ namespace Microsoft.CodeAnalysis
             return state;
         }
 
-        private DocumentState? GetDocumentState(SyntaxTree? syntaxTree, ProjectId? projectId)
+        internal DocumentState? GetDocumentState(SyntaxTree? syntaxTree, ProjectId? projectId)
         {
             if (syntaxTree != null)
             {
                 // is this tree known to be associated with a document?
-                var docId = DocumentState.GetDocumentIdForTree(syntaxTree);
-                if (docId != null && (projectId == null || docId.ProjectId == projectId))
+                var documentId = DocumentState.GetDocumentIdForTree(syntaxTree);
+                if (documentId != null && (projectId == null || documentId.ProjectId == projectId))
                 {
                     // does this solution even have the document?
-                    var document = GetProjectState(docId.ProjectId)?.GetDocumentState(docId);
-                    if (document != null)
+                    var projectState = GetProjectState(documentId.ProjectId);
+                    if (projectState != null)
                     {
-                        // does this document really have the syntax tree?
-                        if (document.TryGetSyntaxTree(out var documentTree) && documentTree == syntaxTree)
+                        var document = projectState.GetDocumentState(documentId);
+                        if (document != null)
                         {
-                            return document;
+                            // does this document really have the syntax tree?
+                            if (document.TryGetSyntaxTree(out var documentTree) && documentTree == syntaxTree)
+                            {
+                                return document;
+                            }
+                        }
+                        else
+                        {
+                            var generatedDocument = TryGetSourceGeneratedDocumentForAlreadyGeneratedId(documentId);
+
+                            if (generatedDocument != null)
+                            {
+                                // does this document really have the syntax tree?
+                                if (generatedDocument.TryGetSyntaxTree(out var documentTree) && documentTree == syntaxTree)
+                                {
+                                    return generatedDocument;
+                                }
+                            }
                         }
                     }
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis
                         }
                         else
                         {
-                            var generatedDocument = TryGetSourceGeneratedDocumentForAlreadyGeneratedId(documentId);
+                            var generatedDocument = TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentId);
 
                             if (generatedDocument != null)
                             {
@@ -1785,9 +1785,9 @@ namespace Microsoft.CodeAnalysis
         /// generated. This method exists to implement <see cref="Solution.GetDocument(SyntaxTree?)"/> and is best avoided unless you're doing something
         /// similarly tricky like that.
         /// </remarks>
-        public SourceGeneratedDocumentState? TryGetSourceGeneratedDocumentForAlreadyGeneratedId(DocumentId documentId)
+        public SourceGeneratedDocumentState? TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(DocumentId documentId)
         {
-            return GetCompilationTracker(documentId.ProjectId).TryGetSourceGeneratedDocumentForAlreadyGeneratedId(documentId);
+            return GetCompilationTracker(documentId.ProjectId).TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentId);
         }
 
         /// <summary>


### PR DESCRIPTION
Turns out we had three implementations of the logic for "here's a syntax tree, give me the document for it"; I had only updated one to deal with generated files. This unifies the various methods to just one that has the "real" logic and then the other two just call into that. The one with the real logic is the one that just produces a State, so that way callers asking for a State or a Id don't implicitly realize the Document wrappers unless necessary.

Oddly the existing implementations we had weren't quite consistent: some also checked that the tree passed in actually matched the snapshot, and some didn't. The scenario where this matters is you have a sequence of:

1. Get the syntax tree for a Document.
2. Fork the Solution snapshot, making a change that changes the syntax tree.
3. Ask the new Solution snapshot for the Document passing the old SyntaxTree.

It appears in our old code GetDocument() would have returned null (because the trees no longer matched), whereas GetDocumentId() would have worked. I'm guessing this is just a failure to keep the code in sync like I failed to do; I'm favoring the more precise behavior that also checks the matching trees.