### PR TITLE
Extract IFindDefinitionService into to the features layer

### DIFF
--- a/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
+++ b/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;
@@ -21,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.GoToDefinition
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public CSharpGoToDefinitionService(
             IThreadingContext threadingContext,
-            Lazy<IStreamingFindUsagesPresenter> streamingPresenter)
+            IStreamingFindUsagesPresenter streamingPresenter)
             : base(threadingContext, streamingPresenter)
         {
         }

--- a/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
+++ b/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;

--- a/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToSymbolService.cs
+++ b/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToSymbolService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;

--- a/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
         }
 
         private static IEnumerable<IPeekableItem> GetPeekableItemsForNavigableItems(
-            IEnumerable<INavigableItem> navigableItems, Project project,
+            IEnumerable<INavigableItem>? navigableItems, Project project,
             IPeekResultFactory peekResultFactory,
             CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             _streamingPresenter = streamingPresenter;
         }
 
-        async Task<IEnumerable<INavigableItem>> IGoToDefinitionService.FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken)
+        async Task<IEnumerable<INavigableItem>?> IGoToDefinitionService.FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken)
             => await FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
 
         public bool TryGoToDefinition(Document document, int position, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -2,15 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -33,6 +36,9 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             _threadingContext = threadingContext;
             _streamingPresenter = streamingPresenter;
         }
