### PR TITLE
Allow pattern matching `null` against pointer types when the pointer types contain nested type parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -345,7 +345,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     HashSet<DiagnosticInfo>? useSiteDiagnostics = null;
                     if (expression.ConstantValue == ConstantValue.Null)
                     {
-                        if (inputType.IsNonNullableValueType())
+                        // Function pointers are value types, but they can be assigned null, so they can be matched against null.
+                        if (inputType.IsNonNullableValueType() && inputType.TypeKind != TypeKind.FunctionPointer)
                         {
                             // We do not permit matching null against a struct type.
                             diagnostics.Add(ErrorCode.ERR_ValueCantBeNull, expression.Syntax.Location, inputType);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -345,8 +345,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     HashSet<DiagnosticInfo>? useSiteDiagnostics = null;
                     if (expression.ConstantValue == ConstantValue.Null)
                     {
-                        // Function pointers are value types, but they can be assigned null, so they can be matched against null.
-                        if (inputType.IsNonNullableValueType() && inputType.TypeKind != TypeKind.FunctionPointer)
+                        // Pointers are value types, but they can be assigned null, so they can be matched against null.
+                        if (inputType.IsNonNullableValueType() && !inputType.IsPointerOrFunctionPointer())
                         {
                             // We do not permit matching null against a struct type.
                             diagnostics.Add(ErrorCode.ERR_ValueCantBeNull, expression.Syntax.Location, inputType);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -11181,20 +11181,24 @@ unsafe
         {
             var verifier = CompileAndVerifyFunctionPointers(@"
 using System;
-using System.Threading.Tasks;
 unsafe
 {
     test<int>(null);
+    test<int>(&intTest);
 
     static void test<T>(delegate*<T, void> f)
     {
         Console.WriteLine(f == null);
         Console.WriteLine(f is null);
     }
+
+    static void intTest(int i) {}
 }
 ", expectedOutput: @"
 True
-True");
+True
+False
+False");
 
             verifier.VerifyIL("<Program>$.<<Main>$>g__test|0_0<T>(delegate*<T, void>)", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -11176,6 +11176,45 @@ unsafe
             );
         }
 
+        [Fact, WorkItem(49639, "https://github.com/dotnet/roslyn/issues/49639")]
+        public void CompareToNullWithNestedUnconstrainedTypeParameter()
+        {
+            var verifier = CompileAndVerifyFunctionPointers(@"
+using System;
+using System.Threading.Tasks;
+unsafe
+{
+    test<int>(null);
+
+    static void test<T>(delegate*<T, void> f)
+    {
+        Console.WriteLine(f == null);
+        Console.WriteLine(f is null);
+    }
+}
+", expectedOutput: @"
+True
+True");
+
+            verifier.VerifyIL("<Program>$.<<Main>$>g__test|0_0<T>(delegate*<T, void>)", @"
+{
+  // Code size       21 (0x15)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  conv.u
+  IL_0003:  ceq
+  IL_0005:  call       ""void System.Console.WriteLine(bool)""
+  IL_000a:  ldarg.0
+  IL_000b:  ldc.i4.0
+  IL_000c:  conv.u
+  IL_000d:  ceq
+  IL_000f:  call       ""void System.Console.WriteLine(bool)""
+  IL_0014:  ret
+}
+");
+        }
+
         private static readonly Guid s_guid = new Guid("97F4DBD4-F6D1-4FAD-91B3-1001F92068E5");
         private static readonly BlobContentId s_contentId = new BlobContentId(s_guid, 0x04030201);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -9539,6 +9539,92 @@ unsafe struct S
 ");
         }
 
+        [Fact, WorkItem(49639, "https://github.com/dotnet/roslyn/issues/49639")]
+        public void CompareToNullWithNestedUnconstrainedTypeParameter()
+        {
+            var verifier = CompileAndVerify(@"
+using System;
+unsafe
+{
+    test<int>(null);
+    S<int> s = default;
+    test<int>(&s);
+
+    static void test<T>(S<T>* s)
+    {
+        Console.WriteLine(s == null);
+        Console.WriteLine(s is null);
+    }
+}
+
+struct S<T> {}
+", options: TestOptions.UnsafeReleaseExe, expectedOutput: @"
+True
+True
+False
+False");
+
+            verifier.VerifyIL("<Program>$.<<Main>$>g__test|0_0<T>(S<T>*)", @"
+{
+  // Code size       21 (0x15)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  conv.u
+  IL_0003:  ceq
+  IL_0005:  call       ""void System.Console.WriteLine(bool)""
+  IL_000a:  ldarg.0
+  IL_000b:  ldc.i4.0
+  IL_000c:  conv.u
+  IL_000d:  ceq
+  IL_000f:  call       ""void System.Console.WriteLine(bool)""
+  IL_0014:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(49639, "https://github.com/dotnet/roslyn/issues/49639")]
+        public void CompareToNullWithPointerToUnmanagedTypeParameter()
+        {
+            var verifier = CompileAndVerify(@"
+using System;
+unsafe
+{
+    test<int>(null);
+    int i = 0;
+    test<int>(&i);
+
+    static void test<T>(T* t) where T : unmanaged
+    {
+        Console.WriteLine(t == null);
+        Console.WriteLine(t is null);
+    }
+}
+", options: TestOptions.UnsafeReleaseExe, expectedOutput: @"
+True
+True
+False
+False");
+
+            verifier.VerifyIL("<Program>$.<<Main>$>g__test|0_0<T>(T*)", @"
+{
+  // Code size       21 (0x15)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  conv.u
+  IL_0003:  ceq
+  IL_0005:  call       ""void System.Console.WriteLine(bool)""
+  IL_000a:  ldarg.0
+  IL_000b:  ldc.i4.0
+  IL_000c:  conv.u
+  IL_000d:  ceq
+  IL_000f:  call       ""void System.Console.WriteLine(bool)""
+  IL_0014:  ret
+}
+");
+        }
+
         #endregion Pointer comparison tests
 
         #region stackalloc tests


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49639.

I've gone through other references to `IsNonNullableValueType`, and none of them need updating. The rest of the uses center around type parameter constraint checking, which function pointers cannot be, and lifted conversion operators, where the underlying value type is being checked with this method, and function pointers cannot be that underlying type.