### PR TITLE
Make LSP cache implementations synchronous

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
                 return Array.Empty<VSCodeAction>();
             }
 
-            await codeActionsCache.UpdateActionSetsAsync(document, request.Range, actionSets.Value, cancellationToken).ConfigureAwait(false);
+            codeActionsCache.UpdateActionSets(document, request.Range, actionSets.Value);
             var documentText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             // Each suggested action set should have a unique set number, which is used for grouping code actions together.
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
                     return ImmutableArray<CodeAction>.Empty;
                 }
 
-                await codeActionsCache.UpdateActionSetsAsync(document, selection, actionSets.Value, cancellationToken).ConfigureAwait(false);
+                codeActionsCache.UpdateActionSets(document, selection, actionSets.Value);
             }
 
             var _ = ArrayBuilder<CodeAction>.GetInstance(out var codeActions);

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             if (_completionListCache != null)
             {
                 // Cache the completion list so we can avoid recomputation in the resolve handler
-                resultId = await _completionListCache.UpdateCacheAsync(list, cancellationToken).ConfigureAwait(false);
+                resultId = _completionListCache.UpdateCache(list);
             }
 
             return new LSP.VSCompletionList

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.CustomProtocol;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Text.Adornments;
 using Newtonsoft.Json.Linq;
 using Roslyn.Utilities;
@@ -61,7 +60,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // See if we have a cache of the completion list we need
             if (_completionListCache != null && data.ResultId.HasValue)
             {
-                list = await _completionListCache.GetCachedCompletionListAsync(data.ResultId.Value, cancellationToken).ConfigureAwait(false);
+                list = _completionListCache.GetCachedCompletionList(data.ResultId.Value);
             }
 
             if (list == null)

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -57,13 +57,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             var resultId = _tokensCache.GetNextResultId();
             var newSemanticTokens = new LSP.SemanticTokens { ResultId = resultId, Data = newSemanticTokensData };
 
-            await _tokensCache.UpdateCacheAsync(
-                request.TextDocument.Uri, newSemanticTokens, cancellationToken).ConfigureAwait(false);
+            _tokensCache.UpdateCache(request.TextDocument.Uri, newSemanticTokens);
 
             // Getting the cached tokens for the document. If we don't have an applicable cached token set,
             // we can't calculate edits, so we must return all semantic tokens instead.
-            var oldSemanticTokensData = await _tokensCache.GetCachedTokensDataAsync(
-                request.TextDocument.Uri, request.PreviousResultId, cancellationToken).ConfigureAwait(false);
+            var oldSemanticTokensData = _tokensCache.GetCachedTokensData(request.TextDocument.Uri, request.PreviousResultId);
             if (oldSemanticTokensData == null)
             {
                 return newSemanticTokens;

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 range: null, cancellationToken).ConfigureAwait(false);
 
             var tokens = new LSP.SemanticTokens { ResultId = resultId, Data = tokensData };
-            await _tokensCache.UpdateCacheAsync(request.TextDocument.Uri, tokens, cancellationToken).ConfigureAwait(false);
+            _tokensCache.UpdateCache(request.TextDocument.Uri, tokens);
             return tokens;
         }
     }

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
             Document document)
         {
             await RunGetCodeActionsAsync(workspace.CurrentSolution, caretLocation);
-            var cacheResults = await cache.GetActionSetsAsync(document, caretLocation.Range, CancellationToken.None);
+            var cacheResults = cache.GetActionSets(document, caretLocation.Range);
             Assert.NotNull(cacheResults);
         }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -222,37 +222,37 @@ class A
 
             // 1 item in cache
             await RunGetCompletionsAsync(workspace.CurrentSolution, completionParams).ConfigureAwait(false);
-            var completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
+            var completionList = cache.GetCachedCompletionList(0);
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 1);
 
             // 2 items in cache
             await RunGetCompletionsAsync(workspace.CurrentSolution, completionParams).ConfigureAwait(false);
-            completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(0);
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(1, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(1);
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 2);
 
             // 3 items in cache
             await RunGetCompletionsAsync(workspace.CurrentSolution, completionParams).ConfigureAwait(false);
-            completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(0);
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(1, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(1);
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(2, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(2);
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 3);
 
             // Maximum size of cache (3) should not be exceeded - oldest item should be ejected
             await RunGetCompletionsAsync(workspace.CurrentSolution, completionParams).ConfigureAwait(false);
-            completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(0);
             Assert.Null(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(1, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(1);
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(2, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(2);
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(3, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(3);
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 3);
         }


### PR DESCRIPTION
Our three existing LSP caches (semantic tokens, completion, code actions) are currently implemented asynchronously. However, this is likely not necessary and we can simplify the code by switching to a synchronous implementation.

First brought up in https://github.com/dotnet/aspnetcore-tooling/pull/2926#discussion_r556120678 (thanks Taylor!).
Fixes #50418.