### PR TITLE
Optimize IOperation.Children Implementation

### DIFF
--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     IOperation operation,
                     (ImmutableDictionary<IFlowAnonymousFunctionOperation, (ControlFlowRegion region, int ordinal)>.Builder map, ControlFlowRegion region) argument)
                 {
-                    foreach (IOperation child in operation.Children)
+                    foreach (IOperation child in ((Operation)operation).ChildOperations)
                     {
                         Visit(child, argument);
                     }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6254,14 +6254,14 @@ oneMoreTime:
         private IOperation VisitNoneOperationStatement(IOperation operation)
         {
             Debug.Assert(_currentStatement == operation);
-            VisitStatements(operation.Children.ToImmutableArray());
+            VisitStatements(((Operation)operation).ChildOperations.ToImmutableArray());
             return new NoneOperation(ImmutableArray<IOperation>.Empty, semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
         private IOperation VisitNoneOperationExpression(IOperation operation)
         {
             return PopStackFrame(PushStackFrame(),
-                                 new NoneOperation(VisitArray(operation.Children.ToImmutableArray()), semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation)));
+                                 new NoneOperation(VisitArray(((Operation)operation).ChildOperations.ToImmutableArray()), semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation)));
         }
 
         public override IOperation VisitInterpolatedString(IInterpolatedStringOperation operation, int? captureIdForResult)
