### PR TITLE
Support global analyzer config levels:

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12968,11 +12968,13 @@ class C
             var analyzerConfigFile = dir.CreateFile(".globalconfig");
             var analyzerConfig = analyzerConfigFile.WriteAllText(@"
 is_global = true
+global_level = 100
 option1 = abc");
 
             var analyzerConfigFile2 = dir.CreateFile(".globalconfig2");
             var analyzerConfig2 = analyzerConfigFile2.WriteAllText(@"
 is_global = true
+global_level = 100
 option1 = def");
 
             var output = VerifyOutput(dir, src, additionalFlags: new[] { "/analyzerconfig:" + analyzerConfig.Path + "," + analyzerConfig2.Path }, expectedWarningCount: 1, includeCurrentAssemblyAsAnalyzerReference: false);
@@ -12985,11 +12987,13 @@ option1 = def");
 
             analyzerConfig = analyzerConfigFile.WriteAllText(@"
 is_global = true
+global_level = 100
 [/file.cs]
 option1 = abc");
 
             analyzerConfig2 = analyzerConfigFile2.WriteAllText(@"
 is_global = true
+global_level = 100
 [/file.cs]
 option1 = def");
 

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2192,11 +2192,9 @@ is_global = true
         }
 
         [Fact]
-        public void GlobalLevelCanBeReadFromConfig()
+        public void GlobalLevelCanBeReadFromAnyConfig()
         {
-            var config = Parse("global_level = 5", "/.globalconfig");
-
-            Assert.True(config.IsGlobal);
+            var config = Parse("global_level = 5", "/.editorconfig");
             Assert.Equal(5, config.GlobalLevel);
         }
 
@@ -2207,6 +2205,15 @@ is_global = true
 
             Assert.True(config.IsGlobal);
             Assert.Equal(100, config.GlobalLevel);
+        }
+
+        [Fact]
+        public void GlobalLevelCanBeOverriddenForUserGlobalConfigs()
+        {
+            var config = Parse("global_level = 5", "/" + AnalyzerConfig.UserGlobalConfigName);
+
+            Assert.True(config.IsGlobal);
+            Assert.Equal(5, config.GlobalLevel);
         }
 
         [Fact]
@@ -2402,6 +2409,22 @@ option1 = value6",
             configs.Free();
         }
 
+        [Fact]
+        public void InvalidGlobalLevelIsIgnored()
+        {
+            var userGlobalConfig = Parse($@"
+is_global = true
+global_level = abc
+", "/.globalconfig");
+
+            var nonUserGlobalConfig = Parse($@"
+is_global = true
+global_level = abc
+", "/.editorconfig");
+
+            Assert.Equal(100, userGlobalConfig.GlobalLevel);
+            Assert.Equal(0, nonUserGlobalConfig.GlobalLevel);
+        }
 
         #endregion
     }

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2201,7 +2201,7 @@ is_global = true
         [Fact]
         public void GlobalLevelDefaultsTo100ForUserGlobalConfigs()
         {
-            var config = Parse("", "/"+AnalyzerConfig.UserGlobalConfigName);
+            var config = Parse("", "/" + AnalyzerConfig.UserGlobalConfigName);
 
             Assert.True(config.IsGlobal);
             Assert.Equal(100, config.GlobalLevel);

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2185,6 +2185,7 @@ is_global = true
         [InlineData("/path/to/globalconfig", false)]
         [InlineData("/path/to/my.globalconfig", false)]
         [InlineData("/.editorconfig", false)]
+        [InlineData("/.globalconfİg", false)]
         public void FileNameCausesConfigToBeReportedAsGlobal(string fileName, bool shouldBeTreatedAsGlobal)
         {
             var config = Parse("", fileName);

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2175,6 +2175,234 @@ is_global = true
         public void GlobalConfigIssuesWarningWithInvalidSectionNames_PlatformSpecific(string sectionName, bool isValidWindows, bool isValidOther)
             => GlobalConfigIssuesWarningWithInvalidSectionNames(sectionName, ExecutionConditionUtil.IsWindows ? isValidWindows : isValidOther);
 
+        [Theory]
+        [InlineData("/.globalconfig", true)]
+        [InlineData("/.GLOBALCONFIG", true)]
+        [InlineData("/.glObalConfiG", true)]
+        [InlineData("/path/to/.globalconfig", true)]
+        [InlineData("/my.globalconfig", false)]
+        [InlineData("/globalconfig", false)]
+        [InlineData("/path/to/globalconfig", false)]
+        [InlineData("/path/to/my.globalconfig", false)]
+        [InlineData("/.editorconfig", false)]
+        public void FileNameCausesConfigToBeReportedAsGlobal(string fileName, bool shouldBeTreatedAsGlobal)
+        {
+            var config = Parse("", fileName);
+            Assert.Equal(shouldBeTreatedAsGlobal, config.IsGlobal);
+        }
+
+        [Fact]
+        public void GlobalLevelCanBeReadFromConfig()
+        {
+            var config = Parse("global_level = 5", "/.globalconfig");
+
+            Assert.True(config.IsGlobal);
+            Assert.Equal(5, config.GlobalLevel);
+        }
+
+        [Fact]
+        public void GlobalLevelDefaultsTo100ForUserGlobalConfigs()
+        {
+            var config = Parse("", "/"+AnalyzerConfig.UserGlobalConfigName);
+
+            Assert.True(config.IsGlobal);
+            Assert.Equal(100, config.GlobalLevel);
+        }
+
+        [Fact]
+        public void GlobalLevelDefaultsToZeroForNonUserGlobalConfigs()
+        {
+            var config = Parse("is_global = true", "/.nugetconfig");
+
+            Assert.True(config.IsGlobal);
+            Assert.Equal(0, config.GlobalLevel);
+        }
+
+        [Fact]
+        public void GlobalLevelIsNotPresentInConfigSet()
+        {
+            var config = Parse("global_level = 123", "/.globalconfig");
+
+            var set = AnalyzerConfigSet.Create(ImmutableArray.Create(config));
+            var globalOptions = set.GlobalConfigOptions;
+
+            Assert.Empty(globalOptions.AnalyzerOptions);
+            Assert.Empty(globalOptions.TreeOptions);
+            Assert.Empty(globalOptions.Diagnostics);
+        }
+
+        [Fact]
+        public void GlobalLevelInSectionIsPresentInConfigSet()
+        {
+            var config = Parse(@"
+[/path]
+global_level = 123", "/.globalconfig");
+
+            var set = AnalyzerConfigSet.Create(ImmutableArray.Create(config));
+            var globalOptions = set.GlobalConfigOptions;
+
+            Assert.Empty(globalOptions.AnalyzerOptions);
+            Assert.Empty(globalOptions.TreeOptions);
+            Assert.Empty(globalOptions.Diagnostics);
+
+            var sectionOptions = set.GetOptionsForSourcePath("/path");
+
+            Assert.Single(sectionOptions.AnalyzerOptions);
+            Assert.Equal("123", sectionOptions.AnalyzerOptions["global_level"]);
+            Assert.Empty(sectionOptions.TreeOptions);
+            Assert.Empty(sectionOptions.Diagnostics);
+        }
+
+        [Theory]
+        [InlineData(1, 2)]
+        [InlineData(2, 1)]
+        [InlineData(-2, -1)]
+        [InlineData(2, -1)]
+        public void GlobalLevelAllowsOverrideOfGlobalKeys(int level1, int level2)
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse($@"
+is_global = true
+global_level = {level1}
+option1 = value1
+", "/.globalconfig1"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = {level2}
+option1 = value2",
+"/.globalconfig2"));
+
+            var globalConfig = AnalyzerConfigSet.MergeGlobalConfigs(configs, out var diagnostics);
+            diagnostics.Verify();
+
+            Assert.Single(globalConfig.GlobalSection.Properties.Keys, "option1");
+
+            string expectedValue = level1 > level2 ? "value1" : "value2";
+            Assert.Single(globalConfig.GlobalSection.Properties.Values, expectedValue);
+
+            configs.Free();
+        }
+
+        [Fact]
+        public void GlobalLevelAllowsOverrideOfSectionKeys()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+is_global = true
+global_level = 1
+
+[/path]
+option1 = value1
+", "/.globalconfig1"));
+
+            configs.Add(Parse(@"
+is_global = true
+global_level = 2
+
+[/path]
+option1 = value2",
+"/.globalconfig2"));
+
+            var globalConfig = AnalyzerConfigSet.MergeGlobalConfigs(configs, out var diagnostics);
+            diagnostics.Verify();
+
+            Assert.Single(globalConfig.NamedSections);
+            Assert.Equal("/path", globalConfig.NamedSections[0].Name);
+            Assert.Single(globalConfig.NamedSections[0].Properties.Keys, "option1");
+            Assert.Single(globalConfig.NamedSections[0].Properties.Values, "value2");
+
+            configs.Free();
+        }
+
+        [Theory]
+        [InlineData(1, 2, 3, "value3")]
+        [InlineData(2, 1, 3, "value3")]
+        [InlineData(3, 2, 1, "value1")]
+        [InlineData(1, 2, 1, "value2")]
+        [InlineData(1, 1, 2, "value3")]
+        [InlineData(2, 1, 1, "value1")]
+        public void GlobalLevelAllowsOverrideOfDuplicateGlobalKeys(int level1, int level2, int level3, string expectedValue)
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse($@"
+is_global = true
+global_level = {level1}
+option1 = value1
+", "/.globalconfig1"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = {level2}
+option1 = value2",
+"/.globalconfig2"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = {level3}
+option1 = value3",
+"/.globalconfig3"));
+
+            var globalConfig = AnalyzerConfigSet.MergeGlobalConfigs(configs, out var diagnostics);
+            diagnostics.Verify();
+
+            Assert.Single(globalConfig.GlobalSection.Properties.Keys, "option1");
+            Assert.Single(globalConfig.GlobalSection.Properties.Values, expectedValue);
+
+            configs.Free();
+        }
+
+        [Fact]
+        public void GlobalLevelReportsConflictsOnlyAtTheHighestLevel()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse($@"
+is_global = true
+global_level = 1
+option1 = value1
+", "/.globalconfig1"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = 1
+option1 = value2",
+"/.globalconfig2"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = 3
+option1 = value3",
+"/.globalconfig3"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = 3
+option1 = value4",
+"/.globalconfig4"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = 2
+option1 = value5",
+"/.globalconfig5"));
+
+            configs.Add(Parse($@"
+is_global = true
+global_level = 2
+option1 = value6",
+"/.globalconfig6"));
+
+            var globalConfig = AnalyzerConfigSet.MergeGlobalConfigs(configs, out var diagnostics);
+
+            // we don't report config1, 2, 5, or 6, because they didn't conflict: 3 + 4 overrode them, but then themselves were conflicting
+            diagnostics.Verify(
+                Diagnostic("MultipleGlobalAnalyzerKeys").WithArguments("option1", "Global Section", "/.globalconfig3, /.globalconfig4").WithLocation(1, 1)
+                );
+
+            configs.Free();
+        }
+
+
         #endregion
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal readonly bool _hasGlobalFileName;
+        private readonly bool _hasGlobalFileName;
 
         private AnalyzerConfig(
             Section globalSection,

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets whether this editorconfig is a global editorconfig.
         /// </summary>
-        internal bool IsGlobal => IsGlobalFileName(this.PathToFile) || GlobalSection.Properties.ContainsKey(GlobalKey);
+        internal bool IsGlobal => _hasGlobalFileName || GlobalSection.Properties.ContainsKey(GlobalKey);
 
         /// <summary>
         /// Get the global level of this config, used to resolve conflicting keys
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     return level;
                 }
