### PR TITLE
Track state separately in NullableWalker for nested and containing methods

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -126,8 +126,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                        diagnostics,
                                        delegateInvokeMethodOpt: delegateType?.DelegateInvokeMethod,
                                        initialState: nullableState,
-                                       analyzedNullabilityMapOpt: null,
-                                       snapshotBuilderOpt: null,
                                        returnTypes);
                 diagnostics.Free();
                 var inferredReturnType = InferReturnType(returnTypes, node: this, Binder, delegateType, Symbol.IsAsync, conversions);

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool HasExplicitlyTypedParameterList { get { return Data.HasExplicitlyTypedParameterList; } }
         public int ParameterCount { get { return Data.ParameterCount; } }
         public TypeWithAnnotations InferReturnType(ConversionsBase conversions, NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
-            => BindForReturnTypeInference(delegateType).GetInferredReturnType(conversions, _nullableState?.Clone(), ref useSiteDiagnostics);
+            => BindForReturnTypeInference(delegateType).GetInferredReturnType(conversions, _nullableState, ref useSiteDiagnostics);
 
         public RefKind RefKind(int index) { return Data.RefKind(index); }
         public void GenerateAnonymousFunctionConversionError(DiagnosticBag diagnostics, TypeSymbol targetType) { Data.GenerateAnonymousFunctionConversionError(diagnostics, targetType); }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1634,6 +1634,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected Optional<TLocalState> NonMonotonicState;
 
+        /// <summary>
+        /// Join state from other try block, potentially in a nested method.
+        /// </summary>
+        protected virtual void JoinTryBlockState(ref TLocalState self, ref TLocalState other)
+        {
+            Join(ref self, ref other);
+        }
+
         private void VisitTryBlockWithAnyTransferFunction(BoundStatement tryBlock, BoundTryStatement node, ref TLocalState tryState)
         {
             if (_nonMonotonicTransfer)
@@ -1646,7 +1654,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (oldTryState.HasValue)
                 {
                     var oldTryStateValue = oldTryState.Value;
-                    Join(ref oldTryStateValue, ref tempTryStateValue);
+                    JoinTryBlockState(ref oldTryStateValue, ref tempTryStateValue);
                     oldTryState = oldTryStateValue;
                 }
 
@@ -1675,7 +1683,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (oldTryState.HasValue)
                 {
                     var oldTryStateValue = oldTryState.Value;
-                    Join(ref oldTryStateValue, ref tempTryStateValue);
+                    JoinTryBlockState(ref oldTryStateValue, ref tempTryStateValue);
                     oldTryState = oldTryStateValue;
                 }
 
@@ -1720,7 +1728,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (oldTryState.HasValue)
                 {
                     var oldTryStateValue = oldTryState.Value;
-                    Join(ref oldTryStateValue, ref tempTryStateValue);
+                    JoinTryBlockState(ref oldTryStateValue, ref tempTryStateValue);
                     oldTryState = oldTryStateValue;
                 }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_LocalFunctions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public bool Visited = false;
         }
 
-        protected abstract TLocalFunctionState CreateLocalFunctionState();
+        protected abstract TLocalFunctionState CreateLocalFunctionState(LocalFunctionSymbol symbol);
 
         private SmallDictionary<LocalFunctionSymbol, TLocalFunctionState>? _localFuncVarUsages = null;
 
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!_localFuncVarUsages.TryGetValue(localFunc, out TLocalFunctionState? usages))
             {
-                usages = CreateLocalFunctionState();
+                usages = CreateLocalFunctionState(localFunc);
                 _localFuncVarUsages[localFunc] = usages;
             }
             return usages;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var i in _endOfRegionState.Assigned.TrueBits())
                 {
-                    if (i >= variableBySlot.Length)
+                    if (i >= variableBySlot.Count)
                     {
                         continue;
                     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             { }
         }
 
-        protected override LocalFunctionState CreateLocalFunctionState() => new LocalFunctionState(UnreachableState());
+        protected override LocalFunctionState CreateLocalFunctionState(LocalFunctionSymbol symbol) => new LocalFunctionState(UnreachableState());
 
         protected override bool Meet(ref LocalState self, ref LocalState other)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.LocalFunctions.cs
@@ -23,7 +23,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             { }
         }
 
