### PR TITLE
Implement PostInitialization in generator driver

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -626,7 +626,7 @@ class C
             TestSyntaxReceiver? receiver = null;
             var exception = new Exception("test exception");
             var testGenerator = new CallbackGenerator(
-                onInit: (i) => 
+                onInit: (i) =>
                 {
                     i.RegisterForSyntaxNotifications(() => receiver = new TestSyntaxReceiver());
                     i.RegisterForPostInitialization((pic) => throw exception);
@@ -682,7 +682,7 @@ class D
             ISyntaxReceiver? receiver = null;
 
             var testGenerator = new CallbackGenerator(
-                onInit: (i) => 
+                onInit: (i) =>
                 {
                     i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
                     i.RegisterForPostInitialization((pic) => pic.AddSource("postInit", source2));
@@ -749,7 +749,7 @@ class D
 
             var testGenerator2 = new CallbackGenerator2(
                 onInit: (i) => i.RegisterForPostInitialization((pic) => pic.AddSource("postInit", source2)),
-                onExecute: (e) => { } 
+                onExecute: (e) => { }
             );
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator, testGenerator2 }, parseOptions: parseOptions);

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -697,13 +697,9 @@ class D
             Assert.IsType<TestSyntaxReceiver>(receiver);
 
             TestSyntaxReceiver testReceiver = (TestSyntaxReceiver)receiver!;
-            Assert.Equal(42, testReceiver.VisitedNodes.Count);
-            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0]);
-            Assert.IsType<ClassDeclarationSyntax>(testReceiver.VisitedNodes[1]);
-            Assert.Equal("C", ((ClassDeclarationSyntax)testReceiver.VisitedNodes[1]).Identifier.Text);
-            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[21]);
-            Assert.IsType<ClassDeclarationSyntax>(testReceiver.VisitedNodes[22]);
-            Assert.Equal("D", ((ClassDeclarationSyntax)testReceiver.VisitedNodes[22]).Identifier.Text);
+
+            var classDeclarations = testReceiver.VisitedNodes.OfType<ClassDeclarationSyntax>().Select(c => c.Identifier.Text);
+            Assert.Equal(new[] { "C", "D" }, classDeclarations);
         }
 
         [Fact]
@@ -759,13 +755,8 @@ class D
             Assert.IsType<TestSyntaxReceiver>(receiver);
 
             TestSyntaxReceiver testReceiver = (TestSyntaxReceiver)receiver!;
-            Assert.Equal(42, testReceiver.VisitedNodes.Count);
-            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0]);
-            Assert.IsType<ClassDeclarationSyntax>(testReceiver.VisitedNodes[1]);
-            Assert.Equal("C", ((ClassDeclarationSyntax)testReceiver.VisitedNodes[1]).Identifier.Text);
-            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[21]);
-            Assert.IsType<ClassDeclarationSyntax>(testReceiver.VisitedNodes[22]);
-            Assert.Equal("D", ((ClassDeclarationSyntax)testReceiver.VisitedNodes[22]).Identifier.Text);
+            var classDeclarations = testReceiver.VisitedNodes.OfType<ClassDeclarationSyntax>().Select(c => c.Identifier.Text);
+            Assert.Equal(new[] { "C", "D" }, classDeclarations);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -8,6 +8,12 @@ Microsoft.CodeAnalysis.GeneratorSyntaxContext.Node.get -> Microsoft.CodeAnalysis
 Microsoft.CodeAnalysis.GeneratorSyntaxContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel
 Microsoft.CodeAnalysis.ISyntaxContextReceiver
 Microsoft.CodeAnalysis.ISyntaxContextReceiver.OnVisitSyntaxNode(Microsoft.CodeAnalysis.GeneratorSyntaxContext context) -> void
