### PR TITLE
[LSP] In brace completion only add a new line between the braces if none exist

### DIFF
--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             // If there is not already an empty line inserted between the braces, insert one.
             TextChange? newLineEdit = null;
             var textToFormat = originalDocumentText;
-            if (!HasExistingEmptyLineBetweenBraces(openingPoint, closingPoint, originalDocumentText))
+            if (ShouldAddEmptyLineBetweenBraces(openingPoint, closingPoint, originalDocumentText))
             {
                 var newLineString = documentOptions.GetOption(FormattingOptions2.NewLine);
                 newLineEdit = new TextChange(new TextSpan(closingPoint - 1, 0), newLineString);
@@ -132,14 +132,14 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             var overallChanges = newLineEdit != null ? GetMergedChanges(newLineEdit.Value, formattingChanges, formattedText) : formattingChanges;
             return new BraceCompletionResult(overallChanges, caretPosition);
 
-            static bool HasExistingEmptyLineBetweenBraces(int openingPoint, int closingPoint, SourceText sourceText)
+            static bool ShouldAddEmptyLineBetweenBraces(int openingPoint, int closingPoint, SourceText sourceText)
             {
-                // Check if there is an empty new line between the braces already.  If not insert one.
-                // This handles razor cases where they insert an additional empty line before calling brace completion.
                 var openingPointLine = sourceText.Lines.GetLineFromPosition(openingPoint).LineNumber;
                 var closingPointLine = sourceText.Lines.GetLineFromPosition(closingPoint).LineNumber;
 
-                return closingPointLine - 2 == openingPointLine && sourceText.Lines[closingPointLine - 1].IsEmptyOrWhitespace();
+                // Only insert an empty new line between the braces if the closing brace is
+                // on the line immediately below the opening point.
+                return closingPointLine - 1 == openingPointLine;
             }
 
             static TextLine GetLineBetweenCurlys(int closingPosition, SourceText text)

--- a/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
@@ -267,6 +267,35 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.OnAutoInsert
             await VerifyNoResult("\n", markup);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        [WorkItem(1260219, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1260219")]
+        public async Task OnAutoInsert_BraceFormattingDoesNotInsertExtraEmptyLines()
+        {
+            // The test starts with the closing brace already on a new line.
+            // In LSP, hitting enter will first trigger a didChange event for the new line character
+            // (bringing the server text to the form below) and then trigger OnAutoInsert
+            // for the new line character.
+            var markup =
+@"class A
+{
+    void M()
+    {
+        
+        {|type:|}
+    }
+}";
+            var expected =
+@"class A
+{
+    void M()
+    {
+
+        $0
+    }
+}";
+            await VerifyMarkupAndExpected("\n", markup, expected);
+        }
+
         private async Task VerifyMarkupAndExpected(string characterTyped, string markup, string expected, bool useTabs = false)
         {
             using var workspace = CreateTestWorkspace(markup, out var locations);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1260219?src=WorkItemMention&src-action=artifact_link

Best described with a gif
Old behavior:
![bf_multiple](https://user-images.githubusercontent.com/5749229/104271703-5f6c9300-5450-11eb-86f8-3b269a120c01.gif)

New behavior:
![bf_only_once](https://user-images.githubusercontent.com/5749229/104271709-6398b080-5450-11eb-9e4a-e90a9b1a0dfe.gif)
