### PR TITLE
Use tfm net5.0-windows

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -345,6 +345,7 @@ function TestUsingRunTests() {
 
   if ($testCoreClr) {
     $args += " --tfm net5.0"
+    $args += " --tfm net5.0-windows"
     $args += " --tfm netcoreapp3.1"
     $args += " --include '\.UnitTests'"
     $args += " --timeout 90"


### PR DESCRIPTION
Just tinkering to try and figure out how we dropped runs of ~7,000 tests recently.