### PR TITLE
Implement ContextVariableArgumentProvider

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ArgumentProviderOrderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ArgumentProviderOrderTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.ArgumentProv
                 typeof(FirstBuiltInArgumentProvider),
 
                 // Built-in providers
+                typeof(ContextVariableArgumentProvider),
                 typeof(DefaultArgumentProvider),
 
                 // Marker for end of built-in argument providers

--- a/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.cs
@@ -1,0 +1,121 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.ArgumentProviders
+{
+    [Trait(Traits.Feature, Traits.Features.Completion)]
+    public class ContextVariableArgumentProviderTests : AbstractCSharpArgumentProviderTests
+    {
+        internal override Type GetArgumentProviderType()
+            => typeof(ContextVariableArgumentProvider);
+
+        [Theory]
+        [InlineData("string")]
+        [InlineData("bool")]
+        [InlineData("int?")]
+        public async Task TestLocalVariable(string type)
+        {
+            var markup = $@"
+class C
+{{
+    void Method()
+    {{
+        {type} arg = default;
+        this.Target($$);
+    }}
+
+    void Target({type} arg)
+    {{
+    }}
+}}
+";
+
+            await VerifyDefaultValueAsync(markup, "arg");
+            await VerifyDefaultValueAsync(markup, expectedDefaultValue: null, previousDefaultValue: "prior");
+        }
+
+        [Theory]
+        [InlineData("string")]
+        [InlineData("bool")]
+        [InlineData("int?")]
+        public async Task TestParameter(string type)
+        {
+            var markup = $@"
+class C
+{{
+    void Method({type} arg)
+    {{
+        this.Target($$);
+    }}
+
+    void Target({type} arg)
+    {{
+    }}
+}}
+";
+
+            await VerifyDefaultValueAsync(markup, "arg");
+            await VerifyDefaultValueAsync(markup, expectedDefaultValue: null, previousDefaultValue: "prior");
+        }
+
+        [Theory]
+        [InlineData("string")]
+        [InlineData("bool")]
+        [InlineData("int?")]
+        public async Task TestInstanceVariable(string type)
+        {
+            var markup = $@"
+class C
+{{
+    {type} arg;
+
+    void Method()
+    {{
+        this.Target($$);
+    }}
+
+    void Target({type} arg)
+    {{
+    }}
+}}
+";
+
+            await VerifyDefaultValueAsync(markup, "arg");
+            await VerifyDefaultValueAsync(markup, expectedDefaultValue: null, previousDefaultValue: "prior");
+        }
+
+        // Note: The current implementation checks for exact type and name match. If this changes, some of these tests
+        // may need to be updated to account for the new behavior.
+        [Theory]
+        [InlineData("object", "string")]
+        [InlineData("string", "object")]
+        [InlineData("bool", "bool?")]
+        [InlineData("bool", "int")]
+        [InlineData("int", "object")]
+        public async Task TestMismatchType(string parameterType, string valueType)
+        {
+            var markup = $@"
+class C
+{{
+    void Method({valueType} arg)
+    {{
+        this.Target($$);
+    }}
+
+    void Target({parameterType} arg)
+    {{
+    }}
+}}
+";
+
+            await VerifyDefaultValueAsync(markup, null);
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviderOrderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviderOrderTests.vb
@@ -24,6 +24,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion
             Dim expectedOrder =
                 {
                 GetType(FirstBuiltInArgumentProvider),
+                GetType(ContextVariableArgumentProvider),
                 GetType(DefaultArgumentProvider),
                 GetType(LastBuiltInArgumentProvider)
                 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.vb
@@ -1,0 +1,102 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.ArgumentProviders
+    <Trait(Traits.Feature, Traits.Features.Completion)>
+    Public Class ContextVariableArgumentProviderTests
+        Inherits AbstractVisualBasicArgumentProviderTests
+
+        Friend Overrides Function GetArgumentProviderType() As Type
+            Return GetType(ContextVariableArgumentProvider)
+        End Function
+
+        <Theory>
+        <InlineData("String")>
+        <InlineData("Boolean")>
+        <InlineData("Integer?")>
+        Public Async Function TestLocalVariable(type As String) As Task
+            Dim markup = $"
+Class C
+    Sub Method()
+        Dim arg As {type} = Nothing
+        Me.Target($$)
+    End Sub
+
+    Sub Target(arg As {type})
+    End Sub
+End Class
+"
+
+            Await VerifyDefaultValueAsync(markup, "arg")
+            Await VerifyDefaultValueAsync(markup, expectedDefaultValue:=Nothing, previousDefaultValue:="prior")
+        End Function
+
+        <Theory>
+        <InlineData("String")>
+        <InlineData("Boolean")>
+        <InlineData("Integer?")>
+        Public Async Function TestParameter(type As String) As Task
+            Dim markup = $"
+Class C
+    Sub Method(arg As {type})
+        Me.Target($$)
+    End Sub
+
+    Sub Target(arg As {type})
+    End Sub
+End Class
+"
+
+            Await VerifyDefaultValueAsync(markup, "arg")
+            Await VerifyDefaultValueAsync(markup, expectedDefaultValue:=Nothing, previousDefaultValue:="prior")
+        End Function
+
+        <Theory>
+        <InlineData("String")>
+        <InlineData("Boolean")>
+        <InlineData("Integer?")>
+        Public Async Function TestInstanceVariable(type As String) As Task
+            Dim markup = $"
+Class C
+    Dim arg As {type}
+
+    Sub Method()
+        Me.Target($$)
+    End Sub
+
+    Sub Target(arg As {type})
+    End Sub
+End Class
+"
+
+            Await VerifyDefaultValueAsync(markup, "arg")
+            Await VerifyDefaultValueAsync(markup, expectedDefaultValue:=Nothing, previousDefaultValue:="prior")
+        End Function
+
+        ' Note: The current implementation checks for exact type and name match. If this changes, some of these tests
+        ' may need to be updated to account for the new behavior.
+        <Theory>
+        <InlineData("Object", "String")>
+        <InlineData("String", "Object")>
+        <InlineData("Boolean", "Boolean?")>
+        <InlineData("Boolean", "Integer")>
+        <InlineData("Integer", "Object")>
+        Public Async Function TestMismatchType(parameterType As String, valueType As String) As Task
+            Dim markup = $"
+Class C
+    Sub Method(arg As {valueType})
+        Me.Target($$)
+    End Sub
+
+    Sub Target(arg As {parameterType})
+    End Sub
+End Class
+"
+
+            Await VerifyDefaultValueAsync(markup, Nothing)
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/Completion/Providers/ContextVariableArgumentProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/Providers/ContextVariableArgumentProvider.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
+{
+    [ExportArgumentProvider(nameof(ContextVariableArgumentProvider), LanguageNames.CSharp)]
+    [ExtensionOrder(After = nameof(FirstBuiltInArgumentProvider))]
+    [Shared]
+    internal sealed class ContextVariableArgumentProvider : ArgumentProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public ContextVariableArgumentProvider()
+        {
+        }
+
+        public override async Task ProvideArgumentAsync(ArgumentContext context)
+        {
+            if (context.PreviousValue is not null)
+            {
+                return;
+            }
+
+            var semanticModel = await context.Document.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            var symbols = semanticModel.LookupSymbols(context.Position, name: context.Parameter.Name);
+            foreach (var symbol in symbols)
+            {
+                if (SymbolEqualityComparer.Default.Equals(context.Parameter.Type, symbol.GetSymbolType()))
+                {
+                    context.DefaultValue = context.Parameter.Name;
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/Providers/DefaultArgumentProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/Providers/DefaultArgumentProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
     [ExportArgumentProvider(nameof(DefaultArgumentProvider), LanguageNames.CSharp)]
-    [ExtensionOrder(After = nameof(FirstBuiltInArgumentProvider))]
+    [ExtensionOrder(After = nameof(ContextVariableArgumentProvider))]
     [Shared]
     internal sealed class DefaultArgumentProvider : AbstractDefaultArgumentProvider
     {

--- a/src/Features/VisualBasic/Portable/Completion/Providers/ContextVariableArgumentProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/Providers/ContextVariableArgumentProvider.vb
@@ -1,0 +1,36 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Host.Mef
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
+    <ExportArgumentProvider(NameOf(ContextVariableArgumentProvider), LanguageNames.VisualBasic)>
+    <ExtensionOrder(After:=NameOf(FirstBuiltInArgumentProvider))>
+    <[Shared]>
+    Friend Class ContextVariableArgumentProvider
+        Inherits ArgumentProvider
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+
+        Public Overrides Async Function ProvideArgumentAsync(context As ArgumentContext) As Task
+            If context.PreviousValue IsNot Nothing Then
+                Return
+            End If
+
+            Dim semanticModel = Await context.Document.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(False)
+            Dim symbols = semanticModel.LookupSymbols(context.Position, name:=context.Parameter.Name)
+            For Each symbol In symbols
+                If SymbolEqualityComparer.Default.Equals(context.Parameter.Type, symbol.GetSymbolType()) Then
+                    context.DefaultValue = context.Parameter.Name
+                    Return
+                End If
+            Next
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/Providers/DefaultArgumentProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/Providers/DefaultArgumentProvider.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     <ExportArgumentProvider(NameOf(DefaultArgumentProvider), LanguageNames.VisualBasic)>
-    <ExtensionOrder(After:=NameOf(FirstBuiltInArgumentProvider))>
+    <ExtensionOrder(After:=NameOf(ContextVariableArgumentProvider))>
     <[Shared]>
     Friend Class DefaultArgumentProvider
         Inherits AbstractDefaultArgumentProvider


### PR DESCRIPTION
This simple `ArgumentProvider` provides values with the same name and type as the target parameter.