-        protected override LocalFunctionState CreateLocalFunctionState()
+        protected override LocalFunctionState CreateLocalFunctionState(LocalFunctionSymbol symbol)
+            => CreateLocalFunctionState();
+
+        private LocalFunctionState CreateLocalFunctionState()
             => new LocalFunctionState(
                 // The bottom state should assume all variables, even new ones, are assigned
                 new LocalState(BitVector.AllSet(nextVariableSlot), normalizeToBottom: true),

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.LocalFunctions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private LocalFunctionState CreateLocalFunctionState()
             => new LocalFunctionState(
                 // The bottom state should assume all variables, even new ones, are assigned
-                new LocalState(BitVector.AllSet(nextVariableSlot), normalizeToBottom: true),
+                new LocalState(BitVector.AllSet(variableBySlot.Count), normalizeToBottom: true),
                 UnreachableState());
 
         protected override void VisitLocalFunctionUse(
@@ -125,8 +125,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BitVector GetCapturedBitmask()
         {
-            BitVector mask = BitVector.AllSet(nextVariableSlot);
-            for (int slot = 1; slot < nextVariableSlot; slot++)
+            int n = variableBySlot.Count;
+            BitVector mask = BitVector.AllSet(n);
+            for (int slot = 1; slot < n; slot++)
             {
                 mask[slot] = IsCapturedInLocalFunction(slot);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.VariableIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.VariableIdentifier.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -87,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Symbol.Equals(other.Symbol, TypeCompareKind.AllIgnoreOptions);
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -239,11 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             int slot = nextVariableSlot++;
             _variableSlot.Add(identifier, slot);
-            while (slot >= variableBySlot.Count)
-            {
-                variableBySlot.Add(default);
-            }
-            variableBySlot[slot] = identifier;
+            variableBySlot.Add(identifier);
             return slot;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefinitelyAssignedWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefinitelyAssignedWalker.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var slot in state1.Assigned.TrueBits())
             {
-                if (slot < variableBySlot.Length &&
+                if (slot < variableBySlot.Count &&
                     state2opt?.IsAssigned(slot) != false &&
                     variableBySlot[slot].Symbol is { } symbol &&
                     symbol.Kind != SymbolKind.Field)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -28,31 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// A mapping from local variables to the index of their slot in a flow analysis local state.
-        /// </summary>
-        protected readonly PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
-
-        /// <summary>
-        /// A mapping from the local variable slot to the symbol for the local variable itself.  This
-        /// is used in the implementation of region analysis (support for extract method) to compute
-        /// the set of variables "always assigned" in a region of code.
-        ///
-        /// The first slot, slot 0, is reserved for indicating reachability, so the first tracked variable will
-        /// be given slot 1. When referring to <see cref="VariableIdentifier.ContainingSlot"/>, slot 0 indicates
-        /// that the variable in <see cref="VariableIdentifier.Symbol"/> is a root, i.e. not nested within another
-        /// tracked variable. Slots &lt; 0 are illegal.
-        /// </summary>
-        protected VariableIdentifier[] variableBySlot = new VariableIdentifier[1];
-
-        /// <summary>
-        /// Variable slots are allocated to local variables sequentially and never reused.  This is
-        /// the index of the next slot number to use.
-        /// </summary>
-        protected int nextVariableSlot = 1;
-
-        private readonly int _maxSlotDepth;
-
-        /// <summary>
         /// A cache for remember which structs are empty.
         /// </summary>
         protected readonly EmptyStructTypeCache _emptyStructTypeCache;
@@ -62,12 +36,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Symbol? member,
             BoundNode node,
             EmptyStructTypeCache emptyStructs,
-            bool trackUnassignments,
-            int maxSlotDepth = 0)
+            bool trackUnassignments)
             : base(compilation, member, node, nonMonotonicTransferFunction: trackUnassignments)
         {
             Debug.Assert(emptyStructs != null);
-            _maxSlotDepth = maxSlotDepth;
             _emptyStructTypeCache = emptyStructs;
         }
 
@@ -85,11 +57,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             _emptyStructTypeCache = emptyStructs;
         }
 
-        protected override void Free()
-        {
-            _variableSlot.Free();
-            base.Free();
-        }
+        protected abstract bool TryGetVariable(VariableIdentifier identifier, out int slot);
+
+        protected abstract int AddVariable(VariableIdentifier identifier);
 
         /// <summary>
         /// Locals are given slots when their declarations are encountered.  We only need give slots
@@ -107,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             containingSlot = DescendThroughTupleRestFields(ref symbol, containingSlot, forceContainingSlotsToExist: false);
 
             int slot;
-            return (_variableSlot.TryGetValue(new VariableIdentifier(symbol, containingSlot), out slot)) ? slot : -1;
+            return TryGetVariable(new VariableIdentifier(symbol, containingSlot), out slot) ? slot : -1;
         }
 
         protected virtual bool IsEmptyStructType(TypeSymbol type)
@@ -137,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             int slot;
 
             // Since analysis may proceed in multiple passes, it is possible the slot is already assigned.
-            if (!_variableSlot.TryGetValue(identifier, out slot))
+            if (!TryGetVariable(identifier, out slot))
             {
                 if (!createIfMissing)
                 {
@@ -150,19 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return -1;
                 }
 
-                if (_maxSlotDepth > 0 && GetSlotDepth(containingSlot) >= _maxSlotDepth)
-                {
-                    return -1;
-                }
-
-                slot = nextVariableSlot++;
-                _variableSlot.Add(identifier, slot);
-                if (slot >= variableBySlot.Length)
-                {
-                    Array.Resize(ref this.variableBySlot, slot * 2);
-                }
-
-                variableBySlot[slot] = identifier;
+                slot = AddVariable(identifier);
             }
 
             if (IsConditionalState)
@@ -176,17 +134,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return slot;
-        }
-
-        private int GetSlotDepth(int slot)
-        {
-            int depth = 0;
-            while (slot > 0)
-            {
-                depth++;
-                slot = variableBySlot[slot].ContainingSlot;
-            }
-            return depth;
         }
 
         /// <summary>
