### PR TITLE
Dedupe navigate-to results across project flavors

### DIFF
--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -110,19 +110,19 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
                 foreach (var declaredSymbolInfo in declarationInfo.DeclaredSymbolInfos)
                 {
-                    AddResultIfMatch(
+                    await AddResultIfMatchAsync(
                         document, declaredSymbolInfo,
                         nameMatcher, containerMatcherOpt,
                         kinds,
                         nameMatches, containerMatches,
-                        result, cancellationToken);
+                        result, cancellationToken).ConfigureAwait(false);
                 }
             }
 
             return result.ToImmutable();
         }
 
-        private static void AddResultIfMatch(
+        private static async Task AddResultIfMatchAsync(
             Document document, DeclaredSymbolInfo declaredSymbolInfo,
             PatternMatcher nameMatcher, PatternMatcher containerMatcherOpt,
             DeclaredSymbolInfoKindSet kinds,
@@ -137,14 +137,15 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 nameMatcher.AddMatches(declaredSymbolInfo.Name, nameMatches) &&
                 containerMatcherOpt?.AddMatches(declaredSymbolInfo.FullyQualifiedContainerName, containerMatches) != false)
             {
-                result.Add(ConvertResult(
-                    declaredSymbolInfo, document, nameMatches, containerMatches));
+                result.Add(await ConvertResultAsync(
+                    declaredSymbolInfo, document, nameMatches, containerMatches, cancellationToken).ConfigureAwait(false));
             }
         }
 
