### PR TITLE
Restore internal API used by VS for Mac

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/VersionStamp.cs
@@ -168,6 +168,25 @@ namespace Microsoft.CodeAnalysis
         public static bool operator !=(VersionStamp left, VersionStamp right)
             => !left.Equals(right);
 
+        /// <summary>
+        /// Check whether given persisted version is re-usable. Used by VS for Mac
+        /// </summary>
+        internal static bool CanReusePersistedVersion(VersionStamp baseVersion, VersionStamp persistedVersion)
+        {
+            if (baseVersion == persistedVersion)
+            {
+                return true;
+            }
+
+            // there was a collision, we can't use these
+            if (baseVersion._localIncrement != 0 || persistedVersion._localIncrement != 0)
+            {
+                return false;
+            }
+
+            return baseVersion._utcLastModified == persistedVersion._utcLastModified;
+        }
+
         bool IObjectWritable.ShouldReuseInSerialization => true;
 
         void IObjectWritable.WriteTo(ObjectWriter writer)


### PR DESCRIPTION
Reverts a tiny part of https://github.com/dotnet/roslyn/pull/49608/

VS for Mac uses this internal function, which accesses private state, so putting this back to unblock the insertion in https://github.com/xamarin/vsmac/pull/2899

Before you ask, VS for Mac uses lots of internals, and creating an externals access for it is not a simple step :)

FYI @jasonmalinowski it looked like you removed this just because it was unused, but would be good to confirm.