### PR TITLE
Add better error info when pulling upstream -vs-deps fails.

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -106,8 +106,10 @@ stages:
           MasterValidationBuild
       condition: and(succeeded(), eq(variables['SourceBranchName'], 'master'))
 
-    - powershell: git pull origin master-vs-deps
+    - task: PowerShell@2
       displayName: Merge master-vs-deps into source branch
+      inputs:
+        filePath: 'scripts\merge-vs-deps.ps1'
       condition: and(succeeded(), eq(variables['SourceBranchName'], 'master'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"

--- a/scripts/merge-vs-deps.ps1
+++ b/scripts/merge-vs-deps.ps1
@@ -1,0 +1,6 @@
+git pull origin master-vs-deps
+if (-not $?)
+{
+    Write-Host "##vso[task.logissue type=error]Failed to merge master-vs-deps into source branch"
+    exit 1
+}


### PR DESCRIPTION
Example: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4268072&view=results

![image](https://user-images.githubusercontent.com/5749229/100925066-57efbc80-3496-11eb-9094-cfb347ef796a.png)