-                else if (IsGlobalFileName(this.PathToFile))
+                else if (_hasGlobalFileName)
                 {
                     return 100;
                 }
@@ -134,6 +134,8 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        internal readonly bool _hasGlobalFileName;
+
         private AnalyzerConfig(
             Section globalSection,
             ImmutableArray<Section> namedSections,
@@ -142,6 +144,7 @@ namespace Microsoft.CodeAnalysis
             GlobalSection = globalSection;
             NamedSections = namedSections;
             PathToFile = pathToFile;
+            _hasGlobalFileName = Path.GetFileName(pathToFile).Equals(UserGlobalConfigName, StringComparison.OrdinalIgnoreCase);
 
             // Find the containing directory and normalize the path separators
             string directory = Path.GetDirectoryName(pathToFile) ?? pathToFile;
@@ -263,8 +266,6 @@ namespace Microsoft.CodeAnalysis
 
             return false;
         }
-
-        private static bool IsGlobalFileName(string fileName) => Path.GetFileName(fileName).Equals(UserGlobalConfigName, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Represents a named section of the editorconfig file, which consists of a name followed by a set

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis
         ///     </description></item>
         ///  </list>
         ///  
-        /// This value is unsued when <see cref="IsGlobal"/> is <c>false</c>;
+        /// This value is unused when <see cref="IsGlobal"/> is <c>false</c>.
         /// </remarks>
         internal int GlobalLevel
         {

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis
                     if ((!keyInSection && !keyDuplicated)   // this key is neither present nor a duplicate, we can add it
                         || (keyInSection && sectionDict[key].globalLevel < globalLevel) // this key should override the existing section one
                         || (keyDuplicated && duplicateDict![key].globalLevel < globalLevel)) // this key should override previous duplicates
-                    { 
+                    {
                         sectionDict[key] = (value, configPath, globalLevel);
 
                         if (keyDuplicated)
@@ -595,7 +595,7 @@ namespace Microsoft.CodeAnalysis
                             duplicateDict!.Remove(key);
                         }
                     }
-                    else if((keyDuplicated && duplicateDict![key].globalLevel == globalLevel)  // this key is another duplicate at the same level
+                    else if ((keyDuplicated && duplicateDict![key].globalLevel == globalLevel) // this key is another duplicate at the same level
                             || (keyInSection && sectionDict[key].globalLevel == globalLevel)) // this key is a duplicate of a current section key
                     {
                         if (duplicateDict is null)

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -605,7 +605,7 @@ namespace Microsoft.CodeAnalysis
                             }
                         }
                         // this key conflicts with a previous one
-                        else if(currentGlobalLevel == globalLevel)
+                        else if (currentGlobalLevel == globalLevel)
                         {
                             if (duplicateDict is null)
                             {

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -481,8 +481,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal struct GlobalAnalyzerConfigBuilder
         {
-            private ImmutableDictionary<string, ImmutableDictionary<string, (string value, string configPath)>.Builder>.Builder? _values;
-            private ImmutableDictionary<string, ImmutableDictionary<string, ArrayBuilder<string>>.Builder>.Builder? _duplicates;
+            private ImmutableDictionary<string, ImmutableDictionary<string, (string value, string configPath, int globalLevel)>.Builder>.Builder? _values;
+            private ImmutableDictionary<string, ImmutableDictionary<string, (int globalLevel, ArrayBuilder<string> configPaths)>.Builder>.Builder? _duplicates;
 
             internal const string GlobalConfigPath = "<Global Config>";
             internal const string GlobalSectionName = "Global Section";
@@ -491,16 +491,16 @@ namespace Microsoft.CodeAnalysis
             {
                 if (_values is null)
                 {
-                    _values = ImmutableDictionary.CreateBuilder<string, ImmutableDictionary<string, (string, string)>.Builder>(Section.NameEqualityComparer);
-                    _duplicates = ImmutableDictionary.CreateBuilder<string, ImmutableDictionary<string, ArrayBuilder<string>>.Builder>(Section.NameEqualityComparer);
+                    _values = ImmutableDictionary.CreateBuilder<string, ImmutableDictionary<string, (string, string, int)>.Builder>(Section.NameEqualityComparer);
+                    _duplicates = ImmutableDictionary.CreateBuilder<string, ImmutableDictionary<string, (int, ArrayBuilder<string>)>.Builder>(Section.NameEqualityComparer);
                 }
 
-                MergeSection(config.PathToFile, config.GlobalSection, isGlobalSection: true);
+                MergeSection(config.PathToFile, config.GlobalSection, config.GlobalLevel, isGlobalSection: true);
                 foreach (var section in config.NamedSections)
                 {
                     if (IsAbsoluteEditorConfigPath(section.Name))
                     {
-                        MergeSection(config.PathToFile, section, isGlobalSection: false);
+                        MergeSection(config.PathToFile, section, config.GlobalLevel, isGlobalSection: false);
                     }
                     else
                     {
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     bool isGlobalSection = string.IsNullOrWhiteSpace(section);
                     string sectionName = isGlobalSection ? GlobalSectionName : section;
-                    foreach ((var keyName, var configPaths) in keys)
+                    foreach ((var keyName, (_, var configPaths)) in keys)
                     {
                         diagnostics.Add(Diagnostic.Create(
                              MultipleGlobalAnalyzerKeysDescriptor,
@@ -562,21 +562,21 @@ namespace Microsoft.CodeAnalysis
                 return new Section(sectionName, result);
             }
 
-            private void MergeSection(string configPath, Section section, bool isGlobalSection)
+            private void MergeSection(string configPath, Section section, int globalLevel, bool isGlobalSection)
             {
                 Debug.Assert(_values is object);
                 Debug.Assert(_duplicates is object);
 
                 if (!_values.TryGetValue(section.Name, out var sectionDict))
                 {
-                    sectionDict = ImmutableDictionary.CreateBuilder<string, (string, string)>(Section.PropertiesKeyComparer);
+                    sectionDict = ImmutableDictionary.CreateBuilder<string, (string, string, int)>(Section.PropertiesKeyComparer);
                     _values.Add(section.Name, sectionDict);
                 }
 
                 _duplicates.TryGetValue(section.Name, out var duplicateDict);
                 foreach ((var key, var value) in section.Properties)
                 {
-                    if (isGlobalSection && Section.PropertiesKeyComparer.Equals(key, GlobalKey))
+                    if (isGlobalSection && (Section.PropertiesKeyComparer.Equals(key, GlobalKey) || Section.PropertiesKeyComparer.Equals(key, GlobalLevelKey)))
                     {
                         continue;
                     }
@@ -584,30 +584,39 @@ namespace Microsoft.CodeAnalysis
                     bool keyInSection = sectionDict.ContainsKey(key);
                     bool keyDuplicated = duplicateDict?.ContainsKey(key) ?? false;
 
-                    // if this key is neither already present, or already duplicate, we can add it
-                    if (!keyInSection && !keyDuplicated)
-                    {
-                        sectionDict.Add(key, (value, configPath));
+                    if ((!keyInSection && !keyDuplicated)   // this key is neither present nor a duplicate, we can add it
+                        || (keyInSection && sectionDict[key].globalLevel < globalLevel) // this key should override the existing section one
+                        || (keyDuplicated && duplicateDict![key].globalLevel < globalLevel)) // this key should override previous duplicates
+                    { 
+                        sectionDict[key] = (value, configPath, globalLevel);
+
+                        if (keyDuplicated)
+                        {
+                            duplicateDict!.Remove(key);
+                        }
                     }
-                    else
+                    else if((keyDuplicated && duplicateDict![key].globalLevel == globalLevel)  // this key is another duplicate at the same level
+                            || (keyInSection && sectionDict[key].globalLevel == globalLevel)) // this key is a duplicate of a current section key
                     {
                         if (duplicateDict is null)
                         {
-                            duplicateDict = ImmutableDictionary.CreateBuilder<string, ArrayBuilder<string>>(Section.PropertiesKeyComparer);
+                            duplicateDict = ImmutableDictionary.CreateBuilder<string, (int, ArrayBuilder<string>)>(Section.PropertiesKeyComparer);
                             _duplicates.Add(section.Name, duplicateDict);
                         }
 
                         // record that this key is now a duplicate
-                        ArrayBuilder<string> configList = keyDuplicated ? duplicateDict[key] : ArrayBuilder<string>.GetInstance();
+                        ArrayBuilder<string> configList = keyDuplicated ? duplicateDict[key].configPaths : ArrayBuilder<string>.GetInstance();
                         configList.Add(configPath);
-                        duplicateDict[key] = configList;
+                        duplicateDict[key] = (globalLevel, configList);
 
                         // if we'd previously added this key, remove it and remember the extra duplicate location
                         if (keyInSection)
                         {
-                            var originalConfigPath = sectionDict[key].configPath;
+                            var originalEntry = sectionDict[key];
+                            Debug.Assert(originalEntry.globalLevel == globalLevel);
+
                             sectionDict.Remove(key);
-                            duplicateDict[key].Insert(0, originalConfigPath);
+                            duplicateDict[key].configPaths.Insert(0, originalEntry.configPath);
                         }
                     }
                 }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -581,7 +581,7 @@ namespace Microsoft.CodeAnalysis
                         continue;
                     }
 
-                    bool keyInSection = sectionDict.TryGetValue(key, out var sectionValue) == true;
+                    bool keyInSection = sectionDict.TryGetValue(key, out var sectionValue);
 
                     (int globalLevel, ArrayBuilder<string> configPaths) duplicateValue = default;
                     bool keyDuplicated = duplicateDict?.TryGetValue(key, out duplicateValue) == true;


### PR DESCRIPTION
- Read the 'global_level' special key
- Allow conflicting keys in global configs to be resolved by level
- Only warn about conflicts that have the same level
- Automatically treat as global and assign a level of 100 for configs called '.globalconfig'
- Add tests

Fixes #48634