### PR TITLE
Bring SignatureHelp support from EditorFeatures.Wpf to EditorFeatures.Cocoa

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseNullPropagation/UseNullPropagationTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseNullPropagation/UseNullPropagationTests.cs
@@ -1070,5 +1070,105 @@ class C
     }
 }");
         }
+
+        [WorkItem(49517, "https://github.com/dotnet/roslyn/issues/49517")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNullPropagation)]
+        public async Task TestParenthesizedExpression()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = [||](o == null) ? null : (o.ToString());
+    }
+}",
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = (o?.ToString());
+    }
+}");
+        }
+
+        [WorkItem(49517, "https://github.com/dotnet/roslyn/issues/49517")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNullPropagation)]
+        public async Task TestReversedParenthesizedExpression()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = [||](o != null) ? (o.ToString()) : null;
+    }
+}",
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = (o?.ToString());
+    }
+}");
+        }
+
+        [WorkItem(49517, "https://github.com/dotnet/roslyn/issues/49517")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNullPropagation)]
+        public async Task TestParenthesizedNull()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = [||]o == null ? (null) : o.ToString();
+    }
+}",
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = o?.ToString();
+    }
+}");
+        }
+
+        [WorkItem(49517, "https://github.com/dotnet/roslyn/issues/49517")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNullPropagation)]
+        public async Task TestReversedParenthesizedNull()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = [||]o != null ? o.ToString() : (null);
+    }
+}",
+@"using System;
+
+class C
+{
+    void M(object o)
+    {
+        var v = o?.ToString();
+    }
+}");
+        }
     }
 }

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
@@ -149,10 +149,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption> supportedDiagnosticsWithOptions)
             : this(supportedDiagnosticsWithOptions.Keys.ToImmutableArray())
         {
-            foreach (var kvp in supportedDiagnosticsWithOptions)
-            {
-                AddDiagnosticIdToOptionMapping(kvp.Key.Id, kvp.Value);
-            }
+            foreach (var (descriptor, option) in supportedDiagnosticsWithOptions)
+                AddDiagnosticIdToOptionMapping(descriptor.Id, option);
         }
 
         /// <summary>
@@ -163,10 +161,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             string language)
             : this(supportedDiagnosticsWithOptions.Keys.ToImmutableArray())
         {
-            foreach (var kvp in supportedDiagnosticsWithOptions)
-            {
-                AddDiagnosticIdToOptionMapping(kvp.Key.Id, kvp.Value, language);
-            }
+            foreach (var (descriptor, option) in supportedDiagnosticsWithOptions)
+                AddDiagnosticIdToOptionMapping(descriptor.Id, option, language);
         }
 
         /// <summary>
@@ -178,15 +174,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             string language)
             : this(supportedDiagnosticsWithLangaugeSpecificOptions.Keys.Concat(supportedDiagnosticsWithPerLanguageOptions.Keys).ToImmutableArray())
         {
-            foreach (var kvp in supportedDiagnosticsWithLangaugeSpecificOptions)
-            {
-                AddDiagnosticIdToOptionMapping(kvp.Key.Id, kvp.Value, language);
-            }
+            foreach (var (descriptor, option) in supportedDiagnosticsWithLangaugeSpecificOptions)
+                AddDiagnosticIdToOptionMapping(descriptor.Id, option, language);
 
-            foreach (var kvp in supportedDiagnosticsWithPerLanguageOptions)
-            {
-                AddDiagnosticIdToOptionMapping(kvp.Key.Id, kvp.Value);
-            }
+            foreach (var (descriptor, option) in supportedDiagnosticsWithPerLanguageOptions)
+                AddDiagnosticIdToOptionMapping(descriptor.Id, option);
         }
 
         private static void AddDiagnosticIdToOptionMapping(string diagnosticId, IPerLanguageOption? option)

--- a/src/Analyzers/Core/Analyzers/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
@@ -98,6 +98,8 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
                 conditionalExpression, out var conditionNode, out var whenTrueNode, out var whenFalseNode);
 
             conditionNode = syntaxFacts.WalkDownParentheses(conditionNode);
+            whenTrueNode = syntaxFacts.WalkDownParentheses(whenTrueNode);
+            whenFalseNode = syntaxFacts.WalkDownParentheses(whenFalseNode);
 
             var conditionIsNegated = false;
             if (syntaxFacts.IsLogicalNotExpression(conditionNode))
@@ -344,6 +346,8 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
 
         private static SyntaxNode? Unwrap(ISyntaxFacts syntaxFacts, SyntaxNode node)
         {
+            node = syntaxFacts.WalkDownParentheses(node);
+
             if (node is TInvocationExpression invocation)
             {
                 return syntaxFacts.GetExpressionOfInvocationExpression(invocation);

--- a/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
@@ -632,10 +632,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 editor.RemoveNode(node, removeOptions);
             }
 
-            foreach (var kvp in nodeReplacementMap)
-            {
-                editor.ReplaceNode(kvp.Key, kvp.Value.WithAdditionalAnnotations(Formatter.Annotation));
-            }
+            foreach (var (node, replacement) in nodeReplacementMap)
+                editor.ReplaceNode(node, replacement.WithAdditionalAnnotations(Formatter.Annotation));
 
             return;
 

--- a/src/Analyzers/Core/CodeFixes/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
@@ -74,6 +74,8 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
                 var whenPart = root.FindNode(diagnostic.AdditionalLocations[2].SourceSpan, getInnermostNodeForTie: true);
                 syntaxFacts.GetPartsOfConditionalExpression(
                     conditionalExpression, out var condition, out var whenTrue, out var whenFalse);
+                whenTrue = syntaxFacts.WalkDownParentheses(whenTrue);
+                whenFalse = syntaxFacts.WalkDownParentheses(whenFalse);
 
                 var whenPartIsNullable = diagnostic.Properties.ContainsKey(UseNullPropagationConstants.WhenPartIsNullable);
                 editor.ReplaceNode(conditionalExpression,

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -565,7 +565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (symbol.TypeKind)
             {
                 case TypeKind.Class when symbol.IsRecord:
-                    return SymbolDisplayPartKind.RecordName;
+                    return SymbolDisplayPartKind.RecordClassName;
                 case TypeKind.Submission:
                 case TypeKind.Module:
                 case TypeKind.Class:

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case SymbolDisplayPartKind.AliasName:
                 case SymbolDisplayPartKind.ClassName:
-                case SymbolDisplayPartKind.RecordName:
+                case SymbolDisplayPartKind.RecordClassName:
                 case SymbolDisplayPartKind.StructName:
                 case SymbolDisplayPartKind.InterfaceName:
                 case SymbolDisplayPartKind.EnumName:

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 findSymbol,
                 format,
                 "A",
-                SymbolDisplayPartKind.RecordName);
+                SymbolDisplayPartKind.RecordClassName);
         }
 
         [Fact, WorkItem(46985, "https://github.com/dotnet/roslyn/issues/46985")]
@@ -84,7 +84,7 @@ namespace N1 {
                 findSymbol,
                 format,
                 "R2",
-                SymbolDisplayPartKind.RecordName);
+                SymbolDisplayPartKind.RecordClassName);
         }
 
         [Fact]
@@ -7650,7 +7650,7 @@ record Person(string First, string Last);
                 "record Person",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.RecordName);
+                SymbolDisplayPartKind.RecordClassName);
         }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,7 +3,7 @@ Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
-Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
+Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordClassName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Compare(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> int
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Equals(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> bool

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayPartKind.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayPartKind.cs
@@ -79,12 +79,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>The name of a field or local constant.</summary>
         ConstantName = 30,
         /// <summary>The name of a record.</summary>
-        RecordName = 31,
+        RecordClassName = 31,
     }
 
     internal static class InternalSymbolDisplayPartKind
     {
-        private const SymbolDisplayPartKind @base = SymbolDisplayPartKind.RecordName + 1;
+        private const SymbolDisplayPartKind @base = SymbolDisplayPartKind.RecordClassName + 1;
         public const SymbolDisplayPartKind Arity = @base + 0;
         public const SymbolDisplayPartKind Other = @base + 1;
     }
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal static bool IsValid(this SymbolDisplayPartKind value)
         {
-            return (value >= SymbolDisplayPartKind.AliasName && value <= SymbolDisplayPartKind.RecordName) ||
+            return (value >= SymbolDisplayPartKind.AliasName && value <= SymbolDisplayPartKind.RecordClassName) ||
                 (value >= InternalSymbolDisplayPartKind.Arity && value <= InternalSymbolDisplayPartKind.Other);
         }
     }

--- a/src/Dependencies/Collections/Internal/HashHelpers.cs
+++ b/src/Dependencies/Collections/Internal/HashHelpers.cs
@@ -1,0 +1,122 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.2/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.CodeAnalysis.Collections.Internal
+{
+    internal static class HashHelpers
+    {
+        // This is the maximum prime smaller than Array.MaxArrayLength
+        public const int MaxPrimeArrayLength = 0x7FEFFFFD;
+
+        public const int HashPrime = 101;
+
+        // Table of prime numbers to use as hash table sizes.
+        // A typical resize algorithm would pick the smallest prime number in this array
+        // that is larger than twice the previous capacity.
+        // Suppose our Hashtable currently has capacity x and enough elements are added
+        // such that a resize needs to occur. Resizing first computes 2x then finds the
+        // first prime in the table greater than 2x, i.e. if primes are ordered
+        // p_1, p_2, ..., p_i, ..., it finds p_n such that p_n-1 < 2x < p_n.
+        // Doubling is important for preserving the asymptotic complexity of the
+        // hashtable operations such as add.  Having a prime guarantees that double
+        // hashing does not lead to infinite loops.  IE, your hash function will be
+        // h1(key) + i*h2(key), 0 <= i < size.  h2 and the size must be relatively prime.
+        // We prefer the low computation costs of higher prime numbers over the increased
+        // memory allocation of a fixed prime number i.e. when right sizing a HashSet.
+        private static readonly int[] s_primes =
+        {
+            3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
+            1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
+            17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
+            187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
+            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369
+        };
+
+        public static bool IsPrime(int candidate)
+        {
+            if ((candidate & 1) != 0)
+            {
+                var limit = (int)Math.Sqrt(candidate);
+                for (var divisor = 3; divisor <= limit; divisor += 2)
+                {
+                    if ((candidate % divisor) == 0)
+                        return false;
+                }
+                return true;
+            }
+            return candidate == 2;
+        }
+
+        public static int GetPrime(int min)
+        {
+            if (min < 0)
+                throw new ArgumentException(SR.Arg_HTCapacityOverflow);
+
+            foreach (var prime in s_primes)
+            {
+                if (prime >= min)
+                    return prime;
+            }
+
+            // Outside of our predefined table. Compute the hard way.
+            for (var i = (min | 1); i < int.MaxValue; i += 2)
+            {
+                if (IsPrime(i) && ((i - 1) % HashPrime != 0))
+                    return i;
+            }
+            return min;
+        }
+
+        // Returns size of hashtable to grow to.
+        public static int ExpandPrime(int oldSize)
+        {
+            var newSize = 2 * oldSize;
+
+            // Allow the hashtables to grow to maximum possible size (~2G elements) before encountering capacity overflow.
+            // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
+            if ((uint)newSize > MaxPrimeArrayLength && MaxPrimeArrayLength > oldSize)
+            {
+                Debug.Assert(MaxPrimeArrayLength == GetPrime(MaxPrimeArrayLength), "Invalid MaxPrimeArrayLength");
+                return MaxPrimeArrayLength;
+            }
+
+            return GetPrime(newSize);
+        }
+
+        /// <summary>Returns approximate reciprocal of the divisor: ceil(2**64 / divisor).</summary>
+        /// <remarks>This should only be used on 64-bit.</remarks>
+        public static ulong GetFastModMultiplier(uint divisor) =>
+            ulong.MaxValue / divisor + 1;
+
+        /// <summary>Performs a mod operation using the multiplier pre-computed with <see cref="GetFastModMultiplier"/>.</summary>
+        /// <remarks>
+        /// PERF: This improves performance in 64-bit scenarios at the expense of performance in 32-bit scenarios. Since
+        /// we only build a single AnyCPU binary, we opt for improved performance in the 64-bit scenario.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint FastMod(uint value, uint divisor, ulong multiplier)
+        {
+            // We use modified Daniel Lemire's fastmod algorithm (https://github.com/dotnet/runtime/pull/406),
+            // which allows to avoid the long multiplication if the divisor is less than 2**31.
+            Debug.Assert(divisor <= int.MaxValue);
+
+            // This is equivalent of (uint)Math.BigMul(multiplier * value, divisor, out _). This version
+            // is faster than BigMul currently because we only need the high bits.
+            var highbits = (uint)(((((multiplier * value) >> 32) + 1) * divisor) >> 32);
+
+            Debug.Assert(highbits == value % divisor);
+            return highbits;
+        }
+    }
+}

