### PR TITLE
Update our test generator for integration tests to generate multiple files

### DIFF
--- a/src/Features/Lsif/GeneratorTest/CompilerInvocationTests.vb
+++ b/src/Features/Lsif/GeneratorTest/CompilerInvocationTests.vb
@@ -162,9 +162,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                         ""sourceRootPath"": ""F:\\""
                     }")
 
-            Dim generatedTree = Assert.Single(compilerInvocation.Compilation.SyntaxTrees)
+            Dim generatedTrees = compilerInvocation.Compilation.SyntaxTrees
 
-            Assert.EndsWith(TestSourceGenerator.HelloWorldGenerator.GeneratedClassName + ".cs", generatedTree.FilePath)
+            Assert.Single(generatedTrees, Function(t) t.FilePath.EndsWith(TestSourceGenerator.HelloWorldGenerator.GeneratedEnglishClassName + ".cs"))
+            Assert.Single(generatedTrees, Function(t) t.FilePath.EndsWith(TestSourceGenerator.HelloWorldGenerator.GeneratedSpanishClassName + ".cs"))
         End Function
     End Class
 End Namespace

--- a/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
+++ b/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
@@ -46,18 +46,20 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(workspace)
 
             Dim projectVertex = Assert.Single(lsif.Vertices.OfType(Of Graph.LsifProject))
-            Dim generatedDocumentVertex = Assert.Single(lsif.GetLinkedVertices(Of Graph.LsifDocument)(projectVertex, "contains"))
+            Dim generatedDocumentVertices = lsif.GetLinkedVertices(Of Graph.LsifDocument)(projectVertex, "contains")
 
-            ' Assert the contents were included and does match the tree
-            Dim contentBase64Encoded = generatedDocumentVertex.Contents
-            Assert.NotNull(contentBase64Encoded)
+            For Each generatedDocumentVertex In generatedDocumentVertices
+                ' Assert the contents were included and does match the tree
+                Dim contentBase64Encoded = generatedDocumentVertex.Contents
+                Assert.NotNull(contentBase64Encoded)
 
-            Dim contents = Encoding.UTF8.GetString(Convert.FromBase64String(contentBase64Encoded))
+                Dim contents = Encoding.UTF8.GetString(Convert.FromBase64String(contentBase64Encoded))
 
-            Dim compilation = Await workspace.CurrentSolution.Projects.Single().GetCompilationAsync()
-            Dim tree = Assert.Single(compilation.SyntaxTrees)
+                Dim compilation = Await workspace.CurrentSolution.Projects.Single().GetCompilationAsync()
+                Dim tree = Assert.Single(compilation.SyntaxTrees, Function(t) t.FilePath = generatedDocumentVertex.Uri.OriginalString)
 
-            Assert.Equal(tree.GetText().ToString(), contents)
+                Assert.Equal(tree.GetText().ToString(), contents)
+            Next
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -44,14 +44,14 @@ internal static class Program
 {
     public static void Main()
     {
-        Console.WriteLine(" + HelloWorldGenerator.GeneratedClassName + @".GetMessage());
+        Console.WriteLine(" + HelloWorldGenerator.GeneratedEnglishClassName + @".GetMessage());
     }
 }");
 
-            VisualStudio.Editor.PlaceCaret(HelloWorldGenerator.GeneratedClassName);
+            VisualStudio.Editor.PlaceCaret(HelloWorldGenerator.GeneratedEnglishClassName);
             VisualStudio.Editor.GoToDefinition();
-            Assert.Equal($"{HelloWorldGenerator.GeneratedClassName}.cs {ServicesVSResources.generated_suffix}", VisualStudio.Shell.GetActiveWindowCaption());
-            Assert.Equal(HelloWorldGenerator.GeneratedClassName, VisualStudio.Editor.GetSelectedText());
+            Assert.Equal($"{HelloWorldGenerator.GeneratedEnglishClassName}.cs {ServicesVSResources.generated_suffix}", VisualStudio.Shell.GetActiveWindowCaption());
+            Assert.Equal(HelloWorldGenerator.GeneratedEnglishClassName, VisualStudio.Editor.GetSelectedText());
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SourceGenerators)]
@@ -62,14 +62,14 @@ internal static class Program
 {
     public static void Main()
     {
-        Console.WriteLine(" + HelloWorldGenerator.GeneratedClassName + @".GetMessage());
+        Console.WriteLine(" + HelloWorldGenerator.GeneratedEnglishClassName + @".GetMessage());
     }
 }");
 
-            VisualStudio.Editor.PlaceCaret(HelloWorldGenerator.GeneratedClassName);
+            VisualStudio.Editor.PlaceCaret(HelloWorldGenerator.GeneratedEnglishClassName);
             VisualStudio.Editor.SendKeys(Shift(VirtualKey.F12));
 
-            string programReferencesCaption = $"'{HelloWorldGenerator.GeneratedClassName}' references";
+            string programReferencesCaption = $"'{HelloWorldGenerator.GeneratedEnglishClassName}' references";
             var results = VisualStudio.FindReferencesWindow.GetContents(programReferencesCaption);
 
             Assert.Collection(
@@ -84,7 +84,7 @@ internal static class Program
                     },
                     reference =>
                     {
-                        Assert.Equal(expected: "Console.WriteLine(" + HelloWorldGenerator.GeneratedClassName + ".GetMessage());", actual: reference.Code);
+                        Assert.Equal(expected: "Console.WriteLine(" + HelloWorldGenerator.GeneratedEnglishClassName + ".GetMessage());", actual: reference.Code);
                         Assert.Equal(expected: 5, actual: reference.Line);
                         Assert.Equal(expected: 26, actual: reference.Column);
                     }

--- a/src/Workspaces/TestSourceGenerator/HelloWorldGenerator.cs
+++ b/src/Workspaces/TestSourceGenerator/HelloWorldGenerator.cs
@@ -11,7 +11,8 @@ namespace Microsoft.CodeAnalysis.TestSourceGenerator
     [Generator]
     public sealed class HelloWorldGenerator : ISourceGenerator
     {
-        public const string GeneratedClassName = "HelloWorld";
+        public const string GeneratedEnglishClassName = "HelloWorld";
+        public const string GeneratedSpanishClassName = "HolaMundo";
 
         public void Initialize(GeneratorInitializationContext context)
         {
@@ -19,12 +20,22 @@ namespace Microsoft.CodeAnalysis.TestSourceGenerator
 
         public void Execute(GeneratorExecutionContext context)
         {
-            context.AddSource(GeneratedClassName, SourceText.From(@"
-internal class " + GeneratedClassName + @"
+            context.AddSource(GeneratedEnglishClassName, SourceText.From(@"
+internal class " + GeneratedEnglishClassName + @"
 {
     public static string GetMessage()
     {
         return ""Hello, World!"";
+    }
+}
+", encoding: Encoding.UTF8));
+
+            context.AddSource(GeneratedSpanishClassName, SourceText.From(@"
+internal class " + GeneratedSpanishClassName + @"
+{
+    public static string GetMessage()
+    {
+        return ""Hola, Mundo!"";
     }
 }
 ", encoding: Encoding.UTF8));


### PR DESCRIPTION
We had a regression (https://github.com/dotnet/roslyn/pull/49673) which only broke if a generator produced multiple files. To prevent that regression from happening again, update our integration test to generate more than one file, so that case is covered.

Closes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1253095