### PR TITLE
Allow access to semantic model during syntax walk

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -250,6 +250,47 @@ class C
         }
 
         [Fact]
+        public void SyntaxContext_Receiver_Visits_Syntax_In_Compilation()
+        {
+            var source = @"
+class C 
+{
+    int Property { get; set; }
+
+    void Function()
+    {
+        var x = 5;
+        x += 4;
+    }
+}
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxContextReceiver? receiver = null;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver()),
+                onExecute: (e) => receiver = e.SyntaxContextReceiver
+                );
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator }, parseOptions: parseOptions);
+            driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+
+            Assert.NotNull(receiver);
+            Assert.IsType<TestSyntaxContextReceiver>(receiver);
+
+            TestSyntaxContextReceiver testReceiver = (TestSyntaxContextReceiver)receiver!;
+            Assert.Equal(21, testReceiver.VisitedNodes.Count);
+            Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0].Node);
+            Assert.NotNull(testReceiver.VisitedNodes[0].SemanticModel);
+            Assert.Equal(testReceiver.VisitedNodes[0].SemanticModel.SyntaxTree, testReceiver.VisitedNodes[0].Node.SyntaxTree);
+        }
+
+        [Fact]
         public void Syntax_Receiver_Is_Not_Reused_Between_Invocations()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -87,7 +87,7 @@ class C { }
             ISyntaxContextReceiver? receiver = null;
 
             var testGenerator = new CallbackGenerator(
-                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver()),
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver()),
                 onExecute: (e) => receiver = e.SyntaxContextReceiver
                 );
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -14,12 +15,12 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities.TestGenerators;
 using Xunit;
+
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 {
     public class SyntaxAwareGeneratorTests
          : CSharpTestBase
     {
-
         [Fact]
         public void Syntax_Receiver_Is_Present_When_Registered()
         {
@@ -72,7 +73,7 @@ class C { }
         }
 
         [Fact]
-        public void Syntax_Receiver_Can_Be_Registered_Only_Once()
+        public void SyntaxContext_Receiver_Is_Present_When_Registered()
         {
             var source = @"
 class C { }
@@ -83,22 +84,130 @@ class C { }
 
             Assert.Single(compilation.SyntaxTrees);
 
+            ISyntaxContextReceiver? receiver = null;
+
             var testGenerator = new CallbackGenerator(
-                onInit: initialize,
-                onExecute: (e) => { }
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver()),
+                onExecute: (e) => receiver = e.SyntaxContextReceiver
                 );
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator }, parseOptions: parseOptions);
             driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
 
-            void initialize(GeneratorInitializationContext initContext)
+            Assert.NotNull(receiver);
+            Assert.IsType<TestSyntaxContextReceiver>(receiver);
+        }
+
+        [Fact]
+        public void SyntaxContext_Receiver_Is_Null_WhenNot_Registered()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxContextReceiver? receiver = null;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => { },
+                onExecute: (e) => receiver = e.SyntaxContextReceiver
+                );
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator }, parseOptions: parseOptions);
+            driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+
+            Assert.Null(receiver);
+        }
+
+        [Fact]
+        public void SyntaxContext_Receiver_Is_Null_When_Syntax_Receiver_Registered()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxContextReceiver? receiver = null;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver()),
+                onExecute: (e) => receiver = e.SyntaxContextReceiver
+                );
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator }, parseOptions: parseOptions);
+            driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+
+            Assert.Null(receiver);
+        }
+
+        [Fact]
+        public void Syntax_Receiver_Is_Null_When_SyntaxContext_Receiver_Registered()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            ISyntaxReceiver? receiver = null;
+
+            var testGenerator = new CallbackGenerator(
+                onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver()),
+                onExecute: (e) => receiver = e.SyntaxReceiver
+                );
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator }, parseOptions: parseOptions);
+            driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+
+            Assert.Null(receiver);
+        }
+
+        [Fact]
+        public void Syntax_Receiver_Can_Be_Registered_Only_Once()
+        {
+            // ISyntaxReceiver + ISyntaxReceiver
+            GeneratorInitializationContext init = new GeneratorInitializationContext(CancellationToken.None);
+            init.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                initContext.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
-                Assert.Throws<InvalidOperationException>(() =>
-                {
-                    initContext.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
-                });
-            }
+                init.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
+            });
+
+            // ISyntaxContextReceiver + ISyntaxContextReceiver
+            init = new GeneratorInitializationContext(CancellationToken.None);
+            init.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                init.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver());
+            });
+
+            // ISyntaxContextReceiver + ISyntaxReceiver
+            init = new GeneratorInitializationContext(CancellationToken.None);
+            init.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                init.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
+            });
+
+
+            // ISyntaxReceiver + ISyntaxContextReceiver
+            init = new GeneratorInitializationContext(CancellationToken.None);
+            init.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                init.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver());
+            });
         }
 
         [Fact]
@@ -215,7 +324,7 @@ class C
 
             var exception = new Exception("Test Exception");
             var testGenerator = new CallbackGenerator(
-                onInit: (i) => i.RegisterForSyntaxNotifications(() => throw exception),
+                onInit: (i) => i.RegisterForSyntaxNotifications((SyntaxReceiverCreator)(() => throw exception)),
                 onExecute: (e) => { Assert.True(false); }
                 );
 
