### PR TITLE
Implement lower and upper bound inference in function pointer parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)delegateInvokeMethodOpt != null)
             {
                 var analyzedArguments = AnalyzedArguments.GetInstance();
-                GetDelegateArguments(source.Syntax, analyzedArguments, delegateInvokeMethodOpt.Parameters, binder.Compilation);
+                GetDelegateOrFunctionPointerArguments(source.Syntax, analyzedArguments, delegateInvokeMethodOpt.Parameters, binder.Compilation);
                 var resolution = binder.ResolveMethodGroup(source, analyzedArguments, useSiteDiagnostics: ref useSiteDiagnostics, inferWithDynamic: true,
                     isMethodGroupConversion: true, returnRefKind: delegateInvokeMethodOpt.RefKind, returnType: delegateInvokeMethodOpt.ReturnType,
                     isFunctionPointerResolution: isFunctionPointer, callingConventionInfo: callingConventionInfo);
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert((object)delegateInvokeMethod != null && !delegateInvokeMethod.HasUseSiteError,
                          "This method should only be called for valid delegate types");
-            GetDelegateArguments(syntax, analyzedArguments, delegateInvokeMethod.Parameters, Compilation);
+            GetDelegateOrFunctionPointerArguments(syntax, analyzedArguments, delegateInvokeMethod.Parameters, Compilation);
             _binder.OverloadResolution.MethodInvocationOverloadResolution(
                 methods: methodGroup.Methods,
                 typeArguments: methodGroup.TypeArguments,
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return conversion;
         }
 
-        public static void GetDelegateArguments(SyntaxNode syntax, AnalyzedArguments analyzedArguments, ImmutableArray<ParameterSymbol> delegateParameters, CSharpCompilation compilation)
+        public static void GetDelegateOrFunctionPointerArguments(SyntaxNode syntax, AnalyzedArguments analyzedArguments, ImmutableArray<ParameterSymbol> delegateParameters, CSharpCompilation compilation)
         {
             foreach (var p in delegateParameters)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1687,8 +1687,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return sourceSignature.RefKind == targetSignature.RefKind
                    && (sourceSignature.ParameterRefKinds.IsDefault, targetSignature.ParameterRefKinds.IsDefault) switch
                    {
+                       (true, false) or (false, true) => false,
                        (true, true) => true,
-                       (true, _) or (_, true) => false,
                        _ => sourceSignature.ParameterRefKinds.SequenceEqual(targetSignature.ParameterRefKinds)
                    };
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1650,7 +1650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                      target.Type is FunctionPointerTypeSymbol { Signature: { ParameterCount: int targetParameterCount } targetSignature } &&
                      sourceParameterCount == targetParameterCount)
             {
-                if (!refKindsEqual(sourceSignature, targetSignature) || !callingConventionsEqual(sourceSignature, targetSignature))
+                if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature) || !callingConventionsEqual(sourceSignature, targetSignature))
                 {
                     return false;
                 }
@@ -1666,14 +1666,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return false;
 
-            static bool refKindsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
-            {
-                return sourceSignature.RefKind == targetSignature.RefKind
-                       && sourceSignature.ParameterRefKinds.IsDefault
-                          ? targetSignature.ParameterRefKinds.IsDefault
-                          : sourceSignature.ParameterRefKinds.SequenceEqual(targetSignature.ParameterRefKinds);
-            }
-
             static bool callingConventionsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
             {
                 if (sourceSignature.CallingConvention != targetSignature.CallingConvention)
@@ -1688,6 +1680,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _ => false
                 };
             }
+        }
+
+        private static bool FunctionPointerRefKindsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
+        {
+            return sourceSignature.RefKind == targetSignature.RefKind
+                   && (sourceSignature.ParameterRefKinds.IsDefault, targetSignature.ParameterRefKinds.IsDefault) switch
+                   {
+                       (true, true) => true,
+                       (true, _) or (_, true) => false,
+                       _ => sourceSignature.ParameterRefKinds.SequenceEqual(targetSignature.ParameterRefKinds)
+                   };
         }
 
         private void ExactTypeArgumentInference(NamedTypeSymbol source, NamedTypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -2142,14 +2145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (sourceSignature.RefKind != targetSignature.RefKind)
-            {
-                return false;
-            }
-
-            if (sourceSignature.ParameterRefKinds.IsDefault
-                ? !targetSignature.ParameterRefKinds.IsDefault
-                : !sourceSignature.ParameterRefKinds.SequenceEqual(targetSignature.ParameterRefKinds))
+            if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature))
             {
                 return false;
             }
