### PR TITLE
Allow you to show advanced members in VB 

### DIFF
--- a/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/PackageRegistration.pkgdef
@@ -18,8 +18,16 @@
 @="{694dd9b6-b865-4c5b-ad85-86356e9c88dc}"
 "Package"="{13c3bbb4-f18f-4111-9f54-a0fb010d9194}"
 "LangResID"=dword:00000065
+
+"DefaultToInsertSpaces"=dword:00000001
+"EnableAdvancedMembersOption"=dword:00000001
 "RequestStockColors"=dword:00000001
+"ShowBraceCompletion"=dword:00000001
+"ShowCompletion"=dword:00000001
 "ShowDropdownBarOption"=dword:00000001
+"ShowSmartIndent"=dword:00000001
+"SupportsImageCaching"=dword:00000001
+// DesignerLoader is still set in the VS Repo since it contains a VS version number
 
 [$RootKey$\Services\{694dd9b6-b865-4c5b-ad85-86356e9c88dc}]
 @="{13c3bbb4-f18f-4111-9f54-a0fb010d9194}"

--- a/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
@@ -170,6 +170,7 @@
 "LangResID"=dword:00000000
 
 "DefaultToInsertSpaces"=dword:00000001
+"EnableAdvancedMembersOption"=dword:00000001
 "HideAdvancedMembersByDefault"=dword:00000001
 "RequestStockColors"=dword:00000001
 "ShowBraceCompletion"=dword:00000001


### PR DESCRIPTION
We already support this for C#, so all of the plumbing is in place. The first commit is cleaning up the C# equivalent of this file, since it was confusing why our files were differing. A PR in the VS repo will clean that bit up momentarily.