### PR TITLE
Ensure that query expressions fully bind expressions

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
@@ -120,3 +120,20 @@ public class Derived : Base<string?>
     public override string? M() { ... } // Derived.M doesn't honor the nullability declaration made by Base.M with its [NotNull] attribute
 }
 ```
+
+20. In *Visual Studio 2019 version 16.9* and greater, the compiler will no longer allow query syntax over constrained type parameters. For example:
+
+```csharp
+using System;
+using System.Collections.Generic;
+ 
+class C
+{
+    static void M<T>() where T : C
+    {
+        var q = from x in T select x; // error CS0119: 'T' is a type parameter, which is not valid in the given context
+    }
+
+    static Func<Func<int, object>, IEnumerable<object>> Select = null;
+}
+```

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -82,11 +82,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             RefAssignable = 8 << ValueKindInsignificantBits,
 
-            /// <summary>
-            /// Expression can be a type
-            /// </summary>
-            Type = 16 << ValueKindInsignificantBits,
-
             ///////////////////
             // The rest are just combinations of the above.
             //
@@ -97,13 +92,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// Basically an RValue, but could be treated differently for the purpose of error reporting
             /// </summary>
             RValueOrMethodGroup = RValue + 1,
-
-            /// <summary>
-            /// Expression is the from expression of a query operation
-            /// and may be an RValue or a type (that could implement the
-            /// query pattern).
-            /// </summary>
-            RValueOrType = RValue | Type,
 
             /// <summary>
             /// Expression can be an LHS of a compound assignment
@@ -414,17 +402,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (RequiresRValueOnly(valueKind))
             {
                 return CheckNotNamespaceOrType(expr, diagnostics);
-            }
-
-            if ((valueKind & ValueKindSignificantBitsMask) == BindValueKind.RValueOrType)
-            {
-                if (expr is BoundNamespaceExpression namespaceExpr)
-                {
-                    Error(diagnostics, ErrorCode.ERR_BadSKunknown, expr.Syntax, namespaceExpr.NamespaceSymbol, MessageID.IDS_SK_NAMESPACE.Localize());
-                    return false;
-                }
-
-                return true;
             }
 
             // constants/literals are strictly RValues

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -82,6 +82,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             RefAssignable = 8 << ValueKindInsignificantBits,
 
+            /// <summary>
+            /// Expression can be a type
+            /// </summary>
+            Type = 16 << ValueKindInsignificantBits,
+
             ///////////////////
             // The rest are just combinations of the above.
             //
@@ -92,6 +97,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// Basically an RValue, but could be treated differently for the purpose of error reporting
             /// </summary>
             RValueOrMethodGroup = RValue + 1,
+
+            /// <summary>
+            /// Expression is the from expression of a query operation
+            /// and may be an RValue or a type (that could implement the
+            /// query pattern).
+            /// </summary>
+            RValueOrType = RValue | Type,
 
             /// <summary>
             /// Expression can be an LHS of a compound assignment
@@ -402,6 +414,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (RequiresRValueOnly(valueKind))
             {
                 return CheckNotNamespaceOrType(expr, diagnostics);
+            }
+
+            if ((valueKind & ValueKindSignificantBitsMask) == BindValueKind.RValueOrType)
+            {
+                if (expr is BoundNamespaceExpression namespaceExpr)
+                {
+                    Error(diagnostics, ErrorCode.ERR_BadSKunknown, expr.Syntax, namespaceExpr.NamespaceSymbol, MessageID.IDS_SK_NAMESPACE.Localize());
+                    return false;
+                }
+
+                return true;
             }
 
             // constants/literals are strictly RValues

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5968,6 +5968,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bind the RHS of a member access expression, given the bound LHS.
         /// It is assumed that CheckValue has not been called on the LHS.
         /// </summary>
+        /// <remarks>
+        /// If new checks are added to this method, they will also need to be added to <see cref="MakeQueryInvocation(CSharpSyntaxNode, BoundExpression, string, TypeSyntax, TypeWithAnnotations, DiagnosticBag)"/>.
+        /// </remarks>
         private BoundExpression BindMemberAccessWithBoundLeft(
             ExpressionSyntax node,
             BoundExpression boundLeft,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             QueryTranslationState state = new QueryTranslationState();
-            state.fromExpression = MakeMemberAccessValue(boundFromExpression, diagnostics);
+            state.fromExpression = CheckValue(MakeMemberAccessValue(boundFromExpression, diagnostics), BindValueKind.RValueOrType, diagnostics);
 
             var x = state.rangeVariable = state.AddRangeVariable(this, fromClause.Identifier, diagnostics);
             for (int i = node.Body.Clauses.Count - 1; i >= 0; i--)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -725,7 +725,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // clean up the receiver
             var ultimateReceiver = receiver;
-            while (ultimateReceiver.Kind == BoundKind.QueryClause) ultimateReceiver = ((BoundQueryClause)ultimateReceiver).Value;
+            while (ultimateReceiver.Kind == BoundKind.QueryClause)
+            {
+                ultimateReceiver = ((BoundQueryClause)ultimateReceiver).Value;
+            }
             Debug.Assert(receiver.Type is object || ultimateReceiver.Type is null);
             if ((object?)ultimateReceiver.Type == null)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -785,6 +785,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Error(diagnostics, ErrorCode.ERR_BadSKunknown, ultimateReceiver.Syntax, ultimateReceiver.Type, MessageID.IDS_SK_TYVAR.Localize());
                 }
             }
+            else if (ultimateReceiver.Kind == BoundKind.TypeOrValueExpression)
+            {
+                // CheckValue will be called by MakeInvocationExpression when it makes the member access, which will resolve
+                // the type or value to the appropriate kind at that point.
+            }
             else if (receiver.Type!.IsVoidType())
             {
                 if (!receiver.HasAnyErrors && !node.HasErrors)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             QueryTranslationState state = new QueryTranslationState();
-            state.fromExpression = CheckValue(MakeMemberAccessValue(boundFromExpression, diagnostics), BindValueKind.RValueOrType, diagnostics);
+            state.fromExpression = MakeMemberAccessValue(boundFromExpression, diagnostics);
 
             var x = state.rangeVariable = state.AddRangeVariable(this, fromClause.Identifier, diagnostics);
             for (int i = node.Body.Clauses.Count - 1; i >= 0; i--)
@@ -747,7 +747,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (ultimateReceiver.Kind == BoundKind.NamespaceExpression)
                 {
-                    diagnostics.Add(ErrorCode.ERR_BadSKunknown, ultimateReceiver.Syntax.Location, ultimateReceiver.Syntax, MessageID.IDS_SK_NAMESPACE.Localize());
+                    diagnostics.Add(ErrorCode.ERR_BadSKunknown, ultimateReceiver.Syntax.Location, ((BoundNamespaceExpression)ultimateReceiver).NamespaceSymbol, MessageID.IDS_SK_NAMESPACE.Localize());
                 }
                 else if (ultimateReceiver.Kind == BoundKind.Lambda || ultimateReceiver.Kind == BoundKind.UnboundLambda)
                 {
@@ -775,6 +775,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 receiver = new BoundBadExpression(receiver.Syntax, LookupResultKind.NotAValue, ImmutableArray<Symbol?>.Empty, ImmutableArray.Create(receiver), CreateErrorType());
             }
+            else if (ultimateReceiver.Kind == BoundKind.TypeExpression)
+            {
+                if (ultimateReceiver.Type.TypeKind == TypeKind.TypeParameter)
+                {
+                    Error(diagnostics, ErrorCode.ERR_BadSKunknown, ultimateReceiver.Syntax, ultimateReceiver.Type, MessageID.IDS_SK_TYVAR.Localize());
+                }
+            }
             else if (receiver.Type!.IsVoidType())
             {
                 if (!receiver.HasAnyErrors && !node.HasErrors)
@@ -783,6 +790,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 receiver = new BoundBadExpression(receiver.Syntax, LookupResultKind.NotAValue, ImmutableArray<Symbol?>.Empty, ImmutableArray.Create(receiver), CreateErrorType());
+            }
+            else
+            {
+                var checkedUltimateReceiver = CheckValue(ultimateReceiver, BindValueKind.RValue, diagnostics);
+                if (checkedUltimateReceiver != ultimateReceiver)
+                {
+                    receiver = updateUltimateReceiver(receiver, ultimateReceiver, checkedUltimateReceiver);
+                }
             }
 
             return (BoundCall)MakeInvocationExpression(
@@ -797,6 +812,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Queries are syntactical rewrites, so we allow fields and properties of delegate types to be invoked,
                 // although no well-known non-generic query method is used atm.
                 allowFieldsAndProperties: true);
+
+            static BoundExpression updateUltimateReceiver(BoundExpression receiver, BoundExpression originalUltimateReceiver, BoundExpression replacementUltimateReceiver)
+            {
+                if (receiver is BoundQueryClause query)
+                {
+                    return query.Update(
+                        updateUltimateReceiver(query.Value, originalUltimateReceiver, replacementUltimateReceiver),
+                        query.DefinedSymbol,
+                        query.Operation,
+                        query.Cast,
+                        query.Binder,
+                        query.UnoptimizedForm,
+                        query.Type);
+                }
+
+                Debug.Assert(receiver == originalUltimateReceiver);
+                return replacementUltimateReceiver;
+            }
         }
 
         protected BoundExpression MakeConstruction(CSharpSyntaxNode node, NamedTypeSymbol toCreate, ImmutableArray<BoundExpression> args, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -4503,24 +4503,24 @@ public class C {
         [Fact, WorkItem(50316, "https://github.com/dotnet/roslyn/issues/50316")]
         public void DefaultIndexedPropertyParameters_IndexerCall()
         {
-            var comp = CreateCompilation(@"
+            CompileAndVerify(@"
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 var c = new C();
 var test = from i in c[1]
-           select i;
+           select i + 1;
+Console.WriteLine(string.Join(string.Empty, test));
 
 public class C {
-    public IEnumerable<int> this[int i1, object o = null]
+    public IEnumerable<int> this[int i1, int i2 = 1]
     {
-        get => null;
+        get => new[] { i2 };
         set {}
     }
 }
-", options: TestOptions.ReleaseExe);
-
-            comp.VerifyEmitDiagnostics();
+", expectedOutput: "2");
         }
 
         [Fact, WorkItem(50316, "https://github.com/dotnet/roslyn/issues/50316")]
@@ -4533,15 +4533,15 @@ Imports System.Runtime.InteropServices
 <ComImport>
 <Guid(""1F9C3731-6AA1-498A-AFA0-359828FCF0CE"")>
 Public Interface I
-    Property X(Optional i as Integer = 0) As IEnumerable(Of Integer)
+    Property X(Optional i as Integer = 1) As IEnumerable(Of Integer)
 End Interface
 
 Public Class A
     Implements I
 
-    Public Property X(Optional i as Integer = 0) As IEnumerable(Of Integer) Implements I.X
+    Public Property X(Optional i as Integer = 1) As IEnumerable(Of Integer) Implements I.X
         Get
-            Return Nothing
+            Return New Integer() { i }
         End Get
         Set
         End Set
@@ -4551,15 +4551,15 @@ End Class
 
             vb.VerifyDiagnostics();
 
-            var comp = CreateCompilation(@"
+            CompileAndVerify(@"
+using System;
 using System.Linq;
 
 I i = new A();
 var test = from @int in i.X
-           select @int;
-", references: new[] { vb.EmitToImageReference() }, options: TestOptions.ReleaseExe);
-
-            comp.VerifyEmitDiagnostics();
+           select @int + 1;
+Console.WriteLine(string.Join(string.Empty, test));
+", references: new[] { vb.EmitToImageReference() }, expectedOutput: "2");
         }
     }
 }


### PR DESCRIPTION
We weren't calling CheckValue on the result of binding `from ... in x` (specifically on the `x` component). This means we were missing a couple of things that CheckValue does:
* Realize property accesses as getters, and ensure that a getter actually exists.
* Ensure default arguments are bound for these property accesses.

Fixes https://github.com/dotnet/roslyn/issues/50316.
