### PR TITLE
Remove unnecessary parens when converting switch statement ot expression

### DIFF
--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionFixAllTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionFixAllTests.cs
@@ -2,18 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using VerifyCS = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.CSharpCodeFixVerifier<
-    Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression.ConvertSwitchStatementToExpressionDiagnosticAnalyzer,
-    Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression.ConvertSwitchStatementToExpressionCodeFixProvider>;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertSwitchStatementToExpression
 {
+    using VerifyCS = CSharpCodeFixVerifier<
+        ConvertSwitchStatementToExpressionDiagnosticAnalyzer,
+        ConvertSwitchStatementToExpressionCodeFixProvider>;
+
     public class ConvertSwitchStatementToExpressionFixAllTests
     {
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
@@ -258,7 +259,7 @@ class Program
     public short Value => 0;
     public bool ValueBoolean()
     {
-        var value = (StatusValue()) switch
+        var value = StatusValue() switch
         {
             DayOfWeek.Monday => Value switch
             {
@@ -306,7 +307,7 @@ class C
     
     public bool method(C c)
     {
-        return ((string)c) switch
+        return (string)c switch
         {
             ""A"" => true,
             _ => false,

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -2008,6 +2006,60 @@ class Program
                 FixedCode = fixedCode,
                 LanguageVersion = CSharp9,
             }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        [WorkItem(49788, "https://github.com/dotnet/roslyn/issues/49788")]
+        public async Task TestParenthesizedExpression1()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"class Program
+{
+    int M(object i)
+    {
+        [|switch|] (i.GetType())
+        {
+            default: return 0;
+        }
+    }
+}",
+@"class Program
+{
+    int M(object i)
+    {
+        return i.GetType() switch
+        {
+            _ => 0,
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        [WorkItem(49788, "https://github.com/dotnet/roslyn/issues/49788")]
+        public async Task TestParenthesizedExpression2()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"class Program
+{
+    int M()
+    {
+        [|switch|] (1 + 1)
+        {
+            default: return 0;
+        }
+    }
+}",
+@"class Program
+{
+    int M()
+    {
+        return (1 + 1) switch
+        {
+            _ => 0,
+        };
+    }
+}");
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -809,6 +809,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                     return OperatorPrecedence.AssignmentAndLambdaExpression;
 
+                case SyntaxKind.SwitchExpression:
+                    return OperatorPrecedence.Switch;
+
                 default:
                     return OperatorPrecedence.None;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/OperatorPrecedence.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/OperatorPrecedence.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         Shift,
         Additive,
         Multiplicative,
+        Switch,
         Range,
         Unary,
         Primary


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49788