### PR TITLE
Keep storage objects of serialized metadata references alive during solution replication

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
+++ b/src/VisualStudio/Core/Test.Next/Mocks/SimpleAssetSource.cs
@@ -36,9 +36,11 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
                 if (_map.TryGetValue(checksum, out var data))
                 {
                     using var stream = new MemoryStream();
+                    using var context = SolutionReplicationContext.Create();
+
                     using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
                     {
-                        _serializerService.Serialize(data, writer, cancellationToken);
+                        _serializerService.Serialize(data, writer, context, cancellationToken);
                     }
 
                     stream.Position = 0;

--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -82,10 +82,11 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var data = (await AssetStorage.GetTestAccessor().GetAssetAsync(checksum, CancellationToken.None).ConfigureAwait(false))!;
             Contract.ThrowIfNull(data.Value);
 
+            using var context = SolutionReplicationContext.Create();
             using var stream = SerializableBytes.CreateWritableStream();
             using (var writer = new ObjectWriter(stream, leaveOpen: true))
             {
-                Serializer.Serialize(data.Value, writer, CancellationToken.None);
+                Serializer.Serialize(data.Value, writer, context, CancellationToken.None);
             }
 
             stream.Position = 0;

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -655,9 +655,11 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var sourceText = SourceText.From("Hello", Encoding.UTF8);
             using (var stream = SerializableBytes.CreateWritableStream())
             {
+                using var context = SolutionReplicationContext.Create();
+
                 using (var objectWriter = new ObjectWriter(stream, leaveOpen: true))
                 {
-                    serializer.Serialize(sourceText, objectWriter, CancellationToken.None);
+                    serializer.Serialize(sourceText, objectWriter, context, CancellationToken.None);
                 }
 
                 stream.Position = 0;
@@ -672,9 +674,11 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             sourceText = SourceText.From("Hello", new NotSerializableEncoding());
             using (var stream = SerializableBytes.CreateWritableStream())
             {
+                using var context = SolutionReplicationContext.Create();
+
                 using (var objectWriter = new ObjectWriter(stream, leaveOpen: true))
                 {
-                    serializer.Serialize(sourceText, objectWriter, CancellationToken.None);
+                    serializer.Serialize(sourceText, objectWriter, context, CancellationToken.None);
                 }
 
                 stream.Position = 0;
@@ -701,9 +705,11 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             void VerifyOptions(CompilationOptions originalOptions)
             {
                 using var stream = SerializableBytes.CreateWritableStream();
+                using var context = SolutionReplicationContext.Create();
+
                 using (var objectWriter = new ObjectWriter(stream, leaveOpen: true))
                 {
-                    serializer.Serialize(originalOptions, objectWriter, CancellationToken.None);
+                    serializer.Serialize(originalOptions, objectWriter, context, CancellationToken.None);
                 }
 
                 stream.Position = 0;
@@ -750,10 +756,11 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
         private static SolutionAsset CloneAsset(ISerializerService serializer, SolutionAsset asset)
         {
             using var stream = SerializableBytes.CreateWritableStream();
+            using var context = SolutionReplicationContext.Create();
 
             using (var writer = new ObjectWriter(stream, leaveOpen: true))
             {
-                serializer.Serialize(asset.Value, writer, CancellationToken.None);
+                serializer.Serialize(asset.Value, writer, context, CancellationToken.None);
             }
 
             stream.Position = 0;

--- a/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
+++ b/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Serialization
     {
         void Serialize(object value, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken);
 
-        void SerializeSourceText(SerializableSourceText text, ObjectWriter writer, CancellationToken cancellationToken);
+        void SerializeSourceText(SerializableSourceText text, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken);
 
         void SerializeCompilationOptions(CompilationOptions options, ObjectWriter writer, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
+++ b/src/Workspaces/Core/Portable/Remote/ISerializerService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 {
     internal interface ISerializerService : IWorkspaceService
     {
-        void Serialize(object value, ObjectWriter writer, CancellationToken cancellationToken);
+        void Serialize(object value, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken);
 
         void SerializeSourceText(SerializableSourceText text, ObjectWriter writer, CancellationToken cancellationToken);
 
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         void SerializeProjectReference(ProjectReference reference, ObjectWriter writer, CancellationToken cancellationToken);
 
-        void SerializeMetadataReference(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken);
+        void SerializeMetadataReference(MetadataReference reference, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken);
 
         void SerializeAnalyzerReference(AnalyzerReference reference, ObjectWriter writer, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -148,11 +148,11 @@ namespace Microsoft.CodeAnalysis.Serialization
                         return;
 
                     case WellKnownSynchronizationKind.SerializableSourceText:
-                        SerializeSourceText((SerializableSourceText)value, writer, cancellationToken);
+                        SerializeSourceText((SerializableSourceText)value, writer, context, cancellationToken);
                         return;
 
                     case WellKnownSynchronizationKind.SourceText:
-                        SerializeSourceText(new SerializableSourceText((SourceText)value), writer, cancellationToken);
+                        SerializeSourceText(new SerializableSourceText((SourceText)value), writer, context, cancellationToken);
                         return;
 
                     case WellKnownSynchronizationKind.OptionSet:

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             }
         }
 
-        public void Serialize(object value, ObjectWriter writer, CancellationToken cancellationToken)
+        public void Serialize(object value, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken)
         {
             var kind = value.GetWellKnownSynchronizationKind();
 
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                         return;
 
                     case WellKnownSynchronizationKind.MetadataReference:
-                        SerializeMetadataReference((MetadataReference)value, writer, cancellationToken);
+                        SerializeMetadataReference((MetadataReference)value, writer, context, cancellationToken);
                         return;
 
                     case WellKnownSynchronizationKind.AnalyzerReference:

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
@@ -146,10 +146,10 @@ namespace Microsoft.CodeAnalysis.Serialization
             return new ProjectReference(projectId, aliases.ToImmutableArrayOrEmpty(), embedInteropTypes);
         }
 
-        public void SerializeMetadataReference(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        public void SerializeMetadataReference(MetadataReference reference, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            WriteMetadataReferenceTo(reference, writer, cancellationToken);
+            WriteMetadataReferenceTo(reference, writer, context, cancellationToken);
         }
 
         private MetadataReference DeserializeMetadataReference(ObjectReader reader, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
@@ -19,11 +19,13 @@ namespace Microsoft.CodeAnalysis.Serialization
     /// </summary>
     internal partial class SerializerService
     {
-        public void SerializeSourceText(SerializableSourceText text, ObjectWriter writer, CancellationToken cancellationToken)
+        public void SerializeSourceText(SerializableSourceText text, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (text.Storage is not null)
             {
+                context.AddResource(text.Storage);
+
                 writer.WriteInt32((int)text.Storage.ChecksumAlgorithm);
                 writer.WriteEncoding(text.Storage.Encoding);
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -61,13 +61,13 @@ namespace Microsoft.CodeAnalysis.Serialization
             return Checksum.Create(stream);
         }
 
-        public virtual void WriteMetadataReferenceTo(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        public virtual void WriteMetadataReferenceTo(MetadataReference reference, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken)
         {
             if (reference is PortableExecutableReference portable)
             {
                 if (portable is ISupportTemporaryStorage supportTemporaryStorage)
                 {
-                    if (TryWritePortableExecutableReferenceBackedByTemporaryStorageTo(supportTemporaryStorage, writer, cancellationToken))
+                    if (TryWritePortableExecutableReferenceBackedByTemporaryStorageTo(supportTemporaryStorage, writer, context, cancellationToken))
                     {
                         return;
                     }
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         }
 
         private static bool TryWritePortableExecutableReferenceBackedByTemporaryStorageTo(
-            ISupportTemporaryStorage reference, ObjectWriter writer, CancellationToken cancellationToken)
+            ISupportTemporaryStorage reference, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken)
         {
             var storages = reference.GetStorages();
             if (storages == null)
@@ -328,10 +328,12 @@ namespace Microsoft.CodeAnalysis.Serialization
 
             foreach (var storage in storages)
             {
-                if (!(storage is ITemporaryStorageWithName storage2))
+                if (storage is not ITemporaryStorageWithName storage2)
                 {
                     return false;
                 }
+
+                context.AddResource(storage);
 
                 pooled.Object.Add((storage2.Name, storage2.Offset, storage2.Size));
             }

--- a/src/Workspaces/Core/Portable/Serialization/SolutionReplicationContext.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SolutionReplicationContext.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.Serialization
+{
+    internal readonly struct SolutionReplicationContext : IDisposable
+    {
+        private readonly ArrayBuilder<IDisposable> _resources;
+
+        private SolutionReplicationContext(ArrayBuilder<IDisposable> resources)
+            => _resources = resources;
+
+        public static SolutionReplicationContext Create()
+            => new(ArrayBuilder<IDisposable>.GetInstance());
+
+        public void AddResource(IDisposable resource)
+            => _resources.Add(resource);
+
+        public void Dispose()
+        {
+            // TODO: https://github.com/dotnet/roslyn/issues/49973
+            // Currently we don't dispose resources, only keep them alive.
+            // Shouldn't we dispose them? 
+            // _resources.All(resource => resource.Dispose());
+            _resources.Free();
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -138,11 +138,12 @@ namespace Microsoft.CodeAnalysis
         public static Checksum Create<T>(WellKnownSynchronizationKind kind, T value, ISerializerService serializer)
         {
             using var stream = SerializableBytes.CreateWritableStream();
+            using var context = SolutionReplicationContext.Create();
 
             using (var objectWriter = new ObjectWriter(stream, leaveOpen: true))
             {
                 objectWriter.WriteInt32((int)kind);
-                serializer.Serialize(value, objectWriter, CancellationToken.None);
+                serializer.Serialize(value, objectWriter, context, CancellationToken.None);
             }
 
             stream.Position = 0;

--- a/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Remote
         {
         }
 
-        public override void WriteMetadataReferenceTo(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        public override void WriteMetadataReferenceTo(MetadataReference reference, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken)
         {
             var wellKnownReferenceName = s_wellKnownReferenceNames.GetValueOrDefault(reference, null);
             if (wellKnownReferenceName is not null)
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Remote
             else
             {
                 writer.WriteBoolean(false);
-                base.WriteMetadataReferenceTo(reference, writer, cancellationToken);
+                base.WriteMetadataReferenceTo(reference, writer, context, cancellationToken);
             }
         }
 

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -35,7 +35,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 assetMap = await assetStorage.GetAssetsAsync(scopeId, checksums, cancellationToken).ConfigureAwait(false);
             }
 
-            WriteData(writer, singleAsset, assetMap, serializer, scopeId, checksums, cancellationToken);
+            var replicationContext = assetStorage.GetReplicationContext(scopeId);
+            WriteData(writer, singleAsset, assetMap, serializer, replicationContext, scopeId, checksums, cancellationToken);
         }
 
         public static void WriteData(
@@ -43,6 +44,7 @@ namespace Microsoft.CodeAnalysis.Remote
             SolutionAsset? singleAsset,
             IReadOnlyDictionary<Checksum, SolutionAsset>? assetMap,
             ISerializerService serializer,
+            SolutionReplicationContext context,
             int scopeId,
             Checksum[] checksums,
             CancellationToken cancellationToken)
@@ -59,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Remote
             if (singleAsset != null)
             {
                 writer.WriteInt32(1);
-                WriteAsset(writer, serializer, checksums[0], singleAsset, cancellationToken);
+                WriteAsset(writer, serializer, context, checksums[0], singleAsset, cancellationToken);
                 return;
             }
 
@@ -68,10 +70,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
             foreach (var (checksum, asset) in assetMap)
             {
-                WriteAsset(writer, serializer, checksum, asset, cancellationToken);
+                WriteAsset(writer, serializer, context, checksum, asset, cancellationToken);
             }
 
-            static void WriteAsset(ObjectWriter writer, ISerializerService serializer, Checksum checksum, SolutionAsset asset, CancellationToken cancellationToken)
+            static void WriteAsset(ObjectWriter writer, ISerializerService serializer, SolutionReplicationContext context, Checksum checksum, SolutionAsset asset, CancellationToken cancellationToken)
             {
                 checksum.WriteTo(writer);
                 writer.WriteInt32((int)asset.Kind);
@@ -79,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // null is already indicated by checksum and kind above:
                 if (asset.Value is not null)
                 {
-                    serializer.Serialize(asset.Value, writer, cancellationToken);
+                    serializer.Serialize(asset.Value, writer, context, cancellationToken);
                 }
             }
         }

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -21,7 +21,10 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             public void Dispose()
-                => Contract.ThrowIfFalse(_storages._solutionStates.TryRemove(SolutionInfo.ScopeId, out _));
+            {
+                Contract.ThrowIfFalse(_storages._solutionStates.TryRemove(SolutionInfo.ScopeId, out var entry));
+                entry.ReplicationContext.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/dotnet/roslyn/pull/45953

Fixes #45829
Fixes [AB#1223216](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1223216)