### PR TITLE
Run tests in parallel

### DIFF
--- a/eng/config/xunit.runner.json
+++ b/eng/config/xunit.runner.json
@@ -1,5 +1,5 @@
 {
   "shadowCopy": false,
-  "parallelizeTestCollections": false,
+  "parallelizeTestCollections": true,
   "diagnosticMessages": false
 }

--- a/src/Compilers/CSharp/Test/Emit/Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/Emit/Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.UnitTests</RootNamespace>
     <TargetFrameworks>net5.0;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Test\PdbUtilities\Roslyn.Test.PdbUtilities.csproj" />


### PR DESCRIPTION
* [x] Support projects having tests run in parallel
* [ ] Generate a `[assembly: CollectionBehavior]` attribute in each test project, which defaults to running the tests in sequence but can run in parallel based on a project property
* [ ] For projects that opt-in to parallel execution, make sure this option is not enabled for CI test runs