### PR TITLE
VB: Ensure array access indexes undergo conversion to integer even when there is a mismatch with array rank.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -3893,23 +3893,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 expr = expr.MakeRValue()
             End If
 
-            Dim builder As ArrayBuilder(Of BoundExpression) = Nothing
-            For i = 0 To boundArguments.Length - 1
-                Dim index As BoundExpression = boundArguments(i)
-                If builder Is Nothing AndAlso index.IsLValue Then
-                    builder = ArrayBuilder(Of BoundExpression).GetInstance()
-                    For k = 0 To i - 1
-                        builder.Add(boundArguments(k))
-                    Next
-                End If
+            Dim convertedArguments = ArrayBuilder(Of BoundExpression).GetInstance(boundArguments.Length)
+            Dim int32Type = GetSpecialType(SpecialType.System_Int32, node.ArgumentList, diagnostics)
 
-                If builder IsNot Nothing Then
-                    builder.Add(index.MakeRValue)
-                End If
+            For Each argument In boundArguments
+                convertedArguments.Add(ApplyImplicitConversion(argument.Syntax, int32Type, argument, diagnostics))
             Next
-            If builder IsNot Nothing Then
-                boundArguments = builder.ToImmutableAndFree()
-            End If
+
+            boundArguments = convertedArguments.ToImmutableAndFree()
 
             Dim exprType = expr.Type
             If exprType Is Nothing Then
@@ -3933,13 +3924,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return New BoundArrayAccess(node, expr, boundArguments, arrayType.ElementType, hasErrors:=True)
             End If
 
-            Dim convertedArguments As BoundExpression() = New BoundExpression(boundArguments.Length - 1) {}
-            Dim int32Type = GetSpecialType(SpecialType.System_Int32, node.ArgumentList, diagnostics)
-            For i = 0 To boundArguments.Length - 1
-                convertedArguments(i) = ApplyImplicitConversion(boundArguments(i).Syntax, int32Type, boundArguments(i), diagnostics)
-            Next i
-
-            Return New BoundArrayAccess(node, expr, convertedArguments.AsImmutableOrNull(), arrayType.ElementType)
+            Return New BoundArrayAccess(node, expr, boundArguments, arrayType.ElementType)
         End Function
 
         ' Get the common return type of a set of symbols, or error type if no common return type. Used

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IArrayElementReferenceExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IArrayElementReferenceExpression.vb
@@ -640,13 +640,21 @@ IArrayElementReferenceOperation (OperationKind.ArrayElementReference, Type: Syst
     IParameterReferenceOperation: args (OperationKind.ParameterReference, Type: System.String(), IsInvalid) (Syntax: 'args')
   Indices(2):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsInvalid) (Syntax: '0')
-      IOmittedArgumentOperation (OperationKind.OmittedArgument, Type: null, IsInvalid) (Syntax: '')
+      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: '')
+        Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        Operand: 
+          IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid, IsImplicit) (Syntax: '')
+            Children(1):
+                IOmittedArgumentOperation (OperationKind.OmittedArgument, Type: null, IsInvalid) (Syntax: '')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[
 BC30106: Number of indices exceeds the number of dimensions of the indexed array.
         Dim a = args(0,)'BIND:"args(0,)"
                     ~~~~
+BC30491: Expression does not produce a value.
+        Dim a = args(0,)'BIND:"args(0,)"
+                       ~
 ]]>.Value
 
             VerifyOperationTreeAndDiagnosticsForTest(Of InvocationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)


### PR DESCRIPTION
Fixes #49904.