--- a/src/Dependencies/Collections/Internal/IDictionaryDebugView`2.cs
+++ b/src/Dependencies/Collections/Internal/IDictionaryDebugView`2.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.2/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IDictionaryDebugView.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Collections.Internal
+{
+    internal sealed class IDictionaryDebugView<K, V>
+        where K : notnull
+    {
+        private readonly IDictionary<K, V> _dict;
+
+        public IDictionaryDebugView(IDictionary<K, V> dictionary)
+        {
+            _dict = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<K, V>[] Items
+        {
+            get
+            {
+                var items = new KeyValuePair<K, V>[_dict.Count];
+                _dict.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+
+    internal sealed class DictionaryKeyCollectionDebugView<TKey, TValue>
+    {
+        private readonly ICollection<TKey> _collection;
+
+        public DictionaryKeyCollectionDebugView(ICollection<TKey> collection)
+        {
+            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TKey[] Items
+        {
+            get
+            {
+                var items = new TKey[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+
+    internal sealed class DictionaryValueCollectionDebugView<TKey, TValue>
+    {
+        private readonly ICollection<TValue> _collection;
+
+        public DictionaryValueCollectionDebugView(ICollection<TValue> collection)
+        {
+            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TValue[] Items
+        {
+            get
+            {
+                var items = new TValue[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+}

--- a/src/Dependencies/Collections/Internal/InsertionBehavior.cs
+++ b/src/Dependencies/Collections/Internal/InsertionBehavior.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.2/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/InsertionBehavior.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Collections.Internal
+{
+    /// <summary>
+    /// Used internally to control behavior of insertion into a <see cref="Dictionary{TKey, TValue}"/> or <see cref="HashSet{T}"/>.
+    /// </summary>
+    internal enum InsertionBehavior : byte
+    {
+        /// <summary>
+        /// The default insertion behavior.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies that an existing entry with the same key should be overwritten if encountered.
+        /// </summary>
+        OverwriteExisting = 1,
+
+        /// <summary>
+        /// Specifies that if an existing entry with the same key is encountered, an exception should be thrown.
+        /// </summary>
+        ThrowOnExisting = 2
+    }
+}

--- a/src/Dependencies/Collections/Internal/RoslynUnsafe.cs
+++ b/src/Dependencies/Collections/Internal/RoslynUnsafe.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.CodeAnalysis.Collections.Internal
+{
+    internal static unsafe class RoslynUnsafe
+    {
+        /// <summary>
+        /// Returns a by-ref to type <typeparamref name="T"/> that is a null reference.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T NullRef<T>()
+            => ref Unsafe.AsRef<T>(null);
+
+        /// <summary>
+        /// Returns if a given by-ref to type <typeparamref name="T"/> is a null reference.
+        /// </summary>
+        /// <remarks>
+        /// This check is conceptually similar to <c>(void*)(&amp;source) == nullptr</c>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNullRef<T>(ref T source)
+            => Unsafe.AsPointer(ref source) == null;
+    }
+}

--- a/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
+++ b/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
@@ -10,9 +10,15 @@
     <Import_RootNamespace>Microsoft.CodeAnalysis.Collections</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\HashHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\IDictionaryDebugView`2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\InsertionBehavior.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\RoslynUnsafe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\SegmentedArrayHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\ThrowHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SegmentedArray.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SegmentedArray`1.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SegmentedDictionary`2.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Internal\Strings.resx" GenerateSource="true" ClassName="Microsoft.CodeAnalysis.Collections.Internal.SR" />

--- a/src/Dependencies/Collections/SegmentedArray.cs
+++ b/src/Dependencies/Collections/SegmentedArray.cs
@@ -1,0 +1,301 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Collections.Internal;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    internal static class SegmentedArray
+    {
+        /// <seealso cref="Array.Clear(Array, int, int)"/>
+        internal static void Clear<T>(SegmentedArray<T> array, int index, int length)
+        {
+            foreach (var memory in array.GetSegments(index, length))
+            {
+                memory.Span.Clear();
+            }
+        }
+
+        /// <seealso cref="Array.Copy(Array, Array, int)"/>
+        internal static void Copy<T>(SegmentedArray<T> sourceArray, SegmentedArray<T> destinationArray, int length)
+        {
+            if (length == 0)
+                return;
+
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length));
+            if (length > sourceArray.Length)
+                throw new ArgumentException(SR.Arg_LongerThanSrcArray, nameof(sourceArray));
+            if (length > destinationArray.Length)
+                throw new ArgumentException(SR.Arg_LongerThanDestArray, nameof(destinationArray));
+
+            foreach (var (first, second) in GetSegments(sourceArray, destinationArray, length))
+            {
+                first.CopyTo(second);
+            }
+        }
+
+        private static SegmentEnumerable<T> GetSegments<T>(this SegmentedArray<T> array, int offset, int length)
+            => new(array, offset, length);
+
+        private static AlignedSegmentEnumerable<T> GetSegments<T>(SegmentedArray<T> first, SegmentedArray<T> second, int length)
+            => new(first, second, length);
+
+#pragma warning disable IDE0051 // Remove unused private members (will be used in follow-up)
+        private static AlignedSegmentEnumerable<T> GetSegmentsAligned<T>(SegmentedArray<T> first, int firstOffset, SegmentedArray<T> second, int secondOffset, int length)
+            => new(first, firstOffset, second, secondOffset, length);
+
+        private static UnalignedSegmentEnumerable<T> GetSegmentsUnaligned<T>(SegmentedArray<T> first, int firstOffset, SegmentedArray<T> second, int secondOffset, int length)
+            => new(first, firstOffset, second, secondOffset, length);
+#pragma warning restore IDE0051 // Remove unused private members
+
+        private readonly struct AlignedSegmentEnumerable<T>
+        {
+            private readonly SegmentedArray<T> _first;
+            private readonly int _firstOffset;
+            private readonly SegmentedArray<T> _second;
+            private readonly int _secondOffset;
+            private readonly int _length;
+
+            public AlignedSegmentEnumerable(SegmentedArray<T> first, SegmentedArray<T> second, int length)
+                : this(first, 0, second, 0, length)
+            {
+            }
+
+            public AlignedSegmentEnumerable(SegmentedArray<T> first, int firstOffset, SegmentedArray<T> second, int secondOffset, int length)
+            {
+                _first = first;
+                _firstOffset = firstOffset;
+                _second = second;
+                _secondOffset = secondOffset;
+                _length = length;
+            }
+
+            public AlignedSegmentEnumerator<T> GetEnumerator()
+                => new((T[][])_first.SyncRoot, _firstOffset, (T[][])_second.SyncRoot, _secondOffset, _length);
+        }
+
+        private struct AlignedSegmentEnumerator<T>
+        {
+            private readonly T[][] _firstSegments;
+            private readonly int _firstOffset;
+            private readonly T[][] _secondSegments;
+            private readonly int _secondOffset;
+            private readonly int _length;
+
+            private int _completed;
+            private (Memory<T> first, Memory<T> second) _current;
+
+            public AlignedSegmentEnumerator(T[][] firstSegments, int firstOffset, T[][] secondSegments, int secondOffset, int length)
+            {
+                _firstSegments = firstSegments;
+                _firstOffset = firstOffset;
+                _secondSegments = secondSegments;
+                _secondOffset = secondOffset;
+                _length = length;
+
+                _completed = 0;
+                _current = (Memory<T>.Empty, Memory<T>.Empty);
+            }
+
+            public (Memory<T> first, Memory<T> second) Current => _current;
+
+            public bool MoveNext()
+            {
+                if (_completed == _length)
+                {
+                    _current = (Memory<T>.Empty, Memory<T>.Empty);
+                    return false;
+                }
+
+                var segmentLength = _firstSegments[0].Length;
+                if (_completed == 0)
+                {
+                    var initialFirstSegment = _firstOffset / segmentLength;
+                    var initialFirstSegmentStart = initialFirstSegment * segmentLength;
+                    var initialSecondSegment = _secondOffset / segmentLength;
+                    var initialSecondSegmentStart = initialSecondSegment * segmentLength;
+                    var offset = _firstOffset - initialFirstSegmentStart;
+                    Debug.Assert(offset == (_secondOffset - initialSecondSegmentStart), "Aligned views must start at the same segment offset");
+
+                    var firstSegment = _firstSegments[initialFirstSegment];
+                    var secondSegment = _secondSegments[initialSecondSegment];
+                    var remainingInSegment = firstSegment.Length - offset;
+                    var currentSegmentLength = Math.Min(remainingInSegment, _length);
+                    _current = (firstSegment.AsMemory().Slice(offset, currentSegmentLength), secondSegment.AsMemory().Slice(offset, currentSegmentLength));
+                    _completed = currentSegmentLength;
+                    return true;
+                }
+                else
+                {
+                    var firstSegment = _firstSegments[(_completed + _firstOffset) / segmentLength];
+                    var secondSegment = _secondSegments[(_completed + _secondOffset) / segmentLength];
+                    var currentSegmentLength = Math.Min(segmentLength, _length - _completed);
+                    _current = (firstSegment.AsMemory().Slice(0, currentSegmentLength), secondSegment.AsMemory().Slice(0, currentSegmentLength));
+                    _completed += currentSegmentLength;
+                    return true;
+                }
+            }
+        }
+
+        private readonly struct UnalignedSegmentEnumerable<T>
+        {
+            private readonly SegmentedArray<T> _first;
+            private readonly int _firstOffset;
+            private readonly SegmentedArray<T> _second;
+            private readonly int _secondOffset;
+            private readonly int _length;
+
+            public UnalignedSegmentEnumerable(SegmentedArray<T> first, SegmentedArray<T> second, int length)
+                : this(first, 0, second, 0, length)
+            {
+            }
+
+            public UnalignedSegmentEnumerable(SegmentedArray<T> first, int firstOffset, SegmentedArray<T> second, int secondOffset, int length)
+            {
+                _first = first;
+                _firstOffset = firstOffset;
+                _second = second;
+                _secondOffset = secondOffset;
+                _length = length;
+            }
+
+            public UnalignedSegmentEnumerator<T> GetEnumerator()
+                => new((T[][])_first.SyncRoot, _firstOffset, (T[][])_second.SyncRoot, _secondOffset, _length);
+        }
+
+        private struct UnalignedSegmentEnumerator<T>
+        {
+            private readonly T[][] _firstSegments;
+            private readonly int _firstOffset;
+            private readonly T[][] _secondSegments;
+            private readonly int _secondOffset;
+            private readonly int _length;
+
+            private int _completed;
+            private (Memory<T> first, Memory<T> second) _current;
+
+            public UnalignedSegmentEnumerator(T[][] firstSegments, int firstOffset, T[][] secondSegments, int secondOffset, int length)
+            {
+                _firstSegments = firstSegments;
+                _firstOffset = firstOffset;
+                _secondSegments = secondSegments;
+                _secondOffset = secondOffset;
+                _length = length;
+
+                _completed = 0;
+                _current = (Memory<T>.Empty, Memory<T>.Empty);
+            }
+
+            public (Memory<T> first, Memory<T> second) Current => _current;
+
+            public bool MoveNext()
+            {
+                if (_completed == _length)
+                {
+                    _current = (Memory<T>.Empty, Memory<T>.Empty);
+                    return false;
+                }
+
+                var segmentLength = Math.Max(_firstSegments[0].Length, _secondSegments[0].Length);
+                var initialFirstSegment = (_completed + _firstOffset) / segmentLength;
+                var initialFirstSegmentStart = initialFirstSegment * segmentLength;
+                var initialSecondSegment = (_completed + _secondOffset) / segmentLength;
+                var initialSecondSegmentStart = initialSecondSegment * segmentLength;
+                var firstOffset = _completed + _firstOffset - initialFirstSegmentStart;
+                var secondOffset = _completed + _secondOffset - initialSecondSegmentStart;
+
+                var firstSegment = _firstSegments[initialFirstSegment];
+                var secondSegment = _secondSegments[initialSecondSegment];
+                var remainingInFirstSegment = firstSegment.Length - firstOffset;
+                var remainingInSecondSegment = secondSegment.Length - secondOffset;
+                var currentSegmentLength = Math.Min(Math.Min(remainingInFirstSegment, remainingInSecondSegment), _length);
+                _current = (firstSegment.AsMemory().Slice(firstOffset, currentSegmentLength), secondSegment.AsMemory().Slice(secondOffset, currentSegmentLength));
+                _completed += currentSegmentLength;
+                return true;
+            }
+        }
+
+        private readonly struct SegmentEnumerable<T>
+        {
+            private readonly SegmentedArray<T> _array;
+            private readonly int _offset;
+            private readonly int _length;
+
+            public SegmentEnumerable(SegmentedArray<T> array)
+            {
+                _array = array;
+                _offset = 0;
+                _length = array.Length;
+            }
+
+            public SegmentEnumerable(SegmentedArray<T> array, int offset, int length)
+            {
+                if (offset < 0 || length < 0 || (uint)(offset + length) > (uint)array.Length)
+                    ThrowHelper.ThrowArgumentOutOfRangeException();
+
+                _array = array;
+                _offset = offset;
+                _length = length;
+            }
+
+            public SegmentEnumerator<T> GetEnumerator()
+                => new SegmentEnumerator<T>((T[][])_array.SyncRoot, _offset, _length);
+        }
+
+        private struct SegmentEnumerator<T>
+        {
+            private readonly T[][] _segments;
+            private readonly int _offset;
+            private readonly int _length;
+
+            private int _completed;
+            private Memory<T> _current;
+
+            public SegmentEnumerator(T[][] segments, int offset, int length)
+            {
+                _segments = segments;
+                _offset = offset;
+                _length = length;
+
+                _completed = 0;
+                _current = Memory<T>.Empty;
+            }
+
+            public Memory<T> Current => _current;
+
+            public bool MoveNext()
+            {
+                if (_completed == _length)
+                {
+                    _current = Memory<T>.Empty;
+                    return false;
+                }
+
+                var segmentLength = _segments[0].Length;
+                if (_completed == 0)
+                {
+                    var firstSegment = _offset / segmentLength;
+                    var firstSegmentStart = firstSegment * segmentLength;
+                    var offset = _offset - firstSegmentStart;
+
+                    var segment = _segments[firstSegment];
+                    var remainingInSegment = segment.Length - offset;
+                    _current = segment.AsMemory().Slice(offset, Math.Min(remainingInSegment, _length));
+                    _completed = _current.Length;
+                    return true;
+                }
+                else
+                {
+                    var segment = _segments[(_completed + _offset) / segmentLength];
+                    _current = segment.AsMemory().Slice(0, Math.Min(segmentLength, _length - _completed));
+                    _completed += _current.Length;
+                    return true;
+                }
+            }
+        }
+    }
+}

--- a/src/Dependencies/Collections/SegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/SegmentedDictionary`2.cs
@@ -1,0 +1,1635 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.2/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.Collections.Internal;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    /// <summary>
+    /// Represents a collection of keys and values.
+    /// </summary>
+    /// <remarks>
+    /// <para>This collection has the same performance characteristics as <see cref="Dictionary{TKey, TValue}"/>, but
+    /// uses segmented arrays to avoid allocations in the Large Object Heap.</para>
+    /// </remarks>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+    [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}")]
+    internal sealed class SegmentedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull
+    {
+        private SegmentedArray<int> _buckets;
+        private SegmentedArray<Entry> _entries;
+        private ulong _fastModMultiplier;
+        private int _count;
+        private int _freeList;
+        private int _freeCount;
+        private int _version;
+        private readonly IEqualityComparer<TKey>? _comparer;
+        private KeyCollection? _keys;
+        private ValueCollection? _values;
+        private const int StartOfFreeList = -3;
+
+        public SegmentedDictionary()
+            : this(0, null)
+        {
+        }
+
+        public SegmentedDictionary(int capacity)
+            : this(capacity, null)
+        {
+        }
+
+        public SegmentedDictionary(IEqualityComparer<TKey>? comparer)
+            : this(0, comparer)
+        {
+        }
+
+        public SegmentedDictionary(int capacity, IEqualityComparer<TKey>? comparer)
+        {
+            if (capacity < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
+            }
+
+            if (capacity > 0)
+            {
+                Initialize(capacity);
+            }
+
+            if (comparer != null && comparer != EqualityComparer<TKey>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
+            {
+                _comparer = comparer;
+            }
+        }
+
+        public SegmentedDictionary(IDictionary<TKey, TValue> dictionary)
+            : this(dictionary, null)
+        {
+        }
+
+        public SegmentedDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer)
+            : this(dictionary != null ? dictionary.Count : 0, comparer)
+        {
+            if (dictionary == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.dictionary);
+            }
+
+            // It is likely that the passed-in dictionary is SegmentedDictionary<TKey,TValue>. When this is the case,
+            // avoid the enumerator allocation and overhead by looping through the entries array directly.
+            // We only do this when dictionary is SegmentedDictionary<TKey,TValue> and not a subclass, to maintain
+            // back-compat with subclasses that may have overridden the enumerator behavior.
+            if (dictionary.GetType() == typeof(SegmentedDictionary<TKey, TValue>))
+            {
+                var d = (SegmentedDictionary<TKey, TValue>)dictionary;
+                var count = d._count;
+                var entries = d._entries;
+                for (var i = 0; i < count; i++)
+                {
+                    if (entries[i]._next >= -1)
+                    {
+                        Add(entries[i]._key, entries[i]._value);
+                    }
+                }
+                return;
+            }
+
+            foreach (var pair in dictionary)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        public SegmentedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection)
+            : this(collection, null)
+        {
+        }
+
+        public SegmentedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer)
+            : this((collection as ICollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
+        {
+            if (collection == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
+            }
+
+            foreach (var pair in collection)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        public IEqualityComparer<TKey> Comparer
+        {
+            get
+            {
+                return _comparer ?? EqualityComparer<TKey>.Default;
+            }
+        }
+
+        public int Count => _count - _freeCount;
+
+        public KeyCollection Keys => _keys ??= new KeyCollection(this);
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+        public ValueCollection Values => _values ??= new ValueCollection(this);
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                ref var value = ref FindValue(key);
+                if (!RoslynUnsafe.IsNullRef(ref value))
+                {
+                    return value;
+                }
+
+                ThrowHelper.ThrowKeyNotFoundException(key);
+                return default;
+            }
+            set
+            {
+                var modified = TryInsert(key, value, InsertionBehavior.OverwriteExisting);
+                Debug.Assert(modified);
+            }
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            var modified = TryInsert(key, value, InsertionBehavior.ThrowOnExisting);
+            Debug.Assert(modified); // If there was an existing key and the Add failed, an exception will already have been thrown.
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair)
+            => Add(keyValuePair.Key, keyValuePair.Value);
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            ref var value = ref FindValue(keyValuePair.Key);
+            if (!RoslynUnsafe.IsNullRef(ref value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            ref var value = ref FindValue(keyValuePair.Key);
+            if (!RoslynUnsafe.IsNullRef(ref value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
+            {
+                Remove(keyValuePair.Key);
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Clear()
+        {
+            var count = _count;
+            if (count > 0)
+            {
+                Debug.Assert(_buckets.Length > 0, "_buckets should be non-empty");
+                Debug.Assert(_entries.Length > 0, "_entries should be non-empty");
+
+                SegmentedArray.Clear(_buckets, 0, _buckets.Length);
+
+                _count = 0;
+                _freeList = -1;
+                _freeCount = 0;
+                SegmentedArray.Clear(_entries, 0, count);
+            }
+        }
+
+        public bool ContainsKey(TKey key)
+            => !RoslynUnsafe.IsNullRef(ref FindValue(key));
+
+        public bool ContainsValue(TValue value)
+        {
+            var entries = _entries;
+            if (value == null)
+            {
+                for (var i = 0; i < _count; i++)
+                {
+                    if (entries[i]._next >= -1 && entries[i]._value == null)
+                    {
+                        return true;
+                    }
+                }
+            }
+            else if (typeof(TValue).IsValueType)
+            {
+                // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                for (var i = 0; i < _count; i++)
+                {
+                    if (entries[i]._next >= -1 && EqualityComparer<TValue>.Default.Equals(entries[i]._value, value))
+                    {
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                // https://github.com/dotnet/runtime/issues/10050
+                // So cache in a local rather than get EqualityComparer per loop iteration
+                var defaultComparer = EqualityComparer<TValue>.Default;
+                for (var i = 0; i < _count; i++)
+                {
+                    if (entries[i]._next >= -1 && defaultComparer.Equals(entries[i]._value, value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            if (array == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            }
+
+            if ((uint)index > (uint)array.Length)
+            {
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+            }
+
+            if (array.Length - index < Count)
+            {
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
+            }
+
+            var count = _count;
+            var entries = _entries;
+            for (var i = 0; i < count; i++)
+            {
+                if (entries[i]._next >= -1)
+                {
+                    array[index++] = new KeyValuePair<TKey, TValue>(entries[i]._key, entries[i]._value);
+                }
+            }
+        }
+
+        public Enumerator GetEnumerator()
+            => new(this, Enumerator.KeyValuePair);
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+            => new Enumerator(this, Enumerator.KeyValuePair);
+
+        private ref TValue FindValue(TKey key)
+        {
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+            }
+
+            ref var entry = ref RoslynUnsafe.NullRef<Entry>();
+            if (_buckets.Length > 0)
+            {
+                Debug.Assert(_entries.Length > 0, "expected entries to be non-empty");
+                var comparer = _comparer;
+                if (comparer == null)
+                {
+                    var hashCode = (uint)key.GetHashCode();
+                    var i = GetBucket(hashCode);
+                    var entries = _entries;
+                    uint collisionCount = 0;
+                    if (typeof(TKey).IsValueType)
+                    {
+                        // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+
+                        i--; // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                        do
+                        {
+                            // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                            // Test in if to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length)
+                            {
+                                goto ReturnNotFound;
+                            }
+
+                            entry = ref entries[i];
+                            if (entry._hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entry._key, key))
+                            {
+                                goto ReturnFound;
+                            }
+
+                            i = entry._next;
+
+                            collisionCount++;
+                        } while (collisionCount <= (uint)entries.Length);
+
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        goto ConcurrentOperation;
+                    }
+                    else
+                    {
+                        // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                        // https://github.com/dotnet/runtime/issues/10050
+                        // So cache in a local rather than get EqualityComparer per loop iteration
+                        var defaultComparer = EqualityComparer<TKey>.Default;
+
+                        i--; // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                        do
+                        {
+                            // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                            // Test in if to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length)
+                            {
+                                goto ReturnNotFound;
+                            }
+
+                            entry = ref entries[i];
+                            if (entry._hashCode == hashCode && defaultComparer.Equals(entry._key, key))
+                            {
+                                goto ReturnFound;
+                            }
+
+                            i = entry._next;
+
+                            collisionCount++;
+                        } while (collisionCount <= (uint)entries.Length);
+
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        goto ConcurrentOperation;
+                    }
+                }
+                else
+                {
+                    var hashCode = (uint)comparer.GetHashCode(key);
+                    var i = GetBucket(hashCode);
+                    var entries = _entries;
+                    uint collisionCount = 0;
+                    i--; // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                    do
+                    {
+                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                        // Test in if to drop range check for following array access
+                        if ((uint)i >= (uint)entries.Length)
+                        {
+                            goto ReturnNotFound;
+                        }
+
+                        entry = ref entries[i];
+                        if (entry._hashCode == hashCode && comparer.Equals(entry._key, key))
+                        {
+                            goto ReturnFound;
+                        }
+
+                        i = entry._next;
+
+                        collisionCount++;
+                    } while (collisionCount <= (uint)entries.Length);
+
+                    // The chain of entries forms a loop; which means a concurrent update has happened.
+                    // Break out of the loop and throw, rather than looping forever.
+                    goto ConcurrentOperation;
+                }
+            }
+
+            goto ReturnNotFound;
+
+ConcurrentOperation:
+            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+ReturnFound:
+            ref var value = ref entry._value;
+Return:
+            return ref value;
+ReturnNotFound:
+            value = ref RoslynUnsafe.NullRef<TValue>();
+            goto Return;
+        }
+
+        private int Initialize(int capacity)
+        {
+            var size = HashHelpers.GetPrime(capacity);
+            var buckets = new SegmentedArray<int>(size);
+            var entries = new SegmentedArray<Entry>(size);
+
+            // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
+            _freeList = -1;
+            _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)size);
+            _buckets = buckets;
+            _entries = entries;
+
+            return size;
+        }
+
+        private bool TryInsert(TKey key, TValue value, InsertionBehavior behavior)
+        {
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+            }
+
+            if (_buckets.Length == 0)
+            {
+                Initialize(0);
+            }
+            Debug.Assert(_buckets.Length > 0);
+
+            var entries = _entries;
+            Debug.Assert(entries.Length > 0, "expected entries to be non-empty");
+
+            var comparer = _comparer;
+            var hashCode = (uint)((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key));
+
+            uint collisionCount = 0;
+            ref var bucket = ref GetBucket(hashCode);
+            var i = bucket - 1; // Value in _buckets is 1-based
+
+            if (comparer == null)
+            {
+                if (typeof(TKey).IsValueType)
+                {
+                    // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                    while (true)
+                    {
+                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                        // Test uint in if rather than loop condition to drop range check for following array access
+                        if ((uint)i >= (uint)entries.Length)
+                        {
+                            break;
+                        }
+
+                        if (entries[i]._hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i]._key, key))
+                        {
+                            if (behavior == InsertionBehavior.OverwriteExisting)
+                            {
+                                entries[i]._value = value;
+                                return true;
+                            }
+
+                            if (behavior == InsertionBehavior.ThrowOnExisting)
+                            {
+                                ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
+                            }
+
+                            return false;
+                        }
+
+                        i = entries[i]._next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                    }
+                }
+                else
+                {
+                    // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                    // https://github.com/dotnet/runtime/issues/10050
+                    // So cache in a local rather than get EqualityComparer per loop iteration
+                    var defaultComparer = EqualityComparer<TKey>.Default;
+                    while (true)
+                    {
+                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                        // Test uint in if rather than loop condition to drop range check for following array access
+                        if ((uint)i >= (uint)entries.Length)
+                        {
+                            break;
+                        }
+
+                        if (entries[i]._hashCode == hashCode && defaultComparer.Equals(entries[i]._key, key))
+                        {
+                            if (behavior == InsertionBehavior.OverwriteExisting)
+                            {
+                                entries[i]._value = value;
+                                return true;
+                            }
+
+                            if (behavior == InsertionBehavior.ThrowOnExisting)
+                            {
+                                ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
+                            }
+
+                            return false;
+                        }
+
+                        i = entries[i]._next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                    }
+                }
+            }
+            else
+            {
+                while (true)
+                {
+                    // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                    // Test uint in if rather than loop condition to drop range check for following array access
+                    if ((uint)i >= (uint)entries.Length)
+                    {
+                        break;
+                    }
+
+                    if (entries[i]._hashCode == hashCode && comparer.Equals(entries[i]._key, key))
+                    {
+                        if (behavior == InsertionBehavior.OverwriteExisting)
+                        {
+                            entries[i]._value = value;
+                            return true;
+                        }
+
+                        if (behavior == InsertionBehavior.ThrowOnExisting)
+                        {
+                            ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
+                        }
+
+                        return false;
+                    }
+
+                    i = entries[i]._next;
+
+                    collisionCount++;
+                    if (collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+            }
+
+            int index;
+            if (_freeCount > 0)
+            {
+                index = _freeList;
+                Debug.Assert((StartOfFreeList - entries[_freeList]._next) >= -1, "shouldn't overflow because `next` cannot underflow");
+                _freeList = StartOfFreeList - entries[_freeList]._next;
+                _freeCount--;
+            }
+            else
+            {
+                var count = _count;
+                if (count == entries.Length)
+                {
+                    Resize();
+                    bucket = ref GetBucket(hashCode);
+                }
+                index = count;
+                _count = count + 1;
+                entries = _entries;
+            }
+
+            ref var entry = ref entries![index];
+            entry._hashCode = hashCode;
+            entry._next = bucket - 1; // Value in _buckets is 1-based
+            entry._key = key;
+            entry._value = value; // Value in _buckets is 1-based
+            bucket = index + 1;
+            _version++;
+            return true;
+        }
+
+        private void Resize()
+            => Resize(HashHelpers.ExpandPrime(_count));
+
+        private void Resize(int newSize)
+        {
+            Debug.Assert(_entries.Length > 0, "_entries should be non-empty");
+            Debug.Assert(newSize >= _entries.Length);
+
+            var entries = new SegmentedArray<Entry>(newSize);
+
+            var count = _count;
+            SegmentedArray.Copy(_entries, entries, count);
+
+            // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
+            _buckets = new SegmentedArray<int>(newSize);
+            _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
+            for (var i = 0; i < count; i++)
+            {
+                if (entries[i]._next >= -1)
+                {
+                    ref var bucket = ref GetBucket(entries[i]._hashCode);
+                    entries[i]._next = bucket - 1; // Value in _buckets is 1-based
+                    bucket = i + 1;
+                }
+            }
+
+            _entries = entries;
+        }
+
+        public bool Remove(TKey key)
+        {
+            // The overload Remove(TKey key, out TValue value) is a copy of this method with one additional
+            // statement to copy the value for entry being removed into the output parameter.
+            // Code has been intentionally duplicated for performance reasons.
+
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+            }
+
+            if (_buckets.Length > 0)
+            {
+                Debug.Assert(_entries.Length > 0, "entries should be non-empty");
+                uint collisionCount = 0;
+                var hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
+                ref var bucket = ref GetBucket(hashCode);
+                var entries = _entries;
+                var last = -1;
+                var i = bucket - 1; // Value in buckets is 1-based
+                while (i >= 0)
+                {
+                    ref var entry = ref entries[i];
+
+                    if (entry._hashCode == hashCode && (_comparer?.Equals(entry._key, key) ?? EqualityComparer<TKey>.Default.Equals(entry._key, key)))
+                    {
+                        if (last < 0)
+                        {
+                            bucket = entry._next + 1; // Value in buckets is 1-based
+                        }
+                        else
+                        {
+                            entries[last]._next = entry._next;
+                        }
+
+                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                        entry._next = StartOfFreeList - _freeList;
+
+#if NETCOREAPP
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+#endif
+                        {
+                            entry._key = default!;
+                        }
+
+#if NETCOREAPP
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+#endif
+                        {
+                            entry._value = default!;
+                        }
+
+                        _freeList = i;
+                        _freeCount++;
+                        return true;
+                    }
+
+                    last = i;
+                    i = entry._next;
+
+                    collisionCount++;
+                    if (collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+            }
+            return false;
+        }
+
+        public bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
+        {
+            // This overload is a copy of the overload Remove(TKey key) with one additional
+            // statement to copy the value for entry being removed into the output parameter.
+            // Code has been intentionally duplicated for performance reasons.
+
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+            }
+
+            if (_buckets.Length > 0)
+            {
+                Debug.Assert(_entries.Length > 0, "entries should be non-empty");
+                uint collisionCount = 0;
+                var hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
+                ref var bucket = ref GetBucket(hashCode);
+                var entries = _entries;
+                var last = -1;
+                var i = bucket - 1; // Value in buckets is 1-based
+                while (i >= 0)
+                {
+                    ref var entry = ref entries[i];
+
+                    if (entry._hashCode == hashCode && (_comparer?.Equals(entry._key, key) ?? EqualityComparer<TKey>.Default.Equals(entry._key, key)))
+                    {
+                        if (last < 0)
+                        {
+                            bucket = entry._next + 1; // Value in buckets is 1-based
+                        }
+                        else
+                        {
+                            entries[last]._next = entry._next;
+                        }
+
+                        value = entry._value;
+
+                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                        entry._next = StartOfFreeList - _freeList;
+
+#if NETCOREAPP
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+#endif
+                        {
+                            entry._key = default!;
+                        }
+
+#if NETCOREAPP
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+#endif
+                        {
+                            entry._value = default!;
+                        }
+
+                        _freeList = i;
+                        _freeCount++;
+                        return true;
+                    }
+
+                    last = i;
+                    i = entry._next;
+
+                    collisionCount++;
+                    if (collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+        {
+            ref var valRef = ref FindValue(key);
+            if (!RoslynUnsafe.IsNullRef(ref valRef))
+            {
+                value = valRef;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public bool TryAdd(TKey key, TValue value)
+            => TryInsert(key, value, InsertionBehavior.None);
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+            => CopyTo(array, index);
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            if (array == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            }
+
+            if (array.Rank != 1)
+            {
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported);
+            }
+
+            if (array.GetLowerBound(0) != 0)
+            {
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound);
+            }
+
+            if ((uint)index > (uint)array.Length)
+            {
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+            }
+
+            if (array.Length - index < Count)
+            {
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
+            }
+
+            if (array is KeyValuePair<TKey, TValue>[] pairs)
+            {
+                CopyTo(pairs, index);
+            }
+            else if (array is DictionaryEntry[] dictEntryArray)
+            {
+                var entries = _entries;
+                for (var i = 0; i < _count; i++)
+                {
+                    if (entries[i]._next >= -1)
+                    {
+                        dictEntryArray[index++] = new DictionaryEntry(entries[i]._key, entries[i]._value);
+                    }
+                }
+            }
+            else
+            {
+                var objects = array as object[];
+                if (objects == null)
+                {
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
+                }
+
+                try
+                {
+                    var count = _count;
+                    var entries = _entries;
+                    for (var i = 0; i < count; i++)
+                    {
+                        if (entries[i]._next >= -1)
+                        {
+                            objects[index++] = new KeyValuePair<TKey, TValue>(entries[i]._key, entries[i]._value);
+                        }
+                    }
+                }
+                catch (ArrayTypeMismatchException)
+                {
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => new Enumerator(this, Enumerator.KeyValuePair);
+
+        /// <summary>
+        /// Ensures that the dictionary can hold up to 'capacity' entries without any further expansion of its backing storage
+        /// </summary>
+        public int EnsureCapacity(int capacity)
+        {
+            if (capacity < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
+            }
+
+            var currentCapacity = _entries.Length;
+            if (currentCapacity >= capacity)
+            {
+                return currentCapacity;
+            }
+
+            _version++;
+
+            if (_buckets.Length == 0)
+            {
+                return Initialize(capacity);
+            }
+
+            var newSize = HashHelpers.GetPrime(capacity);
+            Resize(newSize);
+            return newSize;
+        }
+
+        /// <summary>
+        /// Sets the capacity of this dictionary to what it would be if it had been originally initialized with all its entries
+        /// </summary>
+        /// <remarks>
+        /// This method can be used to minimize the memory overhead
+        /// once it is known that no new elements will be added.
+        ///
+        /// To allocate minimum size storage array, execute the following statements:
+        ///
+        /// dictionary.Clear();
+        /// dictionary.TrimExcess();
+        /// </remarks>
+        public void TrimExcess()
+            => TrimExcess(Count);
+
+        /// <summary>
+        /// Sets the capacity of this dictionary to hold up 'capacity' entries without any further expansion of its backing storage
+        /// </summary>
+        /// <remarks>
+        /// This method can be used to minimize the memory overhead
+        /// once it is known that no new elements will be added.
+        /// </remarks>
+        public void TrimExcess(int capacity)
+        {
+            if (capacity < Count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
+            }
+
+            var newSize = HashHelpers.GetPrime(capacity);
+            var oldEntries = _entries;
+            var currentCapacity = oldEntries.Length;
+            if (newSize >= currentCapacity)
+            {
+                return;
+            }
+
+            var oldCount = _count;
+            _version++;
+            Initialize(newSize);
+            var entries = _entries;
+            var count = 0;
+            for (var i = 0; i < oldCount; i++)
+            {
+                var hashCode = oldEntries[i]._hashCode; // At this point, we know we have entries.
+                if (oldEntries[i]._next >= -1)
+                {
+                    ref var entry = ref entries[count];
+                    entry = oldEntries[i];
+                    ref var bucket = ref GetBucket(hashCode);
+                    entry._next = bucket - 1; // Value in _buckets is 1-based
+                    bucket = count + 1;
+                    count++;
+                }
+            }
+
+            _count = count;
+            _freeCount = 0;
+        }
+
+        bool ICollection.IsSynchronized => false;
+
+        object ICollection.SyncRoot => this;
+
+        bool IDictionary.IsFixedSize => false;
+
+        bool IDictionary.IsReadOnly => false;
+
+        ICollection IDictionary.Keys => Keys;
+
+        ICollection IDictionary.Values => Values;
+
+        object? IDictionary.this[object key]
+        {
+            get
+            {
+                if (IsCompatibleKey(key))
+                {
+                    ref var value = ref FindValue((TKey)key);
+                    if (!RoslynUnsafe.IsNullRef(ref value))
+                    {
+                        return value;
+                    }
+                }
+
+                return null;
+            }
+            set
+            {
+                if (key == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+                }
+                ThrowHelper.IfNullAndNullsAreIllegalThenThrow<TValue>(value, ExceptionArgument.value);
+
+                try
+                {
+                    var tempKey = (TKey)key;
+                    try
+                    {
+                        this[tempKey] = (TValue)value!;
+                    }
+                    catch (InvalidCastException)
+                    {
+                        ThrowHelper.ThrowWrongValueTypeArgumentException(value, typeof(TValue));
+                    }
+                }
+                catch (InvalidCastException)
+                {
+                    ThrowHelper.ThrowWrongKeyTypeArgumentException(key, typeof(TKey));
+                }
+            }
+        }
+
+        private static bool IsCompatibleKey(object key)
+        {
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+            }
+            return key is TKey;
+        }
+
+        void IDictionary.Add(object key, object? value)
+        {
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+            }
+            ThrowHelper.IfNullAndNullsAreIllegalThenThrow<TValue>(value, ExceptionArgument.value);
+
+            try
+            {
+                var tempKey = (TKey)key;
+
+                try
+                {
+                    Add(tempKey, (TValue)value!);
+                }
+                catch (InvalidCastException)
+                {
+                    ThrowHelper.ThrowWrongValueTypeArgumentException(value, typeof(TValue));
+                }
+            }
+            catch (InvalidCastException)
+            {
+                ThrowHelper.ThrowWrongKeyTypeArgumentException(key, typeof(TKey));
+            }
+        }
+
+        bool IDictionary.Contains(object key)
+        {
+            if (IsCompatibleKey(key))
+            {
+                return ContainsKey((TKey)key);
+            }
+
+            return false;
+        }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+            => new Enumerator(this, Enumerator.DictEntry);
+
+        void IDictionary.Remove(object key)
+        {
+            if (IsCompatibleKey(key))
+            {
+                Remove((TKey)key);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref int GetBucket(uint hashCode)
+        {
+            var buckets = _buckets;
+            return ref buckets[(int)HashHelpers.FastMod(hashCode, (uint)buckets.Length, _fastModMultiplier)];
+        }
+
+        private struct Entry
+        {
+            public uint _hashCode;
+            /// <summary>
+            /// 0-based index of next entry in chain: -1 means end of chain
+            /// also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
+            /// so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+            /// </summary>
+            public int _next;
+            public TKey _key;     // Key of entry
+            public TValue _value; // Value of entry
+        }
+
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
+        {
+            private readonly SegmentedDictionary<TKey, TValue> _dictionary;
+            private readonly int _version;
+            private int _index;
+            private KeyValuePair<TKey, TValue> _current;
+            private readonly int _getEnumeratorRetType;  // What should Enumerator.Current return?
+
+            internal const int DictEntry = 1;
+            internal const int KeyValuePair = 2;
+
+            internal Enumerator(SegmentedDictionary<TKey, TValue> dictionary, int getEnumeratorRetType)
+            {
+                _dictionary = dictionary;
+                _version = dictionary._version;
+                _index = 0;
+                _getEnumeratorRetType = getEnumeratorRetType;
+                _current = default;
+            }
+
+            public bool MoveNext()
+            {
+                if (_version != _dictionary._version)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                }
+
+                // Use unsigned comparison since we set index to dictionary.count+1 when the enumeration ends.
+                // dictionary.count+1 could be negative if dictionary.count is int.MaxValue
+                while ((uint)_index < (uint)_dictionary._count)
+                {
+                    ref var entry = ref _dictionary._entries[_index++];
+
+                    if (entry._next >= -1)
+                    {
+                        _current = new KeyValuePair<TKey, TValue>(entry._key, entry._value);
+                        return true;
+                    }
+                }
+
+                _index = _dictionary._count + 1;
+                _current = default;
+                return false;
+            }
+
+            public KeyValuePair<TKey, TValue> Current => _current;
+
+            public void Dispose()
+            {
+            }
+
+            object? IEnumerator.Current
+            {
+                get
+                {
+                    if (_index == 0 || (_index == _dictionary._count + 1))
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+                    }
+
+                    if (_getEnumeratorRetType == DictEntry)
+                    {
+                        return new DictionaryEntry(_current.Key, _current.Value);
+                    }
+
+                    return new KeyValuePair<TKey, TValue>(_current.Key, _current.Value);
+                }
+            }
+
+            void IEnumerator.Reset()
+            {
+                if (_version != _dictionary._version)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                }
+
+                _index = 0;
+                _current = default;
+            }
+
+            DictionaryEntry IDictionaryEnumerator.Entry
+            {
+                get
+                {
+                    if (_index == 0 || (_index == _dictionary._count + 1))
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+                    }
+
+                    return new DictionaryEntry(_current.Key, _current.Value);
+                }
+            }
+
+            object IDictionaryEnumerator.Key
+            {
+                get
+                {
+                    if (_index == 0 || (_index == _dictionary._count + 1))
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+                    }
+
+                    return _current.Key;
+                }
+            }
+
+            object? IDictionaryEnumerator.Value
+            {
+                get
+                {
+                    if (_index == 0 || (_index == _dictionary._count + 1))
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+                    }
+
+                    return _current.Value;
+                }
+            }
+        }
+
+        [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        public sealed class KeyCollection : ICollection<TKey>, ICollection, IReadOnlyCollection<TKey>
+        {
+            private readonly SegmentedDictionary<TKey, TValue> _dictionary;
+
+            public KeyCollection(SegmentedDictionary<TKey, TValue> dictionary)
+            {
+                if (dictionary == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.dictionary);
+                }
+
+                _dictionary = dictionary;
+            }
+
+            public Enumerator GetEnumerator()
+                => new Enumerator(_dictionary);
+
+            public void CopyTo(TKey[] array, int index)
+            {
+                if (array == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+                }
+
+                if (index < 0 || index > array.Length)
+                {
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+                }
+
+                if (array.Length - index < _dictionary.Count)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
+                }
+
+                var count = _dictionary._count;
+                var entries = _dictionary._entries;
+                for (var i = 0; i < count; i++)
+                {
+                    if (entries[i]._next >= -1)
+                        array[index++] = entries[i]._key;
+                }
+            }
+
+            public int Count => _dictionary.Count;
+
+            bool ICollection<TKey>.IsReadOnly => true;
+
+            void ICollection<TKey>.Add(TKey item)
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_KeyCollectionSet);
+
+            void ICollection<TKey>.Clear()
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_KeyCollectionSet);
+
+            bool ICollection<TKey>.Contains(TKey item)
+                => _dictionary.ContainsKey(item);
+
+            bool ICollection<TKey>.Remove(TKey item)
+            {
+                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_KeyCollectionSet);
+                return false;
+            }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+                => new Enumerator(_dictionary);
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => new Enumerator(_dictionary);
+
+            void ICollection.CopyTo(Array array, int index)
+            {
+                if (array == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+                }
+
+                if (array.Rank != 1)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported);
+                }
+
+                if (array.GetLowerBound(0) != 0)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound);
+                }
+
+                if ((uint)index > (uint)array.Length)
+                {
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+                }
+
+                if (array.Length - index < _dictionary.Count)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
+                }
+
+                if (array is TKey[] keys)
+                {
+                    CopyTo(keys, index);
+                }
+                else
+                {
+                    var objects = array as object[];
+                    if (objects == null)
+                    {
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
+                    }
+
+                    var count = _dictionary._count;
+                    var entries = _dictionary._entries;
+                    try
+                    {
+                        for (var i = 0; i < count; i++)
+                        {
+                            if (entries[i]._next >= -1)
+                                objects[index++] = entries[i]._key;
+                        }
+                    }
+                    catch (ArrayTypeMismatchException)
+                    {
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
+                    }
+                }
+            }
+
+            bool ICollection.IsSynchronized => false;
+
+            object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+            public struct Enumerator : IEnumerator<TKey>, IEnumerator
+            {
+                private readonly SegmentedDictionary<TKey, TValue> _dictionary;
+                private int _index;
+                private readonly int _version;
+                private TKey? _currentKey;
+
+                internal Enumerator(SegmentedDictionary<TKey, TValue> dictionary)
+                {
+                    _dictionary = dictionary;
+                    _version = dictionary._version;
+                    _index = 0;
+                    _currentKey = default;
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    if (_version != _dictionary._version)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                    }
+
+                    while ((uint)_index < (uint)_dictionary._count)
+                    {
+                        ref var entry = ref _dictionary._entries[_index++];
+
+                        if (entry._next >= -1)
+                        {
+                            _currentKey = entry._key;
+                            return true;
+                        }
+                    }
+
+                    _index = _dictionary._count + 1;
+                    _currentKey = default;
+                    return false;
+                }
+
+                public TKey Current => _currentKey!;
+
+                object? IEnumerator.Current
+                {
+                    get
+                    {
+                        if (_index == 0 || (_index == _dictionary._count + 1))
+                        {
+                            ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+                        }
+
+                        return _currentKey;
+                    }
+                }
+
+                void IEnumerator.Reset()
+                {
+                    if (_version != _dictionary._version)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                    }
+
+                    _index = 0;
+                    _currentKey = default;
+                }
+            }
+        }
+
+        [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        public sealed class ValueCollection : ICollection<TValue>, ICollection, IReadOnlyCollection<TValue>
+        {
+            private readonly SegmentedDictionary<TKey, TValue> _dictionary;
+
+            public ValueCollection(SegmentedDictionary<TKey, TValue> dictionary)
+            {
+                if (dictionary == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.dictionary);
+                }
+
+                _dictionary = dictionary;
+            }
+
+            public Enumerator GetEnumerator()
+                => new Enumerator(_dictionary);
+
+            public void CopyTo(TValue[] array, int index)
+            {
+                if (array == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+                }
+
+                if ((uint)index > array.Length)
+                {
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+                }
+
+                if (array.Length - index < _dictionary.Count)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
+                }
+
+                var count = _dictionary._count;
+                var entries = _dictionary._entries;
+                for (var i = 0; i < count; i++)
+                {
+                    if (entries[i]._next >= -1)
+                        array[index++] = entries[i]._value;
+                }
+            }
+
+            public int Count => _dictionary.Count;
+
+            bool ICollection<TValue>.IsReadOnly => true;
+
+            void ICollection<TValue>.Add(TValue item)
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ValueCollectionSet);
+
+            bool ICollection<TValue>.Remove(TValue item)
+            {
+                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ValueCollectionSet);
+                return false;
+            }
+
+            void ICollection<TValue>.Clear()
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ValueCollectionSet);
+
+            bool ICollection<TValue>.Contains(TValue item)
+                => _dictionary.ContainsValue(item);
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+                => new Enumerator(_dictionary);
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => new Enumerator(_dictionary);
+
+            void ICollection.CopyTo(Array array, int index)
+            {
+                if (array == null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+                }
+
+                if (array.Rank != 1)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported);
+                }
+
+                if (array.GetLowerBound(0) != 0)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound);
+                }
+
+                if ((uint)index > (uint)array.Length)
+                {
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+                }
+
+                if (array.Length - index < _dictionary.Count)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
+                }
+
+                if (array is TValue[] values)
+                {
+                    CopyTo(values, index);
+                }
+                else
+                {
+                    var objects = array as object[];
+                    if (objects == null)
+                    {
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
+                    }
+
+                    var count = _dictionary._count;
+                    var entries = _dictionary._entries;
+                    try
+                    {
+                        for (var i = 0; i < count; i++)
+                        {
+                            if (entries[i]._next >= -1)
+                                objects[index++] = entries[i]._value!;
+                        }
+                    }
+                    catch (ArrayTypeMismatchException)
+                    {
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
+                    }
+                }
+            }
+
+            bool ICollection.IsSynchronized => false;
+
+            object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+            public struct Enumerator : IEnumerator<TValue>, IEnumerator
+            {
+                private readonly SegmentedDictionary<TKey, TValue> _dictionary;
+                private int _index;
+                private readonly int _version;
+                private TValue? _currentValue;
+
+                internal Enumerator(SegmentedDictionary<TKey, TValue> dictionary)
+                {
+                    _dictionary = dictionary;
+                    _version = dictionary._version;
+                    _index = 0;
+                    _currentValue = default;
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    if (_version != _dictionary._version)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                    }
+
+                    while ((uint)_index < (uint)_dictionary._count)
+                    {
+                        ref var entry = ref _dictionary._entries[_index++];
+
+                        if (entry._next >= -1)
+                        {
+                            _currentValue = entry._value;
+                            return true;
+                        }
+                    }
+                    _index = _dictionary._count + 1;
+                    _currentValue = default;
+                    return false;
+                }
+
+                public TValue Current => _currentValue!;
+
+                object? IEnumerator.Current
+                {
+                    get
+                    {
+                        if (_index == 0 || (_index == _dictionary._count + 1))
+                        {
+                            ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+                        }
+
+                        return _currentValue;
+                    }
+                }
+
+                void IEnumerator.Reset()
+                {
+                    if (_version != _dictionary._version)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                    }
+
+                    _index = 0;
+                    _currentValue = default;
+                }
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
+++ b/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
@@ -10,6 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Core.Wpf\SignatureHelp\**\*.cs" LinkBase="SignatureHelp" />
+    <Compile Include="..\Core.Wpf\IDebuggerTextView2.cs" Link="IDebuggerTextView2.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
     <ProjectReference Include="..\..\Features\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
     <ProjectReference Include="..\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             ImmutableArray<CompletionFilterWithState> filters)
         {
             // See which filters might be enabled based on the typed code
-            var _ = PooledHashSet<CompletionFilter>.GetInstance(out var textFilteredFilters);
+            using var _ = PooledHashSet<CompletionFilter>.GetInstance(out var textFilteredFilters);
             textFilteredFilters.AddRange(filteredList.SelectMany(n => n.VSCompletionItem.Filters));
 
             // When no items are available for a given filter, it becomes unavailable.

--- a/src/EditorFeatures/DiagnosticsTestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.MoveToNamespace;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
@@ -73,11 +74,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
                         Assert.NotNull(expectedSymbolChanges);
 
                         var checkedCodeActions = new HashSet<TestSymbolRenamedCodeActionOperationFactoryWorkspaceService.Operation>(renamedCodeActionsOperations.Length);
-                        foreach (var kvp in expectedSymbolChanges)
+                        foreach (var (originalName, newName) in expectedSymbolChanges)
                         {
-                            var originalName = kvp.Key;
-                            var newName = kvp.Value;
-
                             var codeAction = renamedCodeActionsOperations.FirstOrDefault(a => a._symbol.ToDisplayString() == originalName);
                             Assert.Equal(newName, codeAction?._newName);
                             Assert.False(checkedCodeActions.Contains(codeAction));

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
@@ -362,10 +363,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             if (options != null)
             {
                 var optionSet = workspace.Options;
-                foreach (var kvp in options)
-                {
-                    optionSet = optionSet.WithChangedOption(kvp.Key, kvp.Value);
-                }
+                foreach (var (key, value) in options)
+                    optionSet = optionSet.WithChangedOption(key, value);
 
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(optionSet));
             }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -463,13 +463,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 // algorithm in MarkupTestFile
                 mappedSpans[string.Empty] = mappedSpans[string.Empty].OrderBy(s => s.End).ThenBy(s => -s.Start).ToImmutableArray();
 
-                foreach (var kvp in document.AnnotatedSpans)
+                foreach (var (key, spans) in document.AnnotatedSpans)
                 {
-                    mappedSpans[kvp.Key] = mappedSpans.ContainsKey(kvp.Key)
-                        ? mappedSpans[kvp.Key]
+                    mappedSpans[key] = mappedSpans.ContainsKey(key)
+                        ? mappedSpans[key]
                         : ImmutableArray<TextSpan>.Empty;
 
-                    foreach (var span in kvp.Value)
+                    foreach (var span in spans)
                     {
                         var snapshotSpan = span.ToSnapshotSpan(document.GetTextBuffer().CurrentSnapshot);
                         var mappedSpan = projectionBuffer.CurrentSnapshot.MapFromSourceSnapshot(snapshotSpan).Cast<Span?>().SingleOrDefault();
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                         }
 
                         // but if they do, it must be only 1
-                        mappedSpans[kvp.Key] = mappedSpans[kvp.Key].Add(mappedSpan.Value.ToTextSpan());
+                        mappedSpans[key] = mappedSpans[key].Add(mappedSpan.Value.ToTextSpan());
                     }
                 }
             }

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             // If there is not already an empty line inserted between the braces, insert one.
             TextChange? newLineEdit = null;
             var textToFormat = originalDocumentText;
