### PR TITLE
Use IEventListener to register workspaces for LSP instead of inside AbstractPackage

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLspWorkspaceRegistrationEventListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLspWorkspaceRegistrationEventListener.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
+{
+    [ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.Host, WorkspaceKind.MiscellaneousFiles, WorkspaceKind.MetadataAsSource), Shared]
+    internal class VisualStudioLspWorkspaceRegistrationEventListener : IEventListener<object>
+    {
+        private readonly ILspWorkspaceRegistrationService _lspWorkspaceRegistrationService;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public VisualStudioLspWorkspaceRegistrationEventListener(ILspWorkspaceRegistrationService lspWorkspaceRegistrationService)
+        {
+            _lspWorkspaceRegistrationService = lspWorkspaceRegistrationService;
+        }
+
+        public void StartListening(Workspace workspace, object _)
+        {
+            _lspWorkspaceRegistrationService.Register(workspace);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -86,10 +86,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             }
 
             LoadComponentsInUIContextOnceSolutionFullyLoadedAsync(cancellationToken).Forget();
-
-            var workspaceRegistrationSerivce = this.ComponentModel.GetService<ILspWorkspaceRegistrationService>();
-            workspaceRegistrationSerivce.Register(this.Workspace);
-            workspaceRegistrationSerivce.Register(miscellaneousFilesWorkspace);
         }
 
         protected override async Task LoadComponentsAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Per @jasonmalinowski  AbstractPackage initialization is only used for certain initialization paths (e.g. tools options, object browser, old project system com bits).  In general other roslyn initialization is done via MEF and does not go through the UI thread bound package initialization.

So instead of registering workspaces in the package load (which doesn't match 1:1 with workspace creation) we instead register the workspaces exactly when they are created via the IEventListener infrastructure.

Fixes https://github.com/dotnet/roslyn/issues/50386