### PR TITLE
Use enum member instead of casting number

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2015,8 +2015,7 @@ namespace Microsoft.CodeAnalysis
 
             if (enableHighEntropyVA)
             {
-                // IMAGE_DLLCHARACTERISTICS_HIGH_ENTROPY_VA
-                result |= (DllCharacteristics)0x0020;
+                result |= DllCharacteristics.HighEntropyVirtualAddressSpace;
             }
 
             if (configureToExecuteInAppContainer)


### PR DESCRIPTION
Replacing a number literal with usage of the equivalent enum member.

For context:

https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#dll-characteristics
https://docs.microsoft.com/en-us/dotnet/api/system.reflection.portableexecutable.dllcharacteristics?view=net-5.0
