### PR TITLE
VB: Report non-Const locals used in an expression that must have a constant value.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
@@ -1295,10 +1295,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If boundExpression.Kind = BoundKind.Local Then
                     Dim local = DirectCast(boundExpression, BoundLocal).LocalSymbol
                     If Not local.IsConst Then
+                        ReportDiagnostic(diagnostics, boundExpression.Syntax, ERRID.ERR_RequiredConstExpr)
                         Return Nothing
                     End If
 
-                    Return local.GetConstantValue(Me)
+                    Return If(nonConstantDetected, Nothing, local.GetConstantValue(Me))
                 End If
 
                 ' Check that the expression is constant.
@@ -1330,9 +1331,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim binaryOperator = DirectCast(boundExpression, BoundBinaryOperator)
                             ' the right side is expected to be shorter for binary operations, so we use
                             ' recursion for this side.
-                            If GetExpressionConstantValueIfAny(binaryOperator.Right, diagnostics, context) Is Nothing Then
-                                nonConstantDetected = True
-                            End If
+                            GetExpressionConstantValueIfAny(binaryOperator.Right, diagnostics, context)
+                            nonConstantDetected = True
                             boundExpression = binaryOperator.Left
 
                         Case BoundKind.UnaryOperator

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenConstLocal.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenConstLocal.vb
@@ -818,6 +818,109 @@ End Module
 23334800
             ]]>)
         End Sub
+
+        <Fact()>
+        <WorkItem(49902, "https://github.com/dotnet/roslyn/issues/49902")>
+        Public Sub BadConstantValue_1()
+            Dim compilation = CreateCompilation(
+<compilation>
+    <file name="c.vb">
+Class Test
+
+    Shared Sub Main()
+        Dim z As Integer = 2
+        Const w As Integer = 2 ^ z
+    End Sub
+
+End Class
+    </file>
+</compilation>)
+
+            compilation.AssertTheseEmitDiagnostics(
+<expected>
+BC30059: Constant expression is required.
+        Const w As Integer = 2 ^ z
+                                 ~
+</expected>)
+        End Sub
+
+        <Fact()>
+        <WorkItem(49902, "https://github.com/dotnet/roslyn/issues/49902")>
+        Public Sub BadConstantValue_2()
+            Dim compilation = CreateCompilation(
+<compilation>
+    <file name="c.vb">
+Class Test
+
+    Shared Sub Main()
+        Dim z As Integer = 2
+        Const w As Integer = z
+    End Sub
+
+End Class
+    </file>
+</compilation>)
+
+            compilation.AssertTheseEmitDiagnostics(
+<expected>
+BC30059: Constant expression is required.
+        Const w As Integer = z
+                             ~
+</expected>)
+        End Sub
+
+        <Fact()>
+        <WorkItem(49902, "https://github.com/dotnet/roslyn/issues/49902")>
+        Public Sub BadConstantValue_3()
+            Dim compilation = CreateCompilation(
+<compilation>
+    <file name="c.vb">
+Class Test
+
+    Shared Sub Main()
+        Dim z As Integer = 2
+        Const w As Integer = z ^ 2
+    End Sub
+
+End Class
+    </file>
+</compilation>)
+
+            compilation.AssertTheseEmitDiagnostics(
+<expected>
+BC30059: Constant expression is required.
+        Const w As Integer = z ^ 2
+                             ~
+</expected>)
+        End Sub
+
+        <Fact()>
+        <WorkItem(49902, "https://github.com/dotnet/roslyn/issues/49902")>
+        Public Sub BadConstantValue_4()
+            Dim compilation = CreateCompilation(
+<compilation>
+    <file name="c.vb">
+Class Test
+
+    Shared Sub Main()
+        Dim z As Integer = 2
+        Const w As Integer = z ^ z
+    End Sub
+
+End Class
+    </file>
+</compilation>)
+
+            compilation.AssertTheseEmitDiagnostics(
+<expected>
+BC30059: Constant expression is required.
+        Const w As Integer = z ^ z
+                             ~
+BC30059: Constant expression is required.
+        Const w As Integer = z ^ z
+                                 ~
+</expected>)
+        End Sub
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IConversionExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IConversionExpression.vb
@@ -2587,6 +2587,9 @@ IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDecla
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[
+BC30059: Constant expression is required.
+        Const s As SByte = i'BIND:"Const s As SByte = i"
+                           ~
 BC30512: Option Strict On disallows implicit conversions from 'Integer' to 'SByte'.
         Const s As SByte = i'BIND:"Const s As SByte = i"
                            ~


### PR DESCRIPTION
Fixes #49902.