+Microsoft.CodeAnalysis.GeneratorInitializationContext.RegisterForPostInitialization(System.Action<Microsoft.CodeAnalysis.GeneratorPostInitializationContext> callback) -> void
+Microsoft.CodeAnalysis.GeneratorPostInitializationContext
+Microsoft.CodeAnalysis.GeneratorPostInitializationContext.AddSource(string hintName, Microsoft.CodeAnalysis.Text.SourceText sourceText) -> void
+Microsoft.CodeAnalysis.GeneratorPostInitializationContext.AddSource(string hintName, string source) -> void
+Microsoft.CodeAnalysis.GeneratorPostInitializationContext.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.CodeAnalysis.GeneratorPostInitializationContext.GeneratorPostInitializationContext() -> void
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -73,6 +73,8 @@ namespace Microsoft.CodeAnalysis
 
         public void AddRange(ImmutableArray<GeneratedSourceText> texts) => _sourcesAdded.AddRange(texts);
 
+        public void AddRange(ImmutableArray<GeneratedSyntaxTree> trees) => _sourcesAdded.AddRange(trees.SelectAsArray(t => new GeneratedSourceText(t.HintName, t.Text)));
+
         public void RemoveSource(string hintName)
         {
             hintName = AppendExtensionIfRequired(hintName);

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratedSyntaxTree.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratedSyntaxTree.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A syntax tree created by a <see cref="ISourceGenerator"/>
+    /// </summary>
+    internal readonly struct GeneratedSyntaxTree
+    {
+        public SourceText Text { get; }
+
+        public string HintName { get; }
+
+        public SyntaxTree Tree { get; }
+
+        public GeneratedSyntaxTree(string hintName, SourceText text, SyntaxTree tree)
+        {
+            this.Text = text;
+            this.HintName = hintName;
+            this.Tree = tree;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis
         /// Adds source code in the form of a <see cref="string"/> to the compilation.
         /// </summary>
         /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
-        /// <param name="source">The source code to be add to the compilation</param>
+        /// <param name="source">The source code to add to the compilation</param>
         public void AddSource(string hintName, string source) => AddSource(hintName, SourceText.From(source, Encoding.UTF8));
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// This method allows a generator to opt-in to an extra phase in the generator lifecycle called PostInitialization. After being initialized
         /// any generators that have opted in will have their provided callback invoked with a <see cref="GeneratorPostInitializationContext"/> instance
-        /// that can be used to alter to the compilation that is provided to subsequent generator phases.
+        /// that can be used to alter the compilation that is provided to subsequent generator phases.
         /// 
         /// For example a generator may choose to add sources during PostInitialization. These will be added to the compilation before execution and
         /// will be visited by a registered <see cref="ISyntaxReceiver"/> and available for semantic analysis as part of the <see cref="GeneratorExecutionContext.Compilation"/>
@@ -237,14 +237,14 @@ namespace Microsoft.CodeAnalysis
         public CancellationToken CancellationToken { get; }
 
         /// <summary>
-        /// Adds source code in the form of a <see cref="string"/> to the compilation that will be availble during subsequent phases
+        /// Adds source code in the form of a <see cref="string"/> to the compilation that will be available during subsequent phases
         /// </summary>
         /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
-        /// <param name="source">The source code to be add to the compilation</param>
+        /// <param name="source">The source code to add to the compilation</param>
         public void AddSource(string hintName, string source) => AddSource(hintName, SourceText.From(source, Encoding.UTF8));
 
         /// <summary>
-        /// Adds a <see cref="SourceText"/> to the compilation that will be availble during subsequent phases
+        /// Adds a <see cref="SourceText"/> to the compilation that will be available during subsequent phases
         /// </summary>
         /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
         /// <param name="sourceText">The <see cref="SourceText"/> to add to the compilation</param>

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -166,6 +166,26 @@ namespace Microsoft.CodeAnalysis
             CheckIsEmpty(InfoBuilder.SyntaxContextReceiverCreator, $"{nameof(SyntaxReceiverCreator)} / {nameof(SyntaxContextReceiverCreator)}");
             InfoBuilder.SyntaxContextReceiverCreator = receiverCreator;
         }
+        
+        /// <summary>
+        /// Register a callback that is invoked after initialization.
+        /// </summary>
+        /// <remarks>
+        /// This method allows a generator to opt-in to an extra phase in the generator lifecycle called PostInitialization. After being initialized
+        /// any generators that have opted in will have their provided callback invoked with a <see cref="GeneratorPostInitializationContext"/> instance
+        /// that can be used to alter to the compilation that is provided to subsequent generator phases.
+        /// 
+        /// For example a generator may choose to add sources during PostInitialization. These will be added to the compilation before execution and
+        /// will be visited by a registered <see cref="ISyntaxReceiver"/> and available for semantic analysis as part of the <see cref="GeneratorExecutionContext.Compilation"/>
+        /// 
+        /// Note that any sources added during PostInitialization <i>will</i> be visible to the later phases of other generators operation on the compilation. 
+        /// </remarks>
+        /// <param name="callback">An <see cref="Action{T}"/> that accepts a <see cref="GeneratorPostInitializationContext"/> that will be invoked after initialization.</param>
+        public void RegisterForPostInitialization(Action<GeneratorPostInitializationContext> callback)
+        {
+            CheckIsEmpty(InfoBuilder.PostInitCallback);
+            InfoBuilder.PostInitCallback = callback;
+        }
 
         private static void CheckIsEmpty<T>(T x, string? typeName = null) where T : class?
         {
@@ -196,6 +216,39 @@ namespace Microsoft.CodeAnalysis
         /// The <see cref="SemanticModel" /> that can be queried to obtain information about <see cref="Node"/>.
         /// </summary>
         public SemanticModel SemanticModel { get; }
+    }
+
+    /// <summary>
+    /// Context passed to a source generator when it has opted-in to PostInitialization via <see cref="GeneratorInitializationContext.RegisterForPostInitialization(Action{GeneratorPostInitializationContext})"/>
+    /// </summary>
+    public readonly struct GeneratorPostInitializationContext
+    {
+        private readonly AdditionalSourcesCollection _additionalSources;
+
+        internal GeneratorPostInitializationContext(AdditionalSourcesCollection additionalSources, CancellationToken cancellationToken)
+        {
+            _additionalSources = additionalSources;
+            CancellationToken = cancellationToken;
+        }
+
+        /// <summary>
+        /// A <see cref="CancellationToken"/> that can be checked to see if the PostInitialization should be cancelled.
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
+
+        /// <summary>
+        /// Adds source code in the form of a <see cref="string"/> to the compilation that will be availble during subsequent phases
+        /// </summary>
+        /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
+        /// <param name="source">The source code to be add to the compilation</param>
+        public void AddSource(string hintName, string source) => AddSource(hintName, SourceText.From(source, Encoding.UTF8));
+
+        /// <summary>
+        /// Adds a <see cref="SourceText"/> to the compilation that will be availble during subsequent phases
+        /// </summary>
+        /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
+        /// <param name="sourceText">The <see cref="SourceText"/> to add to the compilation</param>
+        public void AddSource(string hintName, SourceText sourceText) => _additionalSources.Add(hintName, sourceText);
     }
 
     internal readonly struct GeneratorEditContext

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis
             CheckIsEmpty(InfoBuilder.SyntaxContextReceiverCreator, $"{nameof(SyntaxReceiverCreator)} / {nameof(SyntaxContextReceiverCreator)}");
             InfoBuilder.SyntaxContextReceiverCreator = receiverCreator;
         }
-        
+
         /// <summary>
         /// Register a callback that is invoked after initialization.
         /// </summary>

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -368,11 +368,11 @@ namespace Microsoft.CodeAnalysis
             ArrayBuilder<SyntaxTree> trees = ArrayBuilder<SyntaxTree>.GetInstance();
             foreach (var generatorState in state.GeneratorStates)
             {
-                foreach (var source in generatorState.GeneratedTrees)
+                foreach (var generatedTree in generatorState.GeneratedTrees)
                 {
-                    if (source.Tree is object && compilation.ContainsSyntaxTree(source.Tree))
+                    if (generatedTree.Tree is object && compilation.ContainsSyntaxTree(generatedTree.Tree))
                     {
-                        trees.Add(source.Tree);
+                        trees.Add(generatedTree.Tree);
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -135,11 +135,22 @@ namespace Microsoft.CodeAnalysis
                                 => new GeneratorRunResult(generator,
                                                           diagnostics: generatorState.Diagnostics,
                                                           exception: generatorState.Exception,
-                                                          generatedSources: generatorState.PostInitTrees
-                                                                              .Union(generatorState.GeneratedTrees)
-                                                                              .Select(t => new GeneratedSourceResult(t.Tree, t.Text, t.HintName))
-                                                                              .ToImmutableArray()));
+                                                          generatedSources: getGeneratorSources(generatorState)));
             return new GeneratorDriverRunResult(results);
+
+            static ImmutableArray<GeneratedSourceResult> getGeneratorSources(GeneratorState generatorState)
+            {
+                ArrayBuilder<GeneratedSourceResult> sources = ArrayBuilder<GeneratedSourceResult>.GetInstance(generatorState.PostInitTrees.Length + generatorState.GeneratedTrees.Length);
+                foreach (var tree in generatorState.PostInitTrees)
+                {
+                    sources.Add(new GeneratedSourceResult(tree.Tree, tree.Text, tree.HintName));
+                }
+                foreach (var tree in generatorState.GeneratedTrees)
+                {
+                    sources.Add(new GeneratedSourceResult(tree.Tree, tree.Text, tree.HintName));
+                }
+                return sources.ToImmutableAndFree();
+            }
         }
 
         internal GeneratorDriverState RunGeneratorsCore(Compilation compilation, DiagnosticBag? diagnosticsBag, CancellationToken cancellationToken = default)

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis
 {
     internal readonly struct GeneratorInfo
@@ -10,12 +12,15 @@ namespace Microsoft.CodeAnalysis
 
         internal SyntaxContextReceiverCreator? SyntaxContextReceiverCreator { get; }
 
+        internal Action<GeneratorPostInitializationContext>? PostInitCallback { get; }
+
         internal bool Initialized { get; }
 
-        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxContextReceiverCreator? receiverCreator)
+        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxContextReceiverCreator? receiverCreator, Action<GeneratorPostInitializationContext>? postInitCallback)
         {
             EditCallback = editCallback;
             SyntaxContextReceiverCreator = receiverCreator;
+            PostInitCallback = postInitCallback;
             Initialized = true;
         }
 
