### PR TITLE
Test classification spans when testing signature help items

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -851,6 +851,7 @@ class C
             await TestAsync(markup, expectedOrderedItems);
         }
 
+        [WorkItem(50114, "https://github.com/dotnet/roslyn/issues/50114")]
         [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public async Task DeclaringGenericTypeWithDocCommentList()
         {

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
@@ -847,6 +848,45 @@ class C
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task DeclaringGenericTypeWithDocCommentList()
+        {
+            var markup = @"
+/// <summary>
+/// List:
+/// <list>
+/// <item>
+/// <description>
+/// Item 1.
+/// </description>
+/// </item>
+/// </list>
+/// </summary>
+class G<S, T> { };
+
+class C
+{
+    void Goo()
+    {
+        [|G<int, $$|]>
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("G<S, T>", "List:\r\n\r\nItem 1.",
+                classificationTypeNames: new List<string>
+                {
+                    ClassificationTypeNames.Text,
+                    ClassificationTypeNames.WhiteSpace,
+                    ClassificationTypeNames.WhiteSpace,
+                    ClassificationTypeNames.WhiteSpace,
+                    ClassificationTypeNames.Text,
+                    ClassificationTypeNames.WhiteSpace
+                }));
+
             await TestAsync(markup, expectedOrderedItems);
         }
     }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -12,6 +12,7 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp.Presentation;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -20,6 +21,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -241,6 +243,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             if (expectedTestItem.Description != null)
             {
                 Assert.Equal(expectedTestItem.Description, ToString(actualSignatureHelpItem.DescriptionParts));
+            }
+
+            // Always get and realise the classified spans, even if no expected spans are passed in, to at least validate that
+            // exceptions aren't thrown
+            var classifiedSpans = actualSignatureHelpItem.DocumentationFactory(CancellationToken.None).ToClassifiedSpans().ToList();
+            if (expectedTestItem.ClassificationTypeNames != null)
+            {
+                Assert.Equal(string.Join(", ", expectedTestItem.ClassificationTypeNames), string.Join(", ", classifiedSpans.Select(s => s.ClassificationType)));
             }
         }
 

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable disable
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 {
@@ -47,6 +48,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
         /// </summary>
         public readonly bool IsSelected;
 
+        /// <summary>
+        /// The classification spans for the method documentation
+        /// </summary>
+        public readonly IEnumerable<string> ClassificationTypeNames;
+
         public SignatureHelpTestItem(
             string signature,
             string methodDocumentation = null,
@@ -54,7 +60,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             int? currentParameterIndex = null,
             string description = null,
             string prettyPrintedSignature = null,
-            bool isSelected = false)
+            bool isSelected = false,
+            IEnumerable<string> classificationTypeNames = null)
         {
             this.Signature = signature;
             this.MethodDocumentation = methodDocumentation;
@@ -63,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             this.Description = description;
             this.PrettyPrintedSignature = prettyPrintedSignature;
             this.IsSelected = isSelected;
+            this.ClassificationTypeNames = classificationTypeNames;
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
@@ -12,17 +11,17 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
         /// <summary>
         /// Includes prefix, signature, suffix.
         /// </summary>
-        public readonly string Signature;
+        public readonly string? Signature;
 
         /// <summary>
         /// The method xml documentation.
         /// </summary>
-        public readonly string MethodDocumentation;
+        public readonly string? MethodDocumentation;
 
         /// <summary>
         /// The (currently selected/expected) parameter documentation. This can be null.
         /// </summary>
-        public readonly string ParameterDocumentation;
+        public readonly string? ParameterDocumentation;
 
         /// <summary>
         /// The currently selected parameter index. For some reason it can be null.
@@ -35,12 +34,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
         /// Anonymous Types:
         ///     'a is new { string Name, int Age }
         /// </summary>
-        public readonly string Description;
+        public readonly string? Description;
 
         /// <summary>
         /// Includes prefix, signature, suffix in pretty-printed form (i.e. when the signature wraps).
         /// </summary>
-        public readonly string PrettyPrintedSignature;
+        public readonly string? PrettyPrintedSignature;
 
         /// <summary>
         /// Whether this item is expected to be selected.
@@ -51,17 +50,17 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
         /// <summary>
         /// The classification spans for the method documentation
         /// </summary>
-        public readonly IEnumerable<string> ClassificationTypeNames;
+        public readonly IEnumerable<string>? ClassificationTypeNames;
 
         public SignatureHelpTestItem(
-            string signature,
-            string methodDocumentation = null,
-            string parameterDocumentation = null,
+            string? signature,
+            string? methodDocumentation = null,
+            string? parameterDocumentation = null,
             int? currentParameterIndex = null,
-            string description = null,
-            string prettyPrintedSignature = null,
+            string? description = null,
+            string? prettyPrintedSignature = null,
             bool isSelected = false,
-            IEnumerable<string> classificationTypeNames = null)
+            IEnumerable<string>? classificationTypeNames = null)
         {
             this.Signature = signature;
             this.MethodDocumentation = methodDocumentation;

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 {

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -229,6 +229,11 @@ namespace Microsoft.CodeAnalysis
                 case TextTags.Record:
                     return ClassificationTypeNames.RecordName;
 
+                case TextTags.ContainerStart:
+                case TextTags.ContainerEnd:
+                    // These tags are not visible so classify them as whitespace
+                    return ClassificationTypeNames.WhiteSpace;
+
                 default:
                     throw ExceptionUtilities.UnexpectedValue(taggedTextTag);
             }

--- a/src/Workspaces/Remote/Core/GlobalNotificationRemoteDeliveryService.cs
+++ b/src/Workspaces/Remote/Core/GlobalNotificationRemoteDeliveryService.cs
@@ -72,6 +72,10 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             lock (_globalNotificationsGate)
             {
+                // Pass TaskContinuationOptions.OnlyOnRanToCompletion to avoid delivering further notifications once the task gets canceled or fails.
+                // The cancellation happens only when VS is shutting down. The task might fail if communication with OOP fails. 
+                // Once that happens there is not point in sending more notifications to the remote service.
+
                 _globalNotificationsTask = _globalNotificationsTask.SafeContinueWithFromAsync(
                     SendStartNotificationAsync, _cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
             }
@@ -103,6 +107,10 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             lock (_globalNotificationsGate)
             {
+                // Pass TaskContinuationOptions.OnlyOnRanToCompletion to avoid delivering further notifications once the task gets canceled or fails.
+                // The cancellation happens only when VS is shutting down. The task might fail if communication with OOP fails. 
+                // Once that happens there is not point in sending more notifications to the remote service.
+
                 _globalNotificationsTask = _globalNotificationsTask.SafeContinueWithFromAsync(
                     previous => SendStoppedNotificationAsync(previous, e), _cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
             }


### PR DESCRIPTION
Fixes #50114

If there are existing tests for this, I couldn't find them, so this is a little odd, so open to suggestions for a better approach.