+
+        async Task<IEnumerable<INavigableItem>> IGoToDefinitionService.FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken)
+            => await FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
 
         public bool TryGoToDefinition(Document document, int position, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -4,62 +4,42 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 {
     // GoToDefinition
-    internal abstract class AbstractGoToDefinitionService : IGoToDefinitionService
+    internal abstract class AbstractGoToDefinitionService : AbstractFindDefinitionService, IGoToDefinitionService
     {
         private readonly IThreadingContext _threadingContext;
 
         /// <summary>
         /// Used to present go to definition results in <see cref="TryGoToDefinition(Document, int, CancellationToken)"/>
-        /// This is lazily created as the LSP server only calls <see cref="FindDefinitionsAsync(Document, int, CancellationToken)"/>
-        /// and therefore never needs to construct the presenter.
         /// </summary>
-        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenter;
+        private readonly IStreamingFindUsagesPresenter _streamingPresenter;
 
         protected AbstractGoToDefinitionService(
             IThreadingContext threadingContext,
-            Lazy<IStreamingFindUsagesPresenter> streamingPresenter)
+            IStreamingFindUsagesPresenter streamingPresenter)
         {
             _threadingContext = threadingContext;
             _streamingPresenter = streamingPresenter;
         }
 
-        public async Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(
-            Document document, int position, CancellationToken cancellationToken)
-        {
-            var symbolService = document.GetLanguageService<IGoToDefinitionSymbolService>();
-            var (symbol, _) = await symbolService.GetSymbolAndBoundSpanAsync(document, position, includeType: true, cancellationToken).ConfigureAwait(false);
-
-            // Try to compute source definitions from symbol.
-            var items = symbol != null
-                ? NavigableItemFactory.GetItemsFromPreferredSourceLocations(document.Project.Solution, symbol, displayTaggedParts: null, cancellationToken: cancellationToken)
-                : null;
-
-            // realize the list here so that the consumer await'ing the result doesn't lazily cause
-            // them to be created on an inappropriate thread.
-            return items?.ToList();
-        }
-
         public bool TryGoToDefinition(Document document, int position, CancellationToken cancellationToken)
         {
             // Try to compute the referenced symbol and attempt to go to definition for the symbol.
-            var symbolService = document.GetLanguageService<IGoToDefinitionSymbolService>();
+            var symbolService = document.GetRequiredLanguageService<IGoToDefinitionSymbolService>();
             var (symbol, _) = symbolService.GetSymbolAndBoundSpanAsync(document, position, includeType: true, cancellationToken).WaitAndGetResult(cancellationToken);
             if (symbol is null)
                 return false;
@@ -76,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
                 symbol,
                 document.Project.Solution,
                 _threadingContext,
-                _streamingPresenter.Value,
+                _streamingPresenter,
                 thirdPartyNavigationAllowed: isThirdPartyNavigationAllowed,
                 cancellationToken: cancellationToken);
         }
@@ -118,19 +98,20 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
                 FindUsagesHelpers.GetDisplayName(symbol));
 
             return _threadingContext.JoinableTaskFactory.Run(() =>
-                _streamingPresenter.Value.TryNavigateToOrPresentItemsAsync(
+                _streamingPresenter.TryNavigateToOrPresentItemsAsync(
                     _threadingContext, solution.Workspace, title, definitions));
         }
 
         private static bool IsThirdPartyNavigationAllowed(ISymbol symbolToNavigateTo, int caretPosition, Document document, CancellationToken cancellationToken)
         {
             var syntaxRoot = document.GetSyntaxRootSynchronously(cancellationToken);
-            var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
+            var syntaxFactsService = document.GetRequiredLanguageService<ISyntaxFactsService>();
             var containingTypeDeclaration = syntaxFactsService.GetContainingTypeDeclaration(syntaxRoot, caretPosition);
 
             if (containingTypeDeclaration != null)
             {
                 var semanticModel = document.GetSemanticModelAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+                Debug.Assert(semanticModel != null);
 
                 // Allow third parties to navigate to all symbols except types/constructors
                 // if we are navigating from the corresponding type.

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.GoToDefinition;
@@ -25,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             var document = context.Document;
             var position = context.Position;
             var cancellationToken = context.CancellationToken;
-            var service = document.GetLanguageService<IGoToDefinitionSymbolService>();
+            var service = document.GetRequiredLanguageService<IGoToDefinitionSymbolService>();
 
             // [includeType: false]
             // Enable Ctrl+Click on tokens with aliased, referenced or declared symbol.

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
@@ -6,6 +6,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Threading;
 

--- a/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
@@ -2,14 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
-using Microsoft.CodeAnalysis.GoToDefinition;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Navigation;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
-    internal interface IGoToDefinitionService : ILanguageService, IFindDefinitionService
+    internal interface IGoToDefinitionService : ILanguageService
     {
+        /// <inheritdoc cref="CodeAnalysis.GoToDefinition.IFindDefinitionService.FindDefinitionsAsync(Document, int, CancellationToken)"/>
+        // Keep changes to this method in sync with CodeAnalysis.GoToDefinition.IFindDefinitionService
+        Task<IEnumerable<INavigableItem>?> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
+
         /// <summary>
         /// Finds the definitions for the symbol at the specific position in the document and then 
         /// navigates to them.

--- a/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
@@ -4,21 +4,14 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Navigation;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
-    internal interface IGoToDefinitionService : ILanguageService
+    internal interface IGoToDefinitionService : ILanguageService, IFindDefinitionService
     {
-        /// <summary>
-        /// Finds the definitions for the symbol at the specific position in the document.
-        /// </summary>
-        Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
-
         /// <summary>
         /// Finds the definitions for the symbol at the specific position in the document and then 
         /// navigates to them.

--- a/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Host;

--- a/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IGoToDefinitionService.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor
     {
         /// <inheritdoc cref="CodeAnalysis.GoToDefinition.IFindDefinitionService.FindDefinitionsAsync(Document, int, CancellationToken)"/>
         // Keep changes to this method in sync with CodeAnalysis.GoToDefinition.IFindDefinitionService
+        // Obsoletion is tracked with https://github.com/dotnet/roslyn/issues/50391
         Task<IEnumerable<INavigableItem>?> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/EditorFeatures/Core/GoToDefinition/IGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IGoToSymbolService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
@@ -101,7 +101,7 @@ class C
                 Dim cursorBuffer = cursorDocument.GetTextBuffer()
                 Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
 
-                Dim goToDefService = New CSharpGoToDefinitionService(threadingContext, New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter))
+                Dim goToDefService = New CSharpGoToDefinitionService(threadingContext, presenter)
 
                 Dim waitContext = New TestUIThreadOperationContext(updatesBeforeCancel)
                 GoToDefinitionCommandHandler.TryExecuteCommand(document, cursorPosition, goToDefService, New CommandExecutionContext(waitContext))

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -107,10 +107,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
         Private Shared Sub Test(workspaceDefinition As XElement, Optional expectedResult As Boolean = True)
             Test(workspaceDefinition, expectedResult,
                 Function(document, cursorPosition, threadingContext, presenter)
-                    Dim lazyPresenter = New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)
                     Dim goToDefService = If(document.Project.Language = LanguageNames.CSharp,
-                        DirectCast(New CSharpGoToDefinitionService(threadingContext, lazyPresenter), IGoToDefinitionService),
-                        New VisualBasicGoToDefinitionService(threadingContext, lazyPresenter))
+                        DirectCast(New CSharpGoToDefinitionService(threadingContext, presenter), IGoToDefinitionService),
+                        New VisualBasicGoToDefinitionService(threadingContext, presenter))
 
                     Return goToDefService.TryGoToDefinition(document, cursorPosition, CancellationToken.None)
                 End Function)

--- a/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
+++ b/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.GoToDefinition
         <ImportingConstructor>
         <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
         Public Sub New(threadingContext As IThreadingContext,
-                       streamingPresenter As Lazy(Of IStreamingFindUsagesPresenter))
+                       streamingPresenter As IStreamingFindUsagesPresenter)
             MyBase.New(threadingContext, streamingPresenter)
         End Sub
     End Class

--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpFindDefinitionService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpFindDefinitionService.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.GoToDefinition;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.CSharp.GoToDefinition
+{
+    [ExportLanguageService(typeof(IFindDefinitionService), LanguageNames.CSharp), Shared]
+    internal class CSharpFindDefinitionService : AbstractFindDefinitionService
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpFindDefinitionService()
+        {
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpFindDefinitionService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpFindDefinitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.GoToDefinition;

--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
@@ -5,13 +5,11 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Composition;
-using Microsoft.CodeAnalysis.Editor.GoToDefinition;
-using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Host.Mef;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.GoToDefinition
+namespace Microsoft.CodeAnalysis.CSharp.GoToDefinition
 {
     [ExportLanguageService(typeof(IGoToDefinitionSymbolService), LanguageNames.CSharp), Shared]
     internal class CSharpGoToDefinitionSymbolService : AbstractGoToDefinitionSymbolService

--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.GoToDefinition;

--- a/src/Features/Core/Portable/GoToDefinition/AbstractFindDefinitionService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/AbstractFindDefinitionService.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Navigation;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.GoToDefinition
+{
+    internal class AbstractFindDefinitionService : IFindDefinitionService
+    {
+        public async Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(
+            Document document, int position, CancellationToken cancellationToken)
+        {
+            var symbolService = document.GetLanguageService<IGoToDefinitionSymbolService>();
+            var (symbol, _) = await symbolService.GetSymbolAndBoundSpanAsync(document, position, includeType: true, cancellationToken).ConfigureAwait(false);
+
+            // Try to compute source definitions from symbol.
+            var items = symbol != null
+                ? NavigableItemFactory.GetItemsFromPreferredSourceLocations(document.Project.Solution, symbol, displayTaggedParts: null, cancellationToken: cancellationToken)
+                : null;
+
+            // realize the list here so that the consumer await'ing the result doesn't lazily cause
+            // them to be created on an inappropriate thread.
+            return items?.ToList();
+        }
+    }
+}

--- a/src/Features/Core/Portable/GoToDefinition/AbstractFindDefinitionService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/AbstractFindDefinitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -15,10 +13,10 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
 {
     internal class AbstractFindDefinitionService : IFindDefinitionService
     {
-        public async Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(
+        public async Task<IEnumerable<INavigableItem>?> FindDefinitionsAsync(
             Document document, int position, CancellationToken cancellationToken)
         {
-            var symbolService = document.GetLanguageService<IGoToDefinitionSymbolService>();
+            var symbolService = document.GetRequiredLanguageService<IGoToDefinitionSymbolService>();
             var (symbol, _) = await symbolService.GetSymbolAndBoundSpanAsync(document, position, includeType: true, cancellationToken).ConfigureAwait(false);
 
             // Try to compute source definitions from symbol.

--- a/src/Features/Core/Portable/GoToDefinition/AbstractFindDefinitionService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/AbstractFindDefinitionService.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Navigation;
@@ -13,20 +12,16 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
 {
     internal class AbstractFindDefinitionService : IFindDefinitionService
     {
-        public async Task<IEnumerable<INavigableItem>?> FindDefinitionsAsync(
+        public async Task<ImmutableArray<INavigableItem>> FindDefinitionsAsync(
             Document document, int position, CancellationToken cancellationToken)
         {
             var symbolService = document.GetRequiredLanguageService<IGoToDefinitionSymbolService>();
             var (symbol, _) = await symbolService.GetSymbolAndBoundSpanAsync(document, position, includeType: true, cancellationToken).ConfigureAwait(false);
 
             // Try to compute source definitions from symbol.
-            var items = symbol != null
+            return symbol != null
                 ? NavigableItemFactory.GetItemsFromPreferredSourceLocations(document.Project.Solution, symbol, displayTaggedParts: null, cancellationToken: cancellationToken)
-                : null;
-
-            // realize the list here so that the consumer await'ing the result doesn't lazily cause
-            // them to be created on an inappropriate thread.
-            return items?.ToList();
+                : ImmutableArray<INavigableItem>.Empty;
         }
     }
 }

--- a/src/Features/Core/Portable/GoToDefinition/AbstractGoToDefinitionSymbolService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/AbstractGoToDefinitionSymbolService.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
+namespace Microsoft.CodeAnalysis.GoToDefinition
 {
     internal abstract class AbstractGoToDefinitionSymbolService : IGoToDefinitionSymbolService
     {

--- a/src/Features/Core/Portable/GoToDefinition/AbstractGoToDefinitionSymbolService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/AbstractGoToDefinitionSymbolService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,11 +15,11 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
     {
         protected abstract ISymbol FindRelatedExplicitlyDeclaredSymbol(ISymbol symbol, Compilation compilation);
 
-        public async Task<(ISymbol, TextSpan)> GetSymbolAndBoundSpanAsync(Document document, int position, bool includeType, CancellationToken cancellationToken)
+        public async Task<(ISymbol?, TextSpan)> GetSymbolAndBoundSpanAsync(Document document, int position, bool includeType, CancellationToken cancellationToken)
         {
             var workspace = document.Project.Solution.Workspace;
 
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var semanticInfo = await SymbolFinder.GetSemanticInfoAtPositionAsync(semanticModel, position, workspace, cancellationToken).ConfigureAwait(false);
             var symbol = GetSymbol(semanticInfo, includeType);
 
@@ -33,7 +31,7 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
             return (FindRelatedExplicitlyDeclaredSymbol(symbol, semanticModel.Compilation), semanticInfo.Span);
         }
 
-        private static ISymbol GetSymbol(TokenSemanticInfo semanticInfo, bool includeType)
+        private static ISymbol? GetSymbol(TokenSemanticInfo semanticInfo, bool includeType)
         {
             // Prefer references to declarations. It's more likely that the user is attempting to 
             // go to a definition at some other location, rather than the definition they're on. 

--- a/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -15,6 +15,6 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
         /// <summary>
         /// Finds the definitions for the symbol at the specific position in the document.
         /// </summary>
-        Task<IEnumerable<INavigableItem>?> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
+        Task<ImmutableArray<INavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
@@ -16,6 +16,5 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
         /// Finds the definitions for the symbol at the specific position in the document.
         /// </summary>
         Task<IEnumerable<INavigableItem>?> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
-
     }
 }

--- a/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +15,7 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
         /// <summary>
         /// Finds the definitions for the symbol at the specific position in the document.
         /// </summary>
-        Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
+        Task<IEnumerable<INavigableItem>?> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
 
     }
 }

--- a/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/IFindDefinitionService.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Navigation;
+
+namespace Microsoft.CodeAnalysis.GoToDefinition
+{
+    internal interface IFindDefinitionService : ILanguageService
+    {
+        /// <summary>
+        /// Finds the definitions for the symbol at the specific position in the document.
+        /// </summary>
+        Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
+
+    }
+}

--- a/src/Features/Core/Portable/GoToDefinition/IGoToDefinitionSymbolService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/IGoToDefinitionSymbolService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -13,6 +11,6 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
 {
     internal interface IGoToDefinitionSymbolService : ILanguageService
     {
-        Task<(ISymbol, TextSpan)> GetSymbolAndBoundSpanAsync(Document document, int position, bool includeType, CancellationToken cancellationToken);
+        Task<(ISymbol?, TextSpan)> GetSymbolAndBoundSpanAsync(Document document, int position, bool includeType, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/GoToDefinition/IGoToDefinitionSymbolService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/IGoToDefinitionSymbolService.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
+namespace Microsoft.CodeAnalysis.GoToDefinition
 {
     internal interface IGoToDefinitionSymbolService : ILanguageService
     {

--- a/src/Features/Core/Portable/Navigation/NavigableItemFactory.cs
+++ b/src/Features/Core/Portable/Navigation/NavigableItemFactory.cs
@@ -27,14 +27,14 @@ namespace Microsoft.CodeAnalysis.Navigation
         public static INavigableItem GetItemFromDeclaredSymbolInfo(DeclaredSymbolInfo declaredSymbolInfo, Document document)
             => new DeclaredSymbolNavigableItem(document, declaredSymbolInfo);
 
-        public static IEnumerable<INavigableItem> GetItemsFromPreferredSourceLocations(
+        public static ImmutableArray<INavigableItem> GetItemsFromPreferredSourceLocations(
             Solution solution,
             ISymbol symbol,
             ImmutableArray<TaggedText>? displayTaggedParts,
             CancellationToken cancellationToken)
         {
             var locations = GetPreferredSourceLocations(solution, symbol, cancellationToken);
-            return locations.Select(loc => GetItemFromSymbolLocation(
+            return locations.SelectAsArray(loc => GetItemFromSymbolLocation(
                 solution, symbol, loc, displayTaggedParts));
         }
 

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var definitionService = document.Project.LanguageServices.GetRequiredService<IFindDefinitionService>();
             var definitions = await definitionService.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
-            if (definitions != null && definitions.Count() > 0)
+            if (definitions?.Any() == true)
             {
                 foreach (var definition in definitions)
                 {

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -123,6 +123,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             static async Task<IEnumerable<INavigableItem>?> GetDefinitions(Document document, int position, CancellationToken cancellationToken)
             {
+                // Try IFindDefinitionService first. Until partners implement this, it could fail to find a service, so fall back if it's null.
                 var findDefinitionService = document.GetLanguageService<IFindDefinitionService>();
                 if (findDefinitionService != null)
                 {

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             return locations.ToArrayAndFree();
 
+            // local functions
             static bool ShouldInclude(INavigableItem item, bool typeOnly)
             {
                 if (!typeOnly)
@@ -129,7 +130,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 }
 
                 // Removal of this codepath is tracked by https://github.com/dotnet/roslyn/issues/50391.
-                var goToDefinitionsService = document.GetLanguageService<IGoToDefinitionService>();
+                var goToDefinitionsService = document.GetRequiredLanguageService<IGoToDefinitionService>();
                 return await goToDefinitionsService.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -6,8 +6,8 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
 
-            var definitionService = document.Project.LanguageServices.GetRequiredService<IGoToDefinitionService>();
+            var definitionService = document.Project.LanguageServices.GetRequiredService<IFindDefinitionService>();
             var definitions = await definitionService.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
             if (definitions != null && definitions.Count() > 0)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -122,14 +122,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             static async Task<IEnumerable<INavigableItem>?> GetDefinitions(Document document, int position, CancellationToken cancellationToken)
             {
-                var findDefinitionService = document.Project.LanguageServices.GetService<IFindDefinitionService>();
+                var findDefinitionService = document.GetLanguageService<IFindDefinitionService>();
                 if (findDefinitionService != null)
                 {
                     return await findDefinitionService.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
                 }
 
                 // Removal of this codepath is tracked by https://github.com/dotnet/roslyn/issues/50391.
-                var goToDefinitionsService = document.Project.LanguageServices.GetRequiredService<IGoToDefinitionService>();
+                var goToDefinitionsService = document.GetLanguageService<IGoToDefinitionService>();
                 return await goToDefinitionsService.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicFindDefinitionService.vb
+++ b/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicFindDefinitionService.vb
@@ -1,0 +1,19 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.GoToDefinition
+Imports Microsoft.CodeAnalysis.Host.Mef
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.GoToDefinition
+    <ExportLanguageService(GetType(IFindDefinitionService), LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicFindDefinitionService
+        Inherits AbstractFindDefinitionService
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
+++ b/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
@@ -3,12 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Composition
-Imports Microsoft.CodeAnalysis.Editor.GoToDefinition
-Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.CodeAnalysis.GoToDefinition
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
-Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.GoToDefinition
+Namespace Microsoft.CodeAnalysis.VisualBasic.GoToDefinition
     <ExportLanguageService(GetType(IGoToDefinitionSymbolService), LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicGoToDefinitionSymbolService
         Inherits AbstractGoToDefinitionSymbolService

--- a/src/Tools/ExternalAccess/FSharp/GoToDefinition/IFSharpFindDefinitionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/GoToDefinition/IFSharpFindDefinitionService.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.GoToDefinition
 {
-
     internal interface IFSharpFindDefinitionService
     {
         /// <summary>

--- a/src/Tools/ExternalAccess/FSharp/GoToDefinition/IFSharpFindDefinitionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/GoToDefinition/IFSharpFindDefinitionService.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.GoToDefinition
+{
+
+    internal interface IFSharpFindDefinitionService
+    {
+        /// <summary>
+        /// Finds the definitions for the symbol at the specific position in the document.
+        /// </summary>
+        Task<ImmutableArray<FSharpNavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken);
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/Internal/GoToDefinition/FSharpFindDefinitionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/GoToDefinition/FSharpFindDefinitionService.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.FSharp.GoToDefinition;
+using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Navigation;
+using Microsoft.CodeAnalysis.GoToDefinition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Navigation;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.GoToDefinition
+{
+    [ExportLanguageService(typeof(IFindDefinitionService), LanguageNames.FSharp), Shared]
+    internal class FSharpFindDefinitionService : IFindDefinitionService
+    {
+        private readonly IFSharpFindDefinitionService _service;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FSharpFindDefinitionService(IFSharpFindDefinitionService service)
+        {
+            _service = service;
+        }
+
+        public async Task<ImmutableArray<INavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var items = await _service.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
+            return items.SelectAsArray(x => (INavigableItem)new InternalFSharpNavigableItem(x));
+        }
+    }
+}


### PR DESCRIPTION
This is mainly taking the part of `IGoToDefinitionService` that LSP depends on and pulling it into a new `IFindDefinitionService` in the features layer. The only real implementation change is taking a `Lazy` that was used to avoid realizing the stream provider in the LSP case and making it non-lazy, as LSP no longer depends on the service.