@@ -417,27 +526,43 @@ class C
                 );
         }
 
-        class TestSyntaxReceiver : ISyntaxReceiver
+        class TestReceiverBase<T>
         {
-            private readonly Action<SyntaxNode>? _callback;
+            private readonly Action<T>? _callback;
 
-            public List<SyntaxNode> VisitedNodes { get; } = new List<SyntaxNode>();
+            public List<T> VisitedNodes { get; } = new List<T>();
 
             public int Tag { get; }
 
-            public TestSyntaxReceiver(int tag = 0, Action<SyntaxNode>? callback = null)
+            public TestReceiverBase(int tag = 0, Action<T>? callback = null)
             {
                 Tag = tag;
                 _callback = callback;
             }
 
-            public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+            public void OnVisitSyntaxNode(T syntaxNode)
             {
                 VisitedNodes.Add(syntaxNode);
                 if (_callback is object)
                 {
                     _callback(syntaxNode);
                 }
+            }
+        }
+
+        class TestSyntaxReceiver : TestReceiverBase<SyntaxNode>, ISyntaxReceiver
+        {
+            public TestSyntaxReceiver(int tag = 0, Action<SyntaxNode>? callback = null)
+                : base(tag, callback)
+            {
+            }
+        }
+
+        class TestSyntaxContextReceiver : TestReceiverBase<GeneratorSyntaxContext>, ISyntaxContextReceiver
+        {
+            public TestSyntaxContextReceiver(int tag = 0, Action<GeneratorSyntaxContext>? callback = null)
+                : base(tag, callback)
+            {
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -135,17 +135,19 @@ class C { }
 
             Assert.Single(compilation.SyntaxTrees);
 
-            ISyntaxContextReceiver? receiver = null;
+            ISyntaxReceiver? syntaxReceiver = null;
+            ISyntaxContextReceiver? contextReceiver = null;
 
             var testGenerator = new CallbackGenerator(
                 onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxReceiver()),
-                onExecute: (e) => receiver = e.SyntaxContextReceiver
+                onExecute: (e) => { syntaxReceiver = e.SyntaxReceiver; contextReceiver = e.SyntaxContextReceiver; }
                 );
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator }, parseOptions: parseOptions);
             driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
 
-            Assert.Null(receiver);
+            Assert.Null(contextReceiver);
+            Assert.NotNull(syntaxReceiver);
         }
 
         [Fact]
@@ -160,17 +162,19 @@ class C { }
 
             Assert.Single(compilation.SyntaxTrees);
 
-            ISyntaxReceiver? receiver = null;
+            ISyntaxReceiver? syntaxReceiver = null;
+            ISyntaxContextReceiver? contextReceiver = null;
 
             var testGenerator = new CallbackGenerator(
                 onInit: (i) => i.RegisterForSyntaxNotifications(() => new TestSyntaxContextReceiver()),
-                onExecute: (e) => receiver = e.SyntaxReceiver
+                onExecute: (e) => { syntaxReceiver = e.SyntaxReceiver; contextReceiver = e.SyntaxContextReceiver; }
                 );
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator }, parseOptions: parseOptions);
             driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
 
-            Assert.Null(receiver);
+            Assert.Null(syntaxReceiver);
+            Assert.NotNull(contextReceiver);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
+Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext
+Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.GeneratorSyntaxReceiverContext() -> void
+Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.Node.get -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel
 Microsoft.CodeAnalysis.ISyntaxReceiverBase
+Microsoft.CodeAnalysis.ISyntaxReceiverWithContext
+Microsoft.CodeAnalysis.ISyntaxReceiverWithContext.OnVisitSyntaxNode(Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext context) -> void
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,18 +1,18 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
-Microsoft.CodeAnalysis.GeneratorExecutionContext.SyntaxReceiverWithContext.get -> Microsoft.CodeAnalysis.ISyntaxReceiverWithContext
-Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext
-Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.GeneratorSyntaxReceiverContext() -> void
-Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.Node.get -> Microsoft.CodeAnalysis.SyntaxNode
-Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel
-Microsoft.CodeAnalysis.ISyntaxReceiverBase
-Microsoft.CodeAnalysis.ISyntaxReceiverWithContext
-Microsoft.CodeAnalysis.ISyntaxReceiverWithContext.OnVisitSyntaxNode(Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext context) -> void
+Microsoft.CodeAnalysis.GeneratorExecutionContext.SyntaxContextReceiver.get -> Microsoft.CodeAnalysis.ISyntaxContextReceiver
+Microsoft.CodeAnalysis.GeneratorInitializationContext.RegisterForSyntaxNotifications(Microsoft.CodeAnalysis.SyntaxContextReceiverCreator receiverCreator) -> void
+Microsoft.CodeAnalysis.GeneratorSyntaxContext
+Microsoft.CodeAnalysis.GeneratorSyntaxContext.GeneratorSyntaxContext() -> void
+Microsoft.CodeAnalysis.GeneratorSyntaxContext.Node.get -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.GeneratorSyntaxContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel
+Microsoft.CodeAnalysis.ISyntaxContextReceiver
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string
+Microsoft.CodeAnalysis.SyntaxContextReceiverCreator
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Compare(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> int
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Equals(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> bool
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGenerators(string language) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
+Microsoft.CodeAnalysis.ISyntaxReceiverBase
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ Microsoft.CodeAnalysis.GeneratorSyntaxContext.GeneratorSyntaxContext() -> void
 Microsoft.CodeAnalysis.GeneratorSyntaxContext.Node.get -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.GeneratorSyntaxContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel
 Microsoft.CodeAnalysis.ISyntaxContextReceiver
+Microsoft.CodeAnalysis.ISyntaxContextReceiver.OnVisitSyntaxNode(Microsoft.CodeAnalysis.GeneratorSyntaxContext context) -> void
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
+Microsoft.CodeAnalysis.GeneratorExecutionContext.SyntaxReceiverWithContext.get -> Microsoft.CodeAnalysis.ISyntaxReceiverWithContext
 Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext
 Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.GeneratorSyntaxReceiverContext() -> void
 Microsoft.CodeAnalysis.GeneratorSyntaxReceiverContext.Node.get -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -146,6 +146,28 @@ namespace Microsoft.CodeAnalysis
                 throw new InvalidOperationException(string.Format(CodeAnalysisResources.Single_type_per_generator_0, typeof(T).Name));
             }
         }
