### PR TITLE
Run Spanish tests in release mode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,11 +39,11 @@ jobs:
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:
-    testRunName: 'Test Windows Desktop Spanish Debug 32'
-    jobName: Test_Windows_Desktop_Spanish_Debug_32
-    buildJobName: Build_Windows_Debug
-    testArtifactName: Transport_Artifacts_Windows_Debug
-    configuration: Debug
+    testRunName: 'Test Windows Desktop Spanish Release 32'
+    jobName: Test_Windows_Desktop_Spanish_Release_32
+    buildJobName: Build_Windows_Release
+    testArtifactName: Transport_Artifacts_Windows_Release
+    configuration: Release
     testArguments: -testDesktop -test32
     queueName: 'BuildPool.Windows.10.Amd64.ES.VS2017.Open'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,16 +39,6 @@ jobs:
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:
-    testRunName: 'Test Windows Desktop Spanish Release 32'
-    jobName: Test_Windows_Desktop_Spanish_Release_32
-    buildJobName: Build_Windows_Release
-    testArtifactName: Transport_Artifacts_Windows_Release
-    configuration: Release
-    testArguments: -testDesktop -test32
-    queueName: 'BuildPool.Windows.10.Amd64.ES.VS2017.Open'
-
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
     testRunName: 'Test Windows Desktop Debug 64'
     jobName: Test_Windows_Desktop_Debug_64
     buildJobName: Build_Windows_Debug
@@ -73,6 +63,16 @@ jobs:
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
     testArguments: -testDesktop -test32
+
+- template: eng/pipelines/test-windows-job.yml
+  parameters:
+    testRunName: 'Test Windows Desktop Spanish Release 32'
+    jobName: Test_Windows_Desktop_Spanish_Release_32
+    buildJobName: Build_Windows_Release
+    testArtifactName: Transport_Artifacts_Windows_Release
+    configuration: Release
+    testArguments: -testDesktop -test32
+    queueName: 'BuildPool.Windows.10.Amd64.ES.VS2017.Open'
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:


### PR DESCRIPTION
Data from Azure DevOps indicates that .NET Framework Release tests take about 6-7 minutes less than .NET Framework Debug tests. Since Spanish is our longest-running job, let's shave those minutes off by running the tests in Release mode instead of Debug mode.