### PR TITLE
Always use hard links when building in CI

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -234,6 +234,7 @@ function BuildSolution() {
   $buildFromSource = if ($sourceBuild) { "/p:DotNetBuildFromSource=true" } else { "" }
 
   $generateDocumentationFile = if ($skipDocumentation) { "/p:GenerateDocumentationFile=false" } else { "" }
+  $roslynUseHardLinks = if ($ci) { "/p:ROSLYNUSEHARDLINKS=true" } else { "" }
 
   try {
     MSBuild $toolsetBuildProj `
@@ -261,6 +262,7 @@ function BuildSolution() {
       $msbuildWarnAsError `
       $buildFromSource `
       $generateDocumentationFile `
+      $roslynUseHardLinks `
       @properties
   }
   finally {

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -270,6 +270,11 @@ function BuildSolution {
     generate_documentation_file="/p:GenerateDocumentationFile=false"
   fi
 
+  local roslyn_use_hard_links=""
+    if [[ "$ci" == true ]]; then
+      roslyn_use_hard_links="/p:ROSLYNUSEHARDLINKS=true"
+    fi
+
   # Setting /p:TreatWarningsAsErrors=true is a workaround for https://github.com/Microsoft/msbuild/issues/3062.
   # We don't pass /warnaserror to msbuild (warn_as_error is set to false by default above), but set 
   # /p:TreatWarningsAsErrors=true so that compiler reported warnings, other than IDE0055 are treated as errors. 
@@ -294,6 +299,7 @@ function BuildSolution {
     $test_runtime \
     $mono_tool \
     $generate_documentation_file \
+    $roslyn_use_hard_links \
     $properties
 }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -271,9 +271,9 @@ function BuildSolution {
   fi
 
   local roslyn_use_hard_links=""
-    if [[ "$ci" == true ]]; then
-      roslyn_use_hard_links="/p:ROSLYNUSEHARDLINKS=true"
-    fi
+  if [[ "$ci" == true ]]; then
+    roslyn_use_hard_links="/p:ROSLYNUSEHARDLINKS=true"
+  fi
 
   # Setting /p:TreatWarningsAsErrors=true is a workaround for https://github.com/Microsoft/msbuild/issues/3062.
   # We don't pass /warnaserror to msbuild (warn_as_error is set to false by default above), but set 


### PR DESCRIPTION
Related to #30005

Hard links reduce the amount of writes by ~10GB when enabled in the build. One effect of this is it makes us fit within the size budget of the built-in AzDo Windows agents, which are slower, but highly available (10-30 second wait time versus 5-10 minute wait time.)
