### PR TITLE
Exec PrepareTests.dll instead of 'dotnet run' on project

### DIFF
--- a/eng/prepare-tests.ps1
+++ b/eng/prepare-tests.ps1
@@ -11,7 +11,7 @@ try {
   $dotnet = Ensure-DotnetSdk
   # permissions issues make this a pain to do in PrepareTests itself.
   Remove-Item -Recurse -Force "$RepoRoot\artifacts\testPayload" -ErrorAction SilentlyContinue
-  Exec-Console $dotnet "run --project src\Tools\PrepareTests\PrepareTests.csproj $RepoRoot $RepoRoot\artifacts\testPayload"
+  Exec-Console $dotnet "$RepoRoot\artifacts\bin\PrepareTests\$configuration\net5.0\PrepareTests.dll $RepoRoot $RepoRoot\artifacts\testPayload"
   exit 0
 }
 catch {

--- a/eng/prepare-tests.sh
+++ b/eng/prepare-tests.sh
@@ -28,4 +28,4 @@ InitializeDotNetCli true
 # permissions issues make this a pain to do in PrepareTests itself.
 rm -rf "$repo_root/artifacts/testPayload"
 
-dotnet run --project src/Tools/PrepareTests/PrepareTests.csproj "$repo_root" "$repo_root/artifacts/testPayload"
+dotnet "$repo_root/artifacts/bin/PrepareTests/Debug/net5.0/PrepareTests.dll" "$repo_root" "$repo_root/artifacts/testPayload"


### PR DESCRIPTION
This reduces the "Prepare Test Payload" run time from about 12-15s on Unix to about 2-3s.

It likely reduces run time on Windows, too, but that gets lost in the shuffle of "cracking DLLs is really slow on our Windows machines for some reason."

Old example build: https://dev.azure.com/dnceng/public/_build/results?buildId=922749&view=logs&j=cec4b4e6-75b4-5c53-1ec7-3a9ace327284&t=c4465378-cdcd-58b8-bb7f-da7392fa5871

New build: https://dev.azure.com/dnceng/public/_build/results?buildId=922942&view=logs&j=cec4b4e6-75b4-5c53-1ec7-3a9ace327284&t=c4465378-cdcd-58b8-bb7f-da7392fa5871