### PR TITLE
Ensure we don't create duplicate names in test

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
@@ -106,7 +106,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             asc = new AdditionalSourcesCollection(".cs");
             for (int i = 0; i < 1000; i++)
             {
-                names[i] = r.NextDouble().ToString() + ".cs";
+                // ensure the name is unique (we've seen CI failures where we generate duplicate names)
+                var name = "";
+                do
+                {
+                    name = r.NextDouble().ToString() + ".cs";
+                }
+                while (names.Contains(name));
+
+                names[i] = name;
                 asc.Add(names[i], SourceText.From("", Encoding.UTF8));
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
@@ -106,15 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             asc = new AdditionalSourcesCollection(".cs");
             for (int i = 0; i < 1000; i++)
             {
-                // ensure the name is unique (we've seen CI failures where we generate duplicate names)
-                var name = "";
-                do
-                {
-                    name = r.NextDouble().ToString() + ".cs";
-                }
-                while (names.Contains(name));
-
-                names[i] = name;
+                names[i] = Guid.NewGuid().ToString() + ".cs";
                 asc.Add(names[i], SourceText.From("", Encoding.UTF8));
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             asc = new AdditionalSourcesCollection(".cs");
             for (int i = 0; i < 1000; i++)
             {
-                names[i] = Guid.NewGuid().ToString() + ".cs";
+                names[i] = CSharpTestBase.GetUniqueName() + ".cs";
                 asc.Add(names[i], SourceText.From("", Encoding.UTF8));
             }
 


### PR DESCRIPTION
Trivial PR to make sure we don't generate duplicate names in the `AddedSources_Are_Deterministic ` test, as seen in the failure case here: https://dev.azure.com/dnceng/public/_build/results?buildId=912502&view=ms.vss-test-web.build-test-results-tab&runId=29058568&resultId=110775&paneView=debug