### PR TITLE
Add ProjectOperationBenchmarks

### DIFF
--- a/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace IdeCoreBenchmarks
+{
+    public class ProjectOperationBenchmarks
+    {
+        [MemoryDiagnoser]
+        public class IterateDocuments
+        {
+            private Workspace _workspace;
+            private Project _emptyProject;
+            private Project _hundredProject;
+            private Project _thousandsProject;
+
+            public IterateDocuments()
+            {
+                // These fields are initialized in GlobalSetup
+                _workspace = null!;
+                _emptyProject = null!;
+                _hundredProject = null!;
+                _thousandsProject = null!;
+            }
+
+            [Params(0, 100, 10000)]
+            public int DocumentCount { get; set; }
+
+            private Project Project
+            {
+                get
+                {
+                    return DocumentCount switch
+                    {
+                        0 => _emptyProject,
+                        100 => _hundredProject,
+                        10000 => _thousandsProject,
+                        _ => throw new NotSupportedException($"'{nameof(DocumentCount)}' is out of range"),
+                    };
+                }
+            }
+
+            [GlobalSetup]
+            public void GlobalSetup()
+            {
+                _workspace = new AdhocWorkspace();
+
+                var solution = _workspace.CurrentSolution;
+                _emptyProject = CreateProject(ref solution, name: "A", documentCount: 0);
+                _hundredProject = CreateProject(ref solution, name: "A", documentCount: 100);
+                _thousandsProject = CreateProject(ref solution, name: "A", documentCount: 10000);
+
+                static Project CreateProject(ref Solution solution, string name, int documentCount)
+                {
+                    var projectId = ProjectId.CreateNewId(name);
+                    solution = solution.AddProject(projectId, name, name, LanguageNames.CSharp);
+
+                    var emptySourceText = SourceText.From("", Encoding.UTF8);
+                    for (var i = 0; i < documentCount; i++)
+                    {
+                        var documentName = $"{i}.cs";
+                        var documentId = DocumentId.CreateNewId(projectId, documentName);
+                        solution = solution.AddDocument(documentId, documentName, emptySourceText);
+                    }
+
+                    return solution.GetRequiredProject(projectId);
+                }
+            }
+
+            [Benchmark(Description = "Project.DocumentIds")]
+            public int DocumentIds()
+            {
+                var count = 0;
+                foreach (var _ in Project.DocumentIds)
+                {
+                    count++;
+                }
+
+                return count;
+            }
+
+            [Benchmark(Description = "Project.Documents")]
+            public int Documents()
+            {
+                var count = 0;
+                foreach (var _ in Project.Documents)
+                {
+                    count++;
+                }
+
+                return count;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to #48682

Baseline for net472:

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4250.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4250.0), X64 RyuJIT
```

|              Method | DocumentCount |            Mean |         Error |         StdDev |          Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |-------------- |----------------:|--------------:|---------------:|----------------:|-------:|------:|------:|----------:|
| Project.DocumentIds |             0 |        30.56 ns |      0.239 ns |       0.224 ns |        30.52 ns |      - |     - |     - |         - |
|   Project.Documents |             0 |        72.16 ns |      0.546 ns |       0.511 ns |        72.12 ns | 0.0204 |     - |     - |     128 B |
| Project.DocumentIds |           100 |     5,808.83 ns |     16.180 ns |      15.135 ns |     5,801.97 ns | 0.0076 |     - |     - |      72 B |
|   Project.Documents |           100 |    23,940.13 ns |    192.507 ns |     170.652 ns |    23,898.33 ns | 0.0305 |     - |     - |     201 B |
| Project.DocumentIds |         10000 |   630,369.55 ns |  4,333.417 ns |   3,841.461 ns |   630,697.17 ns |      - |     - |     - |      80 B |
|   Project.Documents |         10000 | 4,625,697.37 ns | 90,883.316 ns | 181,503.802 ns | 4,547,228.91 ns |      - |     - |     - |     256 B |

Baseline for netcoreapp3.1:

|              Method | DocumentCount |            Mean |         Error |        StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |-------------- |----------------:|--------------:|--------------:|-------:|------:|------:|----------:|
| Project.DocumentIds |             0 |        12.38 ns |      0.060 ns |      0.057 ns |      - |     - |     - |         - |
|   Project.Documents |             0 |        69.20 ns |      0.326 ns |      0.305 ns | 0.0191 |     - |     - |     120 B |
| Project.DocumentIds |           100 |     6,248.08 ns |     39.344 ns |     36.802 ns | 0.0076 |     - |     - |      72 B |
|   Project.Documents |           100 |    20,200.63 ns |    178.158 ns |    166.649 ns | 0.0305 |     - |     - |     192 B |
| Project.DocumentIds |         10000 |   656,870.67 ns |  4,355.570 ns |  4,074.203 ns |      - |     - |     - |      72 B |
|   Project.Documents |         10000 | 3,936,493.63 ns | 28,108.377 ns | 26,292.594 ns |      - |     - |     - |     192 B |
