### PR TITLE
Cache identical source generator results

### DIFF
--- a/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
+++ b/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
@@ -3,15 +3,17 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
+Imports System.Runtime.CompilerServices
 Imports System.Threading
-Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeAnalysis.Text
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Public Class VisualBasicGeneratorDriver
         Inherits GeneratorDriver
+
+        Private Shared ReadOnly s_parsedGeneratedSources As New ConditionalWeakTable(Of SourceText, SyntaxTree)()
 
         Private Sub New(state As GeneratorDriverState)
             MyBase.New(state)
@@ -32,7 +34,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function ParseGeneratedSourceText(input As GeneratedSourceText, fileName As String, cancellationToken As CancellationToken) As SyntaxTree
-            Return SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, fileName, cancellationToken)
+            Dim existingTree As SyntaxTree = Nothing
+            If s_parsedGeneratedSources.TryGetValue(input.Text, existingTree) _
+                AndAlso Equals(_state.ParseOptions, existingTree.Options) _
+                AndAlso Equals(fileName, existingTree.FilePath) Then
+                Return existingTree
+            End If
+
+            Dim tree = SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, fileName, cancellationToken)
+
+#If NETCOREAPP Then
+            s_parsedGeneratedSources.AddOrUpdate(input.Text, tree)
+#Else
+            s_parsedGeneratedSources.Remove(input.Text)
+            s_parsedGeneratedSources.Add(input.Text, tree)
+#End If
+
+            Return tree
         End Function
 
         Public Shared Function Create(generators As ImmutableArray(Of ISourceGenerator), Optional additionalTexts As ImmutableArray(Of AdditionalText) = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional analyzerConfigOptionsProvider As AnalyzerConfigOptionsProvider = Nothing) As VisualBasicGeneratorDriver

--- a/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
+++ b/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
@@ -3,17 +3,13 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
-Imports System.Runtime.CompilerServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.CodeAnalysis.Text
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Public Class VisualBasicGeneratorDriver
         Inherits GeneratorDriver
-
-        Private Shared ReadOnly s_parsedGeneratedSources As New ConditionalWeakTable(Of SourceText, SyntaxTree)()
 
         Private Sub New(state As GeneratorDriverState)
             MyBase.New(state)
@@ -34,23 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function ParseGeneratedSourceText(input As GeneratedSourceText, fileName As String, cancellationToken As CancellationToken) As SyntaxTree
-            Dim existingTree As SyntaxTree = Nothing
-            If s_parsedGeneratedSources.TryGetValue(input.Text, existingTree) _
-                AndAlso Equals(_state.ParseOptions, existingTree.Options) _
-                AndAlso Equals(fileName, existingTree.FilePath) Then
-                Return existingTree
-            End If
-
-            Dim tree = SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, fileName, cancellationToken)
-
-#If NETCOREAPP Then
-            s_parsedGeneratedSources.AddOrUpdate(input.Text, tree)
-#Else
-            s_parsedGeneratedSources.Remove(input.Text)
-            s_parsedGeneratedSources.Add(input.Text, tree)
-#End If
-
-            Return tree
+            Return SyntaxFactory.ParseSyntaxTree(input.Text, _state.ParseOptions, fileName, cancellationToken)
         End Function
 
         Public Shared Function Create(generators As ImmutableArray(Of ISourceGenerator), Optional additionalTexts As ImmutableArray(Of AdditionalText) = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional analyzerConfigOptionsProvider As AnalyzerConfigOptionsProvider = Nothing) As VisualBasicGeneratorDriver


### PR DESCRIPTION
Avoid reparsing a `SourceText` produced by a source generator when it uses the same `ParseOptions` and hint name.

This change automatically optimizes IDE scenarios for source generators that cache their results, e.g. the form in #50172.

For the source generator in Roslyn.sln, this change addresses ~65% of the overhead for repeated invocations of the source generator.