### PR TITLE
Fix typo in comment

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Can the given decision dag node, and its successors, be generated as a sequence of
-            // linear tests with a single "golden" path to the try label and all other paths leading
+            // linear tests with a single "golden" path to the true label and all other paths leading
             // to the false label?  This occurs with an is-pattern expression that uses no "or" or "not"
             // pattern forms.
             static bool canProduceLinearSequence(


### PR DESCRIPTION
Found when reviewing #49369. Comment is slightly confusing until you realize that "try" was probably meant to be "true".