### PR TITLE
Warn when comparing function pointer values

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6591,4 +6591,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_UnreadRecordParameter_Title" xml:space="preserve">
     <value>Parameter is unread. Did you forget to use it to initialize the property with that name?</value>
   </data>
+  <data name="WRN_DoNotCompareFunctionPointers" xml:space="preserve">
+    <value>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</value>
+  </data>
+  <data name="WRN_DoNotCompareFunctionPointers_Title" xml:space="preserve">
+    <value>Do not compare function pointer values</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6592,7 +6592,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Parameter is unread. Did you forget to use it to initialize the property with that name?</value>
   </data>
   <data name="WRN_DoNotCompareFunctionPointers" xml:space="preserve">
-    <value>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</value>
+    <value>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</value>
   </data>
   <data name="WRN_DoNotCompareFunctionPointers_Title" xml:space="preserve">
     <value>Do not compare function pointer values</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1926,6 +1926,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UnreadRecordParameter = 8907,
         ERR_BadFieldTypeInRecord = 8908,
 
+        WRN_DoNotCompareFunctionPointers = 8909,
+
         #endregion diagnostics introduced for C# 9.0
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -471,6 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_ReturnNotNullIfNotNull:
                 case ErrorCode.WRN_AnalyzerReferencesFramework:
                 case ErrorCode.WRN_UnreadRecordParameter:
+                case ErrorCode.WRN_DoNotCompareFunctionPointers:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -267,6 +267,7 @@
                 case ErrorCode.WRN_ParameterIsStaticClass:
                 case ErrorCode.WRN_ReturnTypeIsStaticClass:
                 case ErrorCode.WRN_UnreadRecordParameter:
+                case ErrorCode.WRN_DoNotCompareFunctionPointers:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -967,6 +967,16 @@
         <target state="translated">Načtené sestavení se odkazuje na architekturu .NET Framework, což se nepodporuje</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Parametr {0} musí mít při ukončení hodnotu jinou než null, protože parametr {1} není null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -967,6 +967,16 @@
         <target state="translated">Die geladene Assembly verweist auf das .NET Framework. Dies wird nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Der Parameter "{0}" muss beim Beenden einen Wert ungleich NULL aufweisen, weil Parameter "{1}" nicht NULL ist.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -967,6 +967,16 @@
         <target state="translated">El ensamblado que se ha cargado hace referencia a .NET Framework, lo cual no se admite.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">El parámetro "{0}" debe tener un valor que no sea NULL al salir porque el parámetro "{1}" no es NULL.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -967,6 +967,16 @@
         <target state="translated">L'assembly chargé référence le .NET Framework, ce qui n'est pas pris en charge.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Le paramètre '{0}' doit avoir une valeur non null au moment de la sortie, car le paramètre '{1}' a une valeur non null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -967,6 +967,16 @@
         <target state="translated">L'assembly caricato fa riferimento a .NET Framework, che non è supportato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Il parametro '{0}' deve avere un valore non Null quando viene terminato perché il parametro '{1}' è non Null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -967,6 +967,16 @@
         <target state="new">The loaded assembly references .NET Framework, which is not supported.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers">
+        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
+        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">
+        <source>Do not compare function pointer values</source>
+        <target state="new">Do not compare function pointer values</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="new">Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -968,8 +968,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers">
-        <source>Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</source>
-        <target state="new">Function pointer values should not be compared, as JIT tiering and recompilation means that taking the address of a method can return different addresses at different times.</target>
+        <source>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</source>
+        <target state="new">Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_DoNotCompareFunctionPointers_Title">

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -262,6 +262,7 @@ class X
                         case ErrorCode.WRN_ParameterNotNullIfNotNull:
                         case ErrorCode.WRN_ReturnNotNullIfNotNull:
                         case ErrorCode.WRN_UnreadRecordParameter:
+                        case ErrorCode.WRN_DoNotCompareFunctionPointers:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:
@@ -417,6 +418,7 @@ class X
                     ErrorCode.WRN_RecordEqualsWithoutGetHashCode,
                     ErrorCode.WRN_AnalyzerReferencesFramework,
                     ErrorCode.WRN_UnreadRecordParameter,
+                    ErrorCode.WRN_DoNotCompareFunctionPointers,
                 };
 
                 Assert.Contains(error, nullableUnrelatedWarnings);


### PR DESCRIPTION
Because of JIT tiering and recompilation, comparing 2 function pointer values may produce bad results, even when both pointers are to the same method, as they may point to different stubs. Fixes https://github.com/dotnet/roslyn/issues/48919.
