### PR TITLE
Avoid sharing NullableWalker state between method and nested functions

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
@@ -59,6 +59,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return usages;
         }
 
+        protected bool HasAnyLocalFuncUsages => _localFuncVarUsages is object;
+
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement localFunc)
         {
             var oldSymbol = this.CurrentSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
@@ -59,8 +59,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return usages;
         }
 
-        protected bool HasAnyLocalFuncUsages => _localFuncVarUsages is object;
-
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement localFunc)
         {
             var oldSymbol = this.CurrentSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// A mapping from local variables to the index of their slot in a flow analysis local state.
         /// </summary>
-        protected readonly PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
+        protected PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
 
         /// <summary>
         /// A mapping from the local variable slot to the symbol for the local variable itself.  This

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7403,6 +7403,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 delegateInvokeMethod,
                 useDelegateInvokeParameterTypes,
                 ignoreAddedSlotsIfPossible: true);
+
+            _disableDiagnostics = oldDisableDiagnostics;
         }
 
         private static bool UseDelegateInvokeParameterTypes(BoundLambda lambda, MethodSymbol? delegateInvokeMethod)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2507,7 +2507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 state,
                 delegateInvokeMethod: null,
                 useDelegateInvokeParameterTypes: false,
-                ignoreAddedSlots: false);
+                ignoreAddedSlotsIfPossible: false);
 
             SetInvalidResult();
 
@@ -2520,7 +2520,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             LocalState state,
             MethodSymbol? delegateInvokeMethod,
             bool useDelegateInvokeParameterTypes,
-            bool ignoreAddedSlots)
+            bool ignoreAddedSlotsIfPossible)
         {
             var oldSymbol = this.CurrentSymbol;
             this.CurrentSymbol = lambdaOrFunctionSymbol;
@@ -2542,7 +2542,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var oldVariableBySlot = variableBySlot;
             var oldNextVariableSlot = nextVariableSlot;
 
-            if (ignoreAddedSlots)
+            if (ignoreAddedSlotsIfPossible)
             {
                 _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
                 foreach (var pair in oldVariableSlot)
@@ -2599,7 +2599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             _snapshotBuilderOpt?.ExitWalker(this.SaveSharedState(), previousSlot);
 
-            if (ignoreAddedSlots)
+            if (ignoreAddedSlotsIfPossible && !HasAnyLocalFuncUsages)
             {
                 nextVariableSlot = oldNextVariableSlot;
                 variableBySlot = oldVariableBySlot;
@@ -7402,8 +7402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initialState.HasValue ? initialState.Value : State.Clone(),
                 delegateInvokeMethod,
                 useDelegateInvokeParameterTypes,
-                ignoreAddedSlots: true);
-                useDelegateInvokeParameterTypes);
+                ignoreAddedSlotsIfPossible: true);
         }
 
         private static bool UseDelegateInvokeParameterTypes(BoundLambda lambda, MethodSymbol? delegateInvokeMethod)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -415,11 +415,14 @@ class Program
         [InlineData("class Program { static void F() { try { } finally { } } }", "F", false)]
         [InlineData("class Program { static void F() { label: F(); } }", "F", false)]
         [WorkItem(49745, "https://github.com/dotnet/roslyn/issues/49745")]
-        public void NullableState_IsSimpleMethod(string source, string methodName, bool expectedResult)
+        public void NullableState_IsSimpleMethod(string source, string methodName, bool expectedResult, bool ignoreDiagnostics = false)
         {
             var comp = CreateCompilation(source);
-            var diagnostics = comp.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
-            diagnostics.Verify();
+            if (!ignoreDiagnostics)
+            {
+                var diagnostics = comp.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
+                diagnostics.Verify();
+            }
             CheckIsSimpleMethod(comp, methodName, expectedResult);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -374,11 +374,11 @@ class Program
             comp.VerifyEmitDiagnostics();
         }
 
