### PR TITLE
Specify publishing location for Microsoft.CodeAnalysis.Collections

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -82,6 +82,7 @@
       "Microsoft.NETCore.Compilers" : "arcade",
       "Microsoft.CodeAnalysis.Debugging" : "arcade",
       "Microsoft.CodeAnalysis.PooledObjects" : "arcade",
+      "Microsoft.CodeAnalysis.Collections": "arcade",
       "Microsoft.CodeAnalysis.Features" : "arcade",
 
       "Microsoft.CodeAnalysis.EditorFeatures" : "arcade",

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -27,6 +27,7 @@
       "Microsoft.NETCore.Compilers": "arcade",
       "Microsoft.CodeAnalysis.Debugging": "arcade",
       "Microsoft.CodeAnalysis.PooledObjects": "arcade",
+      "Microsoft.CodeAnalysis.Collections": "arcade",
       "Microsoft.CodeAnalysis.Features": "arcade",
 
       "Microsoft.CodeAnalysis.EditorFeatures": "vssdk",


### PR DESCRIPTION
Signed builds are failing because we haven't configured a publishing location for the MS.CA.Collections package - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4308605&view=logs&j=20fcf628-b65c-5865-625a-1cef81cda63b&t=7efdce5b-215a-5afd-980e-58e9cb1ef7e6&l=26

Per @sharwell since this is similar to MS.CA.PooledObjects / MS.CA.Debugging we'll use the same arcade feeds