### PR TITLE
Mark .xlf as generated by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -69,3 +69,4 @@ src/Compilers/CSharp/Portable/Generated/*                  linguist-generated=tr
 src/Compilers/CSharp/Portable/CSharpResources.Designer.cs  linguist-generated=true
 src/Compilers/VisualBasic/Portable/Generated/*             linguist-generated=true
 src/Compilers/VisualBasic/Portable/VBResources.Designer.vb linguist-generated=true
+*.xlf linguist-generated=true


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/roslyn/pull/49980#discussion_r543757580

We may not wish to mark these files as generated by default--but this is probably desirable for most review workflows with the exception of loc PRs. I thought I would open this PR to give us an opportunity to make that decision 😄