@@ -227,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        if (!_variableSlot.TryGetValue(new VariableIdentifier(restField, containingSlot), out containingSlot))
+                        if (!TryGetVariable(new VariableIdentifier(restField, containingSlot), out containingSlot))
                         {
                             return -1;
                         }
@@ -241,18 +188,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         protected abstract bool TryGetReceiverAndMember(BoundExpression expr, out BoundExpression? receiver, [NotNullWhen(true)] out Symbol? member);
-
-        protected Symbol GetNonMemberSymbol(int slot)
-        {
-            VariableIdentifier variableId = variableBySlot[slot];
-            while (variableId.ContainingSlot > 0)
-            {
-                Debug.Assert(variableId.Symbol.Kind == SymbolKind.Field || variableId.Symbol.Kind == SymbolKind.Property || variableId.Symbol.Kind == SymbolKind.Event,
-                    "inconsistent property symbol owner");
-                variableId = variableBySlot[variableId.ContainingSlot];
-            }
-            return variableId.Symbol;
-        }
 
         /// <summary>
         /// Return the slot for a variable, or -1 if it is not tracked (because, for example, it is an empty struct).
@@ -308,22 +243,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return GetOrCreateSlot(member, containingSlot);
-        }
-
-        protected int RootSlot(int slot)
-        {
-            while (true)
-            {
-                ref var varInfo = ref variableBySlot[slot];
-                if (varInfo.ContainingSlot == 0)
-                {
-                    return slot;
-                }
-                else
-                {
-                    slot = varInfo.ContainingSlot;
-                }
-            }
         }
 
         protected static bool HasInitializer(Symbol field) => field switch

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// A mapping from local variables to the index of their slot in a flow analysis local state.
         /// </summary>