@@ -2499,14 +2495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (sourceSignature.RefKind != targetSignature.RefKind)
-            {
-                return false;
-            }
-
-            if (sourceSignature.ParameterRefKinds.IsDefault
-                ? !targetSignature.ParameterRefKinds.IsDefault
-                : !sourceSignature.ParameterRefKinds.SequenceEqual(targetSignature.ParameterRefKinds))
+            if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1650,7 +1650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                      target.Type is FunctionPointerTypeSymbol { Signature: { ParameterCount: int targetParameterCount } targetSignature } &&
                      sourceParameterCount == targetParameterCount)
             {
-                if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature) || !callingConventionsEqual(sourceSignature, targetSignature))
+                if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature) || !FunctionPointerCallingConventionsEqual(sourceSignature, targetSignature))
                 {
                     return false;
                 }
@@ -1665,21 +1665,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return false;
+        }
 
-            static bool callingConventionsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
+        private static bool FunctionPointerCallingConventionsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
+        {
+            if (sourceSignature.CallingConvention != targetSignature.CallingConvention)
             {
-                if (sourceSignature.CallingConvention != targetSignature.CallingConvention)
-                {
-                    return false;
-                }
-
-                return (sourceSignature.GetCallingConventionModifiers(), targetSignature.GetCallingConventionModifiers()) switch
-                {
-                    (null, null) => true,
-                    ({ } sourceModifiers, { } targetModifiers) when sourceModifiers.SetEquals(targetModifiers) => true,
-                    _ => false
-                };
+                return false;
             }
+
+            return (sourceSignature.GetCallingConventionModifiers(), targetSignature.GetCallingConventionModifiers()) switch
+            {
+                (null, null) => true,
+                ({ } sourceModifiers, { } targetModifiers) when sourceModifiers.SetEquals(targetModifiers) => true,
+                _ => false
+            };
         }
 
         private static bool FunctionPointerRefKindsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
@@ -2145,7 +2145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature))
+            if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature) || !FunctionPointerCallingConventionsEqual(sourceSignature, targetSignature))
             {
                 return false;
             }
@@ -2495,7 +2495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature))
+            if (!FunctionPointerRefKindsEqual(sourceSignature, targetSignature) || !FunctionPointerCallingConventionsEqual(sourceSignature, targetSignature))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -869,7 +869,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var isFunctionPointer = delegateOrFunctionPointerType.IsFunctionPointer();
             if ((isFunctionPointer && argument.Kind != BoundKind.UnconvertedAddressOfOperator) ||
-                (!isFunctionPointer && argument.Kind is not BoundKind.UnboundLambda or BoundKind.MethodGroup))
+                (!isFunctionPointer && argument.Kind is not (BoundKind.UnboundLambda or BoundKind.MethodGroup)))
             {
                 return false; // No input types.
             }
@@ -925,7 +925,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var isFunctionPointer = delegateOrFunctionPointerType.IsFunctionPointer();
             if ((isFunctionPointer && argument.Kind != BoundKind.UnconvertedAddressOfOperator) ||
-                (!isFunctionPointer && argument.Kind is not BoundKind.UnboundLambda or BoundKind.MethodGroup))
+                (!isFunctionPointer && argument.Kind is not (BoundKind.UnboundLambda or BoundKind.MethodGroup)))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1650,9 +1650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                      target.Type is FunctionPointerTypeSymbol { Signature: { ParameterCount: int targetParameterCount } targetSignature } &&
                      sourceParameterCount == targetParameterCount)
             {
-                if (sourceSignature.RefKind != targetSignature.RefKind
-                    || sourceSignature.ParameterRefKinds != targetSignature.ParameterRefKinds
-                    || !callingConventionsEqual(sourceSignature, targetSignature))
+                if (!refKindsEqual(sourceSignature, targetSignature) || !callingConventionsEqual(sourceSignature, targetSignature))
                 {
                     return false;
                 }
@@ -1667,6 +1665,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return false;
+
+            static bool refKindsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
+            {
+                return sourceSignature.RefKind == targetSignature.RefKind
+                       && sourceSignature.ParameterRefKinds.IsDefault
+                          ? targetSignature.ParameterRefKinds.IsDefault
+                          : sourceSignature.ParameterRefKinds.SequenceEqual(targetSignature.ParameterRefKinds);
+            }
 
             static bool callingConventionsEqual(FunctionPointerMethodSymbol sourceSignature, FunctionPointerMethodSymbol targetSignature)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -376,6 +377,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type.IsDelegateType() ? (NamedTypeSymbol)type : null;
         }
 
+        public static TypeSymbol? GetDelegateOrFunctionPointerType(this TypeSymbol type)
+        {
+            return (TypeSymbol?)GetDelegateType(type) ?? type as FunctionPointerTypeSymbol;
+        }
+
         /// <summary>
         /// return true if the type is constructed from System.Linq.Expressions.Expression`1
         /// </summary>
