### PR TITLE
XamlProjectService fixes

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Xaml.Diagnostics.Analyzers;
 using Microsoft.VisualStudio.Editor;
@@ -141,7 +142,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 project.AddSourceFile(filePath);
 
                 var documentId = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Single(d => d.ProjectId == project.Id);
-                var document = _workspace.CurrentSolution.GetDocument(documentId)!;
+                _rdtDocumentIds[docCookie] = documentId;
+
+                // Remove the following when https://github.com/dotnet/roslyn/issues/49879 is fixed
+                var document = _workspace.CurrentSolution.GetRequiredDocument(documentId);
                 var hasText = document.TryGetText(out var text);
                 if (!hasText || text?.Container.TryGetTextBuffer() == null)
                 {
@@ -153,8 +157,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                         _workspace.OnDocumentTextChanged(documentId, textContainer.CurrentText, PreservationMode.PreserveIdentity);
                     }
                 }
-
-                _rdtDocumentIds[docCookie] = documentId;
             }
         }
 


### PR DESCRIPTION
- Fixes issue #48651: Initialize VS services on demand on the UI thread
- Fixes DevDiv Bug 1248612: The MainWindow.xaml designer file pops up an "ArgumentException"exception, when clicking "Compare Current and Incoming": Avoid tracking "documents" with empty paths (e.g. while diffing).
- RDT info does not always contain the hierarchy when closing. Switch to a more reliable cookie-based tracking system instead.