### PR TITLE
Add a couple of generator tests

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -135,6 +135,9 @@ class GeneratedClass { }
 
             Assert.Equal(2, outputCompilation.SyntaxTrees.Count());
             Assert.NotEqual(compilation, outputCompilation);
+
+            var generatedClass = outputCompilation.GlobalNamespace.GetTypeMembers("GeneratedClass").Single();
+            Assert.True(generatedClass.Locations.Single().IsInSource);
         }
 
         [Fact]


### PR DESCRIPTION
I've not yet found why the publicAPI analyzer doesn't work with source generators (tracked by issue https://github.com/dotnet/roslyn/issues/50357) but ruled out a few theories.