@@ -443,6 +449,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return default(ImmutableArray<ParameterSymbol>);
             }
             return invokeMethod.Parameters;
+        }
+
+        public static ImmutableArray<ParameterSymbol> DelegateOrFunctionPointerParameters(this TypeSymbol type)
+        {
+            Debug.Assert(type is FunctionPointerTypeSymbol || type.IsDelegateType());
+            if (type is FunctionPointerTypeSymbol { Signature: { Parameters: var functionPointerParameters } })
+            {
+                return functionPointerParameters;
+            }
+            else
+            {
+                return type.DelegateParameters();
+            }
         }
 
         public static bool TryGetElementTypesWithAnnotationsIfTupleType(this TypeSymbol type, out ImmutableArray<TypeWithAnnotations> elementTypes)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -1354,14 +1354,22 @@ unsafe class C
         delegate*<string, void> p1 = null;
         delegate*<object, void> p2 = null;
         M1(p1, p2);
+
+        delegate*<int*, void> p3 = null;
+        delegate*<void*, void> p4 = null;
+        M1(p3, p4);
     }
 }");
 
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (13,9): error CS0411: The type arguments for method 'C.M1<T>(delegate*<T, void>, delegate*<T, void>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(p3, p4);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("C.M1<T>(delegate*<T, void>, delegate*<T, void>)").WithLocation(13, 9)
+            );
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
 
             AssertEx.Equal("void C.M1<System.String>(delegate*<System.String, System.Void> param1, delegate*<System.String, System.Void> param2)",
                            model.GetSymbolInfo(m1Invocation).Symbol.ToTestDisplayString());
@@ -1379,14 +1387,22 @@ unsafe class C
         delegate*<delegate*<string, void>, void> p1 = null;
         delegate*<delegate*<object, void>, void> p2 = null;
         M1(p1, p2);
+
+        delegate*<delegate*<int*, void>, void> p3 = null;
+        delegate*<delegate*<void*, void>, void> p4 = null;
+        M1(p3, p4);
     }
 }");
 
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (13,9): error CS0411: The type arguments for method 'C.M1<T>(delegate*<delegate*<T, void>, void>, delegate*<delegate*<T, void>, void>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(p3, p4);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("C.M1<T>(delegate*<delegate*<T, void>, void>, delegate*<delegate*<T, void>, void>)").WithLocation(13, 9)
+            );
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
 
             AssertEx.Equal("void C.M1<System.Object>(delegate*<delegate*<System.Object, System.Void>, System.Void> param1, delegate*<delegate*<System.Object, System.Void>, System.Void> param2)",
                            model.GetSymbolInfo(m1Invocation).Symbol.ToTestDisplayString());
@@ -1404,14 +1420,22 @@ unsafe class C
         delegate*<delegate*<string>, void> p1 = null;
         delegate*<delegate*<object>, void> p2 = null;
         M1(p1, p2);
+
+        delegate*<delegate*<int*>, void> p3 = null;
+        delegate*<delegate*<void*>, void> p4 = null;
+        M1(p3, p4);
     }
 }");
 
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (13,9): error CS0411: The type arguments for method 'C.M1<T>(delegate*<delegate*<T>, void>, delegate*<delegate*<T>, void>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(p3, p4);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("C.M1<T>(delegate*<delegate*<T>, void>, delegate*<delegate*<T>, void>)").WithLocation(13, 9)
+            );
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
 
             AssertEx.Equal("void C.M1<System.String>(delegate*<delegate*<System.String>, System.Void> param1, delegate*<delegate*<System.String>, System.Void> param2)",
                            model.GetSymbolInfo(m1Invocation).Symbol.ToTestDisplayString());
@@ -1490,14 +1514,22 @@ unsafe class C
         delegate*<string> p1 = null;
         delegate*<object> p2 = null;
         M1(p1, p2);
+
+        delegate*<int*> p3 = null;
+        delegate*<void*> p4 = null;
+        M1(p3, p4);
     }
 }");
 
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (13,9): error CS0411: The type arguments for method 'C.M1<T>(delegate*<T>, delegate*<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(p3, p4);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("C.M1<T>(delegate*<T>, delegate*<T>)").WithLocation(13, 9)
+            );
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
 
             AssertEx.Equal("void C.M1<System.Object>(delegate*<System.Object> param1, delegate*<System.Object> param2)",
                            model.GetSymbolInfo(m1Invocation).Symbol.ToTestDisplayString());
@@ -1515,14 +1547,22 @@ unsafe class C
         delegate*<delegate*<string, void>> p1 = null;
         delegate*<delegate*<object, void>> p2 = null;
         M1(p1, p2);
