### PR TITLE
Fix IDE0079 (unnecessary suppression) false positive

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveUnnecessaryPragmaSuppressionsTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveUnnecessaryPragmaSuppressionsTests.cs
@@ -1284,7 +1284,6 @@ class Class
 }");
         }
 
-
         public sealed class NonLocalDiagnosticsAnalyzerTests : RemoveUnnecessaryInlineSuppressionsTests
         {
             public NonLocalDiagnosticsAnalyzerTests(ITestOutputHelper logger)
@@ -1297,7 +1296,6 @@ class Class
                 public const string DiagnosticId = "NonLocalDiagnosticId";
                 public static readonly DiagnosticDescriptor Descriptor =
                     new(DiagnosticId, "NonLocalDiagnosticTitle", "NonLocalDiagnosticMessage", "NonLocalDiagnosticCategory", DiagnosticSeverity.Warning, isEnabledByDefault: true);
-
 
                 public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveUnnecessaryPragmaSuppressionsTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveUnnecessaryPragmaSuppressionsTests.cs
@@ -1284,6 +1284,54 @@ class Class
 }");
         }
 
+
+        public sealed class NonLocalDiagnosticsAnalyzerTests : RemoveUnnecessaryInlineSuppressionsTests
+        {
+            public NonLocalDiagnosticsAnalyzerTests(ITestOutputHelper logger)
+                : base(logger)
+            {
+            }
+
+            private sealed class NonLocalDiagnosticsAnalyzer : DiagnosticAnalyzer
+            {
+                public const string DiagnosticId = "NonLocalDiagnosticId";
+                public static readonly DiagnosticDescriptor Descriptor =
+                    new(DiagnosticId, "NonLocalDiagnosticTitle", "NonLocalDiagnosticMessage", "NonLocalDiagnosticCategory", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+
+                public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+                public override void Initialize(AnalysisContext context)
+                {
+                    context.RegisterSymbolAction(context =>
+                    {
+                        if (!context.Symbol.ContainingNamespace.IsGlobalNamespace)
+                        {
+                            var diagnostic = Diagnostic.Create(Descriptor, context.Symbol.ContainingNamespace.Locations[0]);
+                            context.ReportDiagnostic(diagnostic);
+                        }
+                    }, SymbolKind.NamedType);
+                }
+            }
+
+            internal override ImmutableArray<DiagnosticAnalyzer> OtherAnalyzers =>
+                ImmutableArray.Create<DiagnosticAnalyzer>(new NonLocalDiagnosticsAnalyzer());
+
+            [Fact, WorkItem(50203, "https://github.com/dotnet/roslyn/issues/50203")]
+            public async Task TestDoNotRemoveInvalidDiagnosticSuppression()
+            {
+                await TestMissingInRegularAndScriptAsync(
+        $@"
+[|#pragma warning disable {NonLocalDiagnosticsAnalyzer.DiagnosticId}
+namespace N
+#pragma warning restore {NonLocalDiagnosticsAnalyzer.DiagnosticId}|]
+{{
+    class Class
+    {{
+    }}
+}}");
+            }
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #50203
IDE0079 analyzer did not account for compilation/non-local diagnostics reported from analyzers

Verified that the added unit test fails prior to the fix with the false positive reported in #50203