### PR TITLE
Annotate remaining ISymbol APIs

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/SemanticFacts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/SemanticFacts.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-
     internal partial class Symbol
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1454,7 +1454,13 @@ namespace Microsoft.CodeAnalysis
                             // a containing assembly, we treat them as in the current assembly for access purposes
                             return assemblyIsInReferences(s.ContainingAssembly ?? this.Assembly);
                         default:
-                            return assemblyIsInReferences(s.ContainingAssembly);
+                            var containingAssembly = s.ContainingAssembly;
+                            if (containingAssembly is null)
+                            {
+                                Debug.Assert(false);
+                                return false;
+                            }
+                            return assemblyIsInReferences(containingAssembly);
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1542,7 +1542,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 await processContainerOnMemberCompletedAsync(symbol.ContainingType, symbol, analyzer).ConfigureAwait(false);
             }
 
-            async Task processContainerOnMemberCompletedAsync(INamespaceOrTypeSymbol containerSymbol, ISymbol processedMemberSymbol, DiagnosticAnalyzer analyzer)
+            async Task processContainerOnMemberCompletedAsync(INamespaceOrTypeSymbol? containerSymbol, ISymbol processedMemberSymbol, DiagnosticAnalyzer analyzer)
             {
                 if (containerSymbol != null &&
                     AnalyzerExecutor.TryExecuteSymbolEndActionsForContainer(containerSymbol, processedMemberSymbol,

--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -363,7 +364,7 @@ namespace Microsoft.CodeAnalysis
                     _builder = builder;
                 }
 
-                private ReferenceGenerator GetReferenceGenerator(ISymbol typeParameterContext)
+                private ReferenceGenerator GetReferenceGenerator(ISymbol? typeParameterContext)
                 {
                     if (_referenceGenerator == null || _referenceGenerator.TypeParameterContext != typeParameterContext)
                     {
@@ -1275,6 +1276,7 @@ namespace Microsoft.CodeAnalysis
                                         parameters.Clear();
                                     }
 
+                                    Debug.Assert(propertySymbol.ContainingSymbol is not null);
                                     if (ParseParameterList(id, ref index, compilation, propertySymbol.ContainingSymbol, parameters)
                                         && AllParametersMatch(propertySymbol.Parameters, parameters))
                                     {
@@ -1367,9 +1369,11 @@ namespace Microsoft.CodeAnalysis
 
             private static ITypeParameterSymbol GetNthTypeParameter(INamedTypeSymbol typeSymbol, int n)
             {
+                Debug.Assert(n >= 0);
                 var containingTypeParameterCount = GetTypeParameterCount(typeSymbol.ContainingType);
                 if (n < containingTypeParameterCount)
                 {
+                    Debug.Assert(typeSymbol.ContainingType is not null);
                     return GetNthTypeParameter(typeSymbol.ContainingType, n);
                 }
 
@@ -1377,7 +1381,7 @@ namespace Microsoft.CodeAnalysis
                 return typeSymbol.TypeParameters[index];
             }
 
-            private static int GetTypeParameterCount(INamedTypeSymbol typeSymbol)
+            private static int GetTypeParameterCount(INamedTypeSymbol? typeSymbol)
             {
                 if (typeSymbol == null)
                 {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6384,7 +6384,7 @@ oneMoreTime:
             // Check if this is an anonymous type property reference with an implicit receiver within an anonymous object initializer.
             if (operation.Instance is IInstanceReferenceOperation instanceReference &&
                 instanceReference.ReferenceKind == InstanceReferenceKind.ImplicitReceiver &&
-                operation.Property.ContainingType.IsAnonymousType &&
+                operation.Property.ContainingType!.IsAnonymousType &&
                 operation.Property.ContainingType == _currentImplicitInstance.AnonymousType)
             {
                 Debug.Assert(_currentImplicitInstance.AnonymousTypePropertyValues is not null);

--- a/src/Compilers/Core/Portable/Symbols/ISymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbol.cs
@@ -58,36 +58,34 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         string MetadataName { get; }
 
-#nullable disable // Skipped for now https://github.com/dotnet/roslyn/issues/39166
         /// <summary>
         /// Gets the <see cref="ISymbol"/> for the immediately containing symbol.
         /// </summary>
-        ISymbol ContainingSymbol { get; }
+        ISymbol? ContainingSymbol { get; }
 
         /// <summary>
         /// Gets the <see cref="IAssemblySymbol"/> for the containing assembly. Returns null if the
         /// symbol is shared across multiple assemblies.
         /// </summary>
-        IAssemblySymbol ContainingAssembly { get; }
+        IAssemblySymbol? ContainingAssembly { get; }
 
         /// <summary>
         /// Gets the <see cref="IModuleSymbol"/> for the containing module. Returns null if the
         /// symbol is shared across multiple modules.
         /// </summary>
-        IModuleSymbol ContainingModule { get; }
+        IModuleSymbol? ContainingModule { get; }
 
         /// <summary>
         /// Gets the <see cref="INamedTypeSymbol"/> for the containing type. Returns null if the
         /// symbol is not contained within a type.
         /// </summary>
-        INamedTypeSymbol ContainingType { get; }
+        INamedTypeSymbol? ContainingType { get; }
 
         /// <summary>
         /// Gets the <see cref="INamespaceSymbol"/> for the nearest enclosing namespace. Returns null if the
         /// symbol isn't contained in a namespace.
         /// </summary>
-        INamespaceSymbol ContainingNamespace { get; }
-#nullable enable
+        INamespaceSymbol? ContainingNamespace { get; }
 
         /// <summary>
         /// Gets a value indicating whether the symbol is the original definition. Returns false


### PR DESCRIPTION
We only have a dozen or so oblivious public APIs left (see https://github.com/dotnet/roslyn/pull/41000).
This PR annotates the public `ISymbol` APIs.