+    }
+
+    /// <summary>
+    /// Context passed to an <see cref="ISyntaxReceiverWithContext"/> when <see cref="ISyntaxReceiverWithContext.OnVisitSyntaxNode(GeneratorSyntaxReceiverContext)"/> is called
+    /// </summary>
+    public struct GeneratorSyntaxReceiverContext
+    {
+        internal GeneratorSyntaxReceiverContext(SyntaxNode node, SemanticModel semanticModel)
+        {
+            Node = node;
+            SemanticModel = semanticModel;
+        }
+
+        /// <summary>
+        /// The <see cref="SyntaxNode"/> currently being visited
+        /// </summary>
+        public SyntaxNode Node { get; }
+
+        /// <summary>
+        /// The <see cref="SemanticModel" /> that can be queried to obtain information about <see cref="Node"/>.
+        /// </summary>
+        public SemanticModel SemanticModel { get; }
     }
 
     internal readonly struct GeneratorEditContext

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis
         public void RegisterForSyntaxNotifications(SyntaxReceiverCreator receiverCreator)
         {
             CheckIsEmpty(InfoBuilder.SyntaxContextReceiverCreator, $"{nameof(SyntaxReceiverCreator)} / {nameof(SyntaxContextReceiverCreator)}");
-            InfoBuilder.SyntaxContextReceiverCreator = () => new SyntaxContextReceiverAdaptor(receiverCreator());
+            InfoBuilder.SyntaxContextReceiverCreator = SyntaxContextReceiverAdaptor.Create(receiverCreator);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis
             InfoBuilder.SyntaxContextReceiverCreator = receiverCreator;
         }
 
-        private static void CheckIsEmpty<T>(T x, string? typeName = null)
+        private static void CheckIsEmpty<T>(T x, string? typeName = null) where T : class
         {
             if (x is object)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis
             InfoBuilder.SyntaxContextReceiverCreator = receiverCreator;
         }
 