-        [ConditionalFactAttribute(typeof(IsRelease))]
+        [Fact]
         [WorkItem(49745, "https://github.com/dotnet/roslyn/issues/49745")]
         public void NullableStateLambdas()
         {
-            const int nFunctions = 5000;
+            const int nFunctions = 10000;
 
             var builder = new StringBuilder();
             builder.AppendLine("#nullable enable");
@@ -391,31 +391,6 @@ class Program
             {
                 builder.AppendLine($"        f = arg{i} => arg{i};");
                 builder.AppendLine($"        f(arg);");
-            }
-            builder.AppendLine("    }");
-            builder.AppendLine("}");
-
-            var source = builder.ToString();
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
-
-        [ConditionalFactAttribute(typeof(IsRelease))]
-        [WorkItem(49745, "https://github.com/dotnet/roslyn/issues/49745")]
-        public void NullableStateLocalFunctions()
-        {
-            const int nFunctions = 1000;
-
-            var builder = new StringBuilder();
-            builder.AppendLine("#nullable enable");
-            builder.AppendLine("class Program");
-            builder.AppendLine("{");
-            builder.AppendLine("    static void F(object x, object y)");
-            builder.AppendLine("    {");
-            for (int i = 0; i < nFunctions; i++)
-            {
-                builder.AppendLine($"        static void Local{i}(object x{i}, object y{i}) {{ }}");
-                builder.AppendLine($"        Local{i}(x, y);");
             }
             builder.AppendLine("    }");
             builder.AppendLine("}");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System.Linq;
@@ -384,13 +385,12 @@ class Program
             builder.AppendLine("#nullable enable");
             builder.AppendLine("class Program");
             builder.AppendLine("{");
-            builder.AppendLine("    static void F(object arg)");
+            builder.AppendLine("    static void F1(System.Func<object, object> f) { }");
+            builder.AppendLine("    static void F2(object arg)");
             builder.AppendLine("    {");
-            builder.AppendLine("        System.Func<object, object> f;");
             for (int i = 0; i < nFunctions; i++)
             {
-                builder.AppendLine($"        f = arg{i} => arg{i};");
-                builder.AppendLine($"        f(arg);");
+                builder.AppendLine($"        F1(arg{i} => arg{i});");
             }
             builder.AppendLine("    }");
             builder.AppendLine("}");
@@ -398,6 +398,51 @@ class Program
             var source = builder.ToString();
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
+
+            CheckIsSimpleMethod(comp, "F2", true);
+        }
+
+        [Theory]
+        [InlineData("class Program { static object F() => null; }", "F", true)]
+        [InlineData("class Program { static void F() { } }", "F", true)]
+        [InlineData("class Program { static void F() { { } { } { } } }", "F", true)]
+        [InlineData("class Program { static void F() { ;;; } }", "F", false)]
+        [InlineData("class Program { static void F2(System.Action a) { } static void F() { F2(() => { }); } }", "F", true)]
+        [InlineData("class Program { static void F() { void Local() { } } }", "F", false)]
+        [InlineData("class Program { static void F() { System.Action a = () => { }; } }", "F", false)]
+        [InlineData("class Program { static void F() { if (true) { } } }", "F", false)]
+        [InlineData("class Program { static void F() { while (true) { } } }", "F", false)]
+        [InlineData("class Program { static void F() { try { } finally { } } }", "F", false)]
+        [InlineData("class Program { static void F() { label: F(); } }", "F", false)]
+        [WorkItem(49745, "https://github.com/dotnet/roslyn/issues/49745")]
+        public void NullableState_IsSimpleMethod(string source, string methodName, bool expectedResult)
+        {
+            var comp = CreateCompilation(source);
+            var diagnostics = comp.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
+            diagnostics.Verify();
+            CheckIsSimpleMethod(comp, methodName, expectedResult);
+        }
+
+        private static void CheckIsSimpleMethod(CSharpCompilation comp, string methodName, bool expectedResult)
+        {
+            var tree = comp.SyntaxTrees[0];
+            var model = (CSharpSemanticModel)comp.GetSemanticModel(tree);
+            var methodDeclaration = tree.GetCompilationUnitRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ToString() == methodName);
+            var methodBody = methodDeclaration.Body;
+            BoundBlock block;
+            if (methodBody is { })
+            {
+                var binder = model.GetEnclosingBinder(methodBody.SpanStart);
+                block = binder.BindEmbeddedBlock(methodBody, new DiagnosticBag());
+            }
+            else
+            {
+                var expressionBody = methodDeclaration.ExpressionBody;
+                var binder = model.GetEnclosingBinder(expressionBody.SpanStart);
+                block = binder.BindExpressionBodyAsBlock(expressionBody, new DiagnosticBag());
+            }
+            var actualResult = NullableWalker.IsSimpleMethodVisitor.IsSimpleMethod(block);
+            Assert.Equal(expectedResult, actualResult);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -415,14 +415,11 @@ class Program
         [InlineData("class Program { static void F() { try { } finally { } } }", "F", false)]
         [InlineData("class Program { static void F() { label: F(); } }", "F", false)]
         [WorkItem(49745, "https://github.com/dotnet/roslyn/issues/49745")]
-        public void NullableState_IsSimpleMethod(string source, string methodName, bool expectedResult, bool ignoreDiagnostics = false)
+        public void NullableState_IsSimpleMethod(string source, string methodName, bool expectedResult)
         {
             var comp = CreateCompilation(source);
-            if (!ignoreDiagnostics)
-            {
-                var diagnostics = comp.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
-                diagnostics.Verify();
-            }
+            var diagnostics = comp.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
+            diagnostics.Verify();
             CheckIsSimpleMethod(comp, methodName, expectedResult);
         }
 


### PR DESCRIPTION
When analyzing a method in `NullableWalker`, avoid sharing `_variableTypes` and `_variableSlots` between that method and any lambdas or local functions. Currently, the parameters and locals for any nested functions are added to the `_variableTypes` and `_variableSlots` tables in the containing method, adding to the state tracked for containing method and any subsequent nested functions. If there are many nested functions, this can significantly increase the size of the tables that are tracked, particularly for the semantic model.

Fixes #49745