@@ -25,7 +30,9 @@ namespace Microsoft.CodeAnalysis
 
             internal SyntaxContextReceiverCreator? SyntaxContextReceiverCreator { get; set; }
 
-            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxContextReceiverCreator);
+            internal Action<GeneratorPostInitializationContext>? PostInitCallback { get; set; }
+
+            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxContextReceiverCreator, PostInitCallback);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -28,8 +28,8 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new generator state that contains information and constant trees
         /// </summary>
-        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> constantTrees)
-            : this(info, constantTrees, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, syntaxReceiver: null, exception: null)
+        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees)
+            : this(info, postInitTrees, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, syntaxReceiver: null, exception: null)
         {
         }
 
@@ -44,14 +44,14 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a generator state that contains results
         /// </summary>
-        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> constantTrees, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics)
-            : this(info, constantTrees, generatedTrees, diagnostics, syntaxReceiver: null, exception: null)
+        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics)
+            : this(info, postInitTrees, generatedTrees, diagnostics, syntaxReceiver: null, exception: null)
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> constantTrees, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, ISyntaxContextReceiver? syntaxReceiver, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, ISyntaxContextReceiver? syntaxReceiver, Exception? exception)
         {
-            this.ConstantTrees = constantTrees;
+            this.PostInitTrees = postInitTrees;
             this.GeneratedTrees = generatedTrees;
             this.Info = info;
             this.Diagnostics = diagnostics;
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis
             this.Exception = exception;
         }
 
