### PR TITLE
Don't generate documentation for builds that feed into tests

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -38,6 +38,7 @@ param (
   [switch]$ci,
   [switch]$collectDumps,
   [switch][Alias('a')]$runAnalyzers,
+  [switch]$skipDocumentation = $false,
   [switch][Alias('d')]$deployExtensions,
   [switch]$prepareMachine,
   [switch]$useGlobalNuGetCache = $true,
@@ -100,6 +101,7 @@ function Print-Usage() {
   Write-Host "  -msbuildEngine <value>    Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -collectDumps             Collect dumps from test runs"
   Write-Host "  -runAnalyzers             Run analyzers during build operations (short: -a)"
+  Write-Host "  -skipDocumentation        Skip generation of XML documentation files"
   Write-Host "  -prepareMachine           Prepare machine for CI run, clean up processes after build"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
   Write-Host "  -warnAsError              Treat all warnings as errors"
@@ -231,6 +233,8 @@ function BuildSolution() {
   # Set DotNetBuildFromSource to 'true' if we're simulating building for source-build.
   $buildFromSource = if ($sourceBuild) { "/p:DotNetBuildFromSource=true" } else { "" }
 
+  $generateDocumentationFile = if ($skipDocumentation) { "/p:GenerateDocumentationFile=false" } else { "" }
+
   try {
     MSBuild $toolsetBuildProj `
       $bl `
@@ -256,6 +260,7 @@ function BuildSolution() {
       $suppressExtensionDeployment `
       $msbuildWarnAsError `
       $buildFromSource `
+      $generateDocumentationFile `
       @properties
   }
   finally {

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -33,6 +33,7 @@ usage()
   echo "  --docker                   Run in a docker container if applicable"
   echo "  --bootstrap                Build using a bootstrap compilers"
   echo "  --runAnalyzers             Run analyzers during build operations"
+  echo "  --skipDocumentation        Skip generation of XML documentation files"
   echo "  --prepareMachine           Prepare machine for CI run, clean up processes after build"
   echo "  --warnAsError              Treat all warnings as errors"
   echo "  --sourceBuild              Simulate building for source-build"
@@ -67,6 +68,7 @@ binary_log=false
 ci=false
 bootstrap=false
 run_analyzers=false
+skip_documentation=false
 prepare_machine=false
 warn_as_error=false
 properties=""
@@ -135,6 +137,9 @@ while [[ $# > 0 ]]; do
       ;;
     --runanalyzers)
       run_analyzers=true
+      ;;
+    --skipdocumentation)
+      skip_documentation=true
       ;;
     --preparemachine)
       prepare_machine=true
@@ -260,6 +265,11 @@ function BuildSolution {
     test_runtime_args="--debug"
   fi
 
+  local generate_documentation_file=""
+  if [[ "$skip_documentation" == true ]]; then
+    generate_documentation_file="/p:GenerateDocumentationFile=false"
+  fi
+
   # Setting /p:TreatWarningsAsErrors=true is a workaround for https://github.com/Microsoft/msbuild/issues/3062.
   # We don't pass /warnaserror to msbuild (warn_as_error is set to false by default above), but set 
   # /p:TreatWarningsAsErrors=true so that compiler reported warnings, other than IDE0055 are treated as errors. 
@@ -283,6 +293,7 @@ function BuildSolution {
     /p:DotNetBuildFromSource=$source_build \
     $test_runtime \
     $mono_tool \
+    $generate_documentation \
     $properties
 }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -293,7 +293,7 @@ function BuildSolution {
     /p:DotNetBuildFromSource=$source_build \
     $test_runtime \
     $mono_tool \
-    $generate_documentation \
+    $generate_documentation_file \
     $properties
 }
 

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -31,7 +31,7 @@ jobs:
     - script: ./eng/build.sh --ci --restore --prepareMachine --binaryLog --configuration ${{ parameters.configuration }}
       displayName: Restore
 
-    - script: ./eng/build.sh --ci --build --publish --pack --prepareMachine --binaryLog --configuration ${{ parameters.configuration }}
+    - script: ./eng/build.sh --ci --build --publish --pack --prepareMachine --binaryLog --skipDocumentation --configuration ${{ parameters.configuration }}
       displayName: Build
 
     - script: ./eng/prepare-tests.sh

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -28,7 +28,7 @@ jobs:
       displayName: Build
       inputs:
         filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -publish -binaryLog 
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -publish -binaryLog -skipDocumentation
 
     - task: PowerShell@2 
       displayName: Prepare Unit Tests

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -20,7 +20,7 @@
 
     <Features>strict</Features>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == ''">true</GenerateDocumentationFile>
     <GenerateFullPaths>true</GenerateFullPaths>
 
     <!-- Set to non-existent file to prevent common targets from importing Microsoft.CodeAnalysis.targets -->

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -20,7 +20,7 @@
 
     <Features>strict</Features>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == ''">true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateFullPaths>true</GenerateFullPaths>
 
     <!-- Set to non-existent file to prevent common targets from importing Microsoft.CodeAnalysis.targets -->


### PR DESCRIPTION
This reduces the size of the compressed Windows test payload from ~448 MB to ~355MB.
Uncompressed size went from ~1.8GB to ~1.1GB.

WizTree: 
![image](https://user-images.githubusercontent.com/5833655/102424566-46db9b00-3fc0-11eb-9a5c-fb99f3f87380.png)


"Before" build artifacts: https://dev.azure.com/dnceng/public/_build/results?buildId=924109&view=artifacts&pathAsName=false&type=publishedArtifacts

"After" build artifacts: https://dev.azure.com/dnceng/public/_build/results?buildId=924379&view=artifacts&pathAsName=false&type=publishedArtifacts

Opened #50023 to demonstrate that errors are given as expected when documentation is malformed.