-        private static void CheckIsEmpty<T>(T x, string? typeName = null) where T : class
+        private static void CheckIsEmpty<T>(T x, string? typeName = null) where T : class?
         {
             if (x is object)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <remarks>
         /// This method allows generators to be 'syntax aware'. Before each generation the <paramref name="receiverCreator"/> will be invoked to create
-        /// an instance of <see cref="ISyntaxReceiver"/>. This receiver will have its <see cref="ISyntaxContextReceiver.OnVisitSyntaxNode(GeneratorSyntaxContext)"/> 
+        /// an instance of <see cref="ISyntaxContextReceiver"/>. This receiver will have its <see cref="ISyntaxContextReceiver.OnVisitSyntaxNode(GeneratorSyntaxContext)"/> 
         /// invoked for each syntax node in the compilation, allowing the receiver to build up information about the compilation before generation occurs.
         /// 
         /// During <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the <see cref="ISyntaxContextReceiver"/> instance that was
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis
         /// A new instance of <see cref="ISyntaxContextReceiver"/> is created prior to every call to <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/>, 
         /// meaning there is no need to manage the lifetime of the receiver or its contents.
         /// </remarks>
-        /// <param name="receiverCreator">A <see cref="SyntaxContextReceiverCreator"/> that can be invoked to create an instance of <see cref="ISyntaxReceiver"/></param>
+        /// <param name="receiverCreator">A <see cref="SyntaxContextReceiverCreator"/> that can be invoked to create an instance of <see cref="ISyntaxContextReceiver"/></param>
         public void RegisterForSyntaxNotifications(SyntaxContextReceiverCreator receiverCreator)
         {
             CheckIsEmpty(InfoBuilder.SyntaxContextReceiverCreator, $"{nameof(SyntaxReceiverCreator)} / {nameof(SyntaxContextReceiverCreator)}");

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis
             AdditionalFiles = additionalTexts;
             AnalyzerConfigOptions = optionsProvider;
             SyntaxReceiver = syntaxReceiver as ISyntaxReceiver;
+            SyntaxReceiverWithContext = syntaxReceiver as ISyntaxReceiverWithContext;
             CancellationToken = cancellationToken;
             _additionalSources = additionalSources;
             _diagnostics = new DiagnosticBag();
@@ -60,6 +61,11 @@ namespace Microsoft.CodeAnalysis
         /// If the generator registered an <see cref="ISyntaxReceiver"/> during initialization, this will be the instance created for this generation pass.
         /// </summary>
         public ISyntaxReceiver? SyntaxReceiver { get; }
+
+        /// <summary>
+        /// If the generator registered an <see cref="ISyntaxReceiverWithContext"/> during initialization, this will be the instance created for this generation pass.
+        /// </summary>
+        public ISyntaxReceiverWithContext? SyntaxReceiverWithContext { get; }
 
         /// <summary>
         /// A <see cref="CancellationToken"/> that can be checked to see if the generation should be cancelled.

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -19,13 +19,13 @@ namespace Microsoft.CodeAnalysis
 
         private readonly AdditionalSourcesCollection _additionalSources;
 
-        internal GeneratorExecutionContext(Compilation compilation, ParseOptions parseOptions, ImmutableArray<AdditionalText> additionalTexts, AnalyzerConfigOptionsProvider optionsProvider, ISyntaxReceiver? syntaxReceiver, AdditionalSourcesCollection additionalSources, CancellationToken cancellationToken = default)
+        internal GeneratorExecutionContext(Compilation compilation, ParseOptions parseOptions, ImmutableArray<AdditionalText> additionalTexts, AnalyzerConfigOptionsProvider optionsProvider, ISyntaxReceiverBase? syntaxReceiver, AdditionalSourcesCollection additionalSources, CancellationToken cancellationToken = default)
         {
             Compilation = compilation;
             ParseOptions = parseOptions;
             AdditionalFiles = additionalTexts;
             AnalyzerConfigOptions = optionsProvider;
-            SyntaxReceiver = syntaxReceiver;
+            SyntaxReceiver = syntaxReceiver as ISyntaxReceiver;
             CancellationToken = cancellationToken;
             _additionalSources = additionalSources;
             _diagnostics = new DiagnosticBag();

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -178,27 +178,25 @@ namespace Microsoft.CodeAnalysis
                                      : SetGeneratorException(MessageProvider, GeneratorState.Uninitialized, generator, ex, diagnosticsBag, isInit: true);
                 }
 
-                // create the syntax receivers if needed
-                Debug.Assert(!(generatorState.Info.SyntaxReceiverCreator is object && generatorState.Info.SyntaxContextReceiverCreator is object));
-                object? receiver = null;
-                try
+                // create the syntax receiver if requested
+                if (generatorState.Info.SyntaxContextReceiverCreator is object)
                 {
-                    receiver = generatorState.Info.SyntaxContextReceiverCreator?.Invoke();
-                    if (receiver is null)
+                    ISyntaxContextReceiver? rx = null;
+                    try
                     {
-                        receiver = generatorState.Info.SyntaxReceiverCreator?.Invoke();
+                        rx = generatorState.Info.SyntaxContextReceiverCreator();
                     }
-                }
-                catch (Exception e)
-                {
-                    generatorState = SetGeneratorException(MessageProvider, generatorState, generator, e, diagnosticsBag);
-                }
+                    catch (Exception e)
+                    {
+                        generatorState = SetGeneratorException(MessageProvider, generatorState, generator, e, diagnosticsBag);
+                    }
 
-                if (receiver is object)
-                {
-                    walkerBuilder.SetItem(i, new GeneratorSyntaxWalker(receiver));
-                    generatorState = generatorState.WithReceiver(receiver);
-                    receiverCount++;
+                    if (rx is object)
+                    {
+                        walkerBuilder.SetItem(i, new GeneratorSyntaxWalker(rx));
+                        generatorState = generatorState.WithReceiver(rx);
+                        receiverCount++;
+                    }
                 }
 
                 stateBuilder.Add(generatorState);

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -204,6 +204,7 @@ namespace Microsoft.CodeAnalysis
                 foreach (var tree in compilation.SyntaxTrees)
                 {
                     var root = tree.GetRoot(cancellationToken);
+                    var semanticModel = compilation.GetSemanticModel(tree);
 
                     // https://github.com/dotnet/roslyn/issues/42629: should be possible to parallelize this
                     for (int i = 0; i < walkerBuilder.Count; i++)
@@ -213,7 +214,7 @@ namespace Microsoft.CodeAnalysis
                         {
                             try
                             {
-                                walker.Visit(root);
+                                walker.VisitWithModel(semanticModel, root);
                             }
                             catch (Exception e)
                             {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -10,12 +10,15 @@ namespace Microsoft.CodeAnalysis
 
         internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; }
 
+        internal SyntaxContextReceiverCreator? SyntaxReceiverWithContextCreator { get; }
+
         internal bool Initialized { get; }
 
-        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxReceiverCreator? receiverCreator)
+        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxReceiverCreator? receiverCreator, SyntaxContextReceiverCreator? receiverWithContextCreator)
         {
             EditCallback = editCallback;
             SyntaxReceiverCreator = receiverCreator;
+            SyntaxReceiverWithContextCreator = receiverWithContextCreator;
             Initialized = true;
         }
 
@@ -25,7 +28,9 @@ namespace Microsoft.CodeAnalysis
 
             internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; set; }
 
-            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxReceiverCreator);
+            internal SyntaxContextReceiverCreator? SyntaxReceiverWithContextCreator { get; set; }
+
+            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxReceiverCreator, SyntaxReceiverWithContextCreator);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis
 
         internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; }
 