-        internal ImmutableArray<GeneratedSyntaxTree> ConstantTrees { get; }
+        internal ImmutableArray<GeneratedSyntaxTree> PostInitTrees { get; }
 
         internal ImmutableArray<GeneratedSyntaxTree> GeneratedTrees { get; }
 
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(this.Exception is null);
             return new GeneratorState(this.Info,
-                                      constantTrees: this.ConstantTrees,
+                                      postInitTrees: this.PostInitTrees,
                                       generatedTrees: this.GeneratedTrees,
                                       diagnostics: this.Diagnostics,
                                       syntaxReceiver: syntaxReceiver,

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -21,7 +21,15 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new generator state that just contains information
         /// </summary>
         public GeneratorState(GeneratorInfo info)
-            : this(info, ImmutableArray<GeneratedSourceText>.Empty, ImmutableArray<SyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, syntaxReceiver: null, exception: null)
+            : this(info, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, syntaxReceiver: null, exception: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new generator state that contains information and constant trees
+        /// </summary>
+        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> constantTrees)
+            : this(info, constantTrees, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, syntaxReceiver: null, exception: null)
         {
         }
 
@@ -29,31 +37,31 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new generator state that contains an exception and the associated diagnostic
         /// </summary>
         public GeneratorState(GeneratorInfo info, Exception e, Diagnostic error)
-            : this(info, ImmutableArray<GeneratedSourceText>.Empty, ImmutableArray<SyntaxTree>.Empty, ImmutableArray.Create(error), syntaxReceiver: null, exception: e)
+            : this(info, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray.Create(error), syntaxReceiver: null, exception: e)
         {
         }
 
         /// <summary>
         /// Creates a generator state that contains results
         /// </summary>
-        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics)
-            : this(info, sourceTexts, trees, diagnostics, syntaxReceiver: null, exception: null)
+        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> constantTrees, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics)
+            : this(info, constantTrees, generatedTrees, diagnostics, syntaxReceiver: null, exception: null)
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, ISyntaxContextReceiver? syntaxReceiver, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> constantTrees, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, ISyntaxContextReceiver? syntaxReceiver, Exception? exception)
         {
-            this.SourceTexts = sourceTexts;
-            this.Trees = trees;
+            this.ConstantTrees = constantTrees;
+            this.GeneratedTrees = generatedTrees;
             this.Info = info;
             this.Diagnostics = diagnostics;
             this.SyntaxReceiver = syntaxReceiver;
             this.Exception = exception;
         }
 