+
+        delegate*<delegate*<int*, void>> p3 = null;
+        delegate*<delegate*<void*, void>> p4 = null;
+        M1(p3, p4);
     }
 }");
 
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (13,9): error CS0411: The type arguments for method 'C.M1<T>(delegate*<delegate*<T, void>>, delegate*<delegate*<T, void>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(p3, p4);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("C.M1<T>(delegate*<delegate*<T, void>>, delegate*<delegate*<T, void>>)").WithLocation(13, 9)
+            );
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
 
             AssertEx.Equal("void C.M1<System.String>(delegate*<delegate*<System.String, System.Void>> param1, delegate*<delegate*<System.String, System.Void>> param2)",
                            model.GetSymbolInfo(m1Invocation).Symbol.ToTestDisplayString());
@@ -1540,14 +1580,22 @@ unsafe class C
         delegate*<delegate*<string>> p1 = null;
         delegate*<delegate*<object>> p2 = null;
         M1(p1, p2);
+
+        delegate*<delegate*<int*>> p3 = null;
+        delegate*<delegate*<void*>> p4 = null;
+        M1(p3, p4);
     }
 }");
 
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (13,9): error CS0411: The type arguments for method 'C.M1<T>(delegate*<delegate*<T>>, delegate*<delegate*<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(p3, p4);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("C.M1<T>(delegate*<delegate*<T>>, delegate*<delegate*<T>>)").WithLocation(13, 9)
+            );
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+            var m1Invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
 
             AssertEx.Equal("void C.M1<System.Object>(delegate*<delegate*<System.Object>> param1, delegate*<delegate*<System.Object>> param2)",
                            model.GetSymbolInfo(m1Invocation).Symbol.ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -2230,7 +2230,7 @@ unsafe
     static string converter(int v) => string.Empty;
     static void Test<T1, T2>(T1 t1, delegate*<T1, T2> func) {}
 }
-", options: TestOptions.UnsafeReleaseExe);
+", options: TestOptions.UnsafeReleaseExe, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped);
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
@@ -2255,7 +2255,7 @@ unsafe
     static string converter(object o) => string.Empty;
     static void Test<T1, T2>(T1 t1, delegate*<T1, T2> func) {}
 }
-", options: TestOptions.UnsafeReleaseExe);
+", options: TestOptions.UnsafeReleaseExe, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped);
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -2297,6 +2297,37 @@ unsafe
             );
         }
 
+        [Fact, WorkItem(50096, "https://github.com/dotnet/roslyn/issues/50096")]
+        public void FunctionPointerInference_ThroughMethodGroup()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe
+{
+    Test1(0, converter);
+    Test2(0, converter);
+
+    static int converter(string v) => 0;
+    static void Test1<T1, T2>(T1 t1, delegate*<T1, T2> func) {}
+    static void Test2<T1, T2>(T2 t2, delegate*<T1, T2> func) {}
+}
+", options: TestOptions.UnsafeReleaseExe);
+
+            comp.VerifyDiagnostics(
+                // (4,5): error CS0411: The type arguments for method 'Test1<T1, T2>(T1, delegate*<T1, T2>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //     Test1(0, converter);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test1").WithArguments("Test1<T1, T2>(T1, delegate*<T1, T2>)").WithLocation(4, 5),
+                // (5,5): error CS0411: The type arguments for method 'Test2<T1, T2>(T2, delegate*<T1, T2>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //     Test2(0, converter);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test2").WithArguments("Test2<T1, T2>(T2, delegate*<T1, T2>)").WithLocation(5, 5),
+                // (8,17): warning CS8321: The local function 'Test1' is declared but never used
+                //     static void Test1<T1, T2>(T1 t1, delegate*<T1, T2> func) {}
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Test1").WithArguments("Test1").WithLocation(8, 17),
+                // (9,17): warning CS8321: The local function 'Test2' is declared but never used
+                //     static void Test2<T1, T2>(T2 t2, delegate*<T1, T2> func) {}
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Test2").WithArguments("Test2").WithLocation(9, 17)
+            );
+        }
+
         [Fact]
         public void FunctionPointerTypeCannotBeUsedInDynamicTypeArguments()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTestBase.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTestBase.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 .Select(x => x.Substring(x.IndexOf("//-", StringComparison.Ordinal) + 3))
                 .ToArray());
 
-            AssertEx.Equal(expected, results);
+            AssertEx.EqualOrDiff(expected, results);
         }
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/43041 implemented exact inference of function pointer parameters and bounds only, and left a few errors in our tests that needed to be handled. This is also the cause of https://github.com/dotnet/roslyn/issues/50096. This implements bounds inference, using the same variance rules that function pointer to function pointer conversions do. Note that for parameters and return types, I'm not considering delegate*->void* conversions, as `T` cannot be either `void` or `void*`.

Spec PR: https://github.com/dotnet/csharplang/pull/4310

Fixes https://github.com/dotnet/roslyn/issues/50096.
