### PR TITLE
Wait for cancellation before closing streams

### DIFF
--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -267,6 +267,12 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
+        /// <param name="service">The service instance.</param>
+        /// <param name="invocation">A callback to asynchronously write data. The callback is required to complete the
+        /// <see cref="PipeWriter"/> except in cases where the callback throws an exception.</param>
+        /// <param name="reader">A callback to asynchronously read data. The callback is allowed, but not required, to
+        /// complete the <see cref="PipeReader"/>.</param>
+        /// <param name="cancellationToken">A cancellation token the operation will observe.</param>
         internal static async ValueTask<TResult> InvokeStreamingServiceAsync<TResult>(
             TService service,
             Func<TService, PipeWriter, CancellationToken, ValueTask> invocation,

--- a/src/Workspaces/Remote/Core/CancellationTokenSourceExtensions.cs
+++ b/src/Workspaces/Remote/Core/CancellationTokenSourceExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    internal static class CancellationTokenSourceExtensions
+    {
+        public static void CancelOnAbnormalCompletion(this CancellationTokenSource cancellationTokenSource, Task task)
+        {
+            _ = task.ContinueWith(
+                _ =>
+                {
+                    try
+                    {
+                        cancellationTokenSource.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // cancellation source is already disposed
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.NotOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+}

--- a/src/Workspaces/Remote/Core/RemoteCallback.cs
+++ b/src/Workspaces/Remote/Core/RemoteCallback.cs
@@ -57,6 +57,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <summary>
         /// Invokes a remote API that streams results back to the caller.
         /// </summary>
+        /// <inheritdoc cref="BrokeredServiceConnection{TService}.InvokeStreamingServiceAsync"/>
         public async ValueTask<TResult> InvokeAsync<TResult>(
             Func<T, PipeWriter, CancellationToken, ValueTask> invocation,
             Func<PipeReader, CancellationToken, ValueTask<TResult>> reader,

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -114,7 +114,6 @@ namespace Microsoft.CodeAnalysis.Remote
                 finally
                 {
                     await localPipe.Writer.CompleteAsync(exception).ConfigureAwait(false);
-                    await pipeReader.CompleteAsync(exception).ConfigureAwait(false);
                 }
             }, mustNotCancelToken);
 


### PR DESCRIPTION
This change ensures `InvokeStreamingServiceAsync` does not close connections while they are still in use, which would lead to `ConnectionLostException` when `OperationCanceledException` is expected.

This fix is conceptually similar to #49371.

Fixes [AB#1258340](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1258340)