-        private static SearchResult ConvertResult(
+        private static async Task<SearchResult> ConvertResultAsync(
             DeclaredSymbolInfo declaredSymbolInfo, Document document,
-            ArrayBuilder<PatternMatch> nameMatches, ArrayBuilder<PatternMatch> containerMatches)
+            ArrayBuilder<PatternMatch> nameMatches, ArrayBuilder<PatternMatch> containerMatches,
+            CancellationToken cancellationToken)
         {
             var matchKind = GetNavigateToMatchKind(nameMatches);
 
@@ -158,9 +159,36 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             foreach (var match in nameMatches)
                 matchedSpans.AddRange(match.MatchedSpans);
 
+            // See if we have a match in a linked file.  If so, see if we have the same match in other projects that
+            // this file is linked in.  If so, include the full set of projects the match is in so we can display that
+            // well in the UI.
+            var additionalMatchingProjects = await GetAdditionalProjectsWithMatchAsync(
+                document, declaredSymbolInfo, cancellationToken).ConfigureAwait(false);
             return new SearchResult(
                 document, declaredSymbolInfo, kind, matchKind, isCaseSensitive, navigableItem,
-                matchedSpans.ToImmutable());
+                matchedSpans.ToImmutable(), additionalMatchingProjects);
+        }
+
+        private static async Task<ImmutableArray<Project>> GetAdditionalProjectsWithMatchAsync(
+            Document document, DeclaredSymbolInfo declaredSymbolInfo, CancellationToken cancellationToken)
+        {
+            using var _ = ArrayBuilder<Project>.GetInstance(out var result);
+
+            var solution = document.Project.Solution;
+            var linkedDocumentIds = document.GetLinkedDocumentIds();
+            foreach (var linkedDocumentId in linkedDocumentIds)
+            {
+                var linkedDocument = solution.GetRequiredDocument(linkedDocumentId);
+                var index = await linkedDocument.GetSyntaxTreeIndexAsync(cancellationToken).ConfigureAwait(false);
+
+                // See if the index for the other file also contains this same info.  If so, merge the results so the
+                // user only sees them as a single hit in the UI.
+                if (index.DeclaredSymbolInfoSet.Contains(declaredSymbolInfo))
+                    result.Add(linkedDocument.Project);
+            }
+
+            result.RemoveDuplicates();
+            return result.ToImmutable();
         }
 
         private static string GetItemKind(DeclaredSymbolInfo declaredSymbolInfo)

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.SearchResult.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.SearchResult.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -18,88 +17,116 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     {
         private class SearchResult : INavigateToSearchResult
         {
-            public string Name => DeclaredSymbolInfo.Name;
-            public string AdditionalInformation => _lazyAdditionalInfo.Value;
-
-            public string Summary { get; }
+            public string AdditionalInformation { get; }
             public string Kind { get; }
             public NavigateToMatchKind MatchKind { get; }
-            public INavigableItem NavigableItem { get; }
             public bool IsCaseSensitive { get; }
+            public string Name { get; }
             public ImmutableArray<TextSpan> NameMatchSpans { get; }
+            public string SecondarySort { get; }
+            public string? Summary => null;
 
-            public readonly Document Document;
-            public readonly DeclaredSymbolInfo DeclaredSymbolInfo;
-
-            private readonly Lazy<string> _lazyAdditionalInfo;
-
-            private string _secondarySort;
+            public INavigableItem NavigableItem { get; }
 
             public SearchResult(
-                Document document, DeclaredSymbolInfo declaredSymbolInfo, string kind,
-                NavigateToMatchKind matchKind, bool isCaseSensitive, INavigableItem navigableItem,
-                ImmutableArray<TextSpan> nameMatchSpans)
+                Document document,
+                DeclaredSymbolInfo declaredSymbolInfo,
+                string kind,
+                NavigateToMatchKind matchKind,
+                bool isCaseSensitive,
+                INavigableItem navigableItem,
+                ImmutableArray<TextSpan> nameMatchSpans,
+                ImmutableArray<Project> additionalMatchingProjects)
             {
-                Document = document;
-                DeclaredSymbolInfo = declaredSymbolInfo;
+                Name = declaredSymbolInfo.Name;
                 Kind = kind;
                 MatchKind = matchKind;
                 IsCaseSensitive = isCaseSensitive;
                 NavigableItem = navigableItem;
                 NameMatchSpans = nameMatchSpans;
+                AdditionalInformation = ComputeAdditionalInformation(document, declaredSymbolInfo, additionalMatchingProjects);
+                SecondarySort = ConstructSecondarySortString(document, declaredSymbolInfo);
+            }
 
-                _lazyAdditionalInfo = new Lazy<string>(() =>
+            private static string ComputeAdditionalInformation(Document document, DeclaredSymbolInfo declaredSymbolInfo, ImmutableArray<Project> additionalMatchingProjects)
+            {
+                var projectName = ComputeProjectName(document, additionalMatchingProjects);
+                switch (declaredSymbolInfo.Kind)
                 {
-                    switch (declaredSymbolInfo.Kind)
-                    {
-                        case DeclaredSymbolInfoKind.Class:
-                        case DeclaredSymbolInfoKind.Record:
-                        case DeclaredSymbolInfoKind.Enum:
-                        case DeclaredSymbolInfoKind.Interface:
-                        case DeclaredSymbolInfoKind.Module:
-                        case DeclaredSymbolInfoKind.Struct:
-                            if (!declaredSymbolInfo.IsNestedType)
-                            {
-                                return string.Format(FeaturesResources.project_0, document.Project.Name);
-                            }
-                            break;
-                    }
+                    case DeclaredSymbolInfoKind.Class:
+                    case DeclaredSymbolInfoKind.Record:
+                    case DeclaredSymbolInfoKind.Enum:
+                    case DeclaredSymbolInfoKind.Interface:
+                    case DeclaredSymbolInfoKind.Module:
+                    case DeclaredSymbolInfoKind.Struct:
+                        if (!declaredSymbolInfo.IsNestedType)
+                        {
+                            return string.Format(FeaturesResources.project_0, projectName);
+                        }
+                        break;
+                }
 
-                    return string.Format(FeaturesResources.in_0_project_1, declaredSymbolInfo.ContainerDisplayName, document.Project.Name);
-                });
+                return string.Format(FeaturesResources.in_0_project_1, declaredSymbolInfo.ContainerDisplayName, projectName);
+            }
+
+            private static string ComputeProjectName(Document document, ImmutableArray<Project> additionalMatchingProjects)
+            {
+                if (TryComputeMergedProjectName(document, additionalMatchingProjects, out var mergedName))
+                    return mergedName;
+
+                // Couldn't compute a merged project name (or only had one project).  Just return the name of hte project itself.
+                return document.Project.Name;
+            }
+
+            private static bool TryComputeMergedProjectName(
+                Document document, ImmutableArray<Project> additionalMatchingProjects, [NotNullWhen(true)] out string? mergedName)
+            {
+                mergedName = null;
+                if (additionalMatchingProjects.Length == 0)
+                    return false;
+
+                var firstProject = document.Project;
+                var (firstProjectName, firstProjectFlavor) = firstProject.State.NameAndFlavor;
+                if (firstProjectName == null)
+                    return false;
+
+                using var _ = ArrayBuilder<string>.GetInstance(out var flavors);
+                flavors.Add(firstProjectFlavor!);
+
+                foreach (var additionalProject in additionalMatchingProjects)
+                {
+                    var (projectName, projectFlavor) = additionalProject.State.NameAndFlavor;
+                    if (projectName != firstProjectName)
+                        return false;
+
+                    flavors.Add(projectFlavor!);
+                }
+
+                flavors.RemoveDuplicates();
+                flavors.Sort();
+
+                mergedName = $"{firstProjectName} ({string.Join(", ", flavors)})";
+                return true;
             }
 
             private static readonly char[] s_dotArray = { '.' };
 
