### PR TITLE
Document state storage

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedDictionaryTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedDictionaryTest.cs
@@ -324,12 +324,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             Assert.Throws<InvalidOperationException>(() => map.GetAddedEntry(0));
         }
 
-        [Fact]
-        public void Ordering_AfterRemovalAndCompact()
+        [Theory]
+        [InlineData(6, 3)]
+        [InlineData(3, 1)]
+        public void Ordering_AfterRemovalAndCompact(int count, int removeKey)
         {
-            const int count = 6;
-            const int removeKey = 3;
-
             var builder = Empty<int, int>()
                 .AddRange(Enumerable.Range(0, count).Select(i => KeyValuePairUtil.Create(i, i)))
                 .ToBuilder();
@@ -343,6 +342,20 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 var e = (i < removeKey) ? i : i + 1;
                 Assert.Equal(e, map.GetAddedEntry(i).Key);
                 Assert.Equal(e, map.GetAddedEntry(i).Value);
+            }
+
+            // test some keys that collide
+            for (int i = 0; i < 2 * count; i++)
+            {
+                if (i == removeKey || i >= count)
+                {
+                    Assert.False(map.ContainsKey(i));
+                }
+                else
+                {
+                    Assert.True(map.TryGetValue(i, out var value));
+                    Assert.Equal(i, value);
+                }
             }
         }
 

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder.cs
@@ -181,6 +181,9 @@ namespace Microsoft.CodeAnalysis.Collections
                 return true;
             }
 
+            public void Compact()
+                => GetOrCreateMutableDictionary().Compact();
+
             public void RemoveRange(IEnumerable<TKey> keys)
             {
                 if (keys is null)

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2.cs
@@ -48,6 +48,10 @@ namespace Microsoft.CodeAnalysis.Collections
     /// 
     /// <para>This type is backed by segmented arrays to avoid using the Large Object Heap without impacting algorithmic
     /// complexity.</para>
+    /// 
+    /// <para>The enumerator of the dictionary yields entries in the order they were added to the dictionary provided that 
+    /// no entry has been removed since the dictionary was created.
+    /// </para>
     /// </remarks>
     /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
     /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
@@ -128,6 +132,13 @@ namespace Microsoft.CodeAnalysis.Collections
             get => ((IDictionary)_dictionary)[key];
             set => throw new NotSupportedException();
         }
+
+        /// <summary>
+        /// Gets <paramref name="index"/>-th entry added to the dictionary.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">An entry has been removed from the dictionary.</exception>
+        public KeyValuePair<TKey, TValue> GetAddedEntry(int index)
+            => _dictionary.GetAddedEntry(index);
 
         public static bool operator ==(ImmutableSegmentedDictionary<TKey, TValue> left, ImmutableSegmentedDictionary<TKey, TValue> right)
             => left.Equals(right);
@@ -234,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 return self;
             }
 
-            var dictionary = new SegmentedDictionary<TKey, TValue>(self._dictionary, self._dictionary.Comparer);
+            var dictionary = new SegmentedDictionary<TKey, TValue>(self._dictionary);
             dictionary[key] = value;
             return new ImmutableSegmentedDictionary<TKey, TValue>(dictionary);
         }

--- a/src/Dependencies/Collections/SegmentedArray`1.cs
+++ b/src/Dependencies/Collections/SegmentedArray`1.cs
@@ -121,6 +121,9 @@ namespace Microsoft.CodeAnalysis.Collections
         }
 
         public object Clone()