-        internal SyntaxContextReceiverCreator? SyntaxReceiverWithContextCreator { get; }
+        internal SyntaxContextReceiverCreator? SyntaxContextReceiverCreator { get; }
 
         internal bool Initialized { get; }
 
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis
         {
             EditCallback = editCallback;
             SyntaxReceiverCreator = receiverCreator;
-            SyntaxReceiverWithContextCreator = receiverWithContextCreator;
+            SyntaxContextReceiverCreator = receiverWithContextCreator;
             Initialized = true;
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -8,17 +8,14 @@ namespace Microsoft.CodeAnalysis
     {
         internal EditCallback<AdditionalFileEdit>? EditCallback { get; }
 
-        internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; }
-
         internal SyntaxContextReceiverCreator? SyntaxContextReceiverCreator { get; }
 
         internal bool Initialized { get; }
 
-        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxReceiverCreator? receiverCreator, SyntaxContextReceiverCreator? receiverWithContextCreator)
+        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxContextReceiverCreator? receiverCreator)
         {
             EditCallback = editCallback;
-            SyntaxReceiverCreator = receiverCreator;
-            SyntaxContextReceiverCreator = receiverWithContextCreator;
+            SyntaxContextReceiverCreator = receiverCreator;
             Initialized = true;
         }
 
@@ -26,11 +23,9 @@ namespace Microsoft.CodeAnalysis
         {
             internal EditCallback<AdditionalFileEdit>? EditCallback { get; set; }
 
-            internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; set; }
+            internal SyntaxContextReceiverCreator? SyntaxContextReceiverCreator { get; set; }
 