-            private string ConstructSecondarySortString()
+            private static string ConstructSecondarySortString(Document document, DeclaredSymbolInfo declaredSymbolInfo)
             {
                 using var _ = ArrayBuilder<string>.GetInstance(out var parts);
 
-                parts.Add(DeclaredSymbolInfo.ParameterCount.ToString("X4"));
-                parts.Add(DeclaredSymbolInfo.TypeParameterCount.ToString("X4"));
-                parts.Add(DeclaredSymbolInfo.Name);
+                parts.Add(declaredSymbolInfo.ParameterCount.ToString("X4"));
+                parts.Add(declaredSymbolInfo.TypeParameterCount.ToString("X4"));
+                parts.Add(declaredSymbolInfo.Name);
 
                 // For partial types, we break up the file name into pieces.  i.e. If we have
                 // Outer.cs and Outer.Inner.cs  then we add "Outer" and "Outer Inner" to 
                 // the secondary sort string.  That way "Outer.cs" will be weighted above
                 // "Outer.Inner.cs"
-                var fileName = Path.GetFileNameWithoutExtension(Document.FilePath ?? "");
+                var fileName = Path.GetFileNameWithoutExtension(document.FilePath ?? "");
                 parts.AddRange(fileName.Split(s_dotArray));
 
                 return string.Join(" ", parts);
-            }
-
-            public string SecondarySort
-            {
-                get
-                {
-                    if (_secondarySort == null)
-                    {
-                        _secondarySort = ConstructSecondarySortString();
-                    }
-
-                    return _secondarySort;
-                }
             }
         }
     }

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearchResultComparer.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearchResultComparer.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.NavigateTo
+{
+    /// <summary>
+    /// Comparer that considers to navigate to results the same if they will navigate to the same document and span.
+    /// This ensures that we don't see tons of results for the same symbol when a file is linked into many projects.
+    /// </summary>
+    internal class NavigateToSearchResultComparer : IEqualityComparer<INavigateToSearchResult>
+    {
+        public static readonly IEqualityComparer<INavigateToSearchResult> Instance = new NavigateToSearchResultComparer();
+
+        private NavigateToSearchResultComparer()
+        {
+        }
+
+        public bool Equals(INavigateToSearchResult? x, INavigateToSearchResult? y)
+            => x?.NavigableItem.Document.FilePath == y?.NavigableItem.Document.FilePath &&
+               x?.NavigableItem.SourceSpan == y?.NavigableItem.SourceSpan;
+
+        public int GetHashCode(INavigateToSearchResult? obj)
+            => Hash.Combine(obj?.NavigableItem.Document.FilePath, obj?.NavigableItem.SourceSpan.GetHashCode() ?? 0);
+    }
+}

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearchResultComparer.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearchResultComparer.cs
@@ -10,6 +10,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     /// <summary>
     /// Comparer that considers to navigate to results the same if they will navigate to the same document and span.
     /// This ensures that we don't see tons of results for the same symbol when a file is linked into many projects.
