### PR TITLE
Semantic model should use the first non-empty token of a node to calculate its position.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1313,10 +1313,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var fullSpan = this.Root.FullSpan;
             var position = node.SpanStart;
-            if (node is StatementSyntax)
+
+            // skip zero-width tokens to get the position, but never get past the end of the node
+            SyntaxToken firstToken = node.GetFirstToken(includeZeroWidth: false);
+            if (firstToken.Node is object)
             {
-                // skip zero-width tokens to get the position, but never get past the end of the node
-                int betterPosition = node.GetFirstToken(includeZeroWidth: false).SpanStart;
+                int betterPosition = firstToken.SpanStart;
                 if (betterPosition < node.Span.End)
                 {
                     position = betterPosition;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -36183,6 +36183,34 @@ public class C : System.Collections.Generic.List<int>
 ";
             CompileAndVerify(source, expectedOutput: @"1");
         }
+
+        [Fact]
+        [WorkItem(49997, "https://github.com/dotnet/roslyn/issues/49997")]
+        public void Issue49997()
+        {
+            var text = @"
+public class Cls
+{
+    public static void Main()
+    {
+        if ()
+        .Test1().Test2(out var x1).Test3();
+    }
+}
+
+static class Ext
+{
+    public static void Test3(this Cls x) {}
+}
+";
+            var compilation = CreateCompilation(text);
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "Test3").Last();
+            Assert.True(model.GetSymbolInfo(node).IsEmpty);
+        }
     }
 
     internal static class OutVarTestsExtensions


### PR DESCRIPTION
This makes sure correct position is used to determine enclosing binder for the node. Fixes #49997.