### PR TITLE
Add switch to skip nullable analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
@@ -114,12 +114,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return NullableWalker.AnalyzeAndRewrite(Compilation, symbol: null, boundRoot, binder, initialState: null, diagnostics, createSnapshots, out snapshotManager, ref remappedSymbols);
         }
 
-#if DEBUG
         protected override void AnalyzeBoundNodeNullability(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool createSnapshots)
         {
             NullableWalker.AnalyzeWithoutRewrite(Compilation, symbol: null, boundRoot, binder, diagnostics, createSnapshots);
         }
-#endif
 
         internal override bool TryGetSpeculativeSemanticModelCore(SyntaxTreeSemanticModel parentModel, int position, ConstructorInitializerSyntax constructorInitializer, out SemanticModel speculativeModel)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -232,14 +232,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
         /// <summary>
-        /// Returns true if nullable analysis should be run and results ignored in cases where analysis
-        /// is not otherwise necessary. Used for testing in debug builds to increase the chance of catching
-        /// nullable regressions (e.g. https://github.com/dotnet/roslyn/issues/40136).
+        /// Returns false if nullable analysis is disabled for the entire compilation.
         /// </summary>
-        /// <return>
-        /// Returns true unless analysis is explicitly disabled.
-        /// </return>
-        internal bool ShouldRunNullableAnalysisAndIgnoreResults => GetNullableAnalysisValue() != false;
+        /// <remarks>
+        /// This method is only used for debug builds. In debug builds, unless analysis is
+        /// explicitly disabled, analysis is run, even though the results may be ignored,
+        /// to increase the chance of catching nullable regressions
+        /// (e.g. https://github.com/dotnet/roslyn/issues/40136).
+        /// </remarks>
+        internal bool IsNullableAnalysisExplicitlyDisabled => GetNullableAnalysisValue() == false;
 #endif
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -135,7 +135,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private ThreeState _lazyShouldRunNullableAnalysis;
 
-        // Nullable analysis data for methods, parameter default values, and attributes. Collected during testing only.
+        /// <summary>
+        /// Nullable analysis data for methods, parameter default values, and attributes.
+        /// The key is a symbol for methods or parameters, and syntax for attributes,
+        /// and the value is the number of entries tracked during analysis of that key.
+        /// The data is collected during testing only.
+        /// </summary>
         internal ConcurrentDictionary<object, int>? NullableAnalysisData;
 
         public override string Language
@@ -189,11 +194,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool FeatureStrictEnabled => Feature("strict") != null;
 
         /// <summary>
-        /// True if we should enable nullable semantic analysis in this compilation.
-        /// </summary>
-        internal bool NullableSemanticAnalysisEnabled => ShouldRunNullableAnalysis;
-
-        /// <summary>
         /// True when the "peverify-compat" feature flag is set or the language version is below C# 7.2.
         /// With this flag we will avoid certain patterns known not be compatible with PEVerify.
         /// The code may be less efficient and may deviate from spec in corner cases.
@@ -202,14 +202,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool IsPeVerifyCompatEnabled => LanguageVersion < LanguageVersion.CSharp7_2 || Feature("peverify-compat") != null;
 
         /// <summary>
-        /// Returns true if nullable analysis should be run in this compilation.
+        /// Returns true if nullable analysis is enabled in this compilation.
         /// </summary>
         /// <return>
         /// Returns true if analysis is explicitly enabled for all methods;
         /// false if analysis is explicitly disabled; and otherwise returns true
         /// if there are any nullable-enabled contexts in the compilation.
         /// </return>
-        internal bool ShouldRunNullableAnalysis
+        internal bool IsNullableAnalysisEnabled
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -235,8 +235,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Returns true if nullable analysis is explicitly enabled for the entire compilation,
-        /// but not otherwise enabled.
+        /// Returns true if nullable analysis is enabled for all methods regardless
+        /// of the actual nullable context.
+        /// If this property returns true but IsNullableAnalysisEnabled returns false,
+        /// any nullable analysis should be enabled but results should be ignored.
         /// </summary>
         /// <remarks>
         /// For DEBUG builds, we treat nullable analysis as enabled for all methods
@@ -244,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// be ignored, to increase the chance of catching nullable regressions
         /// (e.g. https://github.com/dotnet/roslyn/issues/40136).
         /// </remarks>
-        internal bool IsNullableAnalysisExplicitlyEnabled
+        internal bool IsNullableAnalysisEnabledAlways
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                        name).GetPublicSymbol();
         }
 
-#region Constructors and Factories
+        #region Constructors and Factories
 
         private static readonly CSharpCompilationOptions s_defaultOptions = new CSharpCompilationOptions(OutputKind.ConsoleApplication);
         private static readonly CSharpCompilationOptions s_defaultSubmissionOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithReferencesSupersedeLowerVersions(true);
@@ -720,9 +720,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 eventQueue);
         }
 
-#endregion
+        #endregion
 
-#region Submission
+        #region Submission
 
         public new CSharpScriptCompilationInfo? ScriptCompilationInfo { get; }
         internal override ScriptCompilationInfo? CommonScriptCompilationInfo => ScriptCompilationInfo;
@@ -773,9 +773,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-#endregion
+        #endregion
 
-#region Syntax Trees (maintain an ordered list)
+        #region Syntax Trees (maintain an ordered list)
 
         /// <summary>
         /// The syntax trees (parsed from source code) that this compilation was created with.
@@ -1002,9 +1002,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _syntaxAndDeclarations.GetLazyState().OrdinalMap[tree];
         }
 
-#endregion
+        #endregion
 
-#region References
+        #region References
 
         internal override CommonReferenceManager CommonGetBoundReferenceManager()
         {
@@ -1224,9 +1224,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return GetBoundReferenceManager().GetMetadataReference(assemblySymbol);
         }
 
-#endregion
+        #endregion
 
-#region Symbols
+        #region Symbols
 
         /// <summary>
         /// The AssemblySymbol that represents the assembly being created.
@@ -2160,9 +2160,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             LazyInitializer.EnsureInitialized(ref _moduleInitializerMethods).Add(method);
         }
 
-#endregion
+        #endregion
 
-#region Binding
+        #region Binding
 
         /// <summary>
         /// Gets a new SyntaxTreeSemanticModel for the specified syntax tree.
@@ -2389,9 +2389,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-#endregion
+        #endregion
 
-#region Diagnostics
+        #region Diagnostics
 
         internal override CommonMessageProvider MessageProvider
         {
@@ -2788,9 +2788,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result.ToReadOnlyAndFree<Diagnostic>();
         }
 
-#endregion
+        #endregion
 
-#region Resources
+        #region Resources
 
         protected override void AppendDefaultVersionResource(Stream resourceStream)
         {
@@ -2812,9 +2812,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 companyName: sourceAssembly.Company);
         }
 
-#endregion
+        #endregion
 
-#region Emit
+        #region Emit
 
         internal override byte LinkerMajorVersion => 0x30;
 
@@ -3230,9 +3230,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-#endregion
+        #endregion
 
