### PR TITLE
Use Unicode for OutputEncoding

### DIFF
--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -144,8 +144,8 @@ namespace Microsoft.CodeAnalysis.Interactive
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
-                        StandardErrorEncoding = Encoding.UTF8,
-                        StandardOutputEncoding = Encoding.UTF8
+                        StandardErrorEncoding = OutputEncoding,
+                        StandardOutputEncoding = OutputEncoding
                     },
 
                     // enables Process.Exited event to be raised:

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     newProcess.Exited -= ProcessExitedBeforeEstablishingConnection;
                 }
 
-                return new RemoteService(Host, newProcess, newProcessId, jsonRpc, platformInfo);
+                return new RemoteService(Host, newProcess, newProcessId, jsonRpc, platformInfo, Options);
             }
 
             private bool CheckAlive(Process process, string hostPath)

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 const int BaseLength = 4096;
 
                 // Workaround for https://github.com/dotnet/runtime/issues/45503.
-                // Whne the process terminates due to stack overflow the CLR prints out a message that is not correctly encoded to Unicode.
+                // When the process terminates due to stack overflow the CLR prints out a message that is not correctly encoded to Unicode.
                 // Hence it will come out as ASCII bytes interpreted as UTF-16 characters.
                 // We detect known message text in the output stream and transcode it and the output that follows to Unicode.
 

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -17,9 +19,13 @@ namespace Microsoft.CodeAnalysis.Interactive
     {
         internal sealed class RemoteService
         {
+            private static readonly char[] s_unicodeAsciiTranscodingMarkerDesktop = EncodeMarker("\nProcess is terminated due to StackOverflowException.\n");
+            private static readonly char[] s_unicodeAsciiTranscodingMarkerCore = EncodeMarker("Stack overflow.\n");
+
             public readonly Process Process;
             public readonly JsonRpc JsonRpc;
             public readonly InteractiveHostPlatformInfo PlatformInfo;
+            public readonly InteractiveHostOptions Options;
 
             private readonly int _processId;
             private readonly SemaphoreSlim _disposeSemaphore = new SemaphoreSlim(initialCount: 1);
@@ -31,11 +37,12 @@ namespace Microsoft.CodeAnalysis.Interactive
             private Thread? _readErrorOutputThread;      // nulled on dispose
             private volatile ProcessExitHandlerStatus _processExitHandlerStatus;  // set to Handled on dispose
 
-            internal RemoteService(InteractiveHost host, Process process, int processId, JsonRpc jsonRpc, InteractiveHostPlatformInfo platformInfo)
+            internal RemoteService(InteractiveHost host, Process process, int processId, JsonRpc jsonRpc, InteractiveHostPlatformInfo platformInfo, InteractiveHostOptions options)
             {
                 Process = process;
                 JsonRpc = jsonRpc;
                 PlatformInfo = platformInfo;
+                Options = options;
 
                 _host = host;
                 _joinOutputWritingThreadsOnDisposal = _host._joinOutputWritingThreadsOnDisposal;
@@ -99,19 +106,60 @@ namespace Microsoft.CodeAnalysis.Interactive
                 }
             }
 
+            private static char[] EncodeMarker(string ascii)
+            {
+                Debug.Assert(ascii.Length % 2 == 0);
+                return Encoding.Unicode.GetChars(Encoding.ASCII.GetBytes(ascii));
+            }
+
             private void ReadOutput(bool error)
             {
-                var buffer = new char[4096];
+                const int BaseLength = 4096;
+
+                // Workaround for https://github.com/dotnet/runtime/issues/45503.
+                // Whne the process terminates due to stack overflow the CLR prints out a message that is not correctly encoded to Unicode.
+                // Hence it will come out as ASCII bytes interpreted as UTF-16 characters.
+                // We detect known message text in the output stream and transcode it and the output that follows to Unicode.
+
+                var transcodingMarker = Options.Platform == InteractiveHostPlatform.Core ?
+                    s_unicodeAsciiTranscodingMarkerCore : s_unicodeAsciiTranscodingMarkerDesktop;
+
+                var buffer = new char[BaseLength + transcodingMarker.Length];
                 StreamReader reader = error ? Process.StandardError : Process.StandardOutput;
+                bool transcoding = false;
                 try
                 {
                     // loop until the output pipe is closed and has no more data (process is killed):
                     while (!reader.EndOfStream)
                     {
-                        int count = reader.Read(buffer, 0, buffer.Length);
-                        if (count == 0)
+                        int charsRead = reader.Read(buffer, 0, BaseLength);
+                        if (charsRead == 0)
                         {
                             break;
+                        }
+
+                        if (transcoding)
+                        {
+                            charsRead = Transcode(ref buffer, charsRead, 0);
+                        }
+                        else if (error)
+                        {
+                            int transcodingMarkerStart = Array.IndexOf(buffer, transcodingMarker[0], startIndex: 0, count: charsRead);
+                            if (transcodingMarkerStart >= 0)
+                            {
+                                int additionalCharsToRead = transcodingMarkerStart + transcodingMarker.Length - charsRead;
+                                if (additionalCharsToRead > 0)
+                                {
+                                    charsRead += ReadAll(reader, buffer, index: charsRead, length: additionalCharsToRead);
+                                }
+
+                                if (ArraysEqual(buffer, transcodingMarkerStart, transcodingMarker, 0, transcodingMarker.Length))
+                                {
+                                    // once we hit the marker we assume everything that follows is encoded:
+                                    charsRead = Transcode(ref buffer, charsRead, transcodingMarkerStart);
+                                    transcoding = true;
+                                }
+                            }
                         }
 
                         var localHost = _host;
@@ -120,13 +168,70 @@ namespace Microsoft.CodeAnalysis.Interactive
                             break;
                         }
 
-                        localHost.OnOutputReceived(error, buffer, count);
+                        localHost.OnOutputReceived(error, buffer, charsRead);
                     }
                 }
                 catch (Exception e)
                 {
                     Debug.WriteLine("InteractiveHostProcess: exception while reading output from process {0}: {1}", _processId, e.Message);
                 }
+            }
+
+            private static bool ArraysEqual(char[] left, int leftStart, char[] right, int rightStart, int length)
+            {
+                if (leftStart + length > left.Length || rightStart + length > right.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < length; i++)
+                {
+                    if (left[leftStart + i] != right[rightStart + i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            private static int Transcode(ref char[] buffer, int bufferLength, int start)
+            {
+                var newBufferLength = start + (bufferLength - start) * 2;
+                if (buffer.Length < newBufferLength)
+                {
+                    Array.Resize(ref buffer, newBufferLength);
+                }
+
+                for (int i = bufferLength - 1, j = newBufferLength - 2; i >= start; i--, j -= 2)
+                {
+                    var c = buffer[i];
+
+                    // Unicode is little endian:
+                    buffer[j] = (char)(c & 0x00ff);
+                    buffer[j + 1] = (char)(c >> 8);
+                }
+
+                return newBufferLength;
+            }
+
+            private static int ReadAll(StreamReader reader, char[] buffer, int index, int length)
+            {
+                var totalRead = 0;
+                while (!reader.EndOfStream && length > 0)
+                {
+                    var charsRead = reader.Read(buffer, index, length);
+                    if (charsRead == 0)
+                    {
+                        break;
+                    }
+
+                    totalRead += charsRead;
+                    index += charsRead;
+                    length -= charsRead;
+                }
+
+                return totalRead;
             }
 
             // Dispose may called anytime, on any thread.

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 try
                 {
-                    Console.OutputEncoding = Encoding.UTF8;
+                    Console.OutputEncoding = InteractiveHost.OutputEncoding;
                 }
                 catch (IOException ex) when (FatalError.ReportAndCatch(ex))
                 {

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
@@ -139,15 +139,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 _lastTask = Task.FromResult(initialState);
 
-                try
-                {
-                    Console.OutputEncoding = InteractiveHost.OutputEncoding;
-                }
-                catch (IOException ex) when (FatalError.ReportAndCatch(ex))
-                {
-                    // Ignore this exception
-                    // https://github.com/dotnet/roslyn/issues/47571
-                }
+                Console.OutputEncoding = OutputEncoding;
 
                 // We want to be sure to delete the shadow-copied files when the process goes away. Frankly
                 // there's nothing we can do if the process is forcefully quit or goes down in a completely

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
@@ -25,6 +25,14 @@ namespace Microsoft.CodeAnalysis.Interactive
     internal sealed partial class InteractiveHost : IDisposable
     {
         internal const InteractiveHostPlatform DefaultPlatform = InteractiveHostPlatform.Desktop32;
+
+        /// <summary>
+        /// Use Unicode encoding for STDOUT and STDERR of the InteractiveHost process.
+        /// Ideally, we would use UTF8 but SetConsoleOutputCP Windows API fails with "Invalid Handle" when Console.OutputEncoding is set to UTF8.
+        /// (issue tracked by https://github.com/dotnet/roslyn/issues/47571, https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1253106)
+        /// Unicode is not ideal since the message printed directly to STDOUT/STDERR from native code that do not encode the output are going to be garbled
+        /// (e.g. messages reported by CLR stack overflow and OOM exception handlers: https://github.com/dotnet/runtime/issues/45503).
+        /// </summary>
         internal static readonly Encoding OutputEncoding = Encoding.Unicode;
 
         private static readonly JsonRpcTargetOptions s_jsonRpcTargetOptions = new JsonRpcTargetOptions()

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -24,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Interactive
     internal sealed partial class InteractiveHost : IDisposable
     {
         internal const InteractiveHostPlatform DefaultPlatform = InteractiveHostPlatform.Desktop32;
+        internal static readonly Encoding OutputEncoding = Encoding.Unicode;
 
         private static readonly JsonRpcTargetOptions s_jsonRpcTargetOptions = new JsonRpcTargetOptions()
         {

--- a/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
+++ b/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
@@ -177,7 +177,7 @@ STDOUT: {_synchronizedOutput}
             var markPrefix = '\uFFFF';
             var mark = markPrefix + Guid.NewGuid().ToString();
 
-            await remoteService!.JsonRpc.InvokeAsync(nameof(InteractiveHost.Service.RemoteConsoleWriteAsync), Encoding.UTF8.GetBytes(mark), isError).ConfigureAwait(false);
+            await remoteService!.JsonRpc.InvokeAsync(nameof(InteractiveHost.Service.RemoteConsoleWriteAsync), InteractiveHost.OutputEncoding.GetBytes(mark), isError).ConfigureAwait(false);
             while (true)
             {
                 var data = writer.Prefix(mark, ref _outputReadPosition[isError ? 0 : 1]);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47571 and https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1231577.

It's not clear why using UTF8 does not work (issue https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1253106 is tracking further investigation) but it seems using `Unicode` does work. 
Except when the CLR reports stack overflow error message - it does not encode it properly (see https://github.com/dotnet/runtime/issues/45503).
To avoid printing garbled text we detect known CLR messages and transcode the output back to ASCII.