-        protected PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
+        protected readonly PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
 
         /// <summary>
         /// A mapping from the local variable slot to the symbol for the local variable itself.  This

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
@@ -1,0 +1,296 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class NullableWalker
+    {
+        [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+        internal sealed class Variables
+        {
+            private sealed class Factory
+            {
+                internal int NextId;
+                internal int MaxSlotDepth;
+
+                internal Factory(int maxSlotDepth)
+                {
+                    MaxSlotDepth = maxSlotDepth;
+                }
+            }
+
+            private const int IdOffset = 16;
+            private const int IdOrIndexMask = (1 << IdOffset) - 1;
+            private const int IndexMax = IdOrIndexMask;
+
+            private readonly Factory _factory;
+            internal readonly int Id;
+            internal readonly Variables? Container;
+            internal readonly Symbol? Symbol;
+
+            /// <summary>
+            /// A mapping from local variables to the index of their slot in a flow analysis local state.
+            /// </summary>
+            private readonly PooledDictionary<VariableIdentifier, int> _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
+
+            /// <summary>
+            /// The inferred type at the point of declaration of var locals and parameters.
+            /// </summary>
+            private readonly PooledDictionary<Symbol, TypeWithAnnotations> _variableTypes = SpecializedSymbolCollections.GetPooledSymbolDictionaryInstance<Symbol, TypeWithAnnotations>();
+
+            /// <summary>
+            /// A mapping from the local variable slot to the symbol for the local variable itself.  This
+            /// is used in the implementation of region analysis (support for extract method) to compute
+            /// the set of variables "always assigned" in a region of code.
+            ///
+            /// The first slot, slot 0, is reserved for indicating reachability, so the first tracked variable will
+            /// be given slot 1. When referring to VariableIdentifier.ContainingSlot, slot 0 indicates
+            /// that the variable in VariableIdentifier.Symbol is a root, i.e. not nested within another
+            /// tracked variable. Slots &lt; 0 are illegal.
+            /// </summary>
+            private readonly ArrayBuilder<VariableIdentifier> _variableBySlot;
+
+            /// <summary>
+            /// Variable slots are allocated to local variables sequentially and never reused.  This is
+            /// the index of the next slot number to use.
+            /// </summary>
+            private int _nextVariableIndex = 1;
+
+            internal static Variables Create(Symbol? symbol, int maxSlotDepth)
+            {
+                return new Variables(new Factory(maxSlotDepth), container: null, symbol);
+            }
+
+            private Variables(Factory factory, Variables? container, Symbol? symbol)
+            {
+                Debug.Assert(container is null || container.Id < factory.NextId);
+                _factory = factory;
+                // PROTOTYPE: Handle > 64K nested methods (distinct ids). See NullableStateTooManyNestedFunctions().
+                Id = _factory.NextId++;
+                Container = container;
+                Symbol = symbol;
+                _variableBySlot = ArrayBuilder<VariableIdentifier>.GetInstance();
+                _variableBySlot.Add(default); // slot 0 reserved for reachability
+            }
+
+            internal void Free()
+            {
+                // PROTOTYPE:
+#if false
+                Container?.Free();
+                _variableBySlot.Free();
+                _variableTypes.Free();
+                _variableSlot.Free();
+#endif
+            }
+
+            internal Variables CreateNestedFunction(MethodSymbol method)
+            {
+                Debug.Assert(GetVariablesForSymbol(method) is null or { Symbol: null });
+                return new Variables(_factory, this, method);
+            }
+
+            internal int RootSlot(int slot)
+            {
+                while (true)
+                {
+                    int containingSlot = this[slot].ContainingSlot;
+                    if (containingSlot == 0)
+                    {
+                        return slot;
+                    }
+                    else
+                    {
+                        slot = containingSlot;
+                    }
+                }
+            }
+
+            internal bool TryGetValue(VariableIdentifier identifier, out int slot)
+            {
+                var variables = GetVariablesForVariable(identifier);
+                return variables.TryGetValueInternal(identifier, out slot);
+            }
+
+            private bool TryGetValueInternal(VariableIdentifier identifier, out int slot)
+            {
+                if (_variableSlot.TryGetValue(identifier, out int index))
+                {
+                    slot = ConstructSlot(Id, index);
+                    return true;
+                }
+                slot = -1;
+                return false;
+            }
+
+            internal int Add(VariableIdentifier identifier)
+            {
+                if (_nextVariableIndex > IndexMax)
+                {
+                    return -1;
+                }
+                if (GetSlotDepth(identifier.ContainingSlot) >= _factory.MaxSlotDepth)
+                {
+                    return -1;
+                }
+                var variables = GetVariablesForVariable(identifier);
+                return variables.AddInternal(identifier);
+            }
+
+            private int AddInternal(VariableIdentifier identifier)
+            {
+                int index = _nextVariableIndex++;
+                _variableSlot.Add(identifier, index);
+                while (index >= _variableBySlot.Count)
+                {
+                    _variableBySlot.Add(default);
+                }
+                _variableBySlot[index] = identifier;
+                return ConstructSlot(Id, index);
+            }
+
+            internal bool TryGetType(Symbol symbol, out TypeWithAnnotations type)
+            {
+                var variables = GetVariablesContainingVariable(symbol);
+                return variables._variableTypes.TryGetValue(symbol, out type);
+            }
+
+            internal void SetType(Symbol symbol, TypeWithAnnotations type)
+            {
+                var variables = GetVariablesContainingVariable(symbol);
+                Debug.Assert((object)variables == this);
+                variables._variableTypes[symbol] = type;
+            }
+
+            internal VariableIdentifier this[int slot]
+            {
+                get
+                {
+                    (int id, int index) = DeconstructSlot(slot);
+                    var variables = GetVariablesForId(id);
+                    return variables!._variableBySlot[index];
+                }
+            }
+
+            internal int Count => _nextVariableIndex;
+
+            internal void GetMembers(ArrayBuilder<(VariableIdentifier, int)> builder, int containingSlot)
+            {
+                (int id, int index) = DeconstructSlot(containingSlot);
+                var variables = GetVariablesForId(id)!;
+
+                for (index++; index < variables.Count; index++)
+                {
+                    var variable = variables._variableBySlot[index];
+                    if (variable.ContainingSlot == containingSlot)
+                    {
+                        builder.Add((variable, ConstructSlot(id, index)));
+                    }
+                }
+            }
+
+            private Variables GetVariablesForVariable(VariableIdentifier identifier)
+            {
+                int containingSlot = identifier.ContainingSlot;
+                if (containingSlot > 0)
+                {
+                    return GetVariablesForId(DeconstructSlot(containingSlot).Id)!;
+                }
+                return GetVariablesContainingVariable(identifier.Symbol);
+            }
+
+            internal Variables GetVariablesContainingVariable(Symbol symbol)
+            {
+                switch (symbol)
+                {
+                    case LocalSymbol:
+                    case ParameterSymbol:
+                    case MethodSymbol { MethodKind: MethodKind.LocalFunction }:
+                        if (symbol.ContainingSymbol is MethodSymbol method &&
+                            GetVariablesForSymbol(method.PartialImplementationPart ?? method) is { } variables)
+                        {
+                            return variables;
+                        }
+                        break;
+                }
+                return GetVariablesRoot();
+            }
+
+            private Variables GetVariablesRoot()
+            {
+                var variables = this;
+                while (variables.Container is { } container)
+                {
+                    variables = container;
+                }
+                return variables;
+            }
+
+            private Variables? GetVariablesForId(int id)
+            {
+                var variables = this;
+                do
+                {
+                    if (variables.Id == id)
+                    {
+                        return variables;
+                    }
+                    variables = variables.Container;
+                }
+                while (variables is { });
+                return null;
+            }
+
+            private Variables? GetVariablesForSymbol(MethodSymbol symbol)
+            {
+                var variables = this;
+                while (true)
+                {
+                    if (variables.Symbol is null || (object)symbol == variables.Symbol)
+                    {
+                        return variables;
+                    }
+                    variables = variables.Container!;
+                    if (variables is null)
+                    {
+                        return null;
+                    }
+                }
+            }
+
+            private int GetSlotDepth(int slot)
+            {
+                int depth = 0;
+                while (slot > 0)
+                {
+                    depth++;
+                    slot = this[slot].ContainingSlot;
+                }
+                return depth;
+            }
+
+            internal static int ConstructSlot(int id, int index)
+            {
+                return index < 0 ? index : (id << IdOffset) + index;
+            }
+
+            internal static (int Id, int Index) DeconstructSlot(int slot)
+            {
+                Debug.Assert(slot > -1);
+                return slot < 0 ? (0, slot) : ((slot >> IdOffset & IdOrIndexMask), slot & IdOrIndexMask);
+            }
+
+            internal string GetDebuggerDisplay()
+            {
+                var symbol = (object?)Symbol ?? "<null>";
+                return $"Id={Id}, Symbol={symbol}, Count={Count}";
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
@@ -78,16 +78,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             private readonly PooledDictionary<Symbol, TypeWithAnnotations> _variableTypes = SpecializedSymbolCollections.GetPooledSymbolDictionaryInstance<Symbol, TypeWithAnnotations>();
 
             /// <summary>
-            /// A mapping from the local variable slot to the symbol for the local variable itself.  This
-            /// is used in the implementation of region analysis (support for extract method) to compute
-            /// the set of variables "always assigned" in a region of code.
+            /// A mapping from the local variable slot to the symbol for the local variable itself.
             ///
             /// The first slot, slot 0, is reserved for indicating reachability, so the first tracked variable will
             /// be given slot 1. When referring to VariableIdentifier.ContainingSlot, slot 0 indicates
             /// that the variable in VariableIdentifier.Symbol is a root, i.e. not nested within another
-            /// tracked variable. Slots &lt; 0 are illegal.
+            /// tracked variable. Slots less than 0 are illegal.
             /// </summary>
-            private readonly ArrayBuilder<VariableIdentifier> _variableBySlot;
+            private readonly ArrayBuilder<VariableIdentifier> _variableBySlot = ArrayBuilder<VariableIdentifier>.GetInstance(1, default);
 
             internal static Variables Create(Symbol? symbol)
             {
@@ -130,15 +128,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private Variables(NextId nextId, int id, Variables? container, Symbol? symbol)
             {
-                Debug.Assert(container is null || container.Id < nextId.Value);
+                Debug.Assert(container is null || container.Id < id);
                 Debug.Assert(id < nextId.Value);
                 _nextId = nextId;
                 // PROTOTYPE: Handle > 64K nested methods (distinct ids). See NullableStateTooManyNestedFunctions().
                 Id = id;
                 Container = container;
                 Symbol = symbol;
-                _variableBySlot = ArrayBuilder<VariableIdentifier>.GetInstance();
-                _variableBySlot.Add(default); // slot 0 reserved for reachability
             }
 
             internal void Free()

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
@@ -214,7 +214,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal Variables CreateNestedMethodScope(MethodSymbol method)
             {
                 Debug.Assert(GetVariablesForMethodScope(method) is null);
-                Debug.Assert(!(method.ContainingSymbol is MethodSymbol containingMethod) || ((object?)GetVariablesForMethodScope(containingMethod) == this));
+                Debug.Assert(!(method.ContainingSymbol is MethodSymbol containingMethod) ||
+                    ((object?)GetVariablesForMethodScope(containingMethod) == this) ||
+                    Container is null);
 
                 return new Variables(id: GetNextId(), this, method);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
@@ -400,10 +400,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var variables = this;
                 while (true)
                 {
-                    if (variables.Symbol is null)
-                    {
-                        return null;
-                    }
                     if ((object)method == variables.Symbol)
                     {
                         return variables;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
@@ -131,7 +131,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(container is null || container.Id < id);
                 Debug.Assert(id < nextId.Value);
                 _nextId = nextId;
-                // PROTOTYPE: Handle > 64K nested methods (distinct ids). See NullableStateTooManyNestedFunctions().
                 Id = id;
                 Container = container;
                 Symbol = symbol;
@@ -249,10 +248,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 (int id, int index) = DeconstructSlot(containingSlot);
                 var variables = GetVariablesForId(id)!;
-
-                for (index++; index < variables.Count; index++)
+                var variableBySlot = variables._variableBySlot;
+                for (index++; index < variableBySlot.Count; index++)
                 {
-                    var variable = variables._variableBySlot[index];
+                    var variable = variableBySlot[index];
                     if (variable.ContainingSlot == containingSlot)
                     {
                         builder.Add((variable, ConstructSlot(id, index)));

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2681,25 +2681,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<PendingBranch> pendingReturns = RemoveReturns();
             RestorePending(oldPending);
 
-            var location = lambdaOrFunctionSymbol.Locations.FirstOrNone();
-            LeaveParameters(lambdaOrFunctionSymbol.Parameters, lambdaOrFunction.Syntax, location);
-
-            // Intersect the state of all branches out of the local function
-            var stateAtReturn = this.State;
-            foreach (PendingBranch pending in pendingReturns)
-            {
-                this.State = pending.State;
-                BoundNode branch = pending.Branch;
-
-                // Pass the local function identifier as a location if the branch
-                // is null or compiler generated.
-                LeaveParameters(lambdaOrFunctionSymbol.Parameters,
-                  branch?.Syntax,
-                  branch?.WasCompilerGenerated == false ? null : location);
-
-                Join(ref stateAtReturn, ref this.State);
-            }
-
             _snapshotBuilderOpt?.ExitWalker(this.SaveSharedState(), previousSlot);
             _variables = _variables.Container!;
             this.State = oldState;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1461,9 +1461,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             state.Normalize(this, _variables);
         }
 
-        private NullableFlowState GetDefaultState(int slot)
+        private NullableFlowState GetDefaultState(ref LocalState state, int slot)
         {
             Debug.Assert(slot > 0);
+
+            if (!state.Reachable)
+                return NullableFlowState.NotNull;
 
             var variable = _variables[slot];
             var symbol = variable.Symbol;
@@ -2790,7 +2793,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int slot = GetOrCreateSlot(local);
                 if (slot > 0)
                 {
-                    this.State[slot] = GetDefaultState(slot);
+                    this.State[slot] = GetDefaultState(ref this.State, slot);
                     InheritDefaultState(GetDeclaredLocalResult(local).Type, slot);
                 }
             }
@@ -9738,7 +9741,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 for (int index = start; index < capacity; index++)
                 {
                     int slot = Variables.ConstructSlot(Id, index);
-                    SetValue(Id, index, walker.GetDefaultState(slot));
+                    SetValue(Id, index, walker.GetDefaultState(ref this, slot));
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9603,7 +9603,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-        internal sealed class LocalState : ILocalDataFlowState // PROTOTYPE: Pool instances.
+        internal sealed class LocalState : ILocalDataFlowState // PROTOTYPE: Reduce allocations.
         {
             internal readonly int Id;
             internal LocalState? Container;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9592,7 +9592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// A bit array containing the nullability of variables associated with a method scope. If the method is a
         /// nested function (a lambda or a local function), there is a reference to the corresponding instance for
         /// the containing method scope. The instances in the chain are associated with a corresponding
-        /// <see cref="Variables"/> chain, and the Id field in this type matches the Id in the <see cref="Variables"/> chain.
+        /// <see cref="Variables"/> chain, and the <see cref="Id"/> field in this type matches <see cref="Variables.Id"/>.
         /// </summary>
         [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
         internal struct LocalState : ILocalDataFlowState

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The inferred type at the point of declaration of var locals and parameters.
         /// </summary>
-        private PooledDictionary<Symbol, TypeWithAnnotations> _variableTypes = SpecializedSymbolCollections.GetPooledSymbolDictionaryInstance<Symbol, TypeWithAnnotations>();
+        private readonly PooledDictionary<Symbol, TypeWithAnnotations> _variableTypes = SpecializedSymbolCollections.GetPooledSymbolDictionaryInstance<Symbol, TypeWithAnnotations>();
 
         /// <summary>
         /// Binder for symbol being analyzed.
@@ -210,11 +210,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// that would otherwise be taken.
         /// </summary>
         private readonly bool _isSpeculative;
-
-        /// <summary>
-        /// Is a method that contains only blocks, expression statements, and lambdas.
-        /// </summary>
-        private readonly bool _isSimpleMethod;
 
         /// <summary>
         /// True if this walker was created using an initial state.
@@ -406,7 +401,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             _returnTypesOpt = returnTypesOpt;
             _snapshotBuilderOpt = snapshotBuilderOpt;
             _isSpeculative = isSpeculative;
-            _isSimpleMethod = IsSimpleMethodVisitor.IsSimpleMethod(node);
 
             if (initialState != null)
             {
@@ -428,68 +422,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 _hasInitialState = false;
-            }
-        }
-
-        internal sealed class IsSimpleMethodVisitor : BoundTreeWalkerWithStackGuard
-        {
-            private bool _hasComplexity;
-
-            internal static bool IsSimpleMethod(BoundNode? node)
-            {
-                if (node is BoundConstructorMethodBody constructorBody && constructorBody.Initializer is { })
-                {
-                    return false;
-                }
-                if (node is BoundMethodBodyBase methodBody)
-                {
-                    var blockBody = methodBody.BlockBody;
-                    var expressionBody = methodBody.ExpressionBody;
-                    node = blockBody;
-                    if (node is { })
-                    {
-                        if (expressionBody is { }) return false;
-                    }
-                    else
-                    {
-                        node = expressionBody;
-                    }
-                }
-                var visitor = new IsSimpleMethodVisitor();
-                try
-                {
-                    visitor.Visit(node);
-                    return !visitor._hasComplexity;
-                }
-                catch (CancelledByStackGuardException)
-                {
-                    return false;
-                }
-            }
-
-            public override BoundNode? Visit(BoundNode? node)
-            {
-                if (node is null)
-                {
-                    return null;
-                }
-                if (_hasComplexity)
-                {
-                    return node;
-                }
-                if (node is BoundExpression)
-                {
-                    return base.Visit(node);
-                }
-                switch (node.Kind)
-                {
-                    case BoundKind.Block:
-                    case BoundKind.ExpressionStatement:
-                    case BoundKind.ReturnStatement:
-                        return base.Visit(node);
-                }
-                _hasComplexity = true;
-                return node;
             }
         }
 
@@ -2732,37 +2664,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var oldState = this.State;
             this.State = state;
 
-            var oldVariableSlot = _variableSlot;
-            var oldVariableTypes = _variableTypes;
-            var oldVariableBySlot = variableBySlot;
-            var oldNextVariableSlot = nextVariableSlot;
-
-            // As an optimization, if the entire method is simple enough,
-            // we'll reset the set of variable slots and types after analyzing the nested function,
-            // to avoid accumulating entries in the outer function for variables that are
-            // local to the nested function. (Of course, this will drop slots associated
-            // with variables in the outer function that were first used in the nested function,
-            // such as a field access on a captured local, but the state associated with
-            // any such entries are dropped, so the slots can be dropped as well.)
-            // We don't optimize more complicated methods (methods that contain labels,
-            // branches, try blocks, local functions) because we track additional state for
-            // those nodes that might be invalidated if we drop the associated slots or types.
-            if (_isSimpleMethod)
-            {
-                _variableSlot = PooledDictionary<VariableIdentifier, int>.GetInstance();
-                foreach (var pair in oldVariableSlot)
-                {
-                    _variableSlot.Add(pair.Key, pair.Value);
-                }
-                _variableTypes = SpecializedSymbolCollections.GetPooledSymbolDictionaryInstance<Symbol, TypeWithAnnotations>();
-                foreach (var pair in oldVariableTypes)
-                {
-                    _variableTypes.Add(pair.Key, pair.Value);
-                }
-                variableBySlot = new VariableIdentifier[oldVariableBySlot.Length];
-                Array.Copy(oldVariableBySlot, variableBySlot, oldVariableBySlot.Length);
-            }
-
             var previousSlot = _snapshotBuilderOpt?.EnterNewWalker(lambdaOrFunctionSymbol) ?? -1;
 
             var oldPending = SavePending();
@@ -2803,16 +2704,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             _snapshotBuilderOpt?.ExitWalker(this.SaveSharedState(), previousSlot);
-
-            if (_isSimpleMethod)
-            {
-                nextVariableSlot = oldNextVariableSlot;
-                variableBySlot = oldVariableBySlot;
-                _variableTypes.Free();
-                _variableTypes = oldVariableTypes;
-                _variableSlot.Free();
-                _variableSlot = oldVariableSlot;
-            }
 
             this.State = oldState;
             _returnTypesOpt = oldReturnTypes;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1293,8 +1293,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics,
             MethodSymbol? delegateInvokeMethodOpt,
             VariableState initialState,
-            ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol?)>.Builder? analyzedNullabilityMapOpt,
-            SnapshotManager.Builder? snapshotBuilderOpt,
             ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)>? returnTypesOpt)
         {
             var symbol = lambda.Symbol;
@@ -1310,12 +1308,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversions,
                 variables,
                 returnTypesOpt,
-                analyzedNullabilityMapOpt,
-                snapshotBuilderOpt);
+                analyzedNullabilityMapOpt: null,
+                snapshotBuilderOpt: null);
             try
             {
                 var localState = LocalState.Create(initialState.VariableNullableStates).CreateNestedFunction(variables);
-                Analyze(walker, symbol, diagnostics, localState, snapshotBuilderOpt);
+                Analyze(walker, symbol, diagnostics, localState, snapshotBuilderOpt: null);
             }
             finally
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -459,15 +459,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 {
                                     var value = TypeWithState.Create(tempType, tempState);
                                     var inferredType = value.ToTypeWithAnnotations(compilation, asAnnotatedType: boundLocal.DeclarationKind == BoundLocalDeclarationKind.WithInferredType);
-                                    if (_variableTypes.TryGetValue(local, out var existingType))
+                                    if (_variables.TryGetType(local, out var existingType))
                                     {
                                         // merge inferred nullable annotation from different branches of the decision tree
-                                        _variableTypes[local] = TypeWithAnnotations.Create(inferredType.Type, existingType.NullableAnnotation.Join(inferredType.NullableAnnotation));
+                                        inferredType = TypeWithAnnotations.Create(inferredType.Type, existingType.NullableAnnotation.Join(inferredType.NullableAnnotation));
                                     }
-                                    else
-                                    {
-                                        _variableTypes[local] = inferredType;
-                                    }
+                                    _variables.SetType(local, inferredType);
 
                                     int localSlot = GetOrCreateSlot(local, forceSlotEvenIfEmpty: true);
                                     if (localSlot > 0)

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -71,8 +71,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var lazyDisallowedCaptures = walker._lazyDisallowedCaptures;
             var allVariables = walker.variableBySlot;
 
-            walker.Free();
-
             if (lazyDisallowedCaptures != null)
             {
                 foreach (var kvp in lazyDisallowedCaptures)
@@ -112,6 +110,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Hoist anything determined to be live across an await or yield
             variablesToHoist.AddRange(walker._variablesToHoist);
+
+            walker.Free();
 
             return variablesToHoist;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void MarkLocalsUnassigned()
         {
-            for (int i = 0; i < nextVariableSlot; i++)
+            for (int i = 0; i < variableBySlot.Count; i++)
             {
                 var symbol = variableBySlot[i].Symbol;
 


### PR DESCRIPTION
`NullableWalker` now tracks the `LocalState` separately for separate lambdas or local functions within the same containing method to avoid duplicated state across nested methods. Similarly, the dictionaries that map variables to slots and types are now tracked separately.

The state for a nested method is now a linked list of state for that method and each of the containing methods.

If the method contains M nested functions with a total of N variables and fields across the method and all nested functions, the existing implementation holds O(M&ast;N) state and this implementation holds O(N + M&ast;N0) state where N0 is the number of variables and fields in the outer method. (The duplication of N0 could be addressed by storing one copy of the `LocalState` for the outer method rather than including a copy with each nested function.)

Fixes https://github.com/dotnet/roslyn/issues/49745