### PR TITLE
Disable nint/nuint keyword recommendation in preprocessor directives

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/NativeIntegerKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/NativeIntegerKeywordRecommenderTests.cs
@@ -284,5 +284,11 @@ class C
 {
     delegate*$$");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInPreprecessorDirective()
+        {
+            await VerifyAbsenceAsync("#$$");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractNativeIntegerKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractNativeIntegerKeywordRecommender.cs
@@ -19,11 +19,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         private static bool IsValidContext(CSharpSyntaxContext context)
         {
-            if (context.IsPreProcessorDirectiveContext)
-            {
-                return false;
-            }
-
             if (context.IsStatementContext ||
                 context.IsGlobalStatementContext ||
                 context.IsPossibleTupleContext ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractNativeIntegerKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractNativeIntegerKeywordRecommender.cs
@@ -19,6 +19,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         private static bool IsValidContext(CSharpSyntaxContext context)
         {
+            if (context.IsPreProcessorDirectiveContext)
+            {
+                return false;
+            }
+
             if (context.IsStatementContext ||
                 context.IsGlobalStatementContext ||
                 context.IsPossibleTupleContext ||

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1954,15 +1954,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
         public static bool IsStatementContext(this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
         {
-#if false
             // we're in a statement if the thing that comes before allows for
             // statements to follow.  Or if we're on a just started identifier
             // in the first position where a statement can go.
-            if (syntaxTree.IsInPreprocessorDirectiveContext(position, cancellationToken))
+            if (syntaxTree.IsPreProcessorDirectiveContext(position, cancellationToken))
             {
                 return false;
             }
-#endif
 
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
@@ -1972,12 +1970,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
         public static bool IsGlobalStatementContext(this SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
         {
-#if false
-            if (syntaxTree.IsInPreprocessorDirectiveContext(position, cancellationToken))
+            if (syntaxTree.IsPreProcessorDirectiveContext(position, cancellationToken))
             {
                 return false;
             }
-#endif
 
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken)
                                   .GetPreviousTokenIfTouchingWord(position);


### PR DESCRIPTION
Disable `nint` and `nuint` keyword recommendation in preprocessor directive contexts.

The root issue was that the context was wrongly classified as a type context, and that came because it was classified as a global statement context (which a preprocessor directive context cannot be) if there were no using and extern directives in the syntax tree.  
The method `IsGlobalStatementContext` contained an old (and commented out) precondition check for preprocessor directive context; this check is now re-enabled.

Fixes #49743.

![image](https://user-images.githubusercontent.com/823398/100920332-3ebd2f00-34db-11eb-874c-9f185794b395.png)