-            if (!HasExistingEmptyLineBetweenBraces(openingPoint, closingPoint, originalDocumentText))
+            if (ShouldAddEmptyLineBetweenBraces(openingPoint, closingPoint, originalDocumentText))
             {
                 var newLineString = documentOptions.GetOption(FormattingOptions2.NewLine);
                 newLineEdit = new TextChange(new TextSpan(closingPoint - 1, 0), newLineString);
@@ -132,14 +132,14 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             var overallChanges = newLineEdit != null ? GetMergedChanges(newLineEdit.Value, formattingChanges, formattedText) : formattingChanges;
             return new BraceCompletionResult(overallChanges, caretPosition);
 
-            static bool HasExistingEmptyLineBetweenBraces(int openingPoint, int closingPoint, SourceText sourceText)
+            static bool ShouldAddEmptyLineBetweenBraces(int openingPoint, int closingPoint, SourceText sourceText)
             {
-                // Check if there is an empty new line between the braces already.  If not insert one.
-                // This handles razor cases where they insert an additional empty line before calling brace completion.
                 var openingPointLine = sourceText.Lines.GetLineFromPosition(openingPoint).LineNumber;
                 var closingPointLine = sourceText.Lines.GetLineFromPosition(closingPoint).LineNumber;
 
-                return closingPointLine - 2 == openingPointLine && sourceText.Lines[closingPointLine - 1].IsEmptyOrWhitespace();
+                // Only insert an empty new line between the braces if the closing brace is
+                // on the line immediately below the opening point.
+                return closingPointLine - 1 == openingPointLine;
             }
 
             static TextLine GetLineBetweenCurlys(int closingPosition, SourceText text)

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionBatchFixAllProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionBatchFixAllProvider.cs
@@ -270,10 +270,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             // Finally, apply the changes to each document to the solution, producing the
             // new solution.
             var currentSolution = oldSolution;
-            foreach (var kvp in documentIdToFinalText)
-            {
-                currentSolution = currentSolution.WithDocumentText(kvp.Key, kvp.Value);
-            }
+            foreach (var (documentId, finalText) in documentIdToFinalText)
+                currentSolution = currentSolution.WithDocumentText(documentId, finalText);
 
             return currentSolution;
         }
