### PR TITLE
Rename SyntaxPartKind.RecordName to RecordClassName

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -565,7 +565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (symbol.TypeKind)
             {
                 case TypeKind.Class when symbol.IsRecord:
-                    return SymbolDisplayPartKind.RecordName;
+                    return SymbolDisplayPartKind.RecordClassName;
                 case TypeKind.Submission:
                 case TypeKind.Module:
                 case TypeKind.Class:

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case SymbolDisplayPartKind.AliasName:
                 case SymbolDisplayPartKind.ClassName:
-                case SymbolDisplayPartKind.RecordName:
+                case SymbolDisplayPartKind.RecordClassName:
                 case SymbolDisplayPartKind.StructName:
                 case SymbolDisplayPartKind.InterfaceName:
                 case SymbolDisplayPartKind.EnumName:

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 findSymbol,
                 format,
                 "A",
-                SymbolDisplayPartKind.RecordName);
+                SymbolDisplayPartKind.RecordClassName);
         }
 
         [Fact, WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")]
@@ -84,7 +84,7 @@ namespace N1 {
                 findSymbol,
                 format,
                 "R2",
-                SymbolDisplayPartKind.RecordName);
+                SymbolDisplayPartKind.RecordClassName);
         }
 
         [Fact]
@@ -7650,7 +7650,7 @@ record Person(string First, string Last);
                 "record Person",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.RecordName);
+                SymbolDisplayPartKind.RecordClassName);
         }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,7 +3,7 @@ Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
-Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
+Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordClassName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Compare(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> int
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Equals(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> bool

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayPartKind.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayPartKind.cs
@@ -79,12 +79,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>The name of a field or local constant.</summary>
         ConstantName = 30,
         /// <summary>The name of a record.</summary>
-        RecordName = 31,
+        RecordClassName = 31,
     }
 
     internal static class InternalSymbolDisplayPartKind
     {
-        private const SymbolDisplayPartKind @base = SymbolDisplayPartKind.RecordName + 1;
+        private const SymbolDisplayPartKind @base = SymbolDisplayPartKind.RecordClassName + 1;
         public const SymbolDisplayPartKind Arity = @base + 0;
         public const SymbolDisplayPartKind Other = @base + 1;
     }
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal static bool IsValid(this SymbolDisplayPartKind value)
         {
-            return (value >= SymbolDisplayPartKind.AliasName && value <= SymbolDisplayPartKind.RecordName) ||
+            return (value >= SymbolDisplayPartKind.AliasName && value <= SymbolDisplayPartKind.RecordClassName) ||
                 (value >= InternalSymbolDisplayPartKind.Arity && value <= InternalSymbolDisplayPartKind.Other);
         }
     }

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
                             switch (parts[index + 1].Kind)
                             {
                                 case SymbolDisplayPartKind.ClassName:
-                                case SymbolDisplayPartKind.RecordName:
+                                case SymbolDisplayPartKind.RecordClassName:
                                 case SymbolDisplayPartKind.DelegateName:
                                 case SymbolDisplayPartKind.EnumName:
                                 case SymbolDisplayPartKind.ErrorTypeName:
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
                         }
 
                         previousWasClass = part.Kind == SymbolDisplayPartKind.ClassName ||
-                                           part.Kind == SymbolDisplayPartKind.RecordName ||
+                                           part.Kind == SymbolDisplayPartKind.RecordClassName ||
                                            part.Kind == SymbolDisplayPartKind.InterfaceName ||
                                            part.Kind == SymbolDisplayPartKind.StructName;
                     }

--- a/src/Features/Core/Portable/Common/SymbolDisplayPartKindTags.cs
+++ b/src/Features/Core/Portable/Common/SymbolDisplayPartKindTags.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                 SymbolDisplayPartKind.EnumMemberName => TextTags.EnumMember,
                 SymbolDisplayPartKind.ExtensionMethodName => TextTags.ExtensionMethod,
                 SymbolDisplayPartKind.ConstantName => TextTags.Constant,
-                SymbolDisplayPartKind.RecordName => TextTags.Record,
+                SymbolDisplayPartKind.RecordClassName => TextTags.Record,
                 _ => string.Empty,
             };
     }

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 ClassificationTypeNames.Operator => SymbolDisplayPartKind.Operator,
                 ClassificationTypeNames.Punctuation => SymbolDisplayPartKind.Punctuation,
                 ClassificationTypeNames.ClassName => SymbolDisplayPartKind.ClassName,
-                ClassificationTypeNames.RecordName => SymbolDisplayPartKind.RecordName,
+                ClassificationTypeNames.RecordName => SymbolDisplayPartKind.RecordClassName,
                 ClassificationTypeNames.StructName => SymbolDisplayPartKind.StructName,
                 ClassificationTypeNames.InterfaceName => SymbolDisplayPartKind.InterfaceName,
                 ClassificationTypeNames.DelegateName => SymbolDisplayPartKind.DelegateName,


### PR DESCRIPTION
Addresses part of https://github.com/dotnet/roslyn/issues/50297, followup from API review. @dotnet/roslyn-compiler for review.