### PR TITLE
Testing framework does correct pass the parseoptions argument.

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -176,7 +176,7 @@ Public MustInherit Class BasicTestBase
 
         Dim assemblyName As String = Nothing
         Dim sourceTrees = ParseSourceXml(source, parseOptions, assemblyName)
-                        Dim compilation = CreateEmptyCompilation(sourceTrees.ToArray(), allReferences, options, parseOptions, assemblyName:=assemblyName)
+        Dim compilation = CreateEmptyCompilation(sourceTrees.ToArray(), allReferences, options, parseOptions, assemblyName:=assemblyName)
 
         Return MyBase.CompileAndVerifyCommon(
             compilation,

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -176,7 +176,7 @@ Public MustInherit Class BasicTestBase
 
         Dim assemblyName As String = Nothing
         Dim sourceTrees = ParseSourceXml(source, parseOptions, assemblyName)
-        Dim compilation = CreateEmptyCompilation(sourceTrees.ToArray(), allReferences, options, assemblyName:=assemblyName)
+                        Dim compilation = CreateEmptyCompilation(sourceTrees.ToArray(), allReferences, options, parseOptions, assemblyName:=assemblyName)
 
         Return MyBase.CompileAndVerifyCommon(
             compilation,

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -43,6 +43,11 @@ Friend Module CompilationUtils
         If options Is Nothing Then
             options = TestOptions.ReleaseDll
         End If
+        
+        ' update the parseOption (which ensures the language versions a consistant     
+        If parseOptions IsNot Nothing Then
+            options = options.WithParseOptions(parseOptions)
+        End If
 
         ' Using single-threaded build if debugger attached, to simplify debugging.
         If Debugger.IsAttached Then


### PR DESCRIPTION
Pass through the `parseOptions` to the compilation.