### PR TITLE
Run Windows release builds using AzDO windows-2019 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,12 +21,14 @@ jobs:
     jobName: Build_Windows_Debug
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
+    queueName: BuildPool.Windows.10.Amd64.Open
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Build_Windows_Release
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
+    vmImageName: windows-2019
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -9,12 +9,22 @@ parameters:
 - name: configuration
   type: string
   default: 'Debug'
+- name: queueName
+  type: string
+  default: ''
+- name: vmImageName
+  type: string
+  default: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.Open
+    ${{ if ne(parameters.queueName, '') }}:
+      name: NetCorePublic-Pool
+      queue: ${{ parameters.queueName }}
+
+    ${{ if ne(parameters.vmImageName, '') }}:
+      vmImage: ${{ parameters.vmImageName }}
   timeoutInMinutes: 40
 
   steps:


### PR DESCRIPTION
Since we enabled hard links in #50178, we can run our build within the size constraints of the AzDO Windows agents. Let's try changing just one of our builds to use the built-in agent so that we can run it for a while, get some data on how it's performing, and gain confidence about whether or not this change would be a win in our build.