-#region Common Members
+        #region Common Members
 
         protected override Compilation CommonWithReferences(IEnumerable<MetadataReference> newReferences)
         {
@@ -3661,7 +3661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Returns if the compilation has all of the members necessary to emit metadata about

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -243,8 +243,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
 
         /// <summary>
-        /// Converts Feature("run-nullable-analysis") to a bool? value.
-        /// Returns true for "run-nullable-analysis=always"; false for "run-nullable-analysis=never"; null otherwise.
+        /// Returns Feature("run-nullable-analysis") as a bool? value:
+        /// true for "always"; false for "never"; and null otherwise.
         /// </summary>
         private bool? GetNullableAnalysisValue()
         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -216,25 +216,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (!_lazyShouldRunNullableWalker.HasValue())
                 {
+                    _lazyShouldRunNullableWalker = calculateResult();
+                }
+                return _lazyShouldRunNullableWalker.Value();
+
+                ThreeState calculateResult()
+                {
+                    var feature = Feature("nullableAnalysis");
+                    if (feature == "false")
+                    {
+                        return ThreeState.False;
+                    }
+
                     if (Options.NullableContextOptions != NullableContextOptions.Disable)
                     {
-                        _lazyShouldRunNullableWalker = ThreeState.True;
-                        return true;
+                        return ThreeState.True;
                     }
 
                     foreach (var syntaxTree in SyntaxTrees)
                     {
                         if (((CSharpSyntaxTree)syntaxTree).HasNullableEnables())
                         {
-                            _lazyShouldRunNullableWalker = ThreeState.True;
-                            return true;
+                            return ThreeState.True;
                         }
                     }
 
-                    _lazyShouldRunNullableWalker = ThreeState.False;
+                    return ThreeState.False;
                 }
-
-                return _lazyShouldRunNullableWalker.Value();
             }
         }
 
@@ -399,7 +407,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxAndDeclarationManager syntaxAndDeclarations,
             IReadOnlyDictionary<string, string> features,
             SemanticModelProvider? semanticModelProvider,
-            AsyncQueue<CompilationEvent>? eventQueue = null)
+            AsyncQueue<CompilationEvent>? eventQueue)
             : base(assemblyName, references, features, isSubmission, semanticModelProvider, eventQueue)
         {
             WellKnownMemberSignatureComparer = new WellKnownMembersSignatureComparer(this);
@@ -684,6 +692,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.SemanticModelProvider,
                 eventQueue);
         }
+
+        // Nullable analysis data for methods, parameter default values, and attributes. Collected during testing only.
+        internal ConcurrentDictionary<object, int>? NullableAnalysisData;
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -246,6 +246,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+#if DEBUG
+        internal bool ShouldRunNullableWalkerInDebug => Feature("nullableAnalysis") != "false";
+#endif
+
         /// <summary>
         /// The language version that was used to parse the syntax trees of this compilation.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1777,7 +1777,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private Symbol RemapSymbolIfNecessary(Symbol symbol)
         {
-            if (!Compilation.NullableSemanticAnalysisEnabled) return symbol;
+            if (!Compilation.IsNullableAnalysisEnabled) return symbol;
 
             switch (symbol)
             {

--- a/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
@@ -272,11 +272,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return NullableWalker.AnalyzeAndRewrite(Compilation, MemberSymbol, boundRoot, binder, initialState: null, diagnostics, createSnapshots, out snapshotManager, ref remappedSymbols);
         }
 
-#if DEBUG
         protected override void AnalyzeBoundNodeNullability(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool createSnapshots)
         {
             NullableWalker.AnalyzeWithoutRewrite(Compilation, MemberSymbol, boundRoot, binder, diagnostics, createSnapshots);
         }
-#endif
     }
 }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.SpeculativeMemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.SpeculativeMemberSemanticModel.cs
@@ -46,12 +46,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return NullableWalker.AnalyzeAndRewrite(Compilation, MemberSymbol as MethodSymbol, boundRoot, binder, initialState: null, diagnostics, createSnapshots: false, out snapshotManager, ref remappedSymbols);
             }
 
-#if DEBUG
             protected override void AnalyzeBoundNodeNullability(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool createSnapshots)
             {
                 NullableWalker.AnalyzeWithoutRewrite(Compilation, MemberSymbol as MethodSymbol, boundRoot, binder, diagnostics, createSnapshots);
             }
-#endif
 
             internal override bool TryGetSpeculativeSemanticModelCore(SyntaxTreeSemanticModel parentModel, int position, ConstructorInitializerSyntax constructorInitializer, out SemanticModel speculativeModel)
             {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -157,14 +157,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected virtual NullableWalker.SnapshotManager GetSnapshotManager()
         {
             EnsureNullabilityAnalysisPerformedIfNecessary();
-            Debug.Assert(_lazySnapshotManager is object || !Compilation.NullableSemanticAnalysisEnabled);
+            Debug.Assert(_lazySnapshotManager is object || !Compilation.IsNullableAnalysisEnabled);
             return _lazySnapshotManager;
         }
 
         internal ImmutableDictionary<Symbol, Symbol> GetRemappedSymbols()
         {
             EnsureNullabilityAnalysisPerformedIfNecessary();
-            Debug.Assert(_lazyRemappedSymbols is object || this is AttributeSemanticModel || !Compilation.NullableSemanticAnalysisEnabled);
+            Debug.Assert(_lazyRemappedSymbols is object || this is AttributeSemanticModel || !Compilation.IsNullableAnalysisEnabled);
             return _lazyRemappedSymbols;
         }
 
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentNullException(nameof(expression));
             }
 
-            if (!Compilation.NullableSemanticAnalysisEnabled || bindingOption != SpeculativeBindingOption.BindAsExpression)
+            if (!Compilation.IsNullableAnalysisEnabled || bindingOption != SpeculativeBindingOption.BindAsExpression)
             {
                 return GetSpeculativelyBoundExpressionWithoutNullability(position, expression, bindingOption, out binder, out crefSymbols);
             }
@@ -701,7 +701,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private T GetRemappedSymbol<T>(T originalSymbol) where T : Symbol
         {
-            if (!Compilation.NullableSemanticAnalysisEnabled) return originalSymbol;
+            if (!Compilation.IsNullableAnalysisEnabled) return originalSymbol;
 
             EnsureNullabilityAnalysisPerformedIfNecessary();
             if (_lazyRemappedSymbols is null) return originalSymbol;
@@ -1512,11 +1512,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     NodeMapBuilder.AddToMap(bound, _guardedNodeMap, SyntaxTree, syntax);
                 }
 
