### PR TITLE
Fix performance regression in FixAll code path

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -75,6 +75,12 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 return SerializableDiagnosticAnalysisResults.Empty;
             }
 
+            if (_document == null && analyzers.Length < compilationWithAnalyzers.Analyzers.Length)
+            {
+                // PERF: Generate a new CompilationWithAnalyzers with trimmed analyzers for non-document analysis case.
+                compilationWithAnalyzers = compilationWithAnalyzers.Compilation.WithAnalyzers(analyzers, compilationWithAnalyzers.AnalysisOptions);
+            }
+
             var cacheService = _project.Solution.Workspace.Services.GetRequiredService<IProjectCacheService>();
             using var cache = cacheService.EnableCaching(_project.Id);
             var skippedAnalyzersInfo = _project.GetSkippedAnalyzersInfo(_analyzerInfoCache);


### PR DESCRIPTION
Recent move of analyzer diagnostic computation to OOP leads to running all analyzers when computing diagnostics to fix as part of a FixAll operation. This change ensures that we only run the required analyzer when computing diagnostics.

Fixes #49698. Verified that added test fails before the product change. 