+    /// <para/>
+    /// This also has the impact that a linked file (say from a shared project) will only show up for a single project
+    /// that it is linked into. This is believed to actually be desirable as showing multiple hits for effectively the
+    /// same symbol, just for different projects just feels like clutter in the UI without real benefit for the user
+    /// (since navigating will just take the user to the same location).
     /// </summary>
     internal class NavigateToSearchResultComparer : IEqualityComparer<INavigateToSearchResult>
     {

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.NoOpDocumentTrackingService.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.NoOpDocumentTrackingService.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.NavigateTo
+{
+    internal partial class NavigateToSearcher
+    {
+        private class NoOpDocumentTrackingService : IDocumentTrackingService
+        {
+            public static readonly IDocumentTrackingService Instance = new NoOpDocumentTrackingService();
+
+            private NoOpDocumentTrackingService()
+            {
+            }
+
+#pragma warning disable CS0067
+            public event EventHandler<DocumentId>? ActiveDocumentChanged;
+            public event EventHandler<EventArgs>? NonRoslynBufferTextChanged;
+#pragma warning restore CS0067
+
+            public ImmutableArray<DocumentId> GetVisibleDocuments()
+                => ImmutableArray<DocumentId>.Empty;
+
+            public DocumentId? TryGetActiveDocument()
+                => null;
+        }
+    }
+}

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,13 +71,15 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 // order.  That way we provide results for the documents the user is working
                 // on faster than the rest of the solution.
                 var docTrackingService = workspace.Services.GetService<IDocumentTrackingService>();
+
+                var seenItems = new HashSet<INavigateToSearchResult>(NavigateToSearchResultComparer.Instance);
                 if (docTrackingService != null)
                 {
-                    await SearchProjectsInPriorityOrderAsync(docTrackingService).ConfigureAwait(false);
+                    await SearchProjectsInPriorityOrderAsync(docTrackingService, seenItems).ConfigureAwait(false);
                 }
                 else
                 {
-                    await SearchAllProjectsAsync().ConfigureAwait(false);
+                    await SearchAllProjectsAsync(seenItems).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)
@@ -92,7 +95,9 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
         }
 
-        private async Task SearchProjectsInPriorityOrderAsync(IDocumentTrackingService docTrackingService)
+        private async Task SearchProjectsInPriorityOrderAsync(
+            IDocumentTrackingService docTrackingService,
+            HashSet<INavigateToSearchResult> seenItems)
         {
             var processedProjects = new HashSet<Project>();
 
@@ -113,7 +118,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 // Search the active project first.  That way we can deliver results that are
                 // closer in scope to the user quicker without forcing them to do something like
                 // NavToInCurrentDoc
-                await Task.Run(() => SearchAsync(activeProject, priorityDocs), _cancellationToken).ConfigureAwait(false);
+                await Task.Run(() => SearchAsync(activeProject, priorityDocs, seenItems), _cancellationToken).ConfigureAwait(false);
             }
 
             // Now, process all visible docs that were not from the active project.
