### PR TITLE
Code lens: Constructor invocations should count as references of class declarations

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
@@ -7,6 +7,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeLens;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeLens
@@ -248,6 +249,55 @@ public class A
     </Project>
 </Workspace>";
             await RunFullyQualifiedNameTest(input);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        [WorkItem(49636, "https://github.com/dotnet/roslyn/issues/49636")]
+        public async Task TestExplicitParameterlessConstructor()
+        {
+            const string input = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+{|1:public class Foo|}
+{
+    public Foo() { }
+}
+public class B
+{
+    private void Test()
+    {
+        var foo = new Foo();
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>";
+            await RunReferenceTest(input);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        [WorkItem(49636, "https://github.com/dotnet/roslyn/issues/49636")]
+        public async Task TestImplicitParameterlessConstructor()
+        {
+            const string input = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+{|1:public class Foo|}
+{
+}
+public class B
+{
+    private void Test()
+    {
+        var foo = new Foo();
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>";
+            await RunReferenceTest(input);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
@@ -278,6 +278,32 @@ public class B
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
         [WorkItem(49636, "https://github.com/dotnet/roslyn/issues/49636")]
+        public async Task TestExplicitParameterlessConstructor_TwoCalls()
+        {
+            const string input = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+{|2:public class Foo|}
+{
+    public Foo() { }
+}
+public class B
+{
+    private void Test()
+    {
+        var foo1 = new Foo();
+        var foo2 = new Foo();
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>";
+            await RunReferenceTest(input);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        [WorkItem(49636, "https://github.com/dotnet/roslyn/issues/49636")]
         public async Task TestImplicitParameterlessConstructor()
         {
             const string input = @"<Workspace>
@@ -291,6 +317,31 @@ public class B
     private void Test()
     {
         var foo = new Foo();
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>";
+            await RunReferenceTest(input);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        [WorkItem(49636, "https://github.com/dotnet/roslyn/issues/49636")]
+        public async Task TestImplicitParameterlessConstructor_TwoCalls()
+        {
+            const string input = @"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+{|2:public class Foo|}
+{
+}
+public class B
+{
+    private void Test()
+    {
+        var foo1 = new Foo();
+        var foo2 = new Foo();
     }
 }
 ]]>

--- a/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
@@ -258,7 +258,7 @@ public class A
             const string input = @"<Workspace>
     <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
         <Document FilePath=""CurrentDocument.cs""><![CDATA[
-{|1:public class Foo|}
+{|2:public class Foo|}
 {
     public Foo() { }
 }
@@ -283,7 +283,7 @@ public class B
             const string input = @"<Workspace>
     <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
         <Document FilePath=""CurrentDocument.cs""><![CDATA[
-{|2:public class Foo|}
+{|3:public class Foo|}
 {
     public Foo() { }
 }

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -131,8 +131,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
             // reference location for the invocation while computing references count for the named type symbol. 
             var isImplicitReference = _queriedSymbol.Kind == SymbolKind.NamedType &&
                                       (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
-            return isImplicitlyDeclared ||
-                   isImplicitReference ||
+            return (isImplicitlyDeclared && !isImplicitReference) ||
                    !reference.Location.IsInSource ||
                    !definition.Locations.Any(loc => loc.IsInSource);
         }

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
 
         private static bool FilterDefinition(ISymbol definition)
         {
-            return (definition.IsImplicitlyDeclared && !definition.IsConstructor()) ||
+            return definition.IsImplicitlyDeclared ||
                    (definition as IMethodSymbol)?.AssociatedSymbol != null;
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
             // Add remote locations for all the syntax references except the queried syntax node.
             // To query for the partial locations, filter definition locations that occur in source whose span is part of
             // span of any syntax node from Definition.DeclaringSyntaxReferences except for the queried syntax node.
-            var locations = symbol.Locations.Intersect(_queriedSymbol.Locations, LocationComparer.Instance).Any() && !symbol.IsImplicitlyDeclared
+            var locations = symbol.Locations.Intersect(_queriedSymbol.Locations, LocationComparer.Instance).Any()
                 ? GetPartialLocations(symbol, _aggregateCancellationTokenSource.Token)
                 : symbol.Locations;
 

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -126,12 +126,13 @@ namespace Microsoft.CodeAnalysis.CodeLens
         private bool FilterReference(ISymbol definition, ReferenceLocation reference)
         {
             var isImplicitlyDeclared = definition.IsImplicitlyDeclared || definition.IsAccessor();
-            // FindRefs treats a constructor invocation as a reference to the constructor symbol and to the named type symbol that defines it.
-            // While we need to count the cascaded symbol definition from the named type to its constructor, we should not double count the
-            // reference location for the invocation while computing references count for the named type symbol. 
-            var isImplicitReference = _queriedSymbol.Kind == SymbolKind.NamedType &&
-                                      (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
-            return (isImplicitlyDeclared && !isImplicitReference) ||
+            // FindRefs treats a constructor invocation as a reference to the constructor symbol and to the named type symbol that defines it and
+            // so should we. Otherwise named types may have a reference count of 0, even if there are calls to its constructors, which might cause
+            // people think the class is not in use (#49636).
+            // Invocations to implicit parameterless constructors need to be included too.
+            var isConstructorInvocation = _queriedSymbol.Kind == SymbolKind.NamedType &&
+                                          (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
+            return (isImplicitlyDeclared && !isConstructorInvocation) ||
                    !reference.Location.IsInSource ||
                    !definition.Locations.Any(loc => loc.IsInSource);
         }

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
 
         private static bool FilterDefinition(ISymbol definition)
         {
-            return definition.IsImplicitlyDeclared ||
+            return (definition.IsImplicitlyDeclared && !definition.IsConstructor()) ||
                    (definition as IMethodSymbol)?.AssociatedSymbol != null;
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
             // Add remote locations for all the syntax references except the queried syntax node.
             // To query for the partial locations, filter definition locations that occur in source whose span is part of
             // span of any syntax node from Definition.DeclaringSyntaxReferences except for the queried syntax node.
-            var locations = symbol.Locations.Intersect(_queriedSymbol.Locations, LocationComparer.Instance).Any()
+            var locations = symbol.Locations.Intersect(_queriedSymbol.Locations, LocationComparer.Instance).Any() && !symbol.IsImplicitlyDeclared
                 ? GetPartialLocations(symbol, _aggregateCancellationTokenSource.Token)
                 : symbol.Locations;
 


### PR DESCRIPTION
Fixes #49636

Note: This PR changes how references are counted for CodeLens. At the time of writing, this change was not yet approved by the roslyn team. The discussion, why this change is useful can be found in issue #49636.