### PR TITLE
Pick better defaults when adding missing accessibility modifiers to members.

### DIFF
--- a/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
@@ -2,19 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
-using VerifyCS = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.CSharpCodeFixVerifier<
-    Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers.CSharpAddAccessibilityModifiersDiagnosticAnalyzer,
-    Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers.CSharpAddAccessibilityModifiersCodeFixProvider>;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifiers
 {
+    using VerifyCS = CSharpCodeFixVerifier<
+        CSharpAddAccessibilityModifiersDiagnosticAnalyzer,
+        CSharpAddAccessibilityModifiersCodeFixProvider>;
+
     public class AddAccessibilityModifiersTests
     {
         [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)]
@@ -452,6 +453,52 @@ internal class Program
 internal class Program
 {
     private volatile int x;
+}
+");
+        }
+
+        [WorkItem(48899, "https://github.com/dotnet/roslyn/issues/48899")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)]
+        public async Task TestAbstractMethod()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+public abstract class TestClass
+{
+    abstract string {|CS0621:[|Test|]|} { get; }
+}
+",
+@"
+public abstract class TestClass
+{
+    protected abstract string Test { get; }
+}
+");
+        }
+
+        [WorkItem(48899, "https://github.com/dotnet/roslyn/issues/48899")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)]
+        public async Task TestOverriddenMethod()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+public abstract class TestClass
+{
+    public abstract string Test { get; }
+}
+
+public class Derived : TestClass
+{
+    override string {|CS0507:{|CS0621:[|Test|]|}|} { get; }
+}
+",
+@"
+public abstract class TestClass
+{
+    public abstract string Test { get; }
+}
+
+public class Derived : TestClass
+{
+    public override string Test { get; }
 }
 ");
         }

--- a/src/Analyzers/Core/CodeFixes/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersCodeFixProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -49,7 +47,7 @@ namespace Microsoft.CodeAnalysis.AddAccessibilityModifiers
             Document document, ImmutableArray<Diagnostic> diagnostics,
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var diagnostic in diagnostics)
             {
@@ -57,18 +55,51 @@ namespace Microsoft.CodeAnalysis.AddAccessibilityModifiers
                 var declarator = MapToDeclarator(declaration);
 
                 var symbol = semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
+                Contract.ThrowIfNull(symbol);
+
+                var preferredAccessibility = GetPreferredAccessibility(symbol);
 
                 // Check to see if we need to add or remove
                 // If there's a modifier, then we need to remove it, otherwise no modifier, add it.
                 editor.ReplaceNode(
                     declaration,
-                    (currentDeclaration, generator) =>
-                    {
-                        return generator.GetAccessibility(currentDeclaration) == Accessibility.NotApplicable
-                                    ? generator.WithAccessibility(currentDeclaration, symbol.DeclaredAccessibility) // No accessibility was declared, we need to add it
-                                    : generator.WithAccessibility(currentDeclaration, Accessibility.NotApplicable); // There was an accessibility, so remove it                       
-                    });
+                    (currentDeclaration, _) => UpdateAccessibility(currentDeclaration, preferredAccessibility));
             }
+
+            return;
+
+            SyntaxNode UpdateAccessibility(SyntaxNode declaration, Accessibility preferredAccessibility)
+            {
+                var generator = editor.Generator;
+
+                // If there was accessibility on the member, then remove it.  If there was no accessibility, then add
+                // the preferred accessibility for this member.
+                return generator.GetAccessibility(declaration) == Accessibility.NotApplicable
+                    ? generator.WithAccessibility(declaration, preferredAccessibility)
+                    : generator.WithAccessibility(declaration, Accessibility.NotApplicable);
+            }
+        }
+
+        private static Accessibility GetPreferredAccessibility(ISymbol symbol)
+        {
+            // If we have an overridden member, then if we're adding an accessibility modifier, use the
+            // accessibility of the member we're overriding as both should be consistent here.
+            if (symbol.GetOverriddenMember() is { DeclaredAccessibility: var accessibility })
+                return accessibility;
+
+            // Default abstract members to be protected, and virtual members to be public.  They can't be private as
+            // that's not legal.  And these are reasonable default values for them.
+            if (symbol is IMethodSymbol or IPropertySymbol or IEventSymbol)
+            {
+                if (symbol.IsAbstract)
+                    return Accessibility.Protected;
+
+                if (symbol.IsVirtual)
+                    return Accessibility.Public;
+            }
+
+            // Otherwise, default to whatever accessibility no-accessibility means for this member;
+            return symbol.DeclaredAccessibility;
         }
 
         private class MyCodeAction : CustomCodeActions.DocumentChangeAction

--- a/src/Analyzers/VisualBasic/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.vb
@@ -435,5 +435,49 @@ End Module
 "
             Await VerifyVB.VerifyCodeFixAsync(source, source)
         End Function
+
+        <WorkItem(48899, "https://github.com/dotnet/roslyn/issues/48899")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)>
+        Public Async Function TestAbstractMethod() As Task
+            Await VerifyVB.VerifyCodeFixAsync("
+public mustinherit class TestClass
+    mustoverride sub [|Test|]()
+end class
+",
+"
+public mustinherit class TestClass
+    Protected mustoverride sub Test()
+end class
+")
+        End Function
+
+        <WorkItem(48899, "https://github.com/dotnet/roslyn/issues/48899")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddAccessibilityModifiers)>
+        Public Async Function TestOverriddenMethod() As Task
+            Await VerifyVB.VerifyCodeFixAsync("
+public mustinherit class TestClass
+    public mustoverride sub Test()
+end class
+
+public class Derived
+    inherits TestClass
+
+    overrides sub [|Test|]()
+    end sub
+end class
+",
+"
+public mustinherit class TestClass
+    public mustoverride sub Test()
+end class
+
+public class Derived
+    inherits TestClass
+
+    Public overrides sub Test()
+    end sub
+end class
+")
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/48899