+            => CloneImpl();
+
+        internal SegmentedArray<T> CloneImpl()
         {
             var items = (T[][])_items.Clone();
             for (var i = 0; i < items.Length; i++)

--- a/src/Dependencies/Collections/SegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/SegmentedDictionary`2.cs
@@ -1027,6 +1027,10 @@ ReturnNotFound:
             {
                 Initialize(newSize);
             }
+            else
+            {
+                ((IList)_buckets).Clear();
+            }
 
             var entries = _entries;
             var count = 0;
@@ -1045,6 +1049,7 @@ ReturnNotFound:
 
             _count = count;
             _freeCount = 0;
+            _freeList = -1;
         }
 
         bool ICollection.IsSynchronized => false;

--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -220,14 +220,14 @@ class D { }
             // Check that a parse tree for a submission has an empty file path.
             var tree1 = await workspace.CurrentSolution
                 .GetProjectState(project1.Id)
-                .GetDocumentState(document1.Id)
+                .DocumentStates.GetValue(document1.Id)
                 .GetSyntaxTreeAsync(CancellationToken.None);
             Assert.Equal("", tree1.FilePath);
 
             // Check that a parse tree for a script does not have an empty file path.
             var tree2 = await workspace.CurrentSolution
                 .GetProjectState(project2.Id)
-                .GetDocumentState(document2.Id)
+                .DocumentStates.GetValue(document2.Id)
                 .GetSyntaxTreeAsync(CancellationToken.None);
             Assert.Equal("a.csx", tree2.FilePath);
         }
@@ -821,7 +821,7 @@ class D { }
 
             Assert.Equal(1, project.Documents.Count());
             Assert.Equal(1, project.AnalyzerConfigDocuments.Count());
-            Assert.Equal(1, project.State.AnalyzerConfigDocumentIds.Count());
+            Assert.Equal(1, project.State.AnalyzerConfigDocumentStates.Count);
 
             var doc = project.GetDocument(analyzerConfigDoc.Id);
             Assert.Null(doc);

--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -220,14 +220,14 @@ class D { }
             // Check that a parse tree for a submission has an empty file path.
             var tree1 = await workspace.CurrentSolution
                 .GetProjectState(project1.Id)
-                .DocumentStates.GetValue(document1.Id)
+                .DocumentStates.GetState(document1.Id)
                 .GetSyntaxTreeAsync(CancellationToken.None);
             Assert.Equal("", tree1.FilePath);
 
             // Check that a parse tree for a script does not have an empty file path.
             var tree2 = await workspace.CurrentSolution
                 .GetProjectState(project2.Id)
-                .DocumentStates.GetValue(document2.Id)
+                .DocumentStates.GetState(document2.Id)
                 .GetSyntaxTreeAsync(CancellationToken.None);
             Assert.Equal("a.csx", tree2.FilePath);
         }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -792,7 +792,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     foreach (var projectState in solution.State.ProjectStates)
                     {
-                        count += projectState.Value.DocumentIds.Count;
+                        count += projectState.Value.DocumentStates.Count;
                     }
 
                     return count;

--- a/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.CodeAnalysis;
@@ -13,6 +14,8 @@ namespace IdeCoreBenchmarks
 {
     public class ProjectOperationBenchmarks
     {
+        private static readonly SourceText s_newText = SourceText.From("text");
+
         [MemoryDiagnoser]
         public class IterateDocuments
         {
@@ -20,6 +23,7 @@ namespace IdeCoreBenchmarks
             private Project _emptyProject;
             private Project _hundredProject;
             private Project _thousandsProject;
+
 
             public IterateDocuments()
             {
@@ -96,6 +100,17 @@ namespace IdeCoreBenchmarks
                 }
 
                 return count;
+            }
+
+            [Benchmark(Description = "Solution.WithDocumentText")]
+            public void WithDocumentText()
+            {
+                var solution = Project.Solution;
+                var documentId = Project.DocumentIds.FirstOrDefault();
+                if (documentId != null)
+                {
+                    var _ = solution.WithDocumentText(documentId, s_newText);
+                }
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // We log the number of syntax trees that have been parsed even if there was no compilation created yet
             var projectState = solutionState.GetRequiredProjectState(projectId);
             var parsedTrees = 0;
-            foreach (var documentState in projectState.DocumentStates.Values)
+            foreach (var documentState in projectState.DocumentStates.States)
             {
                 if (documentState.TryGetSyntaxTree(out _))
                 {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.RemoveAnalyzerConfigDocumentUndoUnit.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.RemoveAnalyzerConfigDocumentUndoUnit.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             protected override IReadOnlyList<DocumentId> GetDocumentIds(Project fromProject)
-                => fromProject.State.AnalyzerConfigDocumentIds.AsImmutable();
+                => fromProject.State.AnalyzerConfigDocumentStates.Ids;
 
             protected override TextDocument? GetDocument(Solution currentSolution)
                 => currentSolution.GetAnalyzerConfigDocument(this.DocumentId);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var serializer = projectState.LanguageServices.WorkspaceServices.GetService<ISerializerService>();
             var projectStateChecksums = await projectState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
 
-            var textChecksumsTasks = projectState.DocumentStates.Values.Select(async state =>
+            var textChecksumsTasks = projectState.DocumentStates.States.Select(async state =>
             {
                 var documentStateChecksum = await state.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 return documentStateChecksum.Text;

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -72,11 +72,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var serializer = projectState.LanguageServices.WorkspaceServices.GetService<ISerializerService>();
             var projectStateChecksums = await projectState.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
 
-            // Order the documents by FilePath.  Default ordering in the RemoteWorkspace is
-            // to be ordered by Guid (which is not consistent across VS sessions).
-            var textChecksumsTasks = projectState.DocumentStates.OrderBy(d => d.Value.FilePath, StringComparer.Ordinal).Select(async d =>
+            var textChecksumsTasks = projectState.DocumentStates.Values.Select(async state =>
             {
-                var documentStateChecksum = await d.Value.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
+                var documentStateChecksum = await state.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 return documentStateChecksum.Text;
             });
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Serialization
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
 
-        internal static async Task FindAsync<TKey, TValue>(
-            ImmutableSortedDictionary<TKey, TValue> documentStates,
+        internal static async Task FindAsync<TState>(
+            TextDocumentStates<TState> documentStates,
             HashSet<Checksum> searchingChecksumsLeft,
             Dictionary<Checksum, object> result,
-            CancellationToken cancellationToken) where TValue : TextDocumentState
+            CancellationToken cancellationToken) where TState : TextDocumentState
         {
-            foreach (var (_, state) in documentStates)
+            foreach (var state in documentStates.Values)
             {
                 Contract.ThrowIfFalse(state.TryGetStateChecksums(out var stateChecksums));
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             Dictionary<Checksum, object> result,
             CancellationToken cancellationToken) where TState : TextDocumentState
         {
-            foreach (var state in documentStates.Values)
+            foreach (var state in documentStates.States)
             {
                 Contract.ThrowIfFalse(state.TryGetStateChecksums(out var stateChecksums));
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -97,138 +99,67 @@ namespace Microsoft.CodeAnalysis
         }
 
         public IEnumerable<DocumentId> GetAddedDocuments()
-        {
-            foreach (var id in _newProject.DocumentIds)
-            {
-                if (!_oldProject.ContainsDocument(id))
-                {
-                    yield return id;
-                }
-            }
-        }
+            => _newProject.State.DocumentStates.GetAddedStateIds(_oldProject.State.DocumentStates);
 
         public IEnumerable<DocumentId> GetAddedAdditionalDocuments()
-        {
-            foreach (var id in _newProject.AdditionalDocumentIds)
-            {
-                if (!_oldProject.ContainsAdditionalDocument(id))
-                {
-                    yield return id;
-                }
-            }
-        }
+            => _newProject.State.AdditionalDocumentStates.GetAddedStateIds(_oldProject.State.AdditionalDocumentStates);
 
         public IEnumerable<DocumentId> GetAddedAnalyzerConfigDocuments()
-        {
-            foreach (var doc in _newProject.AnalyzerConfigDocuments)
-            {
-                if (!_oldProject.ContainsAnalyzerConfigDocument(doc.Id))
-                {
-                    yield return doc.Id;
-                }
-            }
-        }
+            => _newProject.State.AnalyzerConfigDocumentStates.GetAddedStateIds(_oldProject.State.AnalyzerConfigDocumentStates);
 
         /// <summary>
         /// Get Documents with any changes, including textual and non-textual changes
         /// </summary>
-        /// <returns></returns>
         public IEnumerable<DocumentId> GetChangedDocuments()
             => GetChangedDocuments(onlyGetDocumentsWithTextChanges: false, ignoreUnchangeableDocuments: false);
 
         /// <summary>
-        /// Get Changed Documents:
-        /// When onlyGetDocumentsWithTextChanges is true, only get documents with text changes (we only check text source, not actual content);
-        /// otherwise get documents with any changes i.e. DocumentState changes:
+        /// Get changed documents.
+        /// When <paramref name="onlyGetDocumentsWithTextChanges"/> is true, only get documents with text changes (we only check text source, not actual content);
+        /// otherwise get documents with any changes i.e. <see cref="DocumentState"/> changes:
         /// <see cref="DocumentState.ParseOptions"/>, <see cref="DocumentState.SourceCodeKind"/>, <see cref="TextDocumentState.FilePath"/>
         /// </summary>
-        /// <param name="onlyGetDocumentsWithTextChanges"></param>
-        /// <returns></returns>
         public IEnumerable<DocumentId> GetChangedDocuments(bool onlyGetDocumentsWithTextChanges)
             => GetChangedDocuments(onlyGetDocumentsWithTextChanges, ignoreUnchangeableDocuments: false);
 
         internal IEnumerable<DocumentId> GetChangedDocuments(bool onlyGetDocumentsWithTextChanges, bool ignoreUnchangeableDocuments)
         {
-            foreach (var id in _newProject.DocumentIds)
+            foreach (var newState in _newProject.State.DocumentStates.Values)
             {
-                var newState = _newProject.GetDocumentState(id)!;
-                var oldState = _oldProject.GetDocumentState(id);
-
-                if (oldState != null)
+                var oldState = _oldProject.State.DocumentStates.GetValue(newState.Id);
+                if (oldState == null)
                 {
-                    if (onlyGetDocumentsWithTextChanges)
-                    {
-                        if (newState.HasTextChanged(oldState, ignoreUnchangeableDocuments))
-                            yield return id;
-                    }
-                    else
-                    {
-                        if (newState != oldState)
-                            yield return id;
-                    }
+                    // document was removed
+                    continue;
                 }
+
+                if (newState == oldState)
+                {
+                    continue;
+                }
+
+                if (onlyGetDocumentsWithTextChanges && !newState.HasTextChanged(oldState, ignoreUnchangeableDocuments))
+                {
+                    continue;
+                }
+
+                yield return newState.Id;
             }
         }
 
         public IEnumerable<DocumentId> GetChangedAdditionalDocuments()
-        {
-            // if the document states are different then there is a change.
-            foreach (var id in _newProject.AdditionalDocumentIds)
-            {
-                var newState = _newProject.GetAdditionalDocumentState(id);
-                var oldState = _oldProject.GetAdditionalDocumentState(id);
-                if (oldState != null && newState != oldState)
-                {
-                    yield return id;
-                }
-            }
-        }
+            => _newProject.State.AdditionalDocumentStates.GetChangedStateIds(_oldProject.State.AdditionalDocumentStates);
 
         public IEnumerable<DocumentId> GetChangedAnalyzerConfigDocuments()
-        {
-            // if the document states are different then there is a change.
-            foreach (var doc in _newProject.AnalyzerConfigDocuments)
-            {
-                var newState = _newProject.GetAnalyzerConfigDocumentState(doc.Id);
-                var oldState = _oldProject.GetAnalyzerConfigDocumentState(doc.Id);
-                if (oldState != null && newState != oldState)
-                {
-                    yield return doc.Id;
-                }
-            }
-        }
+            => _newProject.State.AnalyzerConfigDocumentStates.GetChangedStateIds(_oldProject.State.AnalyzerConfigDocumentStates);
 
         public IEnumerable<DocumentId> GetRemovedDocuments()
-        {
-            foreach (var id in _oldProject.DocumentIds)
-            {
-                if (!_newProject.ContainsDocument(id))
-                {
-                    yield return id;
-                }
-            }
-        }
+            => _newProject.State.DocumentStates.GetRemovedStateIds(_oldProject.State.DocumentStates);
 
         public IEnumerable<DocumentId> GetRemovedAdditionalDocuments()
-        {
-            foreach (var id in _oldProject.AdditionalDocumentIds)
-            {
-                if (!_newProject.ContainsAdditionalDocument(id))
-                {
-                    yield return id;
-                }
-            }
-        }
+            => _newProject.State.AdditionalDocumentStates.GetRemovedStateIds(_oldProject.State.AdditionalDocumentStates);
 
         public IEnumerable<DocumentId> GetRemovedAnalyzerConfigDocuments()
-        {
-            foreach (var doc in _oldProject.AnalyzerConfigDocuments)
-            {
-                if (!_newProject.ContainsAnalyzerConfigDocument(doc.Id))
-                {
-                    yield return doc.Id;
-                }
-            }
-        }
+            => _newProject.State.AnalyzerConfigDocumentStates.GetRemovedStateIds(_oldProject.State.AnalyzerConfigDocumentStates);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
@@ -116,17 +116,16 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Get changed documents.
         /// When <paramref name="onlyGetDocumentsWithTextChanges"/> is true, only get documents with text changes (we only check text source, not actual content);
-        /// otherwise get documents with any changes i.e. <see cref="DocumentState"/> changes:
-        /// <see cref="DocumentState.ParseOptions"/>, <see cref="DocumentState.SourceCodeKind"/>, <see cref="TextDocumentState.FilePath"/>
+        /// otherwise get documents with any changes i.e. <see cref="ParseOptions"/>, <see cref="SourceCodeKind"/> and file path.
         /// </summary>
         public IEnumerable<DocumentId> GetChangedDocuments(bool onlyGetDocumentsWithTextChanges)
             => GetChangedDocuments(onlyGetDocumentsWithTextChanges, ignoreUnchangeableDocuments: false);
 
         internal IEnumerable<DocumentId> GetChangedDocuments(bool onlyGetDocumentsWithTextChanges, bool ignoreUnchangeableDocuments)
         {
-            foreach (var newState in _newProject.State.DocumentStates.Values)
+            foreach (var newState in _newProject.State.DocumentStates.States)
             {
-                var oldState = _oldProject.State.DocumentStates.GetValue(newState.Id);
+                var oldState = _oldProject.State.DocumentStates.GetState(newState.Id);
                 if (oldState == null)
                 {
                     // document was removed

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -29,22 +29,20 @@ namespace Microsoft.CodeAnalysis
         /// The documents in this project. They are sorted by <see cref="DocumentId.Id"/> to provide a stable sort for
         /// <see cref="GetChecksumAsync(CancellationToken)"/>.
         /// </summary>
-        private readonly ImmutableSortedDictionary<DocumentId, DocumentState> _documentStates;
+        public readonly TextDocumentStates<DocumentState> DocumentStates;
 
         /// <summary>
         /// The additional documents in this project. They are sorted by <see cref="DocumentId.Id"/> to provide a stable sort for
         /// <see cref="GetChecksumAsync(CancellationToken)"/>.
         /// </summary>
-        private readonly ImmutableSortedDictionary<DocumentId, TextDocumentState> _additionalDocumentStates;
+        public readonly TextDocumentStates<TextDocumentState> AdditionalDocumentStates;
 
         /// <summary>
         /// The analyzer config documents in this project.  They are sorted by <see cref="DocumentId.Id"/> to provide a stable sort for
         /// <see cref="GetChecksumAsync(CancellationToken)"/>.
         /// </summary>
-        private readonly ImmutableSortedDictionary<DocumentId, AnalyzerConfigDocumentState> _analyzerConfigDocumentStates;
+        public readonly TextDocumentStates<AnalyzerConfigDocumentState> AnalyzerConfigDocumentStates;
 
-        private readonly ImmutableList<DocumentId> _documentIds;
-        private readonly ImmutableList<DocumentId> _additionalDocumentIds;
         private readonly AsyncLazy<VersionStamp> _lazyLatestDocumentVersion;
         private readonly AsyncLazy<VersionStamp> _lazyLatestDocumentTopLevelChangeVersion;
 
@@ -62,22 +60,18 @@ namespace Microsoft.CodeAnalysis
             ProjectInfo projectInfo,
             HostLanguageServices languageServices,
             SolutionServices solutionServices,
-            ImmutableList<DocumentId> documentIds,
-            ImmutableList<DocumentId> additionalDocumentIds,
-            ImmutableSortedDictionary<DocumentId, DocumentState> documentStates,
-            ImmutableSortedDictionary<DocumentId, TextDocumentState> additionalDocumentStates,
-            ImmutableSortedDictionary<DocumentId, AnalyzerConfigDocumentState> analyzerConfigDocumentStates,
+            TextDocumentStates<DocumentState> documentStates,
+            TextDocumentStates<TextDocumentState> additionalDocumentStates,
+            TextDocumentStates<AnalyzerConfigDocumentState> analyzerConfigDocumentStates,
             AsyncLazy<VersionStamp> lazyLatestDocumentVersion,
             AsyncLazy<VersionStamp> lazyLatestDocumentTopLevelChangeVersion,
             ValueSource<CachingAnalyzerConfigSet> lazyAnalyzerConfigSet)
         {
             _solutionServices = solutionServices;
             _languageServices = languageServices;
-            _documentIds = documentIds;
-            _additionalDocumentIds = additionalDocumentIds;
-            _documentStates = documentStates;
-            _additionalDocumentStates = additionalDocumentStates;
-            _analyzerConfigDocumentStates = analyzerConfigDocumentStates;
+            DocumentStates = documentStates;
+            AdditionalDocumentStates = additionalDocumentStates;
+            AnalyzerConfigDocumentStates = analyzerConfigDocumentStates;
             _lazyLatestDocumentVersion = lazyLatestDocumentVersion;
             _lazyLatestDocumentTopLevelChangeVersion = lazyLatestDocumentTopLevelChangeVersion;
             _lazyAnalyzerConfigSet = lazyAnalyzerConfigSet;
@@ -102,10 +96,9 @@ namespace Microsoft.CodeAnalysis
             var projectInfoFixed = FixProjectInfo(projectInfo);
 
             // We need to compute our AnalyerConfigDocumentStates first, since we use those to produce our DocumentStates
-            _analyzerConfigDocumentStates = ImmutableSortedDictionary.CreateRange(DocumentIdComparer.Instance,
-                projectInfoFixed.AnalyzerConfigDocuments.Select(d =>
-                    KeyValuePairUtil.Create(d.Id, new AnalyzerConfigDocumentState(d, solutionServices))));
-            _lazyAnalyzerConfigSet = ComputeAnalyzerConfigSetValueSource(_analyzerConfigDocumentStates.Values);
+            AnalyzerConfigDocumentStates = new TextDocumentStates<AnalyzerConfigDocumentState>(projectInfoFixed.AnalyzerConfigDocuments, info => new AnalyzerConfigDocumentState(info, solutionServices));
+
+            _lazyAnalyzerConfigSet = ComputeAnalyzerConfigSetValueSource(AnalyzerConfigDocumentStates);
 
             // Add analyzer config information to the compilation options
             if (projectInfoFixed.CompilationOptions != null)
@@ -115,24 +108,13 @@ namespace Microsoft.CodeAnalysis
                         new WorkspaceSyntaxTreeOptionsProvider(_lazyAnalyzerConfigSet)));
             }
 
-            _documentIds = projectInfoFixed.Documents.Select(d => d.Id).ToImmutableList();
-            _additionalDocumentIds = projectInfoFixed.AdditionalDocuments.Select(d => d.Id).ToImmutableList();
-
             var parseOptions = projectInfoFixed.ParseOptions;
-            var docStates = ImmutableSortedDictionary.CreateRange(DocumentIdComparer.Instance,
-                projectInfoFixed.Documents.Select(d =>
-                    new KeyValuePair<DocumentId, DocumentState>(d.Id,
-                        CreateDocument(d, parseOptions))));
 
-            _documentStates = docStates;
+            DocumentStates = new TextDocumentStates<DocumentState>(projectInfoFixed.Documents, info => CreateDocument(info, parseOptions));
+            AdditionalDocumentStates = new TextDocumentStates<TextDocumentState>(projectInfoFixed.AdditionalDocuments, info => new TextDocumentState(info, solutionServices));
 
-            var additionalDocStates = ImmutableSortedDictionary.CreateRange(DocumentIdComparer.Instance,
-                    projectInfoFixed.AdditionalDocuments.Select(d =>
-                        new KeyValuePair<DocumentId, TextDocumentState>(d.Id, new TextDocumentState(d, solutionServices))));
-
-            _additionalDocumentStates = additionalDocStates;
-            _lazyLatestDocumentVersion = new AsyncLazy<VersionStamp>(c => ComputeLatestDocumentVersionAsync(docStates, additionalDocStates, c), cacheResult: true);
-            _lazyLatestDocumentTopLevelChangeVersion = new AsyncLazy<VersionStamp>(c => ComputeLatestDocumentTopLevelChangeVersionAsync(docStates, additionalDocStates, c), cacheResult: true);
+            _lazyLatestDocumentVersion = new AsyncLazy<VersionStamp>(c => ComputeLatestDocumentVersionAsync(DocumentStates.Map, AdditionalDocumentStates.Map, c), cacheResult: true);
+            _lazyLatestDocumentTopLevelChangeVersion = new AsyncLazy<VersionStamp>(c => ComputeLatestDocumentTopLevelChangeVersionAsync(DocumentStates.Map, AdditionalDocumentStates.Map, c), cacheResult: true);
 
             // ownership of information on document has moved to project state. clear out documentInfo the state is
             // holding on. otherwise, these information will be held onto unnecessarily by projectInfo even after
@@ -258,7 +240,7 @@ namespace Microsoft.CodeAnalysis
 
         public AnalyzerOptions AnalyzerOptions
             => _lazyAnalyzerOptions ??= new AnalyzerOptions(
-                additionalFiles: _additionalDocumentStates.Values.Select(d => new AdditionalTextWithState(d)).ToImmutableArray<AdditionalText>(),
+                additionalFiles: AdditionalDocumentStates.SelectAsArray<AdditionalText>(static state => new AdditionalTextWithState(state)),
                 optionsProvider: new WorkspaceAnalyzerConfigOptionsProvider(this));
 
         public async Task<ImmutableDictionary<string, string>> GetAnalyzerOptionsForPathAsync(
@@ -369,12 +351,12 @@ namespace Microsoft.CodeAnalysis
             public override int GetHashCode() => _lazyAnalyzerConfigSet.GetHashCode();
         }
 
-        private static ValueSource<CachingAnalyzerConfigSet> ComputeAnalyzerConfigSetValueSource(IEnumerable<AnalyzerConfigDocumentState> analyzerConfigDocumentStates)
+        private static ValueSource<CachingAnalyzerConfigSet> ComputeAnalyzerConfigSetValueSource(TextDocumentStates<AnalyzerConfigDocumentState> analyzerConfigDocumentStates)
         {
             return new AsyncLazy<CachingAnalyzerConfigSet>(
                 asynchronousComputeFunction: async cancellationToken =>
                 {
-                    var tasks = analyzerConfigDocumentStates.Select(a => a.GetAnalyzerConfigAsync(cancellationToken));
+                    var tasks = analyzerConfigDocumentStates.Values.Select(a => a.GetAnalyzerConfigAsync(cancellationToken));
                     var analyzerConfigs = await Task.WhenAll(tasks).ConfigureAwait(false);
 
                     cancellationToken.ThrowIfCancellationRequested();
@@ -468,66 +450,11 @@ namespace Microsoft.CodeAnalysis
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
         public bool RunAnalyzers => this.ProjectInfo.RunAnalyzers;
 
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public bool HasDocuments => _documentIds.Count > 0;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IEnumerable<DocumentState> OrderedDocumentStates => this.DocumentIds.Select(GetDocumentState)!;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IReadOnlyList<DocumentId> DocumentIds => _documentIds;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IReadOnlyList<DocumentId> AdditionalDocumentIds => _additionalDocumentIds;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        // Regular documents and additionald documents have an ordering, and so we maintain lists of the IDs in order; in the case of analyzerconfig documents,
-        // we don't define a workspace ordering because they are ordered via fancier algorithms in the compiler based on directory depth.
-        public IEnumerable<DocumentId> AnalyzerConfigDocumentIds => _analyzerConfigDocumentStates.Keys;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public ImmutableSortedDictionary<DocumentId, DocumentState> DocumentStates => _documentStates;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public ImmutableSortedDictionary<DocumentId, TextDocumentState> AdditionalDocumentStates => _additionalDocumentStates;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public ImmutableSortedDictionary<DocumentId, AnalyzerConfigDocumentState> AnalyzerConfigDocumentStates => _analyzerConfigDocumentStates;
-
-        public bool ContainsDocument(DocumentId documentId)
-            => _documentStates.ContainsKey(documentId);
-
-        public bool ContainsAdditionalDocument(DocumentId documentId)
-            => _additionalDocumentStates.ContainsKey(documentId);
-
-        public bool ContainsAnalyzerConfigDocument(DocumentId documentId)
-            => _analyzerConfigDocumentStates.ContainsKey(documentId);
-
-        public DocumentState? GetDocumentState(DocumentId documentId)
-        {
-            _documentStates.TryGetValue(documentId, out var state);
-            return state;
-        }
-
-        public TextDocumentState? GetAdditionalDocumentState(DocumentId documentId)
-        {
-            _additionalDocumentStates.TryGetValue(documentId, out var state);
-            return state;
-        }
-
-        public AnalyzerConfigDocumentState? GetAnalyzerConfigDocumentState(DocumentId documentId)
-        {
-            _analyzerConfigDocumentStates.TryGetValue(documentId, out var state);
-            return state;
-        }
-
         private ProjectState With(
             ProjectInfo? projectInfo = null,
-            ImmutableList<DocumentId>? documentIds = null,
-            ImmutableList<DocumentId>? additionalDocumentIds = null,
-            ImmutableSortedDictionary<DocumentId, DocumentState>? documentStates = null,
-            ImmutableSortedDictionary<DocumentId, TextDocumentState>? additionalDocumentStates = null,
-            ImmutableSortedDictionary<DocumentId, AnalyzerConfigDocumentState>? analyzerConfigDocumentStates = null,
+            TextDocumentStates<DocumentState>? documentStates = null,
+            TextDocumentStates<TextDocumentState>? additionalDocumentStates = null,
+            TextDocumentStates<AnalyzerConfigDocumentState>? analyzerConfigDocumentStates = null,
             AsyncLazy<VersionStamp>? latestDocumentVersion = null,
             AsyncLazy<VersionStamp>? latestDocumentTopLevelChangeVersion = null,
             ValueSource<CachingAnalyzerConfigSet>? analyzerConfigSet = null)
@@ -536,11 +463,9 @@ namespace Microsoft.CodeAnalysis
                 projectInfo ?? _projectInfo,
                 _languageServices,
                 _solutionServices,
-                documentIds ?? _documentIds,
-                additionalDocumentIds ?? _additionalDocumentIds,
-                documentStates ?? _documentStates,
-                additionalDocumentStates ?? _additionalDocumentStates,
-                analyzerConfigDocumentStates ?? _analyzerConfigDocumentStates,
+                documentStates ?? DocumentStates,
+                additionalDocumentStates ?? AdditionalDocumentStates,
+                analyzerConfigDocumentStates ?? AnalyzerConfigDocumentStates,
                 latestDocumentVersion ?? _lazyLatestDocumentVersion,
                 latestDocumentTopLevelChangeVersion ?? _lazyLatestDocumentTopLevelChangeVersion,
                 analyzerConfigSet ?? _lazyAnalyzerConfigSet);
@@ -599,18 +524,9 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            // update parse options for all documents too
-            var docMap = _documentStates;
-
-            foreach (var (docId, oldDocState) in _documentStates)
-            {
-                var newDocState = oldDocState.UpdateParseOptions(options);
-                docMap = docMap.SetItem(docId, newDocState);
-            }
-
             return With(
                 projectInfo: ProjectInfo.WithParseOptions(options).WithVersion(Version.GetNewerVersion()),
-                documentStates: docMap);
+                documentStates: DocumentStates.UpdateValues(static (state, options) => state.UpdateParseOptions(options), options));
         }
 
         public static bool IsSameLanguage(ProjectState project1, ProjectState project2)
@@ -664,37 +580,35 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState AddDocuments(ImmutableArray<DocumentState> documents)
         {
-            Debug.Assert(!documents.Any(d => this.DocumentStates.ContainsKey(d.Id)));
+            Debug.Assert(!documents.Any(d => DocumentStates.Contains(d.Id)));
 
-            return this.With(
-                projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
-                documentIds: _documentIds.AddRange(documents.Select(d => d.Id)),
-                documentStates: _documentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d))));
+            return With(
+                projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
+                documentStates: DocumentStates.AddRange(documents));
         }
 
         public ProjectState AddAdditionalDocuments(ImmutableArray<TextDocumentState> documents)
         {
-            Debug.Assert(!documents.Any(d => this.AdditionalDocumentStates.ContainsKey(d.Id)));
+            Debug.Assert(!documents.Any(d => AdditionalDocumentStates.Contains(d.Id)));
 
-            return this.With(
-                projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
-                additionalDocumentIds: _additionalDocumentIds.AddRange(documents.Select(d => d.Id)),
-                additionalDocumentStates: _additionalDocumentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d))));
+            return With(
+                projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
+                additionalDocumentStates: AdditionalDocumentStates.AddRange(documents));
         }
 
         public ProjectState AddAnalyzerConfigDocuments(ImmutableArray<AnalyzerConfigDocumentState> documents)
         {
-            Debug.Assert(!documents.Any(d => this._analyzerConfigDocumentStates.ContainsKey(d.Id)));
+            Debug.Assert(!documents.Any(d => AnalyzerConfigDocumentStates.Contains(d.Id)));
 
-            var newAnalyzerConfigDocumentStates = _analyzerConfigDocumentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d)));
+            var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.AddRange(documents);
 
             return CreateNewStateForChangedAnalyzerConfigDocuments(newAnalyzerConfigDocumentStates);
         }
 
-        private ProjectState CreateNewStateForChangedAnalyzerConfigDocuments(ImmutableSortedDictionary<DocumentId, AnalyzerConfigDocumentState> newAnalyzerConfigDocumentStates)
+        private ProjectState CreateNewStateForChangedAnalyzerConfigDocuments(TextDocumentStates<AnalyzerConfigDocumentState> newAnalyzerConfigDocumentStates)
         {
-            var newAnalyzerConfigSet = ComputeAnalyzerConfigSetValueSource(newAnalyzerConfigDocumentStates.Values);
-            var projectInfo = ProjectInfo.WithVersion(this.Version.GetNewerVersion());
+            var newAnalyzerConfigSet = ComputeAnalyzerConfigSetValueSource(newAnalyzerConfigDocumentStates);
+            var projectInfo = ProjectInfo.WithVersion(Version.GetNewerVersion());
 
             // Changing analyzer configs changes compilation options
             if (CompilationOptions != null)
@@ -704,7 +618,7 @@ namespace Microsoft.CodeAnalysis
                     .WithCompilationOptions(CompilationOptions.WithSyntaxTreeOptionsProvider(newProvider));
             }
 
-            return this.With(
+            return With(
                 projectInfo: projectInfo,
                 analyzerConfigDocumentStates: newAnalyzerConfigDocumentStates,
                 analyzerConfigSet: newAnalyzerConfigSet);
@@ -714,24 +628,22 @@ namespace Microsoft.CodeAnalysis
         {
             // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
             // for removed documents.
-            return this.With(
-                projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
-                documentIds: _documentIds.RemoveRange(documentIds),
-                documentStates: _documentStates.RemoveRange(documentIds),
-                analyzerConfigSet: ComputeAnalyzerConfigSetValueSource(AnalyzerConfigDocumentStates.Values));
+            return With(
+                projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
+                documentStates: DocumentStates.RemoveRange(documentIds),
+                analyzerConfigSet: ComputeAnalyzerConfigSetValueSource(AnalyzerConfigDocumentStates));
         }
 
         public ProjectState RemoveAdditionalDocuments(ImmutableArray<DocumentId> documentIds)
         {
-            return this.With(
-                projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
-                additionalDocumentIds: _additionalDocumentIds.RemoveRange(documentIds),
-                additionalDocumentStates: _additionalDocumentStates.RemoveRange(documentIds));
+            return With(
+                projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
+                additionalDocumentStates: AdditionalDocumentStates.RemoveRange(documentIds));
         }
 
         public ProjectState RemoveAnalyzerConfigDocuments(ImmutableArray<DocumentId> documentIds)
         {
-            var newAnalyzerConfigDocumentStates = _analyzerConfigDocumentStates.RemoveRange(documentIds);
+            var newAnalyzerConfigDocumentStates = AnalyzerConfigDocumentStates.RemoveRange(documentIds);
 
             return CreateNewStateForChangedAnalyzerConfigDocuments(newAnalyzerConfigDocumentStates);
         }
@@ -740,29 +652,26 @@ namespace Microsoft.CodeAnalysis
         {
             // We create a new CachingAnalyzerConfigSet for the new snapshot to avoid holding onto cached information
             // for removed documents.
-            return this.With(
-                projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()).WithDocuments(SpecializedCollections.EmptyEnumerable<DocumentInfo>()),
-                documentIds: ImmutableList<DocumentId>.Empty,
-                documentStates: ImmutableSortedDictionary.Create<DocumentId, DocumentState>(DocumentIdComparer.Instance),
-                analyzerConfigSet: ComputeAnalyzerConfigSetValueSource(AnalyzerConfigDocumentStates.Values));
+            return With(
+                projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()).WithDocuments(SpecializedCollections.EmptyEnumerable<DocumentInfo>()),
+                documentStates: TextDocumentStates<DocumentState>.Empty,
+                analyzerConfigSet: ComputeAnalyzerConfigSetValueSource(AnalyzerConfigDocumentStates));
         }
 
         public ProjectState UpdateDocument(DocumentState newDocument, bool textChanged, bool recalculateDependentVersions)
         {
-            Debug.Assert(this.ContainsDocument(newDocument.Id));
-
-            var oldDocument = this.GetDocumentState(newDocument.Id)!;
+            var oldDocument = DocumentStates.GetRequiredValue(newDocument.Id);
             if (oldDocument == newDocument)
             {
                 return this;
             }
 
-            var newDocumentStates = _documentStates.SetItem(newDocument.Id, newDocument);
+            var newDocumentStates = DocumentStates.SetValue(newDocument.Id, newDocument);
             GetLatestDependentVersions(
-                newDocumentStates, _additionalDocumentStates, oldDocument, newDocument, recalculateDependentVersions, textChanged,
+                newDocumentStates.Map, AdditionalDocumentStates.Map, oldDocument, newDocument, recalculateDependentVersions, textChanged,
                 out var dependentDocumentVersion, out var dependentSemanticVersion);
 
-            return this.With(
+            return With(
                 documentStates: newDocumentStates,
                 latestDocumentVersion: dependentDocumentVersion,
                 latestDocumentTopLevelChangeVersion: dependentSemanticVersion);
@@ -770,17 +679,15 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState UpdateAdditionalDocument(TextDocumentState newDocument, bool textChanged, bool recalculateDependentVersions)
         {
-            Debug.Assert(this.ContainsAdditionalDocument(newDocument.Id));
-
-            var oldDocument = this.GetAdditionalDocumentState(newDocument.Id)!;
+            var oldDocument = AdditionalDocumentStates.GetRequiredValue(newDocument.Id);
             if (oldDocument == newDocument)
             {
                 return this;
             }
 
-            var newDocumentStates = _additionalDocumentStates.SetItem(newDocument.Id, newDocument);
+            var newDocumentStates = AdditionalDocumentStates.SetValue(newDocument.Id, newDocument);
             GetLatestDependentVersions(
-                _documentStates, newDocumentStates, oldDocument, newDocument, recalculateDependentVersions, textChanged,
+                DocumentStates.Map, newDocumentStates.Map, oldDocument, newDocument, recalculateDependentVersions, textChanged,
                 out var dependentDocumentVersion, out var dependentSemanticVersion);
 
             return this.With(
@@ -791,43 +698,41 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState UpdateAnalyzerConfigDocument(AnalyzerConfigDocumentState newDocument)
         {
-            Debug.Assert(this.ContainsAnalyzerConfigDocument(newDocument.Id));
-
-            var oldDocument = this.GetAnalyzerConfigDocumentState(newDocument.Id);
+            var oldDocument = AnalyzerConfigDocumentStates.GetRequiredValue(newDocument.Id);
             if (oldDocument == newDocument)
             {
                 return this;
             }
 
-            var newDocumentStates = _analyzerConfigDocumentStates.SetItem(newDocument.Id, newDocument);
+            var newDocumentStates = AnalyzerConfigDocumentStates.SetValue(newDocument.Id, newDocument);
 
             return CreateNewStateForChangedAnalyzerConfigDocuments(newDocumentStates);
         }
 
-        public ProjectState UpdateDocumentsOrder(ImmutableList<DocumentId> documentIds)
+        public ProjectState UpdateDocumentsOrder(ImmutableArray<DocumentId> documentIds)
         {
             if (documentIds.IsEmpty)
             {
                 throw new ArgumentOutOfRangeException("The specified documents are empty.", nameof(documentIds));
             }
 
-            if (documentIds.Count != _documentIds.Count)
+            if (documentIds.Length != DocumentStates.Count)
             {
                 throw new ArgumentException($"The specified documents do not equal the project document count.", nameof(documentIds));
             }
 
             var hasOrderChanged = false;
 
-            for (var i = 0; i < documentIds.Count; ++i)
+            for (var i = 0; i < documentIds.Length; ++i)
             {
                 var documentId = documentIds[i];
 
-                if (!ContainsDocument(documentId))
+                if (!DocumentStates.Contains(documentId))
                 {
                     throw new InvalidOperationException($"The document '{documentId}' does not exist in the project.");
                 }
 
-                if (DocumentIds[i] != documentId)
+                if (DocumentStates.Ids[i] != documentId)
                 {
                     hasOrderChanged = true;
                 }
@@ -838,9 +743,9 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return this.With(
-                projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
-                documentIds: documentIds);
+            return With(
+                projectInfo: ProjectInfo.WithVersion(Version.GetNewerVersion()),
+                documentStates: new(documentIds, DocumentStates.Map));
         }
 
         private void GetLatestDependentVersions(
@@ -880,29 +785,6 @@ namespace Microsoft.CodeAnalysis
                 textChanged ?
                     CreateLazyLatestDocumentTopLevelChangeVersion(newDocument, newDocumentStates, newAdditionalDocumentStates) :
                     _lazyLatestDocumentTopLevelChangeVersion;
-        }
-
-        private sealed class DocumentIdComparer : IComparer<DocumentId?>
-        {
-            public static readonly IComparer<DocumentId?> Instance = new DocumentIdComparer();
-
-            private DocumentIdComparer()
-            {
-            }
-
-            public int Compare(DocumentId? x, DocumentId? y)
-            {
-                if (x is null)
-                {
-                    return y is null ? 0 : -1;
-                }
-                else if (y is null)
-                {
-                    return 1;
-                }
-
-                return x.Id.CompareTo(y.Id);
-            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
@@ -45,9 +45,9 @@ namespace Microsoft.CodeAnalysis
                 {
                     // Here, we use the _documentStates and _additionalDocumentStates and visit them in order; we ensure that those are
                     // sorted by ID so we have a consistent sort.
-                    var documentChecksumsTasks = _documentStates.Select(pair => pair.Value.GetChecksumAsync(cancellationToken));
-                    var additionalDocumentChecksumTasks = _additionalDocumentStates.Select(pair => pair.Value.GetChecksumAsync(cancellationToken));
-                    var analyzerConfigDocumentChecksumTasks = _analyzerConfigDocumentStates.Select(pair => pair.Value.GetChecksumAsync(cancellationToken));
+                    var documentChecksumsTasks = DocumentStates.SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);
+                    var additionalDocumentChecksumTasks = AdditionalDocumentStates.SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);
+                    var analyzerConfigDocumentChecksumTasks = AnalyzerConfigDocumentStates.SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);
 
                     var serializer = _solutionServices.Workspace.Services.GetService<ISerializerService>();
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
@@ -43,8 +43,6 @@ namespace Microsoft.CodeAnalysis
             {
                 using (Logger.LogBlock(FunctionId.ProjectState_ComputeChecksumsAsync, FilePath, cancellationToken))
                 {
-                    // Here, we use the _documentStates and _additionalDocumentStates and visit them in order; we ensure that those are
-                    // sorted by ID so we have a consistent sort.
                     var documentChecksumsTasks = DocumentStates.SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);
                     var additionalDocumentChecksumTasks = AdditionalDocumentStates.SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);
                     var analyzerConfigDocumentChecksumTasks = AnalyzerConfigDocumentStates.SelectAsArray(static (state, token) => state.GetChecksumAsync(token), cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1647,7 +1647,7 @@ namespace Microsoft.CodeAnalysis
                 return ImmutableArray<DocumentId>.Empty;
             }
 
-            var documentState = projectState.DocumentStates.GetValue(documentId);
+            var documentState = projectState.DocumentStates.GetState(documentId);
             if (documentState == null)
             {
                 // this document no longer exist

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     var syntaxTrees = new List<SyntaxTree>(capacity: _state.DocumentStates.Count);
 
-                    foreach (var documentState in _state.DocumentStates.Values)
+                    foreach (var documentState in _state.DocumentStates.States)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         syntaxTrees.Add(await documentState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -103,9 +103,9 @@ namespace Microsoft.CodeAnalysis
 
                 public override async Task<Compilation> TransformCompilationAsync(Compilation oldCompilation, CancellationToken cancellationToken)
                 {
-                    var syntaxTrees = new List<SyntaxTree>(capacity: _state.DocumentIds.Count);
+                    var syntaxTrees = new List<SyntaxTree>(capacity: _state.DocumentStates.Count);
 
-                    foreach (var documentState in _state.OrderedDocumentStates)
+                    foreach (var documentState in _state.DocumentStates.Values)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         syntaxTrees.Add(await documentState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis
                     ValueSource<Optional<Compilation>> compilationWithoutGeneratedFilesSource,
                     Compilation compilationWithoutGeneratedFiles,
                     bool hasSuccessfullyLoaded,
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments,
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
                     Compilation finalCompilation,
                     ProjectId projectId,
                     Dictionary<MetadataReference, ProjectId>? metadataReferenceToProjectId)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
                 public static readonly State Empty = new(
                     compilationWithoutGeneratedDocuments: null,
                     declarationOnlyCompilation: null,
-                    generatedDocuments: ImmutableArray<SourceGeneratedDocumentState>.Empty,
+                    generatedDocuments: TextDocumentStates<SourceGeneratedDocumentState>.Empty,
                     generatedDocumentsAreFinal: false);
 
                 /// <summary>
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis
                 /// The best generated documents we have for the current state. <see cref="GeneratedDocumentsAreFinal"/> specifies whether the
                 /// documents are to be considered final and can be reused, or whether they're from a prior snapshot which needs to be recomputed.
                 /// </summary>
-                public ImmutableArray<SourceGeneratedDocumentState> GeneratedDocuments { get; }
+                public TextDocumentStates<SourceGeneratedDocumentState> GeneratedDocuments { get; }
 
                 /// <summary>
                 /// Whether the generated documents in <see cref="GeneratedDocuments"/> are final and should not be regenerated. It's important
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis
                 protected State(
                     ValueSource<Optional<Compilation>>? compilationWithoutGeneratedDocuments,
                     Compilation? declarationOnlyCompilation,
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments,
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
                     bool generatedDocumentsAreFinal)
                 {
                     // Declaration-only compilations should never have any references
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis
 
                 public static State Create(
                     Compilation compilation,
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments,
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
                     ImmutableArray<ValueTuple<ProjectState, CompilationAndGeneratorDriverTranslationAction>> intermediateProjects)
                 {
                     Contract.ThrowIfTrue(intermediateProjects.IsDefault);
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis
 
                 public InProgressState(
                     Compilation inProgressCompilation,
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments,
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
                     ImmutableArray<(ProjectState state, CompilationAndGeneratorDriverTranslationAction action)> intermediateProjects)
                     : base(compilationWithoutGeneratedDocuments: new ConstantValueSource<Optional<Compilation>>(inProgressCompilation),
                            declarationOnlyCompilation: null,
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis
             private sealed class LightDeclarationState : State
             {
                 public LightDeclarationState(Compilation declarationOnlyCompilation,
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments,
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
                     bool generatedDocumentsAreFinal)
                     : base(compilationWithoutGeneratedDocuments: null,
                            declarationOnlyCompilation,
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis
             private sealed class FullDeclarationState : State
             {
                 public FullDeclarationState(Compilation declarationCompilation,
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments,
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
                     bool generatedDocumentsAreFinal)
                     : base(new WeakValueSource<Compilation>(declarationCompilation),
                            declarationCompilation.Clone().RemoveAllReferences(),
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis
                     ValueSource<Optional<Compilation>> compilationWithoutGeneratedFilesSource,
                     Compilation compilationWithoutGeneratedFiles,
                     bool hasSuccessfullyLoaded,
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments,
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
                     UnrootedSymbolSet unrootedSymbolSet)
                     : base(compilationWithoutGeneratedFilesSource,
                            compilationWithoutGeneratedFiles.Clone().RemoveAllReferences(),

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis
         private partial class CompilationTracker
         {
             private static readonly Func<ProjectState, string> s_logBuildCompilationAsync =
-                state => string.Join(",", state.AssemblyName, state.DocumentIds.Count);
+                state => string.Join(",", state.AssemblyName, state.DocumentStates.Count);
 
             public ProjectState ProjectState { get; }
 
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis
                     else
                     {
                         inProgressCompilation = inProgressCompilation.AddSyntaxTrees(tree);
-                        Debug.Assert(!inProgressProject.DocumentIds.Contains(docState.Id));
+                        Debug.Assert(!inProgressProject.DocumentStates.Contains(docState.Id));
                         inProgressProject = inProgressProject.AddDocuments(ImmutableArray.Create(docState));
                     }
                 }
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis
                 DocumentId id,
                 out ProjectState inProgressProject,
                 out Compilation inProgressCompilation,
-                out ImmutableArray<SourceGeneratedDocumentState> sourceGeneratedDocuments,
+                out TextDocumentStates<SourceGeneratedDocumentState> sourceGeneratedDocuments,
                 out Dictionary<MetadataReference, ProjectId>? metadataReferenceToProjectId,
                 CancellationToken cancellationToken)
             {
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis
 
                     // We'll add in whatever generated documents we do have; these may be from a prior run prior to some changes
                     // being made to the project, but it's the best we have so we'll use it.
-                    inProgressCompilation = compilationWithoutGeneratedDocuments.AddSyntaxTrees(sourceGeneratedDocuments.Select(d => d.SyntaxTree));
+                    inProgressCompilation = compilationWithoutGeneratedDocuments.AddSyntaxTrees(sourceGeneratedDocuments.Values.Select(state => state.SyntaxTree));
 
                     // This is likely a bug.  It seems possible to pass out a partial compilation state that we don't
                     // properly record assembly symbols for.
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis
                     inProgressCompilation = compilationWithoutGeneratedDocuments;
                 }
 
-                inProgressCompilation = inProgressCompilation.AddSyntaxTrees(sourceGeneratedDocuments.Select(d => d.SyntaxTree));
+                inProgressCompilation = inProgressCompilation.AddSyntaxTrees(sourceGeneratedDocuments.Values.Select(state => state.SyntaxTree));
 
                 // Now add in back a consistent set of project references.  For project references
                 // try to get either a CompilationReference or a SkeletonReference. This ensures
@@ -575,8 +575,7 @@ namespace Microsoft.CodeAnalysis
                 // If we have already reached FinalState in the past but the compilation was garbage collected, we still have the generated documents
                 // so we can pass those to FinalizeCompilationAsync to avoid the recomputation. This is necessary for correctness as otherwise
                 // we'd be reparsing trees which could result in generated documents changing identity.
-                ImmutableArray<SourceGeneratedDocumentState>? authoritativeGeneratedDocuments =
-                    state.GeneratedDocumentsAreFinal ? state.GeneratedDocuments : null;
+                var authoritativeGeneratedDocuments = state.GeneratedDocumentsAreFinal ? state.GeneratedDocuments : (TextDocumentStates<SourceGeneratedDocumentState>?)null;
 
                 if (compilation == null)
                 {
@@ -629,8 +628,8 @@ namespace Microsoft.CodeAnalysis
                 {
                     var compilation = CreateEmptyCompilation();
 
-                    var trees = ArrayBuilder<SyntaxTree>.GetInstance(ProjectState.DocumentIds.Count);
-                    foreach (var document in ProjectState.OrderedDocumentStates)
+                    var trees = ArrayBuilder<SyntaxTree>.GetInstance(ProjectState.DocumentStates.Count);
+                    foreach (var document in ProjectState.DocumentStates.Values)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         // Include the tree even if the content of the document failed to load.
@@ -640,7 +639,7 @@ namespace Microsoft.CodeAnalysis
                     compilation = compilation.AddSyntaxTrees(trees);
                     trees.Free();
 
-                    WriteState(new FullDeclarationState(compilation, ImmutableArray<SourceGeneratedDocumentState>.Empty, generatedDocumentsAreFinal: false), solutionServices);
+                    WriteState(new FullDeclarationState(compilation, TextDocumentStates<SourceGeneratedDocumentState>.Empty, generatedDocumentsAreFinal: false), solutionServices);
                     return compilation;
                 }
                 catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
@@ -708,13 +707,13 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private struct CompilationInfo
+            private readonly struct CompilationInfo
             {
                 public Compilation Compilation { get; }
                 public bool HasSuccessfullyLoaded { get; }
-                public ImmutableArray<SourceGeneratedDocumentState> GeneratedDocuments { get; }
+                public TextDocumentStates<SourceGeneratedDocumentState> GeneratedDocuments { get; }
 
-                public CompilationInfo(Compilation compilation, bool hasSuccessfullyLoaded, ImmutableArray<SourceGeneratedDocumentState> generatedDocuments)
+                public CompilationInfo(Compilation compilation, bool hasSuccessfullyLoaded, TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments)
                 {
                     Compilation = compilation;
                     HasSuccessfullyLoaded = hasSuccessfullyLoaded;
@@ -733,7 +732,7 @@ namespace Microsoft.CodeAnalysis
             private async Task<CompilationInfo> FinalizeCompilationAsync(
                 SolutionState solution,
                 Compilation compilation,
-                ImmutableArray<SourceGeneratedDocumentState>? authoritativeGeneratedDocuments,
+                TextDocumentStates<SourceGeneratedDocumentState>? authoritativeGeneratedDocuments,
                 CancellationToken cancellationToken)
             {
                 try
@@ -797,9 +796,8 @@ namespace Microsoft.CodeAnalysis
                     // https://github.com/dotnet/roslyn/issues/46418
                     var compilationWithoutGeneratedFiles = compilation;
 
-                    ImmutableArray<SourceGeneratedDocumentState> generatedDocuments;
-
-                    if (authoritativeGeneratedDocuments != null)
+                    TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments;
+                    if (authoritativeGeneratedDocuments.HasValue)
                     {
                         generatedDocuments = authoritativeGeneratedDocuments.Value;
                     }
@@ -809,7 +807,7 @@ namespace Microsoft.CodeAnalysis
 
                         if (generators.Any())
                         {
-                            var additionalTexts = this.ProjectState.AdditionalDocumentStates.Values.SelectAsArray(a => (AdditionalText)new AdditionalTextWithState(a));
+                            var additionalTexts = this.ProjectState.AdditionalDocumentStates.SelectAsArray<AdditionalText>(state => new AdditionalTextWithState(state));
                             var compilationFactory = this.ProjectState.LanguageServices.GetRequiredService<ICompilationFactoryService>();
 
                             var generatorDriver = compilationFactory.CreateGeneratorDriver(
@@ -838,10 +836,10 @@ namespace Microsoft.CodeAnalysis
                             }
                         }
 
-                        generatedDocuments = generatedDocumentsBuilder.ToImmutable();
+                        generatedDocuments = new TextDocumentStates<SourceGeneratedDocumentState>(generatedDocumentsBuilder);
                     }
 
-                    compilation = compilation.AddSyntaxTrees(generatedDocuments.Select(d => d.SyntaxTree));
+                    compilation = compilation.AddSyntaxTrees(generatedDocuments.Values.Select(state => state.SyntaxTree));
 
                     var finalState = FinalState.Create(
                         State.CreateValueSource(compilation, solution.Services),
@@ -1060,7 +1058,7 @@ namespace Microsoft.CodeAnalysis
                 return compilationInfo.HasSuccessfullyLoaded;
             }
 
-            public async Task<ImmutableArray<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(SolutionState solution, CancellationToken cancellationToken)
+            public async ValueTask<TextDocumentStates<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(SolutionState solution, CancellationToken cancellationToken)
             {
                 var compilationInfo = await GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return compilationInfo.GeneratedDocuments;
@@ -1073,12 +1071,7 @@ namespace Microsoft.CodeAnalysis
                 // If we are in FinalState, then we have correctly ran generators and then know the final contents of the
                 // Compilation. The GeneratedDocuments can be filled for intermediate states, but those aren't guaranteed to be
                 // correct and can be re-ran later.
-                if (state is FinalState finalState)
-                {
-                    return finalState.GeneratedDocuments.SingleOrDefault(d => d.Id == documentId);
-                }
-
-                return null;
+                return state is FinalState finalState ? finalState.GeneratedDocuments.GetValue(documentId) : null;
             }
 
             #region Versions

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis
 
                     // We'll add in whatever generated documents we do have; these may be from a prior run prior to some changes
                     // being made to the project, but it's the best we have so we'll use it.
-                    inProgressCompilation = compilationWithoutGeneratedDocuments.AddSyntaxTrees(sourceGeneratedDocuments.Values.Select(state => state.SyntaxTree));
+                    inProgressCompilation = compilationWithoutGeneratedDocuments.AddSyntaxTrees(sourceGeneratedDocuments.States.Select(state => state.SyntaxTree));
 
                     // This is likely a bug.  It seems possible to pass out a partial compilation state that we don't
                     // properly record assembly symbols for.
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis
                     inProgressCompilation = compilationWithoutGeneratedDocuments;
                 }
 
-                inProgressCompilation = inProgressCompilation.AddSyntaxTrees(sourceGeneratedDocuments.Values.Select(state => state.SyntaxTree));
+                inProgressCompilation = inProgressCompilation.AddSyntaxTrees(sourceGeneratedDocuments.States.Select(state => state.SyntaxTree));
 
                 // Now add in back a consistent set of project references.  For project references
                 // try to get either a CompilationReference or a SkeletonReference. This ensures
@@ -629,7 +629,7 @@ namespace Microsoft.CodeAnalysis
                     var compilation = CreateEmptyCompilation();
 
                     var trees = ArrayBuilder<SyntaxTree>.GetInstance(ProjectState.DocumentStates.Count);
-                    foreach (var document in ProjectState.DocumentStates.Values)
+                    foreach (var document in ProjectState.DocumentStates.States)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         // Include the tree even if the content of the document failed to load.
@@ -839,7 +839,7 @@ namespace Microsoft.CodeAnalysis
                         generatedDocuments = new TextDocumentStates<SourceGeneratedDocumentState>(generatedDocumentsBuilder);
                     }
 
-                    compilation = compilation.AddSyntaxTrees(generatedDocuments.Values.Select(state => state.SyntaxTree));
+                    compilation = compilation.AddSyntaxTrees(generatedDocuments.States.Select(state => state.SyntaxTree));
 
                     var finalState = FinalState.Create(
                         State.CreateValueSource(compilation, solution.Services),
@@ -1071,7 +1071,7 @@ namespace Microsoft.CodeAnalysis
                 // If we are in FinalState, then we have correctly ran generators and then know the final contents of the
                 // Compilation. The GeneratedDocuments can be filled for intermediate states, but those aren't guaranteed to be
                 // correct and can be re-ran later.
-                return state is FinalState finalState ? finalState.GeneratedDocuments.GetValue(documentId) : null;
+                return state is FinalState finalState ? finalState.GeneratedDocuments.GetState(documentId) : null;
             }
 
             #region Versions

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -339,13 +339,13 @@ namespace Microsoft.CodeAnalysis
         }
 
         private DocumentState GetRequiredDocumentState(DocumentId documentId)
-            => GetRequiredProjectState(documentId.ProjectId).DocumentStates.GetRequiredValue(documentId);
+            => GetRequiredProjectState(documentId.ProjectId).DocumentStates.GetRequiredState(documentId);
 
         private TextDocumentState GetRequiredAdditionalDocumentState(DocumentId documentId)
-            => GetRequiredProjectState(documentId.ProjectId).AdditionalDocumentStates.GetRequiredValue(documentId);
+            => GetRequiredProjectState(documentId.ProjectId).AdditionalDocumentStates.GetRequiredState(documentId);
 
         private AnalyzerConfigDocumentState GetRequiredAnalyzerConfigDocumentState(DocumentId documentId)
-            => GetRequiredProjectState(documentId.ProjectId).AnalyzerConfigDocumentStates.GetRequiredValue(documentId);
+            => GetRequiredProjectState(documentId.ProjectId).AnalyzerConfigDocumentStates.GetRequiredState(documentId);
 
         internal DocumentState? GetDocumentState(SyntaxTree? syntaxTree, ProjectId? projectId)
         {
@@ -359,7 +359,7 @@ namespace Microsoft.CodeAnalysis
                     var projectState = GetProjectState(documentId.ProjectId);
                     if (projectState != null)
                     {
-                        var document = projectState.DocumentStates.GetValue(documentId);
+                        var document = projectState.DocumentStates.GetState(documentId);
                         if (document != null)
                         {
                             // does this document really have the syntax tree?
@@ -539,9 +539,9 @@ namespace Microsoft.CodeAnalysis
         }
 
         private static IEnumerable<TextDocumentState> GetDocumentStates(ProjectState projectState)
-            => projectState.DocumentStates.Values
-                   .Concat(projectState.AdditionalDocumentStates.Values)
-                   .Concat(projectState.AnalyzerConfigDocumentStates.Values);
+            => projectState.DocumentStates.States
+                   .Concat(projectState.AdditionalDocumentStates.States)
+                   .Concat(projectState.AnalyzerConfigDocumentStates.States);
 
         /// <summary>
         /// Create a new solution instance without the project specified.
@@ -1109,7 +1109,7 @@ namespace Microsoft.CodeAnalysis
         public SolutionState RemoveAnalyzerConfigDocuments(ImmutableArray<DocumentId> documentIds)
         {
             return RemoveDocumentsFromMultipleProjects(documentIds,
-                (projectState, documentId) => projectState.AnalyzerConfigDocumentStates.GetRequiredValue(documentId),
+                (projectState, documentId) => projectState.AnalyzerConfigDocumentStates.GetRequiredState(documentId),
                 (oldProject, documentIds, _) =>
                 {
                     var newProject = oldProject.RemoveAnalyzerConfigDocuments(documentIds);
@@ -1123,7 +1123,7 @@ namespace Microsoft.CodeAnalysis
         public SolutionState RemoveDocuments(ImmutableArray<DocumentId> documentIds)
         {
             return RemoveDocumentsFromMultipleProjects(documentIds,
-                (projectState, documentId) => projectState.DocumentStates.GetRequiredValue(documentId),
+                (projectState, documentId) => projectState.DocumentStates.GetRequiredState(documentId),
                 (projectState, documentIds, documentStates) => (projectState.RemoveDocuments(documentIds), new CompilationAndGeneratorDriverTranslationAction.RemoveDocumentsAction(documentStates)));
         }
 
@@ -1178,7 +1178,7 @@ namespace Microsoft.CodeAnalysis
         public SolutionState RemoveAdditionalDocuments(ImmutableArray<DocumentId> documentIds)
         {
             return RemoveDocumentsFromMultipleProjects(documentIds,
-                (projectState, documentId) => projectState.AdditionalDocumentStates.GetRequiredValue(documentId),
+                (projectState, documentId) => projectState.AdditionalDocumentStates.GetRequiredState(documentId),
                 (projectState, documentIds, documentStates) => (projectState.RemoveAdditionalDocuments(documentIds), new CompilationAndGeneratorDriverTranslationAction.RemoveAdditionalDocumentsAction(documentStates)));
         }
 
@@ -1401,7 +1401,7 @@ namespace Microsoft.CodeAnalysis
             // This method shouldn't have been called if the document has not changed.
             Debug.Assert(oldProject != newProject);
 
-            var oldDocument = oldProject.DocumentStates.GetRequiredValue(newDocument.Id);
+            var oldDocument = oldProject.DocumentStates.GetRequiredState(newDocument.Id);
             var newFilePathToDocumentIdsMap = CreateFilePathToDocumentIdsMapWithFilePath(newDocument.Id, oldDocument.FilePath, newDocument.FilePath);
 
             return ForkProject(
@@ -1418,7 +1418,7 @@ namespace Microsoft.CodeAnalysis
             // This method shouldn't have been called if the document has not changed.
             Debug.Assert(oldProject != newProject);
 
-            var oldDocument = oldProject.AdditionalDocumentStates.GetRequiredValue(newDocument.Id);
+            var oldDocument = oldProject.AdditionalDocumentStates.GetRequiredState(newDocument.Id);
 
             return ForkProject(
                 newProject,
@@ -1691,7 +1691,7 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
-                var doc = GetProjectState(documentId.ProjectId)?.DocumentStates.GetValue(documentId);
+                var doc = GetProjectState(documentId.ProjectId)?.DocumentStates.GetState(documentId);
                 if (doc != null)
                 {
                     if (!doc.TryGetText(out var existingText) || existingText != text)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -220,11 +221,9 @@ namespace Microsoft.CodeAnalysis.Serialization
             Dictionary<Checksum, object> result,
             CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            Debug.Assert(state.TryGetStateChecksums(out var stateChecksum) && this == stateChecksum);
 
-            // verify input
-            Contract.ThrowIfFalse(state.TryGetStateChecksums(out var stateChecksum));
-            Contract.ThrowIfFalse(this == stateChecksum);
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (searchingChecksumsLeft.Remove(Checksum))
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Holds on a <see cref="DocumentId"/> to <see cref="TextDocumentState"/> map and an ordering.
+    /// </summary>
+    internal readonly struct TextDocumentStates<TState>
+        where TState : TextDocumentState
+    {
+        public static readonly TextDocumentStates<TState> Empty = new(ImmutableArray<DocumentId>.Empty, ImmutableDictionary<DocumentId, TState>.Empty);
+
+        /// <summary>
+        /// Ordered <see cref="DocumentId"/>s. This is always an <see cref="ImmutableArray{T}"/>,
+        /// but we hold on its boxed instance to avoid re-boxing when returning this value from public APIs.
+        /// </summary>
+        public readonly IReadOnlyList<DocumentId> Ids;
+
+        public readonly ImmutableDictionary<DocumentId, TState> Map;
+
+        private TextDocumentStates(IReadOnlyList<DocumentId> ids, ImmutableDictionary<DocumentId, TState> map)
+        {
+            Debug.Assert(ids.All(id => map.ContainsKey(id)) && ids.Count == map.Count);
+
+            Ids = ids;
+            Map = map;
+        }
+
+        public TextDocumentStates(ImmutableArray<DocumentId> ids, ImmutableDictionary<DocumentId, TState> map)
+            : this((IReadOnlyList<DocumentId>)ids, map)
+        {
+        }
+
+        public TextDocumentStates(IReadOnlyList<TState> states)
+            : this(states.SelectAsArray(state => state.Id),
+                   states.ToImmutableDictionary(state => state.Id))
+        {
+        }
+
+        public TextDocumentStates(IEnumerable<DocumentInfo> infos, Func<DocumentInfo, TState> stateConstructor)
+            : this(infos.Select(info => info.Id).ToImmutableArray(),
+                    infos.ToImmutableDictionary(info => info.Id, stateConstructor))
+        {
+        }
+
+        public int Count
+            => Ids.Count;
+
+        public bool IsEmpty
+            => Count == 0;
+
+        public bool Contains(DocumentId id)
+            => Map.ContainsKey(id);
+
+        public TState? GetValue(DocumentId documentId)
+            => Map.TryGetValue(documentId, out var state) ? state : null;
+
+        public TState GetRequiredValue(DocumentId documentId)
+            => Map.TryGetValue(documentId, out var state) ? state : throw ExceptionUtilities.Unreachable;
+
+        public IEnumerable<TState> Values
+        {
+            get
+            {
+                foreach (var id in Ids)
+                {
+                    yield return Map[id];
+                }
+            }
+        }
+
+        private ImmutableArray<DocumentId> IdArray
+            => (ImmutableArray<DocumentId>)Ids;
+
+        public ImmutableArray<TValue> SelectAsArray<TValue>(Func<TState, TValue> selector)
+            => IdArray.SelectAsArray(static (id, args) => args.selector(args.Map[id]), (Map, selector));
+
+        public ImmutableArray<TValue> SelectAsArray<TValue, TArg>(Func<TState, TArg, TValue> selector, TArg arg)
+            => IdArray.SelectAsArray(static (id, args) => args.selector(args.Map[id], args.arg), (Map, selector, arg));
+
+        public TextDocumentStates<TState> AddRange(ImmutableArray<TState> states)
+            => new(IdArray.AddRange(states.Select(state => state.Id)),
+                    Map.AddRange(states.Select(state => KeyValuePairUtil.Create(state.Id, state))));
+
+        public TextDocumentStates<TState> RemoveRange(ImmutableArray<DocumentId> ids)
+            => new(IdArray.RemoveRange(ids), Map.RemoveRange(ids));
+
+        internal TextDocumentStates<TState> SetValue(DocumentId id, TState state)
+            => new(Ids, Map.SetItem(id, state));
+
+        public TextDocumentStates<TState> UpdateValues<TArg>(Func<TState, TArg, TState> transformation, TArg arg)
+        {
+            var newMap = Map;
+            foreach (var (id, state) in Map)
+            {
+                newMap = newMap.SetItem(id, transformation(state, arg));
+            }
+
+            return new(Ids, newMap);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="DocumentId"/>s of documents whose state changed when compared to older states.
+        /// </summary>
+        public IEnumerable<DocumentId> GetChangedStateIds(TextDocumentStates<TState> oldStates)
+        {
+            foreach (var id in Ids)
+            {
+                if (oldStates.Map.TryGetValue(id, out var oldState) && oldState != Map[id])
+                {
+                    yield return id;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="DocumentId"/>s of added documents.
+        /// </summary>
+        public IEnumerable<DocumentId> GetAddedStateIds(TextDocumentStates<TState> oldStates)
+        {
+            foreach (var id in Ids)
+            {
+                if (!oldStates.Map.ContainsKey(id))
+                {
+                    yield return id;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="DocumentId"/>s of removed documents.
+        /// </summary>
+        public IEnumerable<DocumentId> GetRemovedStateIds(TextDocumentStates<TState> oldStates)
+        {
+            foreach (var id in oldStates.Ids)
+            {
+                if (!Map.ContainsKey(id))
+                {
+                    yield return id;
+                }
+            }
+        }
+
+        public bool HasAnyStateChanges(TextDocumentStates<TState> oldStates)
+            => !Values.SequenceEqual(oldStates.Values);
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis
 
         public TextDocumentStates(IEnumerable<DocumentInfo> infos, Func<DocumentInfo, TState> stateConstructor)
             : this(infos.Select(info => info.Id).ToImmutableArray(),
-                    infos.ToImmutableDictionary(info => info.Id, stateConstructor))
+                   infos.ToImmutableDictionary(info => info.Id, stateConstructor))
         {
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1349,7 +1349,9 @@ namespace Microsoft.CodeAnalysis
             // Checking for unchangeable documents will only be done if we were asked not to ignore them.
             foreach (var documentId in changedDocumentIds)
             {
-                var document = projectChanges.OldProject.GetDocumentState(documentId) ?? projectChanges.NewProject.GetDocumentState(documentId)!;
+                var document = projectChanges.OldProject.State.DocumentStates.GetValue(documentId) ?? 
+                               projectChanges.NewProject.State.DocumentStates.GetValue(documentId)!;
+
                 if (!document.CanApplyChange())
                 {
                     throw new NotSupportedException(string.Format(WorkspacesResources.Changing_document_0_is_not_supported, document.FilePath ?? document.Name));

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1349,8 +1349,8 @@ namespace Microsoft.CodeAnalysis
             // Checking for unchangeable documents will only be done if we were asked not to ignore them.
             foreach (var documentId in changedDocumentIds)
             {
-                var document = projectChanges.OldProject.State.DocumentStates.GetValue(documentId) ?? 
-                               projectChanges.NewProject.State.DocumentStates.GetValue(documentId)!;
+                var document = projectChanges.OldProject.State.DocumentStates.GetState(documentId) ??
+                               projectChanges.NewProject.State.DocumentStates.GetState(documentId)!;
 
                 if (!document.CanApplyChange())
                 {

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var solution = workspace.CurrentSolution;
-            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Single().Key;
+            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Ids.Single();
             var text = SourceText.From("new text");
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentText(documentId, text, PreservationMode.PreserveIdentity);
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var solution = workspace.CurrentSolution;
-            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Single().Key;
+            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Ids.Single();
             var textAndVersion = TextAndVersion.Create(SourceText.From("new text"), VersionStamp.Default);
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
@@ -499,7 +499,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var solution = workspace.CurrentSolution;
-            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Single().Key;
+            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Ids.Single();
             var loader = new TestTextLoader("new text");
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var solution = workspace.CurrentSolution;
-            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Ids.Single();
+            var documentId = solution.Projects.Single().AnalyzerConfigDocumentIds.Single();
             var text = SourceText.From("new text");
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentText(documentId, text, PreservationMode.PreserveIdentity);
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var solution = workspace.CurrentSolution;
-            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Ids.Single();
+            var documentId = solution.Projects.Single().AnalyzerConfigDocumentIds.Single();
             var textAndVersion = TextAndVersion.Create(SourceText.From("new text"), VersionStamp.Default);
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentText(documentId, textAndVersion, PreservationMode.PreserveIdentity);
@@ -499,7 +499,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var solution = workspace.CurrentSolution;
-            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Ids.Single();
+            var documentId = solution.Projects.Single().AnalyzerConfigDocumentIds.Single();
             var loader = new TestTextLoader("new text");
 
             var newSolution1 = solution.WithAnalyzerConfigDocumentTextLoader(documentId, loader, PreservationMode.PreserveIdentity);

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     project = await UpdateDocumentsAsync(
                         project,
-                        project.State.DocumentStates.Values,
+                        project.State.DocumentStates.States,
                         oldProjectChecksums.Documents,
                         newProjectChecksums.Documents,
                         (solution, documents) => solution.AddDocuments(documents),
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     project = await UpdateDocumentsAsync(
                         project,
-                        project.State.AdditionalDocumentStates.Values,
+                        project.State.AdditionalDocumentStates.States,
                         oldProjectChecksums.AdditionalDocuments,
                         newProjectChecksums.AdditionalDocuments,
                         (solution, documents) => solution.AddAdditionalDocuments(documents),
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     project = await UpdateDocumentsAsync(
                         project,
-                        project.State.AnalyzerConfigDocumentStates.Values,
+                        project.State.AnalyzerConfigDocumentStates.States,
                         oldProjectChecksums.AnalyzerConfigDocuments,
                         newProjectChecksums.AnalyzerConfigDocuments,
                         (solution, documents) => solution.AddAnalyzerConfigDocuments(documents),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableHashMapExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableHashMapExtensions.cs
@@ -18,13 +18,14 @@ namespace Roslyn.Utilities
         /// <typeparam name="TArg">The type of argument supplied to the value factory.</typeparam>
         /// <param name="location">The variable or field to atomically update if the specified <paramref name="key" /> is not in the dictionary.</param>
         /// <param name="key">The key for the value to retrieve or add.</param>
-        /// <param name="valueFactory">The function to execute to obtain the value to insert into the dictionary if the key is not found.</param>
+        /// <param name="valueProvider">The function to execute to obtain the value to insert into the dictionary if the key is not found. Returns null if the value can't be obtained.</param>
         /// <param name="factoryArgument">The argument to pass to the value factory.</param>
-        /// <returns>The value obtained from the dictionary or <paramref name="valueFactory" /> if it was not present.</returns>
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableHashMap<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        /// <returns>The value obtained from the dictionary or <paramref name="valueProvider" /> if it was not present.</returns>
+        public static TValue? GetOrAdd<TKey, TValue, TArg>(ref ImmutableHashMap<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue?> valueProvider, TArg factoryArgument)
             where TKey : notnull
+            where TValue : class
         {
-            Contract.ThrowIfNull(valueFactory);
+            Contract.ThrowIfNull(valueProvider);
 
             var map = Volatile.Read(ref location);
             Contract.ThrowIfNull(map);
@@ -33,7 +34,11 @@ namespace Roslyn.Utilities
                 return existingValue;
             }
 
-            var newValue = valueFactory(key, factoryArgument);
+            var newValue = valueProvider(key, factoryArgument);
+            if (newValue is null)
+            {
+                return null;
+            }
 
             do
             {


### PR DESCRIPTION
- Refactors storage of document ids and states in `ProjectState` to a dedicated data structure: `TextDocumentStates<TState>`.
- Remove sorting of the states by document id that was added to make serialization deterministic. Instead, use the order the documents were added to the project.
- Use  `TextDocumentStates<TState>` for source generated documents as well.
- Improve performance of `Project.Documents` and `Project.DocumentIds`: up to 3.3x and 3.2x faster, respectively. Fixes https://github.com/dotnet/roslyn/issues/48682.

Before

|              Method | DocumentCount |            Mean |         Error |        StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |-------------- |----------------:|--------------:|--------------:|-------:|------:|------:|----------:|
| Project.DocumentIds |             0 |        24.42 ns |      0.194 ns |      0.181 ns |      - |     - |     - |         - |
|   Project.Documents |             0 |        78.83 ns |      0.503 ns |      0.446 ns | 0.0772 |     - |     - |     128 B |
| Project.DocumentIds |           100 |     8,172.07 ns |      8.030 ns |      7.118 ns | 0.0305 |     - |     - |      72 B |
|   Project.Documents |           100 |    24,651.12 ns |     98.105 ns |     91.767 ns | 0.0916 |     - |     - |     201 B |
| Project.DocumentIds |         10000 |   859,548.56 ns |    399.791 ns |    373.965 ns |      - |     - |     - |      80 B |
|   Project.Documents |         10000 | 4,203,826.43 ns | 19,733.173 ns | 18,458.422 ns |      - |     - |     - |     256 B |


After

|              Method | DocumentCount |            Mean |         Error |        StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |-------------- |----------------:|--------------:|--------------:|-------:|------:|------:|----------:|
| Project.DocumentIds |             0 |        84.48 ns |      0.302 ns |      0.283 ns | 0.0434 |     - |     - |      72 B |
|   Project.Documents |             0 |       151.68 ns |      1.314 ns |      1.230 ns | 0.1206 |     - |     - |     201 B |
| Project.DocumentIds |           100 |     2,755.75 ns |      1.143 ns |      1.013 ns | 0.0420 |     - |     - |      72 B |
|   Project.Documents |           100 |    11,579.30 ns |     56.896 ns |     53.221 ns | 0.1068 |     - |     - |     201 B |
| Project.DocumentIds |         10000 |   265,656.30 ns |    143.748 ns |    134.462 ns |      - |     - |     - |      76 B |
|   Project.Documents |         10000 | 1,274,979.73 ns | 12,721.797 ns | 11,899.977 ns |      - |     - |     - |     208 B |


The cost of updating a document however is now very high and might need mitigation (*).

Before

|                    Method | DocumentCount |            Mean |         Error |        StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------- |-------------- |----------------:|--------------:|--------------:|-------:|-------:|------:|----------:|
| Solution.WithDocumentText |           100 |    12,661.10 ns |    252.509 ns |    319.343 ns | 0.8240 | 0.2594 |     - |    5172 B |
| Solution.WithDocumentText |         10000 |    13,574.50 ns |    270.030 ns |    500.518 ns | 0.8545 | 0.2289 |     - |    5425 B |


After (with SetItem re-hashing)

|                    Method | DocumentCount |            Mean |         Error |        StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------- |-------------- |----------------:|--------------:|--------------:|-------:|-------:|------:|----------:|
| Solution.WithDocumentText |           100 |    31,357.70 ns |    620.325 ns |    849.107 ns |  1.8921 |  0.4883 |     - |   11879 B |
| Solution.WithDocumentText |         10000 | 1,318,279.70 ns | 10,640.558 ns |  9,953.185 ns | 78.1250 | 23.4375 |     - |  298152 B |


After (with SetItem copying)
|                    Method | DocumentCount |            Mean |         Error |        StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------- |-------------- |----------------:|--------------:|--------------:|--------:|--------:|------:|----------:|
| Solution.WithDocumentText |           100 |    17,312.28 ns |    344.128 ns |    900.524 ns |  1.4343 |  0.3662 |     - |    9121 B |
| Solution.WithDocumentText |         10000 |    86,724.05 ns |  1,303.059 ns |  1,155.128 ns | 78.6133 | 24.0479 |     - |  297676 B |


Measured on
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen Threadripper 3960X, 1 CPU, 48 logical and 24 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
```

**Implementation**

Uses `ImmutableSegmentedDictionary` as a backing storage for a map of document id to the corresponding document state. 

This data structure allows us to implement very fast lookup and ordered enumeration. The cost is shifted to mutation operations (an addition, removal and update of documents). In practice, this cost of additional/removal shouldn't be high since additions and removals of documents is batched. 

(*) Additional potential memory optimizations of updating operations: 
- the segments that do not change when an item is added/removed/removed can be reused. 
- store values in a separate array, so that the overhead of copying the array on update is smaller
- implement heuristic for re-hashing vs copying in Add, Remove and SetItem operations (e.g. only rehash when the fill of the table is above some percentage threshold)

Relies on `ImmutableSegmentedDictionary` storing entries in the order they were added until an item is removed. Documents this behavior as a guaranteed property of the data structure. The ordering can be restored after removal of an item if `Compact` is called. 

Adds `ImmutableSegmentedDictionary.GetAddedEntry(int index)` method that allows to index into the underlying entries array. This method throws if an item has been removed from the dictionary (without `Compact` called). This API allows us to implement `Project.GetXxxDocumentIds` methods via a direct index into the underlying entries array of the `ImmutableSegmentedDictionary` and completely avoid building and maintaining a separate list of DocumentIds.
