### PR TITLE
Workaround publishing error due to powershell task change

### DIFF
--- a/eng/common/post-build/post-build-utils.ps1
+++ b/eng/common/post-build/post-build-utils.ps1
@@ -68,9 +68,9 @@ function Assign-BuildToChannel([int]$BuildId, [int]$ChannelId) {
 
 function Validate-MaestroVars {
   try {
-    Get-Variable MaestroApiEndPoint -Scope Global | Out-Null
-    Get-Variable MaestroApiVersion -Scope Global | Out-Null
-    Get-Variable MaestroApiAccessToken -Scope Global | Out-Null
+    Get-Variable MaestroApiEndPoint | Out-Null
+    Get-Variable MaestroApiVersion | Out-Null
+    Get-Variable MaestroApiAccessToken | Out-Null
 
     if (!($MaestroApiEndPoint -Match "^http[s]?://maestro-(int|prod).westus2.cloudapp.azure.com$")) {
       Write-PipelineTaskError "MaestroApiEndPoint is not a valid Maestro URL. '$MaestroApiEndPoint'"


### PR DESCRIPTION
Temporarily unblocks signed builds while https://github.com/dotnet/arcade/issues/6673 is fixed

Arcade updates will stomp on these changes but will at least allow us to get signed builds out temporarily.  Future arcade updates should have a fix - https://github.com/dotnet/arcade/pull/6674