@@ -315,11 +313,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 
             var documentIdToFinalText = new ConcurrentDictionary<DocumentId, SourceText>();
             var getFinalDocumentTasks = new List<Task>();
-            foreach (var kvp in documentIdToChangedDocuments)
+            foreach (var (_, changedDocuments) in documentIdToChangedDocuments)
             {
                 getFinalDocumentTasks.Add(GetFinalDocumentTextAsync(
-                    oldSolution, codeActionToDiagnosticLocation, documentIdToFinalText,
-                    kvp.Value, cancellationToken));
+                    oldSolution, codeActionToDiagnosticLocation, documentIdToFinalText, changedDocuments, cancellationToken));
             }
 
             await Task.WhenAll(getFinalDocumentTasks).ConfigureAwait(false);

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
@@ -92,16 +92,15 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             private static async Task<Solution> CreateChangedSolutionAsync(AbstractSuppressionCodeFixProvider fixer, Project triggerProject, ImmutableDictionary<Project, ImmutableArray<Diagnostic>> diagnosticsByProject, CancellationToken cancellationToken)
             {
                 var currentSolution = triggerProject.Solution;
-                foreach (var kvp in diagnosticsByProject)
+                foreach (var (oldProject, diagnostics) in diagnosticsByProject)
                 {
-                    var oldProject = kvp.Key;
                     var currentProject = currentSolution.GetProject(oldProject.Id);
                     var compilation = await currentProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                     var suppressMessageAttribute = compilation.SuppressMessageAttributeType();
 
                     if (suppressMessageAttribute != null)
                     {
-                        var diagnosticsBySymbol = await CreateDiagnosticsBySymbolAsync(oldProject, kvp.Value, cancellationToken).ConfigureAwait(false);
+                        var diagnosticsBySymbol = await CreateDiagnosticsBySymbolAsync(oldProject, diagnostics, cancellationToken).ConfigureAwait(false);
                         if (diagnosticsBySymbol.Any())
                         {
                             var projectCodeAction = new GlobalSuppressMessageFixAllCodeAction(
@@ -126,11 +125,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 var compilation = await suppressionsDoc.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var addImportsService = suppressionsDoc.GetRequiredLanguageService<IAddImportsService>();
 
-                foreach (var kvp in _diagnosticsBySymbol)
+                foreach (var (targetSymbol, diagnostics) in _diagnosticsBySymbol)
                 {
-                    var targetSymbol = kvp.Key;
-                    var diagnostics = kvp.Value;
-
                     foreach (var diagnostic in diagnostics)
                     {
                         Contract.ThrowIfFalse(!diagnostic.IsSuppressed);
@@ -148,10 +144,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             private static async Task<IEnumerable<KeyValuePair<ISymbol, ImmutableArray<Diagnostic>>>> CreateDiagnosticsBySymbolAsync(AbstractSuppressionCodeFixProvider fixer, IEnumerable<KeyValuePair<Document, ImmutableArray<Diagnostic>>> diagnosticsByDocument, CancellationToken cancellationToken)
             {
                 var diagnosticsMapBuilder = ImmutableDictionary.CreateBuilder<ISymbol, List<Diagnostic>>();
-                foreach (var kvp in diagnosticsByDocument)
+                foreach (var (document, diagnostics) in diagnosticsByDocument)
                 {
-                    var document = kvp.Key;
-                    var diagnostics = kvp.Value;
                     foreach (var diagnostic in diagnostics)
                     {
                         Contract.ThrowIfFalse(diagnostic.Location.IsInSource);
@@ -209,10 +203,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 }
 
                 var builder = new List<KeyValuePair<ISymbol, ImmutableArray<Diagnostic>>>();
-                foreach (var kvp in diagnosticsMapBuilder)
-                {
-                    builder.Add(KeyValuePairUtil.Create(kvp.Key, GetUniqueDiagnostics(kvp.Value)));
-                }
+                foreach (var (symbol, diagnostics) in diagnosticsMapBuilder)
+                    builder.Add(KeyValuePairUtil.Create(symbol, GetUniqueDiagnostics(diagnostics)));
 
                 return builder.OrderBy(kvp => kvp.Key.GetDocumentationCommentId() ?? string.Empty);
             }

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
                             switch (parts[index + 1].Kind)
                             {
                                 case SymbolDisplayPartKind.ClassName:
-                                case SymbolDisplayPartKind.RecordName:
+                                case SymbolDisplayPartKind.RecordClassName:
                                 case SymbolDisplayPartKind.DelegateName:
                                 case SymbolDisplayPartKind.EnumName:
                                 case SymbolDisplayPartKind.ErrorTypeName:
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
                         }
 
                         previousWasClass = part.Kind == SymbolDisplayPartKind.ClassName ||
-                                           part.Kind == SymbolDisplayPartKind.RecordName ||
+                                           part.Kind == SymbolDisplayPartKind.RecordClassName ||
                                            part.Kind == SymbolDisplayPartKind.InterfaceName ||
                                            part.Kind == SymbolDisplayPartKind.StructName;
                     }

--- a/src/Features/Core/Portable/Common/SymbolDisplayPartKindTags.cs
+++ b/src/Features/Core/Portable/Common/SymbolDisplayPartKindTags.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                 SymbolDisplayPartKind.EnumMemberName => TextTags.EnumMember,
                 SymbolDisplayPartKind.ExtensionMethodName => TextTags.ExtensionMethod,
                 SymbolDisplayPartKind.ConstantName => TextTags.Constant,
-                SymbolDisplayPartKind.RecordName => TextTags.Record,
+                SymbolDisplayPartKind.RecordClassName => TextTags.Record,
                 _ => string.Empty,
             };
     }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AnonymousTypes.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AnonymousTypes.cs
@@ -6,6 +6,7 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServices
 {
@@ -27,13 +28,12 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             private void InlineAllDelegateAnonymousTypes()
             {
 restart:
-                foreach (var kvp in _groupMap)
+                foreach (var (group, parts) in _groupMap)
                 {
-                    var parts = kvp.Value;
                     var updatedParts = _anonymousTypeDisplayService.InlineDelegateAnonymousTypes(parts, _semanticModel, _position);
                     if (parts != updatedParts)
                     {
-                        _groupMap[kvp.Key] = updatedParts;
+                        _groupMap[group] = updatedParts;
                         goto restart;
                     }
                 }
@@ -56,13 +56,12 @@ restart:
                         info.AnonymousTypesParts);
 
 restart:
-                    foreach (var kvp in _groupMap)
+                    foreach (var (group, parts) in _groupMap)
                     {
-                        var parts = _groupMap[kvp.Key];
                         var updatedParts = info.ReplaceAnonymousTypes(parts);
                         if (parts != updatedParts)
                         {
-                            _groupMap[kvp.Key] = updatedParts;
+                            _groupMap[group] = updatedParts;
                             goto restart;
                         }
                     }

--- a/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
@@ -267,6 +267,35 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.OnAutoInsert
             await VerifyNoResult("\n", markup);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        [WorkItem(1260219, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1260219")]
+        public async Task OnAutoInsert_BraceFormattingDoesNotInsertExtraEmptyLines()
+        {
+            // The test starts with the closing brace already on a new line.
+            // In LSP, hitting enter will first trigger a didChange event for the new line character
+            // (bringing the server text to the form below) and then trigger OnAutoInsert
+            // for the new line character.
+            var markup =
+@"class A
+{
+    void M()
+    {
+        
+        {|type:|}
+    }
+}";
+            var expected =
+@"class A
+{
+    void M()
+    {
+
+        $0
+    }
+}";
+            await VerifyMarkupAndExpected("\n", markup, expected);
+        }
+
         private async Task VerifyMarkupAndExpected(string characterTyped, string markup, string expected, bool useTabs = false)
         {
             using var workspace = CreateTestWorkspace(markup, out var locations);

--- a/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace IdeCoreBenchmarks
+{
+    public class ProjectOperationBenchmarks
+    {
+        [MemoryDiagnoser]
+        public class IterateDocuments
+        {
+            private Workspace _workspace;
+            private Project _emptyProject;
+            private Project _hundredProject;
+            private Project _thousandsProject;
+
+            public IterateDocuments()
+            {
+                // These fields are initialized in GlobalSetup
+                _workspace = null!;
+                _emptyProject = null!;
+                _hundredProject = null!;
+                _thousandsProject = null!;
+            }
+
+            [Params(0, 100, 10000)]
+            public int DocumentCount { get; set; }
+
+            private Project Project
+            {
+                get
+                {
+                    return DocumentCount switch
+                    {
+                        0 => _emptyProject,
+                        100 => _hundredProject,
+                        10000 => _thousandsProject,
+                        _ => throw new NotSupportedException($"'{nameof(DocumentCount)}' is out of range"),
+                    };
+                }
+            }
+
+            [GlobalSetup]
+            public void GlobalSetup()
+            {
+                _workspace = new AdhocWorkspace();
+
+                var solution = _workspace.CurrentSolution;
+                _emptyProject = CreateProject(ref solution, name: "A", documentCount: 0);
+                _hundredProject = CreateProject(ref solution, name: "A", documentCount: 100);
+                _thousandsProject = CreateProject(ref solution, name: "A", documentCount: 10000);
+
+                static Project CreateProject(ref Solution solution, string name, int documentCount)
+                {
+                    var projectId = ProjectId.CreateNewId(name);
+                    solution = solution.AddProject(projectId, name, name, LanguageNames.CSharp);
+
+                    var emptySourceText = SourceText.From("", Encoding.UTF8);
+                    for (var i = 0; i < documentCount; i++)
+                    {
+                        var documentName = $"{i}.cs";
+                        var documentId = DocumentId.CreateNewId(projectId, documentName);
+                        solution = solution.AddDocument(documentId, documentName, emptySourceText);
+                    }
+
+                    return solution.GetRequiredProject(projectId);
+                }
+            }
+
+            [Benchmark(Description = "Project.DocumentIds")]
+            public int DocumentIds()
+            {
+                var count = 0;
+                foreach (var _ in Project.DocumentIds)
+                {
+                    count++;
+                }
+
+                return count;
+            }
+
+            [Benchmark(Description = "Project.Documents")]
+            public int Documents()
+            {
+                var count = 0;
+                foreach (var _ in Project.Documents)
+                {
+                    count++;
+                }
+
+                return count;
+            }
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Impl/Interactive/Commands.vsct
+++ b/src/VisualStudio/CSharp/Impl/Interactive/Commands.vsct
@@ -19,7 +19,6 @@
         <!-- TODO (https://github.com/dotnet/roslyn/issues/6078): RoslynImageCatalogGuid -> ImageCatalogGuid -->
         <Icon guid="RoslynImageCatalogGuid" id="CSInteractiveWindow" />
         <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>AllowClientRole</CommandFlag>
         <Strings>
           <ButtonText>C# Interactive</ButtonText>
         </Strings>

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLspWorkspaceRegistrationEventListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLspWorkspaceRegistrationEventListener.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
+{
+    [ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.Host, WorkspaceKind.MiscellaneousFiles, WorkspaceKind.MetadataAsSource), Shared]
+    internal class VisualStudioLspWorkspaceRegistrationEventListener : IEventListener<object>
+    {
+        private readonly ILspWorkspaceRegistrationService _lspWorkspaceRegistrationService;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public VisualStudioLspWorkspaceRegistrationEventListener(ILspWorkspaceRegistrationService lspWorkspaceRegistrationService)
+        {
+            _lspWorkspaceRegistrationService = lspWorkspaceRegistrationService;
+        }
+
+        public void StartListening(Workspace workspace, object _)
+        {
+            _lspWorkspaceRegistrationService.Register(workspace);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -86,10 +86,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             }
 
             LoadComponentsInUIContextOnceSolutionFullyLoadedAsync(cancellationToken).Forget();
-
-            var workspaceRegistrationSerivce = this.ComponentModel.GetService<ILspWorkspaceRegistrationService>();
-            workspaceRegistrationSerivce.Register(this.Workspace);
-            workspaceRegistrationSerivce.Register(miscellaneousFilesWorkspace);
         }
 
         protected override async Task LoadComponentsAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -453,18 +453,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
         private static ImmutableDictionary<Document, ImmutableArray<Diagnostic>> GetDocumentDiagnosticsMappedToNewSolution(ImmutableDictionary<Document, ImmutableArray<Diagnostic>> documentDiagnosticsToFixMap, Solution newSolution, string language)
         {
             ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Builder builder = null;
-            foreach (var kvp in documentDiagnosticsToFixMap)
+            foreach (var (oldDocument, diagnostics) in documentDiagnosticsToFixMap)
             {
-                if (kvp.Key.Project.Language != language)
-                {
+                if (oldDocument.Project.Language != language)
                     continue;
-                }
 
-                var document = newSolution.GetDocument(kvp.Key.Id);
+                var document = newSolution.GetDocument(oldDocument.Id);
                 if (document != null)
                 {
                     builder ??= ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
-                    builder.Add(document, kvp.Value);
+                    builder.Add(document, diagnostics);
                 }
             }
 
@@ -474,18 +472,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
         private static ImmutableDictionary<Project, ImmutableArray<Diagnostic>> GetProjectDiagnosticsMappedToNewSolution(ImmutableDictionary<Project, ImmutableArray<Diagnostic>> projectDiagnosticsToFixMap, Solution newSolution, string language)
         {
             ImmutableDictionary<Project, ImmutableArray<Diagnostic>>.Builder projectDiagsBuilder = null;
-            foreach (var kvp in projectDiagnosticsToFixMap)
+            foreach (var (oldProject, diagnostics) in projectDiagnosticsToFixMap)
             {
-                if (kvp.Key.Language != language)
-                {
+                if (oldProject.Language != language)
                     continue;
-                }
 
-                var project = newSolution.GetProject(kvp.Key.Id);
+                var project = newSolution.GetProject(oldProject.Id);
                 if (project != null)
                 {
                     projectDiagsBuilder ??= ImmutableDictionary.CreateBuilder<Project, ImmutableArray<Diagnostic>>();
-                    projectDiagsBuilder.Add(project, kvp.Value);
+                    projectDiagsBuilder.Add(project, diagnostics);
                 }
             }
 
@@ -601,16 +597,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
 
             var finalBuilder = ImmutableDictionary.CreateBuilder<Project, ImmutableArray<Diagnostic>>();
             var latestDiagnosticsToFixOpt = filterStaleDiagnostics ? new HashSet<DiagnosticData>() : null;
-            foreach (var kvp in builder)
+            foreach (var (projectId, diagnostics) in builder)
             {
-                var projectId = kvp.Key;
                 var project = _workspace.CurrentSolution.GetProject(projectId);
                 if (project == null || !shouldFixInProject(project))
-                {
                     continue;
-                }
 
-                var diagnostics = kvp.Value;
                 IEnumerable<DiagnosticData> projectDiagnosticsToFix;
                 if (filterStaleDiagnostics)
                 {

--- a/src/VisualStudio/Core/Test.Next/Mocks/TestOptionSet.cs
+++ b/src/VisualStudio/Core/Test.Next/Mocks/TestOptionSet.cs
@@ -39,13 +39,11 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Mocks
 
         internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
         {
-            foreach (var kvp in _values)
+            foreach (var (key, value) in _values)
             {
-                var currentValue = optionSet.GetOption(kvp.Key);
-                if (!object.Equals(currentValue, kvp.Value))
-                {
-                    yield return kvp.Key;
-                }
+                var currentValue = optionSet.GetOption(key);
+                if (!object.Equals(currentValue, value))
+                    yield return key;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 ClassificationTypeNames.Operator => SymbolDisplayPartKind.Operator,
                 ClassificationTypeNames.Punctuation => SymbolDisplayPartKind.Punctuation,
                 ClassificationTypeNames.ClassName => SymbolDisplayPartKind.ClassName,
-                ClassificationTypeNames.RecordName => SymbolDisplayPartKind.RecordName,
+                ClassificationTypeNames.RecordName => SymbolDisplayPartKind.RecordClassName,
                 ClassificationTypeNames.StructName => SymbolDisplayPartKind.StructName,
                 ClassificationTypeNames.InterfaceName => SymbolDisplayPartKind.InterfaceName,
                 ClassificationTypeNames.DelegateName => SymbolDisplayPartKind.DelegateName,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -26,17 +27,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     var compilation = await project.GetCompilationAsync(_cancellationToken).ConfigureAwait(false);
 
                     var documentTasks = new List<Task>();
-                    foreach (var kvp in documentMap)
+                    foreach (var (document, documentQueue) in documentMap)
                     {
-                        var document = kvp.Key;
-
                         if (document.Project == project)
-                        {
-                            var documentQueue = kvp.Value;
-
-                            documentTasks.Add(Task.Run(() => ProcessDocumentQueueAsync(
-                                document, documentQueue), _cancellationToken));
-                        }
+                            documentTasks.Add(Task.Run(() => ProcessDocumentQueueAsync(document, documentQueue), _cancellationToken));
                     }
 
                     await Task.WhenAll(documentTasks).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/StreamingProgressCollector.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/StreamingProgressCollector.cs
@@ -6,10 +6,10 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             lock (_gate)
             {
                 using var _ = ArrayBuilder<ReferencedSymbol>.GetInstance(out var result);
-                foreach (var kvp in _symbolToLocations)
-                    result.Add(new ReferencedSymbol(kvp.Key, kvp.Value.ToImmutableArray()));
+                foreach (var (symbol, locations) in _symbolToLocations)
+                    result.Add(new ReferencedSymbol(symbol, locations.ToImmutableArray()));
 
                 return result.ToImmutable();
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -525,13 +525,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var comparer = GetComparer(ignoreCase: false);
             var result = new OrderPreservingMultiDictionary<int, int>();
 
-            foreach (var kvp in inheritanceMap)
+            foreach (var (baseName, derivedNames) in inheritanceMap)
             {
-                var baseName = kvp.Key;
                 var baseNameIndex = BinarySearch(nodes, baseName);
                 Debug.Assert(baseNameIndex >= 0);
 
-                foreach (var derivedName in kvp.Value)
+                foreach (var derivedName in derivedNames)
                 {
                     foreach (var derivedNameIndex in FindNodeIndices(nodes, derivedName, comparer))
                     {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -320,12 +320,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 // Return all the metadata nodes back to the pool so that they can be
                 // used for the next PEReference we read.
-                foreach (var kvp in _parentToChildren)
+                foreach (var (_, children) in _parentToChildren)
                 {
-                    foreach (var child in kvp.Value)
-                    {
+                    foreach (var child in children)
                         MetadataNode.Free(child);
-                    }
                 }
 
                 MetadataNode.Free(_rootNode);
@@ -342,10 +340,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 {
                     LookupMetadataDefinitions(globalNamespace, definitionMap);
 
-                    foreach (var kvp in definitionMap)
-                    {
-                        GenerateMetadataNodes(_rootNode, kvp.Key, kvp.Value);
-                    }
+                    foreach (var (name, definitions) in definitionMap)
+                        GenerateMetadataNodes(_rootNode, name, definitions);
                 }
                 finally
                 {
@@ -381,10 +377,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         LookupMetadataDefinitions(definition, definitionMap);
                     }
 
-                    foreach (var kvp in definitionMap)
-                    {
-                        GenerateMetadataNodes(childNode, kvp.Key, kvp.Value);
-                    }
+                    foreach (var (name, definitions) in definitionMap)
+                        GenerateMetadataNodes(childNode, name, definitions);
                 }
                 finally
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -131,10 +131,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 lookup(globalNamespace, symbolMap);
 
-                foreach (var kvp in symbolMap)
-                {
-                    GenerateSourceNodes(kvp.Key, 0 /*index of root node*/, kvp.Value, list, lookup);
-                }
+                foreach (var (name, symbols) in symbolMap)
+                    GenerateSourceNodes(name, 0 /*index of root node*/, symbols, list, lookup);
             }
             finally
             {
@@ -166,10 +164,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     lookup(symbol, symbolMap);
                 }
 
-                foreach (var kvp in symbolMap)
-                {
-                    GenerateSourceNodes(kvp.Key, nodeIndex, kvp.Value, list, lookup);
-                }
+                foreach (var (symbolName, symbols) in symbolMap)
+                    GenerateSourceNodes(symbolName, nodeIndex, symbols, list, lookup);
             }
             finally
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ExtensionMethodInfo.cs
@@ -52,15 +52,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 writer.WriteInt32(ReceiverTypeNameToExtensionMethodMap.Count);
 
-                foreach (var kvp in ReceiverTypeNameToExtensionMethodMap)
+                foreach (var (name, indices) in ReceiverTypeNameToExtensionMethodMap)
                 {
-                    writer.WriteString(kvp.Key);
-                    writer.WriteInt32(kvp.Value.Length);
+                    writer.WriteString(name);
+                    writer.WriteInt32(indices.Length);
 
-                    foreach (var declaredSymbolInfoIndex in kvp.Value)
-                    {
+                    foreach (var declaredSymbolInfoIndex in indices)
                         writer.WriteInt32(declaredSymbolInfoIndex);
-                    }
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.WorkspaceOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.WorkspaceOptionSet.cs
@@ -70,13 +70,11 @@ namespace Microsoft.CodeAnalysis.Options
                     yield break;
                 }
 
-                foreach (var kvp in _values)
+                foreach (var (key, value) in _values)
                 {
-                    var currentValue = optionSet?.GetOption(kvp.Key);
-                    if (!object.Equals(currentValue, kvp.Value))
-                    {
-                        yield return kvp.Key;
-                    }
+                    var currentValue = optionSet?.GetOption(key);
+                    if (!object.Equals(currentValue, value))
+                        yield return key;
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_BulkPopulateIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_BulkPopulateIds.cs
@@ -153,10 +153,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
                     // We succeeded inserting all the strings.  Ensure our local cache has all the
                     // values we added.
-                    foreach (var kvp in idToString.Object)
-                    {
-                        _stringToIdMap[kvp.Value] = kvp.Key;
-                    }
+                    foreach (var (id, value) in idToString.Object)
+                        _stringToIdMap[value] = id;
                 }
 
                 return true;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -196,13 +196,10 @@ namespace Microsoft.CodeAnalysis
         {
             var reverseReferencesMap = new Dictionary<ProjectId, HashSet<ProjectId>>();
 
-            foreach (var kvp in _referencesMap)
+            foreach (var (projectId, references) in _referencesMap)
             {
-                var references = kvp.Value;
                 foreach (var referencedId in references)
-                {
-                    reverseReferencesMap.MultiAdd(referencedId, kvp.Key);
-                }
+                    reverseReferencesMap.MultiAdd(referencedId, projectId);
             }
 
             return reverseReferencesMap

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -844,13 +844,9 @@ namespace Microsoft.CodeAnalysis
             {
                 RecordSourceOfAssemblySymbol(compilation.Assembly, this.ProjectState.Id);
 
-                foreach (var kvp in metadataReferenceToProjectId)
+                foreach (var (metadataReference, projectId) in metadataReferenceToProjectId)
                 {
-                    var metadataReference = kvp.Key;
-                    var projectId = kvp.Value;
-
                     var symbol = compilation.GetAssemblyOrModuleSymbol(metadataReference);
-
                     RecordSourceOfAssemblySymbol(symbol, projectId);
                 }
             }

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectDependencyGraphTests.cs
@@ -704,10 +704,8 @@ namespace Microsoft.CodeAnalysis.Host.UnitTests
                 solution = AddProject(solution, projectName);
             }
 
-            foreach (var kvp in references)
-            {
-                solution = AddProjectReferences(solution, kvp.Key, kvp.Value);
-            }
+            foreach (var (name, refs) in references)
+                solution = AddProjectReferences(solution, name, refs);
 
             return solution;
         }

--- a/src/Workspaces/MSBuildTest/FileSet.cs
+++ b/src/Workspaces/MSBuildTest/FileSet.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
@@ -34,10 +35,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         public IEnumerator<(string fileName, object content)> GetEnumerator()
         {
-            foreach (var kvp in _fileMap)
-            {
-                yield return (kvp.Key, kvp.Value);
-            }
+            foreach (var (fileName, content) in _fileMap)
+                yield return (fileName, content);
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetCache.cs
@@ -152,15 +152,13 @@ namespace Microsoft.CodeAnalysis.Remote
             var current = DateTime.UtcNow;
             using (Logger.LogBlock(FunctionId.AssetStorage_CleanAssets, CancellationToken.None))
             {
-                foreach (var kvp in _assets.ToArray())
+                foreach (var (checksum, entry) in _assets.ToArray())
                 {
-                    if (current - kvp.Value.LastAccessed <= _purgeAfterTimeSpan)
-                    {
+                    if (current - entry.LastAccessed <= _purgeAfterTimeSpan)
                         continue;
-                    }
 
                     // If it fails, we'll just leave it in the asset pool.
-                    _assets.TryRemove(kvp.Key, out var _);
+                    _assets.TryRemove(checksum, out var _);
                 }
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/LValueFlowCaptureProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/LValueFlowCaptureProvider.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 #if DEBUG
 using System.Diagnostics;
@@ -71,10 +72,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 #if DEBUG
                 if (lvalueFlowCaptureIdBuilder != null)
                 {
-                    foreach (var kvp in lvalueFlowCaptureIdBuilder)
-                    {
-                        Debug.Assert(kvp.Value == FlowCaptureKind.LValueAndRValueCapture || !rvalueFlowCaptureIds.Contains(kvp.Key), "Flow capture used as both an r-value and an l-value, but with incorrect flow capture kind");
-                    }
+                    foreach (var (captureId, kind) in lvalueFlowCaptureIdBuilder)
+                        Debug.Assert(kind == FlowCaptureKind.LValueAndRValueCapture || !rvalueFlowCaptureIds.Contains(captureId), "Flow capture used as both an r-value and an l-value, but with incorrect flow capture kind");
                 }
 #endif
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -196,15 +196,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             {
                 if (source != null)
                 {
-                    foreach (var kvp in source._reachingWrites)
+                    foreach (var (symbol, operations) in source._reachingWrites)
                     {
-                        if (!result.TryGetValue(kvp.Key, out var values))
+                        if (!result.TryGetValue(symbol, out var values))
                         {
                             values = PooledHashSet<IOperation>.GetInstance();
-                            result.Add(kvp.Key, values);
+                            result.Add(symbol, values);
                         }
 
-                        values.AddRange(kvp.Value);
+                        values.AddRange(operations);
                     }
                 }
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Builder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Builder.cs
@@ -163,10 +163,8 @@ namespace Roslyn.Utilities
                         {
                             Debug.Assert(spilledEdges.Count == (edgeCount - CompactEdgeAllocationSize));
 
-                            foreach (var kvp in spilledEdges)
-                            {
-                                edges.Add(new Edge(kvp.Key, kvp.Value));
-                            }
+                            foreach (var (distance, childIndex) in spilledEdges)
+                                edges.Add(new Edge(distance, childIndex));
                         }
                     }
 


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/50345 moved some files to EditorFeatures.Wpf that are needed by VS for Mac, so this adds them to EditorFeatures.Cocoa so VS Mac can consume them.

An ideal solution here would presumably be an EditorFeatures.Common that can reference Microsoft.VisualStudio.Language.Intellisense, but not WPF, and then these could be shared. I'm not doing that here simply because I have no idea what infrastructure pieces this would require, and its 4pm my time :) Happy to do it if someone wants to let me know whats involved.