### PR TITLE
Report an error for an initialization of a ref-returning property as part of an object initializer inside an expression tree.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -409,6 +409,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(ErrorCode.ERR_DictionaryInitializerInExpressionTree, node);
             }
 
+            if (node.MemberSymbol is PropertySymbol property)
+            {
+                CheckRefReturningPropertyAccess(node, property);
+            }
+
             return base.VisitObjectInitializerMember(node);
         }
 
@@ -468,14 +473,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitIndexerAccess(node);
         }
 
-        public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)
+        private void CheckRefReturningPropertyAccess(BoundNode node, PropertySymbol property)
         {
-            var property = node.PropertySymbol;
-            var method = property.GetMethod; // This is only checking for ref returns, so we don't fall back to the set method.
-            if ((object)method != null && _inExpressionLambda && method.RefKind != RefKind.None)
+            if (_inExpressionLambda && property.RefKind != RefKind.None)
             {
                 Error(ErrorCode.ERR_RefReturningCallInExpressionTree, node);
             }
+        }
+
+        public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)
+        {
+            var property = node.PropertySymbol;
+            CheckRefReturningPropertyAccess(node, property);
             CheckReceiverIfField(node.ReceiverOpt);
             return base.VisitPropertyAccess(node);
         }


### PR DESCRIPTION
Fixes #49617.