### PR TITLE
Fix InvalidCastException on SyntaxGenerator.EnumMember when it is FieldDeclaration

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -849,7 +849,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (fd.Declaration.Variables.Count == 1)
                     {
                         var vd = fd.Declaration.Variables[0];
-                        return (EnumMemberDeclarationSyntax)this.EnumMember(vd.Identifier.ToString(), vd.Initializer);
+                        return (EnumMemberDeclarationSyntax)this.EnumMember(vd.Identifier.ToString(), vd.Initializer?.Value);
                     }
                     break;
             }

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1353,6 +1353,10 @@ public interface IFace
             VerifySyntax<EnumDeclarationSyntax>(
                 Generator.EnumDeclaration("e", members: new[] { Generator.EnumMember("a", Generator.LiteralExpression(0)), Generator.EnumMember("b"), Generator.EnumMember("c", Generator.LiteralExpression(5)) }),
                 "enum e\r\n{\r\n    a = 0,\r\n    b,\r\n    c = 5\r\n}");
+
+            VerifySyntax<EnumDeclarationSyntax>(
+                Generator.EnumDeclaration("e", members: new[] { Generator.FieldDeclaration("a", Generator.IdentifierName("e"), initializer: Generator.LiteralExpression(1)) }),
+                "enum e\r\n{\r\n    a = 1\r\n}");
         }
 
         [Fact]


### PR DESCRIPTION
When getting the `SyntaxNode` for an `EnumDeclaration` using `SyntaxGenerator.Declaration(ISymbol)` an exception:

```
System.InvalidCastException: 'Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Syntax.EqualsValueClauseSyntax' to type 'Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax'.'
```

`VariableDeclaration.Initializer` is and `EqualsValueClauseSyntax` so we should pass down `.Value` which is the actual `ExpressionSyntax` that `EnumMember` is expecting in order to  create an `EqualsValueClause`.