-        internal ImmutableArray<GeneratedSourceText> SourceTexts { get; }
+        internal ImmutableArray<GeneratedSyntaxTree> ConstantTrees { get; }
 
-        internal ImmutableArray<SyntaxTree> Trees { get; }
+        internal ImmutableArray<GeneratedSyntaxTree> GeneratedTrees { get; }
 
         internal GeneratorInfo Info { get; }
 
@@ -70,8 +78,8 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(this.Exception is null);
             return new GeneratorState(this.Info,
-                                      sourceTexts: this.SourceTexts,
-                                      trees: this.Trees,
+                                      constantTrees: this.ConstantTrees,
+                                      generatedTrees: this.GeneratedTrees,
                                       diagnostics: this.Diagnostics,
                                       syntaxReceiver: syntaxReceiver,
                                       exception: null);


### PR DESCRIPTION
## Note: See the accompanying proposal: https://github.com/dotnet/roslyn/issues/49753

This PR implements the proposal with a few small changes:
 1. The phase is called `PostInitialization` instead of `PreExecution` to better emphasize that it doesn't occur before every execution.
 2. The `GeneratorPostInitializationContext` does not include any members other than `AddSource` and `CancellationToken`.

**Rationale for simplifying the context:**

We have identified several customer scenarios that can be solved by this approach, but none that required the extra information. I decided to go with the minimal members required to unlock the scenarios: we can always add more things to it in the future as the need arises, but we can never take them away. 

If we add, e.g. `ParseOptions` we need to track when it changes, and re-run the post init step. Without including it means we don't have to worry about that today, and can just run them once but maintain the ability to add it in future releases if we deem it necessary.


Fixes #49253