-                Debug.Assert((manager is null && (!Compilation.NullableSemanticAnalysisEnabled || syntax != Root || syntax is TypeSyntax ||
+                Debug.Assert((manager is null && (!Compilation.IsNullableAnalysisEnabled || syntax != Root || syntax is TypeSyntax ||
                                                   // Supporting attributes is tracked by
                                                   // https://github.com/dotnet/roslyn/issues/36066
                                                   this is AttributeSemanticModel)) ||
-                             (manager is object && remappedSymbols is object && syntax == Root && Compilation.NullableSemanticAnalysisEnabled && _lazySnapshotManager is null));
+                             (manager is object && remappedSymbols is object && syntax == Root && Compilation.IsNullableAnalysisEnabled && _lazySnapshotManager is null));
                 if (manager is object)
                 {
                     _lazySnapshotManager = manager;
@@ -1918,7 +1918,7 @@ done:
         protected void EnsureNullabilityAnalysisPerformedIfNecessary()
         {
             // If we're in DEBUG mode, enable the analysis unless explicitly disabled, but throw away the results
-            if (!Compilation.NullableSemanticAnalysisEnabled
+            if (!Compilation.IsNullableAnalysisEnabled
 #if DEBUG
                 && !Compilation.ShouldRunNullableAnalysisAndIgnoreResults
 #endif
@@ -1946,7 +1946,7 @@ done:
             // first BoundNode corresponds to the underlying EqualsValueSyntax of the initializer)
             if (_guardedNodeMap.Count > 0)
             {
-                Debug.Assert(!Compilation.NullableSemanticAnalysisEnabled ||
+                Debug.Assert(!Compilation.IsNullableAnalysisEnabled ||
                              _guardedNodeMap.ContainsKey(bindableRoot) ||
                              _guardedNodeMap.ContainsKey(bind(bindableRoot, getDiagnosticBag(), out _).Syntax));
                 return;
@@ -2006,7 +2006,7 @@ done:
             void rewriteAndCache(DiagnosticBag diagnosticBag)
             {
 #if DEBUG
-                if (!Compilation.NullableSemanticAnalysisEnabled)
+                if (!Compilation.IsNullableAnalysisEnabled)
                 {
                     if (Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
                     {
@@ -2022,7 +2022,7 @@ done:
 
             void cache(CSharpSyntaxNode bindableRoot, BoundNode boundRoot, NullableWalker.SnapshotManager snapshotManager, ImmutableDictionary<Symbol, Symbol> remappedSymbols)
             {
-                Debug.Assert(Compilation.NullableSemanticAnalysisEnabled);
+                Debug.Assert(Compilation.IsNullableAnalysisEnabled);
                 GuardedAddBoundTreeForStandaloneSyntax(bindableRoot, boundRoot, snapshotManager, remappedSymbols);
             }
 
@@ -2031,7 +2031,7 @@ done:
                 // In DEBUG without nullable analysis enabled, we want to use a temp diagnosticbag
                 // that can't produce any observable side effects
 #if DEBUG
-                if (!Compilation.NullableSemanticAnalysisEnabled)
+                if (!Compilation.IsNullableAnalysisEnabled)
                 {
                     return new DiagnosticBag();
                 }
@@ -2331,7 +2331,7 @@ foundParent:;
             Debug.Assert(symbol is LocalSymbol ||
                          symbol is ParameterSymbol ||
                          symbol is MethodSymbol { MethodKind: MethodKind.LambdaMethod });
-            Debug.Assert(Compilation.NullableSemanticAnalysisEnabled);
+            Debug.Assert(Compilation.IsNullableAnalysisEnabled);
             EnsureNullabilityAnalysisPerformedIfNecessary();
 
             if (_lazyRemappedSymbols is null)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -2039,9 +2039,10 @@ done:
             ref ImmutableDictionary<Symbol, Symbol>? remappedSymbols);
 
         /// <summary>
-        /// Performs just the analysis step of getting nullability information for a semantic model.
-        /// This is only used when nullable analysis is explicitly enabled for all methods but nullable
-        /// is turned off on a compilation level, giving some extra verification of the nullable flow analysis. 
+        /// Performs the analysis step of getting nullability information for a semantic model but
+        /// does not actually use the results. This gives us extra verification of nullable flow analysis.
+        /// It is only used in contexts where nullable analysis is disabled in the compilation but requested
+        /// through "run-nullable-analysis=always" or when the compiler is running in DEBUG.
         /// </summary>
         protected abstract void AnalyzeBoundNodeNullability(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool createSnapshots);
 #nullable disable

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1918,11 +1918,11 @@ done:
         protected void EnsureNullabilityAnalysisPerformedIfNecessary()
         {
             // If we're in DEBUG mode, enable the analysis unless explicitly disabled, but throw away the results
+            if (!Compilation.NullableSemanticAnalysisEnabled
 #if DEBUG
-            if (!Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
-#else
-            if (!Compilation.NullableSemanticAnalysisEnabled)
+                && !Compilation.ShouldRunNullableAnalysisAndIgnoreResults
 #endif
+                )
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1729,7 +1729,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundNode boundOuterExpression = this.Bind(incrementalBinder, lambdaOrQuery, _ignoredDiagnostics);
 
                 // https://github.com/dotnet/roslyn/issues/35038: We need to do a rewrite here, and create a test that can hit this.
-                if (!Compilation.IsNullableAnalysisEnabled && Compilation.IsNullableAnalysisExplicitlyEnabled)
+                if (!Compilation.IsNullableAnalysisEnabled && Compilation.IsNullableAnalysisEnabledAlways)
                 {
                     AnalyzeBoundNodeNullability(boundOuterExpression, incrementalBinder, diagnostics: new DiagnosticBag(), createSnapshots: false);
                 }
@@ -1915,7 +1915,7 @@ done:
         /// </summary>
         protected void EnsureNullabilityAnalysisPerformedIfNecessary()
         {
-            if (!Compilation.IsNullableAnalysisEnabled && !Compilation.IsNullableAnalysisExplicitlyEnabled)
+            if (!Compilation.IsNullableAnalysisEnabled && !Compilation.IsNullableAnalysisEnabledAlways)
             {
                 return;
             }
@@ -1998,7 +1998,7 @@ done:
 
             void rewriteAndCache(DiagnosticBag diagnosticBag)
             {
-                if (!Compilation.IsNullableAnalysisEnabled && Compilation.IsNullableAnalysisExplicitlyEnabled)
+                if (!Compilation.IsNullableAnalysisEnabled && Compilation.IsNullableAnalysisEnabledAlways)
                 {
                     AnalyzeBoundNodeNullability(boundRoot, binder, diagnosticBag, createSnapshots: true);
                     return;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1730,7 +1730,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // https://github.com/dotnet/roslyn/issues/35038: We need to do a rewrite here, and create a test that can hit this.
 #if DEBUG
-                AnalyzeBoundNodeNullability(boundOuterExpression, incrementalBinder, diagnostics: new DiagnosticBag(), createSnapshots: false);
+                if (Compilation.ShouldRunNullableWalkerInDebug)
+                {
+                    AnalyzeBoundNodeNullability(boundOuterExpression, incrementalBinder, diagnostics: new DiagnosticBag(), createSnapshots: false);
+                }
 #endif
 
                 nodes = GuardedAddBoundTreeAndGetBoundNodeFromMap(lambdaOrQuery, boundOuterExpression);
@@ -2003,7 +2006,10 @@ done:
 #if DEBUG
                 if (!Compilation.NullableSemanticAnalysisEnabled)
                 {
-                    AnalyzeBoundNodeNullability(boundRoot, binder, diagnosticBag, createSnapshots: true);
+                    if (Compilation.ShouldRunNullableWalkerInDebug)
+                    {
+                        AnalyzeBoundNodeNullability(boundRoot, binder, diagnosticBag, createSnapshots: true);
+                    }
                     return;
                 }
 #endif

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1730,7 +1730,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // https://github.com/dotnet/roslyn/issues/35038: We need to do a rewrite here, and create a test that can hit this.
 #if DEBUG
-                if (Compilation.ShouldRunNullableWalkerInDebug)
+                if (Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
                 {
                     AnalyzeBoundNodeNullability(boundOuterExpression, incrementalBinder, diagnostics: new DiagnosticBag(), createSnapshots: false);
                 }
@@ -1917,13 +1917,15 @@ done:
         /// </summary>
         protected void EnsureNullabilityAnalysisPerformedIfNecessary()
         {
-            // If we're in DEBUG mode, always enable the analysis, but throw away the results
-#if !DEBUG
+            // If we're in DEBUG mode, enable the analysis unless explicitly disabled, but throw away the results
+#if DEBUG
+            if (!Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
+#else
             if (!Compilation.NullableSemanticAnalysisEnabled)
+#endif
             {
                 return;
             }
-#endif
 
             // If we have a snapshot manager, then we've already done
             // all the work necessary and we should avoid taking an
@@ -2006,7 +2008,7 @@ done:
 #if DEBUG
                 if (!Compilation.NullableSemanticAnalysisEnabled)
                 {
-                    if (Compilation.ShouldRunNullableWalkerInDebug)
+                    if (Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
                     {
                         AnalyzeBoundNodeNullability(boundRoot, binder, diagnosticBag, createSnapshots: true);
                     }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1917,14 +1917,15 @@ done:
         /// </summary>
         protected void EnsureNullabilityAnalysisPerformedIfNecessary()
         {
-            // If we're in DEBUG mode, enable the analysis unless explicitly disabled, but throw away the results
-            if (!Compilation.IsNullableAnalysisEnabled
-#if DEBUG
-                && Compilation.IsNullableAnalysisExplicitlyDisabled
-#endif
-                )
+            if (!Compilation.IsNullableAnalysisEnabled)
             {
-                return;
+                // If we're in DEBUG mode, enable the analysis unless explicitly disabled, but throw away the results
+#if DEBUG
+                if (Compilation.IsNullableAnalysisExplicitlyDisabled)
+#endif
+                {
+                    return;
+                }
             }
 
             // If we have a snapshot manager, then we've already done

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1730,7 +1730,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // https://github.com/dotnet/roslyn/issues/35038: We need to do a rewrite here, and create a test that can hit this.
 #if DEBUG
-                if (Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
+                if (!Compilation.IsNullableAnalysisExplicitlyDisabled)
                 {
                     AnalyzeBoundNodeNullability(boundOuterExpression, incrementalBinder, diagnostics: new DiagnosticBag(), createSnapshots: false);
                 }
@@ -1920,7 +1920,7 @@ done:
             // If we're in DEBUG mode, enable the analysis unless explicitly disabled, but throw away the results
             if (!Compilation.IsNullableAnalysisEnabled
 #if DEBUG
-                && !Compilation.ShouldRunNullableAnalysisAndIgnoreResults
+                && Compilation.IsNullableAnalysisExplicitlyDisabled
 #endif
                 )
             {
@@ -2008,7 +2008,7 @@ done:
 #if DEBUG
                 if (!Compilation.IsNullableAnalysisEnabled)
                 {
-                    if (Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
+                    if (!Compilation.IsNullableAnalysisExplicitlyDisabled)
                     {
                         AnalyzeBoundNodeNullability(boundRoot, binder, diagnosticBag, createSnapshots: true);
                     }

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -304,11 +304,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return NullableWalker.AnalyzeAndRewrite(Compilation, MemberSymbol, boundRoot, binder, afterInitializersState, diagnostics, createSnapshots, out snapshotManager, ref remappedSymbols);
         }
 
-#if DEBUG
         protected override void AnalyzeBoundNodeNullability(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool createSnapshots)
         {
             NullableWalker.AnalyzeWithoutRewrite(Compilation, MemberSymbol, boundRoot, binder, diagnostics, createSnapshots);
         }
-#endif
     }
 }

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -773,7 +773,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal AttributeSemanticModel CreateSpeculativeAttributeSemanticModel(int position, AttributeSyntax attribute, Binder binder, AliasSymbol aliasOpt, NamedTypeSymbol attributeType)
         {
-            var memberModel = Compilation.NullableSemanticAnalysisEnabled ? GetMemberModel(position) : null;
+            var memberModel = Compilation.IsNullableAnalysisEnabled ? GetMemberModel(position) : null;
             return AttributeSemanticModel.CreateSpeculative(this, attribute, attributeType, aliasOpt, binder, memberModel?.GetRemappedSymbols(), position);
         }
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1689,7 +1689,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ImmutableDictionary<Symbol, Symbol> remappedSymbols = null;
                     var compilation = bodyBinder.Compilation;
                     var isSufficientLangVersion = compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion();
-                    if (compilation.NullableSemanticAnalysisEnabled)
+                    if (compilation.IsNullableAnalysisEnabled)
                     {
                         methodBodyForSemanticModel = NullableWalker.AnalyzeAndRewrite(
                             compilation,

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1689,7 +1689,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ImmutableDictionary<Symbol, Symbol> remappedSymbols = null;
                     var compilation = bodyBinder.Compilation;
                     var isSufficientLangVersion = compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion();
-                    if (compilation.ShouldRunNullableAnalysis)
+                    if (compilation.NullableSemanticAnalysisEnabled)
                     {
                         methodBodyForSemanticModel = NullableWalker.AnalyzeAndRewrite(
                             compilation,

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1689,7 +1689,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ImmutableDictionary<Symbol, Symbol> remappedSymbols = null;
                     var compilation = bodyBinder.Compilation;
                     var isSufficientLangVersion = compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion();
-                    if (compilation.NullableSemanticAnalysisEnabled)
+                    if (compilation.ShouldRunNullableAnalysis)
                     {
                         methodBodyForSemanticModel = NullableWalker.AnalyzeAndRewrite(
                             compilation,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
-            if (compilation.IsNullableAnalysisEnabled)
+            if (compilation.IsNullableAnalysisEnabled && !compilation.IsNullableAnalysisExplicitlyDisabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
@@ -1267,7 +1267,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             newSnapshots = newSnapshotBuilder.ToManagerAndFree();
 
 #if DEBUG
-            if (binder.Compilation.IsNullableAnalysisEnabled)
+            var compilation = binder.Compilation;
+            if (compilation.IsNullableAnalysisEnabled && !compilation.IsNullableAnalysisExplicitlyDisabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, newSnapshots, node);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1159,7 +1159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Analyzes a set of bound nodes, recording updated nullability information. This method is only
-        /// used when nullable is explicitly enabled for all methods but diabled otherwise to verify that
+        /// used when nullable is explicitly enabled for all methods but disabled otherwise to verify that
         /// correct semantic information is being recorded for all bound nodes. The results are thrown away.
         /// </summary>
         internal static void AnalyzeWithoutRewrite(

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
-            if (compilation.NullableSemanticAnalysisEnabled)
+            if (compilation.IsNullableAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
@@ -1267,7 +1267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             newSnapshots = newSnapshotBuilder.ToManagerAndFree();
 
 #if DEBUG
-            if (binder.Compilation.NullableSemanticAnalysisEnabled)
+            if (binder.Compilation.IsNullableAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, newSnapshots, node);
             }
@@ -1293,7 +1293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool CanSkipAnalysis(CSharpCompilation compilation)
         {
-            return compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis;
+            return compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.IsNullableAnalysisEnabled;
         }
 
         internal static bool NeedsAnalysis(CSharpCompilation compilation)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1075,7 +1075,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (CanSkipAnalysis(compilation))
             {
 #if DEBUG
-                if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)
+                if (!compilation.IsNullableAnalysisExplicitlyDisabled)
                 {
                     // Once we address https://github.com/dotnet/roslyn/issues/46579 we should also always pass `getFinalNullableState: true` in debug mode.
                     // We will likely always need to write a 'null' out for the out parameter in this code path, though, because
@@ -1302,7 +1302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
             if (canSkipAnalysis)
             {
-                return compilation.ShouldRunNullableAnalysisAndIgnoreResults;
+                return !compilation.IsNullableAnalysisExplicitlyDisabled;
             }
 #endif
             return !canSkipAnalysis;
@@ -1318,7 +1318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (CanSkipAnalysis(compilation))
             {
 #if DEBUG
-                if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)
+                if (!compilation.IsNullableAnalysisExplicitlyDisabled)
                 {
                     diagnostics = new DiagnosticBag();
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1072,13 +1072,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool getFinalNullableState,
             out VariableState? finalNullableState)
         {
-            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker)
+            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis)
             {
 #if DEBUG
-                if (compilation.ShouldRunNullableWalkerInDebug)
+                if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)
                 {
-                    // Always run analysis in debug builds so that we can more reliably catch
-                    // nullable regressions e.g. https://github.com/dotnet/roslyn/issues/40136
                     // Once we address https://github.com/dotnet/roslyn/issues/46579 we should also always pass `getFinalNullableState: true` in debug mode.
                     // We will likely always need to write a 'null' out for the out parameter in this code path, though, because
                     // we don't want to introduce behavior differences between debug and release builds
@@ -1236,7 +1234,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
-            if (compilation.NullableSemanticAnalysisEnabled)
+            if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
@@ -1269,7 +1267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             newSnapshots = newSnapshotBuilder.ToManagerAndFree();
 
 #if DEBUG
-            if (binder.Compilation.NullableSemanticAnalysisEnabled)
+            if (binder.Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, newSnapshots, node);
             }
@@ -1296,9 +1294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static bool NeedsAnalysis(CSharpCompilation compilation)
         {
 #if DEBUG
-            // Always run analysis in debug builds so that we can more reliably catch
-            // nullable regressions e.g. https://github.com/dotnet/roslyn/issues/40136
-            return compilation.ShouldRunNullableWalkerInDebug;
+            return compilation.ShouldRunNullableAnalysisAndIgnoreResults;
 #else
             var canSkipAnalysis = compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker;
             return !canSkipAnalysis;
@@ -1312,13 +1308,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics)
         {
             var compilation = binder.Compilation;
-            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker)
+            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis)
             {
 #if DEBUG
-                if (compilation.ShouldRunNullableWalkerInDebug)
+                if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)
                 {
-                    // Always run analysis in debug builds so that we can more reliably catch
-                    // nullable regressions e.g. https://github.com/dotnet/roslyn/issues/40136
                     diagnostics = new DiagnosticBag();
                 }
                 else

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1072,7 +1072,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool getFinalNullableState,
             out VariableState? finalNullableState)
         {
-            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis)
+            if (CanSkipAnalysis(compilation))
             {
 #if DEBUG
                 if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)
@@ -1291,14 +1291,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             return rewrittenNode;
         }
 
+        private static bool CanSkipAnalysis(CSharpCompilation compilation)
+        {
+            return compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis;
+        }
+
         internal static bool NeedsAnalysis(CSharpCompilation compilation)
         {
+            var canSkipAnalysis = CanSkipAnalysis(compilation);
 #if DEBUG
-            return compilation.ShouldRunNullableAnalysisAndIgnoreResults;
-#else
-            var canSkipAnalysis = compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis;
-            return !canSkipAnalysis;
+            if (canSkipAnalysis)
+            {
+                return compilation.ShouldRunNullableAnalysisAndIgnoreResults;
+            }
 #endif
+            return !canSkipAnalysis;
         }
 
         /// <summary>Analyzes a node in a "one-off" context, such as for attributes or parameter default values.</summary>
@@ -1308,7 +1315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics)
         {
             var compilation = binder.Compilation;
-            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis)
+            if (CanSkipAnalysis(compilation))
             {
 #if DEBUG
                 if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1075,7 +1075,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker)
             {
 #if DEBUG
-                if (ShouldRunAnalysisInDebug(compilation))
+                if (compilation.ShouldRunNullableWalkerInDebug)
                 {
                     // Always run analysis in debug builds so that we can more reliably catch
                     // nullable regressions e.g. https://github.com/dotnet/roslyn/issues/40136
@@ -1091,13 +1091,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Analyze(compilation, method, node, diagnostics, useConstructorExitWarnings, initialNullableState, getFinalNullableState, out finalNullableState);
         }
-
-#if DEBUG
-        private static bool ShouldRunAnalysisInDebug(CSharpCompilation compilation)
-        {
-            return compilation.Feature("nullableAnalysis") != "false";
-        }
-#endif
 
         internal static void Analyze(
             CSharpCompilation compilation,
@@ -1305,7 +1298,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
             // Always run analysis in debug builds so that we can more reliably catch
             // nullable regressions e.g. https://github.com/dotnet/roslyn/issues/40136
-            return ShouldRunAnalysisInDebug(compilation);
+            return compilation.ShouldRunNullableWalkerInDebug;
 #else
             var canSkipAnalysis = compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker;
             return !canSkipAnalysis;
@@ -1322,7 +1315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker)
             {
 #if DEBUG
-                if (ShouldRunAnalysisInDebug(compilation))
+                if (compilation.ShouldRunNullableWalkerInDebug)
                 {
                     // Always run analysis in debug builds so that we can more reliably catch
                     // nullable regressions e.g. https://github.com/dotnet/roslyn/issues/40136

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1230,7 +1230,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
-            if (compilation.IsNullableAnalysisEnabled || compilation.IsNullableAnalysisEnabledAlways)
+            if (compilation.IsNullableAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
@@ -1263,8 +1263,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             newSnapshots = newSnapshotBuilder.ToManagerAndFree();
 
 #if DEBUG
-            var compilation = binder.Compilation;
-            if (compilation.IsNullableAnalysisEnabled || compilation.IsNullableAnalysisEnabledAlways)
+            if (binder.Compilation.IsNullableAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, newSnapshots, node);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1296,7 +1296,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
             return compilation.ShouldRunNullableAnalysisAndIgnoreResults;
 #else
-            var canSkipAnalysis = compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker;
+            var canSkipAnalysis = compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableAnalysis;
             return !canSkipAnalysis;
 #endif
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
-            if (compilation.ShouldRunNullableAnalysisAndIgnoreResults)
+            if (compilation.NullableSemanticAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
@@ -1267,7 +1267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             newSnapshots = newSnapshotBuilder.ToManagerAndFree();
 
 #if DEBUG
-            if (binder.Compilation.ShouldRunNullableAnalysisAndIgnoreResults)
+            if (binder.Compilation.NullableSemanticAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, newSnapshots, node);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1074,7 +1074,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (CanSkipAnalysis(compilation))
             {
-                if (compilation.IsNullableAnalysisExplicitlyEnabled)
+                if (compilation.IsNullableAnalysisEnabledAlways)
                 {
                     // Once we address https://github.com/dotnet/roslyn/issues/46579 we should also always pass `getFinalNullableState: true` in debug mode.
                     // We will likely always need to write a 'null' out for the out parameter in this code path, though, because
@@ -1230,7 +1230,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
-            if (compilation.IsNullableAnalysisEnabled || compilation.IsNullableAnalysisExplicitlyEnabled)
+            if (compilation.IsNullableAnalysisEnabled || compilation.IsNullableAnalysisEnabledAlways)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
@@ -1264,7 +1264,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             var compilation = binder.Compilation;
-            if (compilation.IsNullableAnalysisEnabled || compilation.IsNullableAnalysisExplicitlyEnabled)
+            if (compilation.IsNullableAnalysisEnabled || compilation.IsNullableAnalysisEnabledAlways)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, newSnapshots, node);
             }
@@ -1295,7 +1295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static bool NeedsAnalysis(CSharpCompilation compilation)
         {
-            return !CanSkipAnalysis(compilation) || compilation.IsNullableAnalysisExplicitlyEnabled;
+            return !CanSkipAnalysis(compilation) || compilation.IsNullableAnalysisEnabledAlways;
         }
 
         /// <summary>Analyzes a node in a "one-off" context, such as for attributes or parameter default values.</summary>
@@ -1307,7 +1307,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var compilation = binder.Compilation;
             if (CanSkipAnalysis(compilation))
             {
-                if (!compilation.IsNullableAnalysisExplicitlyEnabled)
+                if (!compilation.IsNullableAnalysisEnabledAlways)
                 {
                     return;
                 }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9728,18 +9728,14 @@ public class Program
             string[] expectedWarningsNone = Array.Empty<string>();
 
             AssertEx.Equal(expectedWarningsAll, compileAndRun(featureOpt: null));
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis"));
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis=true"));
-            AssertEx.Equal(expectedWarningsNone, compileAndRun("/features:nullableAnalysis=false"));
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis=TRUE")); // unrecognized value (incorrect case) treated as "true"
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis=FALSE")); // unrecognized value (incorrect case) treated as "true"
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis=unknown")); // unrecognized value treated as "true"
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=true"));
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=false"));
-            AssertEx.Equal(expectedWarningsNone, compileAndRun("/features:nullableAnalysis=false,run-nullable-analysis=false"));
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis=false,run-nullable-analysis=true"));
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis=true,run-nullable-analysis=false"));
-            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:nullableAnalysis=true,run-nullable-analysis=true"));
+            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis"));
+            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=always"));
+            AssertEx.Equal(expectedWarningsNone, compileAndRun("/features:run-nullable-analysis=never"));
+            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=ALWAYS")); // unrecognized value (incorrect case) ignored
+            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=NEVER")); // unrecognized value (incorrect case) ignored
+            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=true")); // unrecognized value ignored
+            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=false")); // unrecognized value ignored
+            AssertEx.Equal(expectedWarningsAll, compileAndRun("/features:run-nullable-analysis=unknown")); // unrecognized value ignored
 
             CleanupAllGeneratedFiles(filePath);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableContextTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableContextTests.cs
@@ -4,9 +4,12 @@
 
 #nullable disable
 
+using System.Collections.Concurrent;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -149,5 +152,163 @@ partial class C
                 Assert.True(contextInherited.AnnotationsInherited());
             }
         }
+
+        // See also CommandLineTests.NullableAnalysisFlags().
+        [Fact]
+        public void NullableAnalysisFlags_01()
+        {
+            var source =
+@"#nullable enable
+class Program
+{
+    const object? C1 = null;
+    const object? C2 = null;
+#nullable enable
+    static object F1() => C1;
+#nullable disable
+    static object F2() => C2;
+}";
+
+            // https://github.com/dotnet/roslyn/issues/49746: Currently, if we analyze any members, we analyze all.
+            var expectedAnalyzedKeysAll = new[] { ".cctor", ".ctor", "F1", "F2" };
+
+            verify(parseOptions: TestOptions.Regular, expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", null), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false"));
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "TRUE"), expectedAnalyzedKeysAll); // unrecognized value (incorrect case) treated as "true"
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "FALSE"), expectedAnalyzedKeysAll); // unrecognized value (incorrect case) treated as "true"
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "unknown"), expectedAnalyzedKeysAll); // unrecognized value treated as "true"
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "true"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "false"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false").WithFeature("run-nullable-analysis", "false"));
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false").WithFeature("run-nullable-analysis", "true"), "F1", "F2");
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true").WithFeature("run-nullable-analysis", "false"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true").WithFeature("run-nullable-analysis", "true"), expectedAnalyzedKeysAll);
+
+            void verify(CSharpParseOptions parseOptions, params string[] expectedAnalyzedKeys)
+            {
+                var comp = CreateCompilation(source, parseOptions: parseOptions);
+                comp.NullableAnalysisData = new ConcurrentDictionary<object, int>();
+                if (expectedAnalyzedKeys.Length > 0)
+                {
+                    comp.VerifyDiagnostics(
+                        // (7,27): warning CS8603: Possible null reference return.
+                        //     static object F1() => C1;
+                        Diagnostic(ErrorCode.WRN_NullReferenceReturn, "C1").WithLocation(7, 27));
+                }
+                else
+                {
+                    comp.VerifyDiagnostics();
+                }
+
+                var actualAnalyzedKeys = GetNullableDataKeysAsStrings(comp.NullableAnalysisData);
+                AssertEx.Equal(expectedAnalyzedKeys, actualAnalyzedKeys);
+            }
+        }
+
+        [Fact]
+        public void NullableAnalysisFlags_02()
+        {
+            var source =
+@"#nullable enable
+class Program
+{
+    const object? C1 = null;
+    const object? C2 = null;
+#nullable enable
+    static void F1(object obj = C1) { }
+#nullable disable
+    static void F2(object obj = C2) { }
+}";
+
+            // https://github.com/dotnet/roslyn/issues/49746: Currently, if we analyze any members, we analyze all.
+            var expectedAnalyzedKeysAll = new[] { ".cctor", ".ctor", "= C1", "= C2", "F1", "F2" };
+
+            verify(parseOptions: TestOptions.Regular, expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", null), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false"));
+
+            void verify(CSharpParseOptions parseOptions, params string[] expectedAnalyzedKeys)
+            {
+                var comp = CreateCompilation(source, parseOptions: parseOptions);
+                comp.NullableAnalysisData = new ConcurrentDictionary<object, int>();
+                if (expectedAnalyzedKeys.Length > 0)
+                {
+                    comp.VerifyDiagnostics(
+                        // (7,33): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                        //     static void F1(object obj = C1) { }
+                        Diagnostic(ErrorCode.WRN_NullAsNonNullable, "C1").WithLocation(7, 33));
+                }
+                else
+                {
+                    comp.VerifyDiagnostics();
+                }
+
+                var actualAnalyzedKeys = GetNullableDataKeysAsStrings(comp.NullableAnalysisData);
+                AssertEx.Equal(expectedAnalyzedKeys, actualAnalyzedKeys);
+            }
+        }
+
+        [Fact]
+        public void NullableAnalysisFlags_03()
+        {
+            var sourceA =
+@"#nullable enable
+public class A : System.Attribute
+{
+    public A(object obj) { }
+    public const object? C1 = null;
+    public const object? C2 = null;
+}";
+            var refA = CreateCompilation(sourceA).EmitToImageReference();
+
+            var sourceB =
+@"#nullable enable
+[A(A.C1)]
+struct B1
+{
+}
+#nullable disable
+[A(A.C2)]
+struct B2
+{
+}";
+
+            // https://github.com/dotnet/roslyn/issues/49746: Currently, if we analyze any members, we analyze all.
+            var expectedAnalyzedKeysAll = new[] { ".cctor", ".cctor", "A(A.C1)", "A(A.C2)" };
+
+            verify(parseOptions: TestOptions.Regular, expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", null), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false"));
+
+            void verify(CSharpParseOptions parseOptions, params string[] expectedAnalyzedKeys)
+            {
+                var comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: parseOptions);
+                comp.NullableAnalysisData = new ConcurrentDictionary<object, int>();
+                if (expectedAnalyzedKeys.Length > 0)
+                {
+                    comp.VerifyDiagnostics(
+                        // (2,4): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                        // [A(A.C1)]
+                        Diagnostic(ErrorCode.WRN_NullAsNonNullable, "A.C1").WithLocation(2, 4));
+                }
+                else
+                {
+                    comp.VerifyDiagnostics();
+                }
+
+                var actualAnalyzedKeys = GetNullableDataKeysAsStrings(comp.NullableAnalysisData);
+                AssertEx.Equal(expectedAnalyzedKeys, actualAnalyzedKeys);
+            }
+        }
+
+        private static string[] GetNullableDataKeysAsStrings(ConcurrentDictionary<object, int> nullableData) =>
+            nullableData.Keys.Select(key => GetNullableDataKeyAsString(key)).OrderBy(key => key).ToArray();
+
+        private static string GetNullableDataKeyAsString(object key) =>
+            key is Symbol symbol ? symbol.MetadataName : ((SyntaxNode)key).ToString();
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableContextTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableContextTests.cs
@@ -173,18 +173,14 @@ class Program
             var expectedAnalyzedKeysAll = new[] { ".cctor", ".ctor", "F1", "F2" };
 
             verify(parseOptions: TestOptions.Regular, expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", null), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true"), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false"));
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "TRUE"), expectedAnalyzedKeysAll); // unrecognized value (incorrect case) treated as "true"
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "FALSE"), expectedAnalyzedKeysAll); // unrecognized value (incorrect case) treated as "true"
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "unknown"), expectedAnalyzedKeysAll); // unrecognized value treated as "true"
-            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "true"), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "false"), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false").WithFeature("run-nullable-analysis", "false"));
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false").WithFeature("run-nullable-analysis", "true"), "F1", "F2");
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true").WithFeature("run-nullable-analysis", "false"), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true").WithFeature("run-nullable-analysis", "true"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", null), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "always"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "never"));
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "ALWAYS"), expectedAnalyzedKeysAll); // unrecognized value (incorrect case) ignored
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "NEVER"), expectedAnalyzedKeysAll); // unrecognized value (incorrect case) ignored
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "true"), expectedAnalyzedKeysAll); // unrecognized value ignored
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "false"), expectedAnalyzedKeysAll); // unrecognized value ignored
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "unknown"), expectedAnalyzedKeysAll); // unrecognized value ignored
 
             void verify(CSharpParseOptions parseOptions, params string[] expectedAnalyzedKeys)
             {
@@ -226,9 +222,9 @@ class Program
             var expectedAnalyzedKeysAll = new[] { ".cctor", ".ctor", "= C1", "= C2", "F1", "F2" };
 
             verify(parseOptions: TestOptions.Regular, expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", null), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true"), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false"));
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", null), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "always"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "never"));
 
             void verify(CSharpParseOptions parseOptions, params string[] expectedAnalyzedKeys)
             {
@@ -280,9 +276,9 @@ struct B2
             var expectedAnalyzedKeysAll = new[] { ".cctor", ".cctor", "A(A.C1)", "A(A.C2)" };
 
             verify(parseOptions: TestOptions.Regular, expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", null), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true"), expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false"));
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", null), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "always"), expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "never"));
 
             void verify(CSharpParseOptions parseOptions, params string[] expectedAnalyzedKeys)
             {
@@ -323,13 +319,9 @@ class Program
             var expectedAnalyzedKeysAll = new[] { ".cctor", ".ctor", "F" };
 
             verify(parseOptions: TestOptions.Regular, expectedFlowState: true, expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", null), expectedFlowState: true, expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true"), expectedFlowState: true, expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false"), expectedFlowState: false);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false").WithFeature("run-nullable-analysis", "false"), expectedFlowState: false);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "false").WithFeature("run-nullable-analysis", "true"), expectedFlowState: true, "F");
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true").WithFeature("run-nullable-analysis", "false"), expectedFlowState: false, expectedAnalyzedKeysAll);
-            verify(parseOptions: TestOptions.Regular.WithFeature("nullableAnalysis", "true").WithFeature("run-nullable-analysis", "true"), expectedFlowState: true, expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", null), expectedFlowState: true, expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "always"), expectedFlowState: true, expectedAnalyzedKeysAll);
+            verify(parseOptions: TestOptions.Regular.WithFeature("run-nullable-analysis", "never"), expectedFlowState: false);
 
             void verify(CSharpParseOptions parseOptions, bool expectedFlowState, params string[] expectedAnalyzedKeys)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -7,6 +7,7 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Text;
 using Xunit;
@@ -399,9 +400,13 @@ class Program
 
             var source = builder.ToString();
             var comp = CreateCompilation(source);
+            comp.NullableAnalysisData = new ConcurrentDictionary<object, int>();
             comp.VerifyDiagnostics();
 
             CheckIsSimpleMethod(comp, "F2", true);
+
+            var method = comp.GetMember("Program.F2");
+            Assert.Equal(1, comp.NullableAnalysisData[method]);
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -177,7 +177,7 @@ void local() => System.Console.WriteLine(2);
 
             static void verifyModel(CSharpCompilation comp, SyntaxTree tree1, bool nullableEnabled = false)
             {
-                Assert.Equal(nullableEnabled, comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+                Assert.Equal(nullableEnabled, comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
                 var model1 = comp.GetSemanticModel(tree1);
 
                 verifyModelForGlobalStatements(tree1, model1);
@@ -302,7 +302,7 @@ IMethodBodyOperation (OperationKind.MethodBody, Type: null) (Syntax: 'local(); .
 
             static void verifyModel(CSharpCompilation comp, SyntaxTree tree1, SyntaxTree tree2, bool nullableEnabled = false)
             {
-                Assert.Equal(nullableEnabled, comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+                Assert.Equal(nullableEnabled, comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
                 var model1 = comp.GetSemanticModel(tree1);
 
                 verifyModelForGlobalStatements(tree1, model1);
@@ -467,7 +467,7 @@ void local() => System.Console.WriteLine(i);
 
             static void verifyModel(CSharpCompilation comp, SyntaxTree tree1, SyntaxTree tree2)
             {
-                Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+                Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
                 var model1 = comp.GetSemanticModel(tree1);
                 var localDecl = tree1.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
@@ -519,7 +519,7 @@ System.Console.Write(i);
 
             var tree1 = comp.SyntaxTrees[0];
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var model1 = comp.GetSemanticModel(tree1);
             var localDecl = tree1.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
@@ -559,7 +559,7 @@ void local() => System.Console.WriteLine(i);
 
             static void verifyModel(CSharpCompilation comp, SyntaxTree tree1)
             {
-                Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+                Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
                 var model1 = comp.GetSemanticModel(tree1);
                 var localDecl = tree1.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
@@ -683,7 +683,7 @@ System.Console.WriteLine(s);
 
             CompileAndVerify(comp, expectedOutput: "Hi!");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
@@ -855,7 +855,7 @@ System.Console.Write(x);
                 Diagnostic(ErrorCode.ERR_SimpleProgramMultipleUnitsWithTopLevelStatements, "int").WithLocation(2, 1)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -969,7 +969,7 @@ System.Console.Write(x);
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(4, 5)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -1024,7 +1024,7 @@ System.Console.Write(args);
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "args").WithArguments("args").WithLocation(2, 8)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -1379,7 +1379,7 @@ class C1
                 Diagnostic(ErrorCode.ERR_SimpleProgramLocalIsReferencedOutsideOfTopLevelStatement, "x").WithArguments("x").WithLocation(6, 30)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree2 = comp.SyntaxTrees[1];
             var model2 = comp.GetSemanticModel(tree2);
@@ -1397,7 +1397,7 @@ class C1
                 Diagnostic(ErrorCode.ERR_SimpleProgramLocalIsReferencedOutsideOfTopLevelStatement, "x").WithArguments("x").WithLocation(6, 30)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             tree2 = comp.SyntaxTrees[0];
             model2 = comp.GetSemanticModel(tree2);
@@ -1657,7 +1657,7 @@ namespace N1
             var getHashCode = ((Compilation)comp).GetMember("System.Object." + nameof(GetHashCode));
             var testType = ((Compilation)comp).GetTypeByMetadataName("Test");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -1680,7 +1680,7 @@ namespace N1
             Assert.DoesNotContain(declSymbol, symbols);
             Assert.Same(testType, model1.LookupNamespacesAndTypes(localDecl.SpanStart, name: "Test").Single());
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var nameRefs = tree1.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Test").ToArray();
 
@@ -1830,7 +1830,7 @@ namespace N1
             var getHashCode = ((Compilation)comp).GetMember("System.Object." + nameof(GetHashCode));
             var testType = ((Compilation)comp).GetTypeByMetadataName("Test");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -1853,7 +1853,7 @@ namespace N1
             Assert.DoesNotContain(declSymbol, symbols);
             Assert.Same(testType, model1.LookupNamespacesAndTypes(localDecl.SpanStart, name: "Test").Single());
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree2 = comp.SyntaxTrees[1];
             var model2 = comp.GetSemanticModel(tree2);
@@ -2056,7 +2056,7 @@ namespace N1
 
             var testType = ((Compilation)comp).GetTypeByMetadataName("Test");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -2220,7 +2220,7 @@ namespace N1
 
             var testType = ((Compilation)comp).GetTypeByMetadataName("Test");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -2398,7 +2398,7 @@ namespace N1
 
             var testType = ((Compilation)comp).GetTypeByMetadataName("Test");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -2890,7 +2890,7 @@ void local()
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "local").WithArguments("local").WithLocation(7, 1)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -3913,7 +3913,7 @@ namespace N1
 
             var testType = ((Compilation)comp).GetTypeByMetadataName("args");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -4062,7 +4062,7 @@ namespace N1
 
             var testType = ((Compilation)comp).GetTypeByMetadataName("args");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree = comp.SyntaxTrees[1];
             var model = comp.GetSemanticModel(tree);
@@ -4187,7 +4187,7 @@ void local()
 
             CompileAndVerify(comp, expectedOutput: "15");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
@@ -4470,7 +4470,7 @@ void local2()
                 Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "local2").WithArguments("local2").WithLocation(5, 6)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -4534,7 +4534,7 @@ void local2()
                 Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "local1").WithArguments("local1").WithLocation(7, 6)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -4583,7 +4583,7 @@ void args(int x)
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "args").WithArguments("args").WithLocation(3, 6)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -4853,7 +4853,7 @@ label1: System.Console.WriteLine(""Hi!"");
 
             CompileAndVerify(comp, expectedOutput: "Hi!");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
@@ -4910,7 +4910,7 @@ goto label1;
                 Diagnostic(ErrorCode.ERR_SimpleProgramMultipleUnitsWithTopLevelStatements, "label1").WithLocation(2, 1)
                 );
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree1 = comp.SyntaxTrees[0];
             var model1 = comp.GetSemanticModel(tree1);
@@ -4938,7 +4938,7 @@ args: System.Console.WriteLine(""Hi!"");
 
             CompileAndVerify(comp, expectedOutput: "Hi!");
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
+            Assert.False(comp.IsNullableAnalysisEnabled); // To make sure we test incremental binding for SemanticModel
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -1747,7 +1747,7 @@ class C
                 //         object o = null;
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "o").WithArguments("o").WithLocation(9, 16));
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled);
+            Assert.False(comp.IsNullableAnalysisEnabled);
 
             comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
@@ -1764,7 +1764,7 @@ class C
                 //         object o = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(9, 20));
 
-            Assert.True(comp.NullableSemanticAnalysisEnabled);
+            Assert.True(comp.IsNullableAnalysisEnabled);
         }
 
         private class CSharp73ProvidesNullableSemanticInfo_Analyzer : DiagnosticAnalyzer

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -1736,9 +1736,20 @@ class C
 }
 ";
 