@@ -122,7 +127,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             {
                 // make sure we only process this project if we didn't already process it above.
                 if (processedProjects.Add(currentProject))
-                    tasks.Add(Task.Run(() => SearchAsync(currentProject, priorityDocs.ToImmutableArray()), _cancellationToken));
+                    tasks.Add(Task.Run(() => SearchAsync(currentProject, priorityDocs.ToImmutableArray(), seenItems), _cancellationToken));
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -133,26 +138,29 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             {
                 // make sure we only process this project if we didn't already process it above.
                 if (processedProjects.Add(currentProject))
-                    tasks.Add(Task.Run(() => SearchAsync(currentProject, ImmutableArray<Document>.Empty), _cancellationToken));
+                    tasks.Add(Task.Run(() => SearchAsync(currentProject, ImmutableArray<Document>.Empty, seenItems), _cancellationToken));
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
-        private async Task SearchAllProjectsAsync()
+        private async Task SearchAllProjectsAsync(HashSet<INavigateToSearchResult> seenItems)
         {
             // Search each project with an independent threadpool task.
             var searchTasks = _solution.Projects.Select(
-                p => Task.Run(() => SearchAsync(p, priorityDocuments: ImmutableArray<Document>.Empty), _cancellationToken)).ToArray();
+                p => Task.Run(() => SearchAsync(p, priorityDocuments: ImmutableArray<Document>.Empty, seenItems), _cancellationToken)).ToArray();
 
             await Task.WhenAll(searchTasks).ConfigureAwait(false);
         }
 
-        private async Task SearchAsync(Project project, ImmutableArray<Document> priorityDocuments)
+        private async Task SearchAsync(
+            Project project,
+            ImmutableArray<Document> priorityDocuments,
+            HashSet<INavigateToSearchResult> seenItems)
         {
             try
             {
-                await SearchCoreAsync(project, priorityDocuments).ConfigureAwait(false);
+                await SearchCoreAsync(project, priorityDocuments, seenItems).ConfigureAwait(false);
             }
             finally
             {
@@ -160,7 +168,10 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
         }
 
-        private async Task SearchCoreAsync(Project project, ImmutableArray<Document> priorityDocuments)
+        private async Task SearchCoreAsync(
+            Project project,
+            ImmutableArray<Document> priorityDocuments,
+            HashSet<INavigateToSearchResult> seenItems)
         {
             if (_searchCurrentDocument && _currentDocument?.Project != project)
                 return;
@@ -182,6 +193,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                         {
                             foreach (var result in results)
                             {
+                                lock (seenItems)
+                                {
+                                    if (!seenItems.Add(result))
+                                        continue;
+                                }
+
                                 await _callback.AddItemAsync(project, result, _cancellationToken).ConfigureAwait(false);
                             }
                         }

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -193,6 +193,9 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                         {
                             foreach (var result in results)
                             {
+                                // If we're seeing a dupe in another project, then filter it out here.  The results from
+                                // the individual projects will already contain the information about all the projects
+                                // leading to a better condensed view that doesn't look like it contains duplicate info.
                                 lock (seenItems)
                                 {
                                     if (!seenItems.Add(result))

--- a/src/Workspaces/Core/Portable/FindSymbols/DeclaredSymbolInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/DeclaredSymbolInfo.cs
@@ -219,6 +219,8 @@ $@"Invalid span in {nameof(DeclaredSymbolInfo)}.
                Hash.Combine(NameSuffix,
                Hash.Combine(ContainerDisplayName,
                Hash.Combine(FullyQualifiedContainerName,
-               Hash.Combine(Span.GetHashCode(), (int)_flags)))));
+               Hash.Combine(Span.GetHashCode(),
+               Hash.Combine((int)_flags,
+               Hash.CombineValues(InheritanceNames)))))));
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.DeclarationInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.DeclarationInfo.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -33,7 +32,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 try
                 {
                     var declaredSymbolCount = reader.ReadInt32();
-                    using var _ = ArrayBuilder<DeclaredSymbolInfo>.GetInstance(out var result);
+                    using var _ = ArrayBuilder<DeclaredSymbolInfo>.GetInstance(declaredSymbolCount, out var result);
                     for (var i = 0; i < declaredSymbolCount; i++)
                         result.Add(DeclaredSymbolInfo.ReadFrom_ThrowsOnFailure(stringTable, reader));
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.DeclarationInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.DeclarationInfo.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
@@ -24,7 +23,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 writer.WriteInt32(DeclaredSymbolInfos.Length);
                 foreach (var declaredSymbolInfo in DeclaredSymbolInfos)
+                {
                     declaredSymbolInfo.WriteTo(writer);
+                }
             }
 
             public static DeclarationInfo? TryReadFrom(StringTable stringTable, ObjectReader reader)
@@ -32,11 +33,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 try
                 {
                     var declaredSymbolCount = reader.ReadInt32();
-                    using var _ = ArrayBuilder<DeclaredSymbolInfo>.GetInstance(declaredSymbolCount, out var result);
+                    var builder = ImmutableArray.CreateBuilder<DeclaredSymbolInfo>(declaredSymbolCount);
                     for (var i = 0; i < declaredSymbolCount; i++)
-                        result.Add(DeclaredSymbolInfo.ReadFrom_ThrowsOnFailure(stringTable, reader));
+                    {
+                        builder.Add(DeclaredSymbolInfo.ReadFrom_ThrowsOnFailure(stringTable, reader));
+                    }
 
-                    return new DeclarationInfo(result.ToImmutable());
+                    return new DeclarationInfo(builder.MoveToImmutable());
                 }
                 catch (Exception)
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -21,6 +22,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private readonly ContextInfo _contextInfo;
         private readonly DeclarationInfo _declarationInfo;
         private readonly ExtensionMethodInfo _extensionMethodInfo;
+        private readonly Lazy<HashSet<DeclaredSymbolInfo>> _declaredSymbolInfoSet;
 
         private SyntaxTreeIndex(
             Checksum checksum,
@@ -36,6 +38,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             _contextInfo = contextInfo;
             _declarationInfo = declarationInfo;
             _extensionMethodInfo = extensionMethodInfo;
+            _declaredSymbolInfoSet = new(() => new(this.DeclaredSymbolInfos));
         }
 
         private static readonly ConditionalWeakTable<Document, SyntaxTreeIndex> s_documentToIndex = new();

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -42,11 +42,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public bool ContainsTupleExpressionOrTupleType => _contextInfo.ContainsTupleExpressionOrTupleType;
         public bool ContainsGlobalAttributes => _contextInfo.ContainsGlobalAttributes;
 
-        private HashSet<DeclaredSymbolInfo> _declaredSymbolInfoSet;
-
         /// <summary>
         /// Same as <see cref="DeclaredSymbolInfos"/>, just stored as a set for easy containment checks.
         /// </summary>
-        public HashSet<DeclaredSymbolInfo> DeclaredSymbolInfoSet => _declaredSymbolInfoSet ??= new HashSet<DeclaredSymbolInfo>(DeclaredSymbolInfos);
+        public HashSet<DeclaredSymbolInfo> DeclaredSymbolInfoSet => _declaredSymbolInfoSet.Value;
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageServices;
 
@@ -40,5 +41,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public bool ContainsIndexerMemberCref => _contextInfo.ContainsIndexerMemberCref;
         public bool ContainsTupleExpressionOrTupleType => _contextInfo.ContainsTupleExpressionOrTupleType;
         public bool ContainsGlobalAttributes => _contextInfo.ContainsGlobalAttributes;
+
+        private HashSet<DeclaredSymbolInfo> _declaredSymbolInfoSet;
+        public HashSet<DeclaredSymbolInfo> DeclaredSymbolInfoSet => _declaredSymbolInfoSet ??= new HashSet<DeclaredSymbolInfo>(DeclaredSymbolInfos);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -43,6 +43,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public bool ContainsGlobalAttributes => _contextInfo.ContainsGlobalAttributes;
 
         private HashSet<DeclaredSymbolInfo> _declaredSymbolInfoSet;
+
+        /// <summary>
+        /// Same as <see cref="DeclaredSymbolInfos"/>, just stored as a set for easy containment checks.
+        /// </summary>
         public HashSet<DeclaredSymbolInfo> DeclaredSymbolInfoSet => _declaredSymbolInfoSet ??= new HashSet<DeclaredSymbolInfo>(DeclaredSymbolInfos);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -370,7 +370,6 @@ namespace Microsoft.CodeAnalysis
             private static readonly Regex s_projectNameAndFlavor = new Regex(@"^(?<name>.*?)\s*\((?<flavor>.*?)\)$", RegexOptions.Compiled);
 
             private Checksum? _lazyChecksum;
-            private (string? name, string? flavor)? _lazyFlavorInfo;
 
             /// <summary>
             /// The unique Id of the project.
@@ -393,16 +392,7 @@ namespace Microsoft.CodeAnalysis
             /// <c>Microsoft.CodeAnalysis.Workspace</c> and the flavor <c>netcoreapp3.1</c>.  Values may be null <see
             /// langword="null"/> if the name does not contain a flavor.
             /// </summary>
-            public (string? name, string? flavor) NameAndFlavor => _lazyFlavorInfo ??= ComputeFlavorInfo();
-
-            private (string? name, string? flavor) ComputeFlavorInfo()
-            {
-                var match = s_projectNameAndFlavor.Match(Name);
-                if (match?.Success != true)
-                    return default;
-
-                return (match.Groups["name"].Value, match.Groups["flavor"].Value);
-            }
+            public (string? name, string? flavor) NameAndFlavor { get; }
 
             /// <summary>
             /// The name of the assembly that this project will create, without file extension.
@@ -492,6 +482,10 @@ namespace Microsoft.CodeAnalysis
                 HasAllInformation = hasAllInformation;
                 RunAnalyzers = runAnalyzers;
                 TelemetryId = telemetryId;
+
+                var match = s_projectNameAndFlavor.Match(Name);
+                if (match?.Success == true)
+                    NameAndFlavor = (match.Groups["name"].Value, match.Groups["flavor"].Value);
             }
 
             public ProjectAttributes With(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -425,6 +425,10 @@ namespace Microsoft.CodeAnalysis
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
         public string Name => this.ProjectInfo.Name;
 
+        /// <inheritdoc cref="ProjectInfo.NameAndFlavor"/>
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        public (string? name, string? flavor) NameAndFlavor => this.ProjectInfo.NameAndFlavor;
+
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
         public bool IsSubmission => this.ProjectInfo.IsSubmission;
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4564579/103105678-0beeee00-45e4-11eb-8356-6a578dee9270.png)


After:

![image](https://user-images.githubusercontent.com/4564579/103194892-da9d4900-4895-11eb-859a-a7e99a9239c9.png)

Note the duplicate results across netcoreapp3.1 and netcoreapp2.0 are gone and you now just get one result for all those flavors.  There are still multiple results due to partial files, and we need to make that better, but that's out of scope here.

--

We accomplish this by deduping results that map back to the same file path and same location in that file.  There's no point showing multiple results of that sort as all those results will just end navigating back to the exact same file and location.

A more ideal approach might be some mechanism to show that there are multiple results across all the linked projects for a file.  However, that's not really supported in the streaming model that navigate-to currently presents us.