-            internal SyntaxContextReceiverCreator? SyntaxReceiverWithContextCreator { get; set; }
-
-            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxReceiverCreator, SyntaxReceiverWithContextCreator);
+            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxContextReceiverCreator);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, ISyntaxReceiverBase? syntaxReceiver, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, object? syntaxReceiver, Exception? exception)
         {
             this.SourceTexts = sourceTexts;
             this.Trees = trees;
@@ -57,16 +57,16 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorInfo Info { get; }
 
-        internal ISyntaxReceiverBase? SyntaxReceiver { get; }
+        internal object? SyntaxReceiver { get; }
 
         internal Exception? Exception { get; }
 
         internal ImmutableArray<Diagnostic> Diagnostics { get; }
 
         /// <summary>
-        /// Adds an <see cref="ISyntaxReceiverBase"/> to this generator state
+        /// Adds a syntax receiver to this generator state
         /// </summary>
-        internal GeneratorState WithReceiver(ISyntaxReceiverBase syntaxReceiver)
+        internal GeneratorState WithReceiver(object syntaxReceiver)
         {
             Debug.Assert(this.Exception is null);
             return new GeneratorState(this.Info,

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, ISyntaxReceiver? syntaxReceiver, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, ISyntaxReceiverBase? syntaxReceiver, Exception? exception)
         {
             this.SourceTexts = sourceTexts;
             this.Trees = trees;
@@ -57,16 +57,16 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorInfo Info { get; }
 
-        internal ISyntaxReceiver? SyntaxReceiver { get; }
+        internal ISyntaxReceiverBase? SyntaxReceiver { get; }
 
         internal Exception? Exception { get; }
 
         internal ImmutableArray<Diagnostic> Diagnostics { get; }
 
         /// <summary>
-        /// Adds an <see cref="ISyntaxReceiver"/> to this generator state
+        /// Adds an <see cref="ISyntaxReceiverBase"/> to this generator state
         /// </summary>
-        internal GeneratorState WithReceiver(ISyntaxReceiver syntaxReceiver)
+        internal GeneratorState WithReceiver(ISyntaxReceiverBase syntaxReceiver)
         {
             Debug.Assert(this.Exception is null);
             return new GeneratorState(this.Info,

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, object? syntaxReceiver, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, ISyntaxContextReceiver? syntaxReceiver, Exception? exception)
         {
             this.SourceTexts = sourceTexts;
             this.Trees = trees;
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorInfo Info { get; }
 
-        internal object? SyntaxReceiver { get; }
+        internal ISyntaxContextReceiver? SyntaxReceiver { get; }
 
         internal Exception? Exception { get; }
 
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Adds a syntax receiver to this generator state
         /// </summary>
-        internal GeneratorState WithReceiver(object syntaxReceiver)
+        internal GeneratorState WithReceiver(ISyntaxContextReceiver syntaxReceiver)
         {
             Debug.Assert(this.Exception is null);
             return new GeneratorState(this.Info,

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
@@ -8,11 +8,11 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class GeneratorSyntaxWalker : SyntaxWalker
     {
-        private readonly object _syntaxReceiver;
+        private readonly ISyntaxContextReceiver _syntaxReceiver;
 
         private SemanticModel? _semanticModel;
 
-        internal GeneratorSyntaxWalker(object syntaxReceiver)
+        internal GeneratorSyntaxWalker(ISyntaxContextReceiver syntaxReceiver)
         {
             _syntaxReceiver = syntaxReceiver;
         }
@@ -30,16 +30,8 @@ namespace Microsoft.CodeAnalysis
 
         public override void Visit(SyntaxNode node)
         {
-            switch (_syntaxReceiver)
-            {
-                case ISyntaxReceiver syntaxReceiver:
-                    syntaxReceiver.OnVisitSyntaxNode(node);
-                    break;
-                case ISyntaxContextReceiver syntaxReceiverWithContext:
-                    Debug.Assert(_semanticModel is object && _semanticModel.SyntaxTree == node.SyntaxTree);
-                    syntaxReceiverWithContext.OnVisitSyntaxNode(new GeneratorSyntaxContext(node, _semanticModel));
-                    break;
-            }
+            Debug.Assert(_semanticModel is object && _semanticModel.SyntaxTree == node.SyntaxTree);
+            _syntaxReceiver.OnVisitSyntaxNode(new GeneratorSyntaxContext(node, _semanticModel));
             base.Visit(node);
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
@@ -2,15 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace Microsoft.CodeAnalysis
 {
     internal sealed class GeneratorSyntaxWalker : SyntaxWalker
     {
         private readonly ISyntaxReceiverBase _syntaxReceiver;
 
+        private SemanticModel? _semanticModel;
+
         internal GeneratorSyntaxWalker(ISyntaxReceiverBase syntaxReceiver)
         {
             _syntaxReceiver = syntaxReceiver;
+        }
+
+        public void VisitWithModel(SemanticModel model, SyntaxNode node)
+        {
+            Debug.Assert(_semanticModel is null);
+            _semanticModel = model;
+            Visit(node);
+            _semanticModel = null;
         }
 
         public override void Visit(SyntaxNode node)
@@ -19,6 +31,10 @@ namespace Microsoft.CodeAnalysis
             {
                 case ISyntaxReceiver syntaxReceiver:
                     syntaxReceiver.OnVisitSyntaxNode(node);
+                    break;
+                case ISyntaxReceiverWithContext syntaxReceiverWithContext:
+                    Debug.Assert(_semanticModel is object && _semanticModel.SyntaxTree == node.SyntaxTree);
+                    syntaxReceiverWithContext.OnVisitSyntaxNode(new GeneratorSyntaxReceiverContext(node, _semanticModel));
                     break;
             }
             base.Visit(node);

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
@@ -6,16 +6,21 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class GeneratorSyntaxWalker : SyntaxWalker
     {
-        private readonly ISyntaxReceiver _syntaxReceiver;
+        private readonly ISyntaxReceiverBase _syntaxReceiver;
 
-        internal GeneratorSyntaxWalker(ISyntaxReceiver syntaxReceiver)
+        internal GeneratorSyntaxWalker(ISyntaxReceiverBase syntaxReceiver)
         {
             _syntaxReceiver = syntaxReceiver;
         }
 
         public override void Visit(SyntaxNode node)
         {
-            _syntaxReceiver.OnVisitSyntaxNode(node);
+            switch (_syntaxReceiver)
+            {
+                case ISyntaxReceiver syntaxReceiver:
+                    syntaxReceiver.OnVisitSyntaxNode(node);
+                    break;
+            }
             base.Visit(node);
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -5,6 +5,17 @@
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
+    /// The base interface of <see cref="ISyntaxReceiver"/>
+    /// </summary>
+    /// <remarks>
+    /// This interface is used internally in Roslyn to support backwards compatibility, and should not be implemented directly by consumers.
+    /// </remarks>
+    public interface ISyntaxReceiverBase
+    {
+        // BACK COMPAT - Do not add any members to this interface.
+    }
+
+    /// <summary>
     /// Receives notifications of each syntax node in the compilation before generation runs
     /// </summary>
     /// <remarks>
@@ -23,7 +34,7 @@ namespace Microsoft.CodeAnalysis
     /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
     /// is free to store state without worrying about lifetime or reuse.
     /// </remarks>
-    public interface ISyntaxReceiver
+    public interface ISyntaxReceiver : ISyntaxReceiverBase
     {
         /// <summary>
         /// Called for each <see cref="SyntaxNode"/> in the compilation
@@ -36,5 +47,5 @@ namespace Microsoft.CodeAnalysis
     /// Allows a generator to provide instances of an <see cref="ISyntaxReceiver"/>
     /// </summary>
     /// <returns>An instance of an <see cref="ISyntaxReceiver"/></returns>
-    public delegate ISyntaxReceiver SyntaxReceiverCreator();
+    public delegate ISyntaxReceiverBase SyntaxReceiverCreator();
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -75,6 +75,6 @@ namespace Microsoft.CodeAnalysis
     /// Allows a generator to provide instances of an <see cref="ISyntaxContextReceiver"/>
     /// </summary>
     /// <returns>An instance of an <see cref="ISyntaxContextReceiver"/></returns>
-    public delegate ISyntaxContextReceiver SyntaxContextReceiverCreator();
+    public delegate ISyntaxContextReceiver? SyntaxContextReceiverCreator();
 
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -4,40 +4,29 @@
 
 namespace Microsoft.CodeAnalysis
 {
-    /// <summary>
-    /// The base interface of <see cref="ISyntaxReceiver"/>
-    /// </summary>
-    /// <remarks>
-    /// This interface is used internally in Roslyn to support backwards compatibility, and should not be implemented directly by consumers.
-    /// </remarks>
-    public interface ISyntaxReceiverBase
-    {
-        // BACK COMPAT - Do not add any members to this interface.
-    }
-
-    /// <summary>
-    /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation before generation runs
-    /// </summary>
-    /// <remarks>
-    /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiver"/>
-    /// via a <see cref="SyntaxReceiverCreator"/>.
-    /// 
-    /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
-    /// obtain an instance of <see cref="ISyntaxReceiver"/>. This instance will have its 
-    /// <see cref="OnVisitSyntaxNode(SyntaxNode)"/> called for every syntax node in the compilation.
-    /// 
-    /// The <see cref="ISyntaxReceiver"/> can record any information about the nodes visited. During
-    /// <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the 
-    /// created instance via the <see cref="GeneratorExecutionContext.SyntaxReceiver"/> property. The
-    /// information contained can be used to perform final generation.
-    /// 
-    /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
-    /// is free to store state without worrying about lifetime or reuse.
-    /// 
-    /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
-    /// <see cref="ISyntaxReceiverWithContext" />, not both.
-    /// </remarks>
-    public interface ISyntaxReceiver : ISyntaxReceiverBase
+     /// <summary>
+     /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation before generation runs
+     /// </summary>
+     /// <remarks>
+     /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiver"/>
+     /// via a <see cref="SyntaxReceiverCreator"/>.
+     /// 
+     /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
+     /// obtain an instance of <see cref="ISyntaxReceiver"/>. This instance will have its 
+     /// <see cref="OnVisitSyntaxNode(SyntaxNode)"/> called for every syntax node in the compilation.
+     /// 
+     /// The <see cref="ISyntaxReceiver"/> can record any information about the nodes visited. During
+     /// <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the 
+     /// created instance via the <see cref="GeneratorExecutionContext.SyntaxReceiver"/> property. The
+     /// information contained can be used to perform final generation.
+     /// 
+     /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
+     /// is free to store state without worrying about lifetime or reuse.
+     /// 
+     /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
+     /// <see cref="ISyntaxContextReceiver" />, not both.
+     /// </remarks>
+    public interface ISyntaxReceiver
     {
         /// <summary>
         /// Called for each <see cref="SyntaxNode"/> in the compilation
@@ -50,7 +39,7 @@ namespace Microsoft.CodeAnalysis
     /// Allows a generator to provide instances of an <see cref="ISyntaxReceiver"/>
     /// </summary>
     /// <returns>An instance of an <see cref="ISyntaxReceiver"/></returns>
-    public delegate ISyntaxReceiverBase SyntaxReceiverCreator();
+    public delegate ISyntaxReceiver SyntaxReceiverCreator();
 
     /// <summary>
     /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation, along with a  
@@ -58,27 +47,34 @@ namespace Microsoft.CodeAnalysis
     /// runs.
     /// </summary>
     /// <remarks>
-    /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiverWithContext"/>
+    /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxContextReceiver"/>
     /// via a <see cref="SyntaxReceiverCreator"/>.
     /// 
     /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
-    /// obtain an instance of <see cref="ISyntaxReceiverWithContext"/>. This instance will have its 
-    /// <see cref="OnVisitSyntaxNode(GeneratorSyntaxReceiverContext)"/> called for every syntax node
+    /// obtain an instance of <see cref="ISyntaxContextReceiver"/>. This instance will have its 
+    /// <see cref="OnVisitSyntaxNode(GeneratorSyntaxContext)"/> called for every syntax node
     /// in the compilation.
     /// 
-    /// The <see cref="ISyntaxReceiverWithContext"/> can record any information about the nodes visited. 
+    /// The <see cref="ISyntaxContextReceiver"/> can record any information about the nodes visited. 
     /// During <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the 
-    /// created instance via the <see cref="GeneratorExecutionContext.SyntaxReceiverWithContext"/> property. The
+    /// created instance via the <see cref="GeneratorExecutionContext.SyntaxContextReceiver"/> property. The
     /// information contained can be used to perform final generation.
     /// 
-    /// A new instance of <see cref="ISyntaxReceiverWithContext"/> is created per-generation, meaning the instance
+    /// A new instance of <see cref="ISyntaxContextReceiver"/> is created per-generation, meaning the instance
     /// is free to store state without worrying about lifetime or reuse. 
     /// 
     /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
-    /// <see cref="ISyntaxReceiverWithContext" />, not both.
+    /// <see cref="ISyntaxContextReceiver" />, not both.
     /// </remarks>
-    public interface ISyntaxReceiverWithContext : ISyntaxReceiverBase
+    public interface ISyntaxContextReceiver
     {
-        void OnVisitSyntaxNode(GeneratorSyntaxReceiverContext context);
+        void OnVisitSyntaxNode(GeneratorSyntaxContext context);
     }
+
+    /// <summary>
+    /// Allows a generator to provide instances of an <see cref="ISyntaxContextReceiver"/>
+    /// </summary>
+    /// <returns>An instance of an <see cref="ISyntaxContextReceiver"/></returns>
+    public delegate ISyntaxContextReceiver SyntaxContextReceiverCreator();
+
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis
     }
 
     /// <summary>
-    /// Receives notifications of each syntax node in the compilation before generation runs
+    /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation before generation runs
     /// </summary>
     /// <remarks>
     /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiver"/>
@@ -33,6 +33,9 @@ namespace Microsoft.CodeAnalysis
     /// 
     /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
     /// is free to store state without worrying about lifetime or reuse.
+    /// 
+    /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
+    /// <see cref="ISyntaxReceiverWithContext" />, not both.
     /// </remarks>
     public interface ISyntaxReceiver : ISyntaxReceiverBase
     {
@@ -48,4 +51,34 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     /// <returns>An instance of an <see cref="ISyntaxReceiver"/></returns>
     public delegate ISyntaxReceiverBase SyntaxReceiverCreator();
+
+    /// <summary>
+    /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation, along with a  
+    /// <see cref="SemanticModel"/> that can be queried to obtain more information, before generation
+    /// runs.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiverWithContext"/>
+    /// via a <see cref="SyntaxReceiverCreator"/>.
+    /// 
+    /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
+    /// obtain an instance of <see cref="ISyntaxReceiverWithContext"/>. This instance will have its 
+    /// <see cref="OnVisitSyntaxNode(GeneratorSyntaxReceiverContext)"/> called for every syntax node
+    /// in the compilation.
+    /// 
+    /// The <see cref="ISyntaxReceiverWithContext"/> can record any information about the nodes visited. 
+    /// During <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the 
+    /// created instance via the <see cref="GeneratorExecutionContext.SyntaxReceiverWithContext"/> property. The
+    /// information contained can be used to perform final generation.
+    /// 
+    /// A new instance of <see cref="ISyntaxReceiverWithContext"/> is created per-generation, meaning the instance
+    /// is free to store state without worrying about lifetime or reuse. 
+    /// 
+    /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
+    /// <see cref="ISyntaxReceiverWithContext" />, not both.
+    /// </remarks>
+    public interface ISyntaxReceiverWithContext : ISyntaxReceiverBase
+    {
+        void OnVisitSyntaxNode(GeneratorSyntaxReceiverContext context);
+    }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -4,28 +4,28 @@
 
 namespace Microsoft.CodeAnalysis
 {
-     /// <summary>
-     /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation before generation runs
-     /// </summary>
-     /// <remarks>
-     /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiver"/>
-     /// via a <see cref="SyntaxReceiverCreator"/>.
-     /// 
-     /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
-     /// obtain an instance of <see cref="ISyntaxReceiver"/>. This instance will have its 
-     /// <see cref="OnVisitSyntaxNode(SyntaxNode)"/> called for every syntax node in the compilation.
-     /// 
-     /// The <see cref="ISyntaxReceiver"/> can record any information about the nodes visited. During
-     /// <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the 
-     /// created instance via the <see cref="GeneratorExecutionContext.SyntaxReceiver"/> property. The
-     /// information contained can be used to perform final generation.
-     /// 
-     /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
-     /// is free to store state without worrying about lifetime or reuse.
-     /// 
-     /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
-     /// <see cref="ISyntaxContextReceiver" />, not both.
-     /// </remarks>
+    /// <summary>
+    /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation before generation runs
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiver"/>
+    /// via a <see cref="SyntaxReceiverCreator"/>.
+    /// 
+    /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
+    /// obtain an instance of <see cref="ISyntaxReceiver"/>. This instance will have its 
+    /// <see cref="OnVisitSyntaxNode(SyntaxNode)"/> called for every syntax node in the compilation.
+    /// 
+    /// The <see cref="ISyntaxReceiver"/> can record any information about the nodes visited. During
+    /// <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the 
+    /// created instance via the <see cref="GeneratorExecutionContext.SyntaxReceiver"/> property. The
+    /// information contained can be used to perform final generation.
+    /// 
+    /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
+    /// is free to store state without worrying about lifetime or reuse.
+    /// 
+    /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
+    /// <see cref="ISyntaxContextReceiver" />, not both.
+    /// </remarks>
     public interface ISyntaxReceiver
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Wraps an <see cref="ISyntaxReceiver"/> in an <see cref="ISyntaxContextReceiver"/>
+    /// </summary>
+    internal class SyntaxContextReceiverAdaptor : ISyntaxContextReceiver
+    {
+        public SyntaxContextReceiverAdaptor(ISyntaxReceiver? receiver)
+        {
+            Receiver = receiver;
+        }
+
+        public ISyntaxReceiver? Receiver { get; }
+
+        public void OnVisitSyntaxNode(GeneratorSyntaxContext context) => Receiver?.OnVisitSyntaxNode(context.Node);
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Wraps an <see cref="ISyntaxReceiver"/> in an <see cref="ISyntaxContextReceiver"/>
     /// </summary>
-    internal class SyntaxContextReceiverAdaptor : ISyntaxContextReceiver
+    internal sealed class SyntaxContextReceiverAdaptor : ISyntaxContextReceiver
     {
         public SyntaxContextReceiverAdaptor(ISyntaxReceiver? receiver)
         {

--- a/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
                 return new SyntaxContextReceiverAdaptor(rx);
             }
             // in the case that the creator function returns null, we'll also return a null adaptor
-            return null!;
+            return null;
         };
     }
 }


### PR DESCRIPTION
This is an implementation for https://github.com/dotnet/roslyn/issues/49873 

Essentially we allow for a new kind of walker than takes a context, instead of just the node itself. On that context we pass the node and a semantic model for the tree the node belongs to. In this way we can re-use the same semantic model for all walkers of the tree, without keeping it alive any longer than we need to.

User can query the model at the point of node acquisition, allowing them to know upfront whether to keep the node or discard it, and no longer need to access the semantic model in the execute method itself.

It's not a particularly complicated PR, but I've broken it out into a couple of commits that should help explain the approach.