### PR TITLE
Normalize pointers to have asterisk next to type instead of identifier

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -495,6 +495,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return true;
             }
 
+            // No space before an asterisk that's part of a PointerTypeSyntax.
+            if (next.IsKind(SyntaxKind.AsteriskToken) && next.Parent is PointerTypeSyntax)
+            {
+                return false;
+            }
+
+            // The last asterisk of a pointer declaration should be followed by a space.
+            if (token.IsKind(SyntaxKind.AsteriskToken) && token.Parent is PointerTypeSyntax && next.IsKind(SyntaxKind.IdentifierToken))
+            {
+                return true;
+            }
+
             if (IsKeyword(token.Kind()))
             {
                 if (!next.IsKind(SyntaxKind.ColonToken) &&

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -502,7 +502,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
 
             // The last asterisk of a pointer declaration should be followed by a space.
-            if (token.IsKind(SyntaxKind.AsteriskToken) && token.Parent is PointerTypeSyntax && next.IsKind(SyntaxKind.IdentifierToken))
+            if (token.IsKind(SyntaxKind.AsteriskToken) && token.Parent is PointerTypeSyntax &&
+                (next.IsKind(SyntaxKind.IdentifierToken) || next.Parent.IsKind(SyntaxKind.IndexerDeclaration)))
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -180,6 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("int **p;", "int** p;")]
         [InlineData("int**p1,p2;", "int** p1, p2;")]
         [InlineData("int **p1, p2;", "int** p1, p2;")]
+        [InlineData("delegate * <int, void> p1;", "delegate*<int, void> p1;")]
         [WorkItem(49733, "https://github.com/dotnet/roslyn/issues/49733")]
         public void TestNormalizeAsteriskInPointerDeclaration(string text, string expected)
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -180,7 +180,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("int **p;", "int** p;")]
         [InlineData("int**p1,p2;", "int** p1, p2;")]
         [InlineData("int **p1, p2;", "int** p1, p2;")]
-        [InlineData("int **p1, p2;", "int** p1, p2;")]
         [WorkItem(49733, "https://github.com/dotnet/roslyn/issues/49733")]
         public void TestNormalizeAsteriskInPointerDeclaration(string text, string expected)
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("int **p;", "int** p;")]
         [InlineData("int**p1,p2;", "int** p1, p2;")]
         [InlineData("int **p1, p2;", "int** p1, p2;")]
-        [InlineData("delegate * <int, void> p1;", "delegate*<int, void> p1;")]
+        [InlineData("delegate * <int, void> p1;", "delegate *<int, void> p1;")]
         [WorkItem(49733, "https://github.com/dotnet/roslyn/issues/49733")]
         public void TestNormalizeAsteriskInPointerDeclaration(string text, string expected)
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -180,7 +180,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("int **p;", "int** p;")]
         [InlineData("int**p1,p2;", "int** p1, p2;")]
         [InlineData("int **p1, p2;", "int** p1, p2;")]
-        [InlineData("delegate * <int, void> p1;", "delegate *<int, void> p1;")]
         [WorkItem(49733, "https://github.com/dotnet/roslyn/issues/49733")]
         public void TestNormalizeAsteriskInPointerDeclaration(string text, string expected)
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -171,6 +171,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeStatement("Func<string, int> f = blah;", "Func<string, int> f = blah;");
         }
 
+        [Theory]
+        [InlineData("int*p;", "int* p;")]
+        [InlineData("int *p;", "int* p;")]
+        [InlineData("int*p1,p2;", "int* p1, p2;")]
+        [InlineData("int *p1, p2;", "int* p1, p2;")]
+        [InlineData("int**p;", "int** p;")]
+        [InlineData("int **p;", "int** p;")]
+        [InlineData("int**p1,p2;", "int** p1, p2;")]
+        [InlineData("int **p1, p2;", "int** p1, p2;")]
+        [WorkItem(49733, "https://github.com/dotnet/roslyn/issues/49733")]
+        public void TestNormalizeAsteriskInPointerDeclaration(string text, string expected)
+        {
+            TestNormalizeStatement(text, expected);
+        }
+
         private void TestNormalizeStatement(string text, string expected)
         {
             var node = SyntaxFactory.ParseStatement(text);

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -180,10 +180,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("int **p;", "int** p;")]
         [InlineData("int**p1,p2;", "int** p1, p2;")]
         [InlineData("int **p1, p2;", "int** p1, p2;")]
+        [InlineData("int **p1, p2;", "int** p1, p2;")]
         [WorkItem(49733, "https://github.com/dotnet/roslyn/issues/49733")]
         public void TestNormalizeAsteriskInPointerDeclaration(string text, string expected)
         {
             TestNormalizeStatement(text, expected);
+        }
+
+        [Fact]
+        [WorkItem(49733, "https://github.com/dotnet/roslyn/issues/49733")]
+        public void TestNormalizeAsteriskInPointerReturnTypeOfIndexer()
+        {
+            var text = @"public unsafe class C
+{
+  int*this[int x,int y]{get=>(int*)0;}
+}";
+            var expected = @"public unsafe class C
+{
+  int* this[int x, int y] { get => (int*)0; }
+}";
+            TestNormalizeDeclaration(text, expected);
         }
 
         private void TestNormalizeStatement(string text, string expected)

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -201,6 +201,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration(text, expected);
         }
 
+        [Fact]
+        public void TestNormalizeAsteriskInVoidPointerCast()
+        {
+            var text = @"public unsafe class C
+{
+  void*this[int x,int y]{get   =>  (  void  *   ) 0;}
+}";
+            var expected = @"public unsafe class C
+{
+  void* this[int x, int y] { get => (void*)0; }
+}";
+            TestNormalizeDeclaration(text, expected);
+        }
+
         private void TestNormalizeStatement(string text, string expected)
         {
             var node = SyntaxFactory.ParseStatement(text);

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1800,7 +1800,7 @@ public class C { } // end").Members[0];
             VerifySyntax<MethodDeclarationSyntax>(
                 Generator.Declaration(
                     _emptyCompilation.GetTypeByMetadataName("System.IntPtr").GetMembers("ToPointer").Single()),
-@"public unsafe void *ToPointer()
+@"public unsafe void* ToPointer()
 {
 }");
         }


### PR DESCRIPTION
Apply @sharwell's feedback on #49875

Fixes #49733