-            var featureFlagOff = TestOptions.Regular8.WithFeature("run-nullable-analysis", "false");
+            var featureFlagOff = TestOptions.Regular8.WithFeature("run-nullable-analysis", "never");
 
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: featureFlagOff);
+            comp.VerifyDiagnostics(
+                // (5,12): warning CS0414: The field 'C.field' is assigned but its value is never used
+                //     object field = null;
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "field").WithArguments("C.field").WithLocation(5, 12),
+                // (9,16): warning CS0219: The variable 'o' is assigned but its value is never used
+                //         object o = null;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "o").WithArguments("o").WithLocation(9, 16));
+
+            Assert.False(comp.NullableSemanticAnalysisEnabled);
+
+            comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (5,12): warning CS0414: The field 'C.field' is assigned but its value is never used
                 //     object field = null;
@@ -1753,7 +1764,7 @@ class C
                 //         object o = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(9, 20));
 
-            Assert.False(comp.NullableSemanticAnalysisEnabled);
+            Assert.True(comp.NullableSemanticAnalysisEnabled);
         }
 
         private class CSharp73ProvidesNullableSemanticInfo_Analyzer : DiagnosticAnalyzer
@@ -2557,8 +2568,8 @@ class C
             }
         }
 
-        [InlineData("true")]
-        [InlineData("false")]
+        [InlineData("always")]
+        [InlineData("never")]
         [Theory, WorkItem(37659, "https://github.com/dotnet/roslyn/issues/37659")]
         public void InvalidCodeVar_GetsCorrectSymbol(string flagState)
         {

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -442,7 +442,7 @@ getOperation:
         /// </summary>
         internal static void VerifyTypes(this CSharpCompilation compilation, SyntaxTree tree = null)
         {
-            Assert.True(compilation.NullableSemanticAnalysisEnabled);
+            Assert.True(compilation.IsNullableAnalysisEnabled);
 
             if (tree == null)
             {

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -6524,7 +6524,7 @@ class C
         Public Async Function CompletionBeforeVarWithEnableNullableReferenceAnalysisIDEFeatures(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateTestStateFromWorkspace(
                  <Workspace>
-                     <Project Language="C#" LanguageVersion="8" CommonReferences="true" AssemblyName="CSProj" Features="run-nullable-analysis">
+                     <Project Language="C#" LanguageVersion="8" CommonReferences="true" AssemblyName="CSProj" Features="run-nullable-analysis=always">
                          <Document><![CDATA[
 class C
 {


### PR DESCRIPTION
Add a switch that allows skipping nullable analysis completely for the compilation, or running nullable analysis on all methods in the compilation.

```
run-nullable-analysis=always  // analyze all methods
run-nullable-analysis=never   // skip all analysis
run-nullable-analysis=<other> // unrecognized value silently ignored
```

From a project file: `<Features>run-nullable-analysis=never</Features>`

From the command line: `-features:run-nullable-analysis=never`