@@ -6683,7 +6683,7 @@ oneMoreTime:
         public override IOperation VisitInvalid(IInvalidOperation operation, int? captureIdForResult)
         {
             var children = ArrayBuilder<IOperation>.GetInstance();
-            children.AddRange(operation.Children);
+            children.AddRange(((InvalidOperation)operation).Children);
 
             if (children.Count != 0 && children.Last().Kind == OperationKind.ObjectOrCollectionInitializer)
             {

--- a/src/Compilers/Core/Portable/Operations/Operation.Enumerable.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.Enumerable.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections;
+using System;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal abstract partial class Operation : IOperation
+    {
+        /// <summary>
+        /// Implements a struct-based enumerable for <see cref="Operation"/> nodes, using a slot-based system that tracks
+        /// the current slot, and the current index in the slot if the current slot is an immutable array. This type is not hardened
+        /// to <code>default(Enumerable)</code>, and will null reference in these cases.
+        /// </summary>
+        [NonDefaultable]
+        internal readonly struct Enumerable : IEnumerable<IOperation>
+        {
+            private readonly Operation _operation;
+
+            internal Enumerable(Operation operation)
+            {
+                _operation = operation;
+            }
+
+            public Enumerator GetEnumerator() => new Enumerator(_operation);
+
+            public ImmutableArray<IOperation> ToImmutableArray()
+            {
+                switch (_operation)
+                {
+                    case NoneOperation { Children: var children }:
+                        return children;
+                    case InvalidOperation { Children: var children }:
+                        return children;
+                    case var _ when !GetEnumerator().MoveNext():
+                        return ImmutableArray<IOperation>.Empty;
+                    default:
+                        var builder = ArrayBuilder<IOperation>.GetInstance();
+                        foreach (var child in this)
+                        {
+                            builder.Add(child);
+                        }
+                        return builder.ToImmutableAndFree();
+                }
+            }
+
+            IEnumerator<IOperation> IEnumerable<IOperation>.GetEnumerator() => this.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Implements a struct-based enumerator for <see cref="Operation"/> nodes, using a slot-based system that tracks
+        /// the current slot, and the current index in the slot if the current slot is an immutable array. This type is not hardened
+        /// to <code>default(Enumerator)</code>, and will null reference in these cases. Implementation of the <see cref="Enumerator.MoveNext"/>
+        /// and <see cref="Enumerator.Current"/> members are delegated to the virtual <see cref="Operation.MoveNext(int, int)"/> and
+        /// <see cref="Operation.GetCurrent(int, int)"/> methods, respectively. Calling <see cref="Current"/> after
+        /// <see cref="Enumerator.MoveNext"/> has returned false will throw an <see cref="InvalidOperationException"/>.
+        /// </summary>
+        [NonDefaultable]
+        internal struct Enumerator : IEnumerator<IOperation>
+        {
+            private readonly Operation _operation;
+            private int _currentSlot;
+            private int _currentIndex;
+
+            public Enumerator(Operation operation)
+            {
+                _operation = operation;
+                _currentSlot = -1;
+                _currentIndex = -1;
+            }
+
+            public IOperation Current
+            {
+                get
+                {
+                    Debug.Assert(_operation != null && _currentSlot >= 0 && _currentIndex >= 0);
+                    return _operation.GetCurrent(_currentSlot, _currentIndex);
+                }
+            }
+
+            public bool MoveNext()
+            {
+                bool result;
+                (result, _currentSlot, _currentIndex) = _operation.MoveNext(_currentSlot, _currentIndex);
+                return result;
+            }
+
+            void IEnumerator.Reset()
+            {
+                _currentSlot = -1;
+                _currentIndex = -1;
+            }
+
+            object? IEnumerator.Current => this.Current;
+            void IDisposable.Dispose() { }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Roslyn.Utilities;
@@ -19,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         internal override IOperation VisitNoneOperation(IOperation operation, object? argument)
         {
-            return new NoneOperation(VisitArray(operation.Children.ToImmutableArray()), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
+            return new NoneOperation(VisitArray(((Operation)operation).ChildOperations.ToImmutableArray()), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
         public override IOperation VisitFlowAnonymousFunction(IFlowAnonymousFunctionOperation operation, object? argument)
@@ -45,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         public override IOperation VisitInvalid(IInvalidOperation operation, object? argument)
         {
-            return new InvalidOperation(VisitArray(operation.Children.ToImmutableArray()), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
+            return new InvalidOperation(VisitArray(((InvalidOperation)operation).Children), ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.Type, operation.GetConstantValue(), operation.IsImplicit);
         }
 
         public override IOperation VisitFlowCapture(IFlowCaptureOperation operation, object? argument)

--- a/src/Compilers/Core/Portable/Operations/OperationExtensions.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationExtensions.cs
@@ -85,8 +85,8 @@ namespace Microsoft.CodeAnalysis.Operations
                 yield return operation;
             }
 
-            var stack = ArrayBuilder<IEnumerator<IOperation>>.GetInstance();
-            stack.Push(operation.Children.GetEnumerator());
+            var stack = ArrayBuilder<Operation.Enumerator>.GetInstance();
+            stack.Push(((Operation)operation).ChildOperations.GetEnumerator());
 
             while (stack.Any())
             {
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 if (current != null)
                 {
                     yield return current;
-                    stack.Push(current.Children.GetEnumerator());
+                    stack.Push(((Operation)current).ChildOperations.GetEnumerator());
                 }
             }
 

--- a/src/Compilers/Core/Portable/Operations/OperationWalker.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationWalker.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>
@@ -14,17 +12,12 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private int _recursionDepth;
 
-        internal void VisitArray<T>(IEnumerable<T> operations) where T : IOperation
+        private void VisitChildOperations(IOperation operation)
         {
-            foreach (var operation in operations)
+            foreach (var child in ((Operation)operation).ChildOperations)
             {
-                VisitOperationArrayElement(operation);
+                Visit(child);
             }
-        }
-
-        internal void VisitOperationArrayElement<T>(T operation) where T : IOperation
-        {
-            Visit(operation);
         }
 
         public override void Visit(IOperation? operation)
@@ -46,12 +39,12 @@ namespace Microsoft.CodeAnalysis.Operations
 
         public override void DefaultVisit(IOperation operation)
         {
-            VisitArray(operation.Children);
+            VisitChildOperations(operation);
         }
 
         internal override void VisitNoneOperation(IOperation operation)
         {
-            VisitArray(operation.Children);
+            VisitChildOperations(operation);
         }
     }
 
@@ -63,17 +56,12 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private int _recursionDepth;
 
-        internal void VisitArray<T>(IEnumerable<T> operations, TArgument argument) where T : IOperation
+        private void VisitChildrenOperations(IOperation operation, TArgument argument)
         {
-            foreach (var operation in operations)
+            foreach (var child in ((Operation)operation).ChildOperations)
             {
-                VisitOperationArrayElement(operation, argument);
+                Visit(child, argument);
             }
-        }
-
-        internal void VisitOperationArrayElement<T>(T operation, TArgument argument) where T : IOperation
-        {
-            Visit(operation, argument);
         }
 
         public override object? Visit(IOperation? operation, TArgument argument)
@@ -97,13 +85,13 @@ namespace Microsoft.CodeAnalysis.Operations
 
         public override object? DefaultVisit(IOperation operation, TArgument argument)
         {
-            VisitArray(operation.Children, argument);
+            VisitChildrenOperations(operation, argument);
             return null;
         }
 
         internal override object? VisitNoneOperation(IOperation operation, TArgument argument)
         {
-            VisitArray(operation.Children, argument);
+            VisitChildrenOperations(operation, argument);
             return null;
         }
     }

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private void VisitArray<T>(ImmutableArray<T> list, string header, bool logElementCount, bool logNullForDefault = false)
             where T : IOperation
         {
-            VisitArrayCommon(list, header, logElementCount, logNullForDefault, VisitOperationArrayElement);
+            VisitArrayCommon(list, header, logElementCount, logNullForDefault, o => Visit(o));
         }
 
         private void VisitArray(ImmutableArray<ISymbol> list, string header, bool logElementCount, bool logNullForDefault = false)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.Verifier.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.Verifier.cs
@@ -51,6 +51,15 @@ namespace IOperationGenerator
                     }
                 }
 
+                foreach (var prop in GetAllGeneratedIOperationProperties(abstractNode))
+                {
+                    if (IsImmutableArray(prop.Type, out _) && prop.Type.Contains("?"))
+                    {
+                        Console.WriteLine($"{abstractNode.Name}.{prop.Name} has nullable IOperation elements. This is not allowed in IOperation and will mess up Children generation.");
+                        error = true;
+                    }
+                }
+
                 if (!(abstractNode is Node node))
                     continue;
                 if (node.SkipChildrenGeneration || node.SkipClassGeneration)


### PR DESCRIPTION
Optimizes the implemention of IOperation.Children by using a struct enumerable/enumerator internally, with slot/index tracking, and exposing this as ChildOperations on Operation internally. Uses of IOperation.Children in internal compiler code such as Descendents() and OperationWalker have been updated to use this new property, making significant improvements to memory usage. I've taken some benchmarks with 3 different scenarios:

1. master (2766389028b)
2. old-children. This uses the same Children implementation as master, but otherwise uses the new non-lazy generation in features/ioperation.
3. better-children. This is the implementation of Children in this branch.

### AnalyzerRunner Results

Note: times are somewhat variable. I've run the benchmarks a few times and while on the whole ms taken does appear to be improved, I can't say it has with statistic certainty. Memory usage, on the other hand, is much more deterministic, and I can confidently say that we save a few GBs of allocations. This run was performed using Microsoft.CodeAnalysis.Analyzers (which is heavily IOperation-based).

**branch**|** time**|** bytes allocated**
:-----:|:-----:|:-----:
master (2766389028b)| 536240ms|123,258,378,656
old-children| 538872ms|122,012,083,264
better-children| 526784ms|119,468,190,816

### dotnet/performance Roslyn Benchmarks

The main benchmark to pay attention to here is GetDiagnosticsWithAnalyzers, but I included the rest for completeness. There's not a clear-cut win in terms of execution times, but there is nearly 100MB saved in memory usage in our bench.

#### master

|                      Method |        Job | UnrollFactor |        Mean |     Error |    StdDev |      Median |         Min |         Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |----------- |------------- |------------:|----------:|----------:|------------:|------------:|------------:|------------:|-----------:|----------:|----------:|
|       CompileMethodsAndEmit | Job-ZZBXBK |           16 |  5,243.7 ms | 103.96 ms | 289.79 ms |  5,175.5 ms |  4,906.4 ms |  6,126.8 ms |  82000.0000 | 23000.0000 |         - |    497 MB |
|           SerializeMetadata | Job-ZZBXBK |           16 |    320.2 ms |   3.17 ms |   5.64 ms |    319.3 ms |    308.5 ms |    334.6 ms |   4000.0000 |  1000.0000 |         - |     34 MB |
|              GetDiagnostics | Job-KZXNEV |            1 |  4,314.1 ms |  97.91 ms | 287.16 ms |  4,209.7 ms |  3,901.5 ms |  5,160.1 ms |  73000.0000 | 21000.0000 |         - |    379 MB |
| GetDiagnosticsWithAnalyzers | Job-KZXNEV |            1 | 11,486.9 ms | 112.89 ms | 120.79 ms | 11,496.5 ms | 11,295.6 ms | 11,695.0 ms | 202000.0000 | 59000.0000 | 1000.0000 |  1,215 MB |

#### old-children

|                      Method |        Job | UnrollFactor |        Mean |    Error |    StdDev |      Median |         Min |         Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |----------- |------------- |------------:|---------:|----------:|------------:|------------:|------------:|------------:|-----------:|----------:|----------:|
|       CompileMethodsAndEmit | Job-XXOYTR |           16 |  5,047.9 ms | 34.00 ms |  31.81 ms |  5,040.0 ms |  4,992.4 ms |  5,097.3 ms |  82000.0000 | 24000.0000 |         - |    497 MB |
|           SerializeMetadata | Job-XXOYTR |           16 |    325.8 ms |  2.97 ms |   5.13 ms |    324.6 ms |    317.4 ms |    338.2 ms |   3000.0000 |  1000.0000 |         - |     34 MB |
|              GetDiagnostics | Job-QCCYOV |            1 |  3,708.4 ms | 29.22 ms |  24.40 ms |  3,704.9 ms |  3,669.2 ms |  3,765.8 ms |  73000.0000 | 17000.0000 |         - |    378 MB |
| GetDiagnosticsWithAnalyzers | Job-QCCYOV |            1 | 11,112.4 ms | 99.31 ms | 135.93 ms | 11,096.5 ms | 10,884.7 ms | 11,436.8 ms | 195000.0000 | 55000.0000 | 1000.0000 |  1,178 MB |

#### better-children

|                      Method |        Job | UnrollFactor |        Mean |     Error |    StdDev |      Median |         Min |         Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |----------- |------------- |------------:|----------:|----------:|------------:|------------:|------------:|------------:|-----------:|----------:|----------:|
|       CompileMethodsAndEmit | Job-UBJCRB |           16 |  5,113.7 ms |  40.92 ms |  34.17 ms |  5,097.6 ms |  5,078.3 ms |  5,198.1 ms |  81000.0000 | 22000.0000 |         - |    497 MB |
|           SerializeMetadata | Job-UBJCRB |           16 |    336.1 ms |   3.67 ms |  10.71 ms |    335.6 ms |    315.6 ms |    365.7 ms |   4000.0000 |  1000.0000 |         - |     34 MB |
|              GetDiagnostics | Job-OIOLXP |            1 |  3,768.2 ms |  23.62 ms |  20.94 ms |  3,765.4 ms |  3,741.8 ms |  3,821.4 ms |  72000.0000 | 19000.0000 |         - |    378 MB |
| GetDiagnosticsWithAnalyzers | Job-OIOLXP |            1 | 11,328.5 ms | 113.10 ms | 121.01 ms | 11,317.0 ms | 11,155.9 ms | 11,573.5 ms | 193000.0000 | 60000.0000 | 2000.0000 |  1,156 MB |

### RPS

A test insertion with this payload is [here](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/291438). The DDRIT failures are unrelated, and a fix is being merged into dotnet/roslyn shortly.
