### PR TITLE
Include underlying type in enum decl syntax when generating it from a symbol

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -820,11 +820,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers modifiers,
             IEnumerable<SyntaxNode> members)
         {
+            return EnumDeclaration(name, null, accessibility, modifiers, members);
+        }
+
+        internal override SyntaxNode EnumDeclaration(string name, SyntaxNode underlyingType, Accessibility accessibility = Accessibility.NotApplicable, DeclarationModifiers modifiers = default, IEnumerable<SyntaxNode> members = null)
+        {
+            List<BaseTypeSyntax> underlyingTypeList = underlyingType != null ? new() { SyntaxFactory.SimpleBaseType((TypeSyntax)underlyingType) } : null;
+
             return SyntaxFactory.EnumDeclaration(
                 default,
                 AsModifierList(accessibility, modifiers, SyntaxKind.EnumDeclaration),
                 name.ToIdentifierToken(),
-                null,
+                underlyingTypeList != null ? SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(underlyingTypeList)) : null,
                 this.AsEnumMembers(members));
         }
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -820,18 +820,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers modifiers,
             IEnumerable<SyntaxNode> members)
         {
-            return EnumDeclaration(name, null, accessibility, modifiers, members);
+            return EnumDeclaration(name, underlyingType: null, accessibility, modifiers, members);
         }
 
         internal override SyntaxNode EnumDeclaration(string name, SyntaxNode underlyingType, Accessibility accessibility = Accessibility.NotApplicable, DeclarationModifiers modifiers = default, IEnumerable<SyntaxNode> members = null)
         {
-            List<BaseTypeSyntax> underlyingTypeList = underlyingType != null ? new() { SyntaxFactory.SimpleBaseType((TypeSyntax)underlyingType) } : null;
-
             return SyntaxFactory.EnumDeclaration(
                 default,
                 AsModifierList(accessibility, modifiers, SyntaxKind.EnumDeclaration),
                 name.ToIdentifierToken(),
-                underlyingTypeList != null ? SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(underlyingTypeList)) : null,
+                underlyingType != null ? SyntaxFactory.BaseList(SyntaxFactory.SingletonSeparatedList((BaseTypeSyntax)SyntaxFactory.SimpleBaseType((TypeSyntax)underlyingType))) : null,
                 this.AsEnumMembers(members));
         }
 

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1823,6 +1823,20 @@ public class C { } // end").Members[0];
 }");
         }
 
+        [Fact]
+        public void TestEnumWithUnderlyingTypeFromSymbol()
+        {
+            VerifySyntax<EnumDeclarationSyntax>(
+                    Generator.Declaration(
+                        _emptyCompilation.GetTypeByMetadataName("System.Security.SecurityRuleSet")),
+@"public enum SecurityRuleSet : global::System.Byte
+{
+    None = 0,
+    Level1 = 1,
+    Level2 = 2
+}");
+        }
+
         #endregion
 
         #region Add/Insert/Remove/Get declarations & members/elements

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1829,7 +1829,7 @@ public class C { } // end").Members[0];
             VerifySyntax<EnumDeclarationSyntax>(
                     Generator.Declaration(
                         _emptyCompilation.GetTypeByMetadataName("System.Security.SecurityRuleSet")),
-@"public enum SecurityRuleSet : global::System.Byte
+@"public enum SecurityRuleSet : byte
 {
     None = 0,
     Level1 = 1,

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -514,6 +514,16 @@ namespace Microsoft.CodeAnalysis.Editing
             IEnumerable<SyntaxNode> members = null);
 
         /// <summary>
+        /// Creates an enum declaration
+        /// </summary>
+        internal abstract SyntaxNode EnumDeclaration(
+            string name,
+            SyntaxNode underlyingType,
+            Accessibility accessibility = Accessibility.NotApplicable,
+            DeclarationModifiers modifiers = default,
+            IEnumerable<SyntaxNode> members = null);
+
+        /// <summary>
         /// Creates an enum member
         /// </summary>
         public abstract SyntaxNode EnumMember(string name, SyntaxNode expression = null);
@@ -606,6 +616,7 @@ namespace Microsoft.CodeAnalysis.Editing
                         case TypeKind.Enum:
                             declaration = EnumDeclaration(
                                 type.Name,
+                                type.EnumUnderlyingType?.SpecialType == SpecialType.System_Int32 ? null : TypeExpression(type.EnumUnderlyingType),
                                 accessibility: type.DeclaredAccessibility,
                                 members: type.GetMembers().Where(s => s.Kind == SymbolKind.Field).Select(m => Declaration(m)));
                             break;

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -616,7 +616,7 @@ namespace Microsoft.CodeAnalysis.Editing
                         case TypeKind.Enum:
                             declaration = EnumDeclaration(
                                 type.Name,
-                                type.EnumUnderlyingType?.SpecialType == SpecialType.System_Int32 ? null : TypeExpression(type.EnumUnderlyingType),
+                                type.EnumUnderlyingType?.SpecialType == SpecialType.System_Int32 ? null : TypeExpression(type.EnumUnderlyingType.SpecialType),
                                 accessibility: type.DeclaredAccessibility,
                                 members: type.GetMembers().Where(s => s.Kind == SymbolKind.Field).Select(m => Declaration(m)));
                             break;

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -1453,11 +1453,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                                                   Optional accessibility As Accessibility = Accessibility.NotApplicable,
                                                   Optional modifiers As DeclarationModifiers = Nothing,
                                                   Optional members As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
-            Dim underlyingTypeClause As AsClauseSyntax = Nothing
 
-            If underlyingType IsNot Nothing Then
-                underlyingTypeClause = SyntaxFactory.SimpleAsClause(DirectCast(underlyingType, TypeSyntax))
-            End If
+            Dim underlyingTypeClause = If(underlyingType Is Nothing, Nothing, SyntaxFactory.SimpleAsClause(DirectCast(underlyingType, TypeSyntax)))
 
             Return SyntaxFactory.EnumBlock(
                 enumStatement:=SyntaxFactory.EnumStatement(

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -1445,12 +1445,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional modifiers As DeclarationModifiers = Nothing,
             Optional members As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
 
+            Return EnumDeclaration(name, Nothing, accessibility, modifiers, members)
+        End Function
+
+        Friend Overrides Function EnumDeclaration(name As String,
+                                                  underlyingType As SyntaxNode,
+                                                  Optional accessibility As Accessibility = Accessibility.NotApplicable,
+                                                  Optional modifiers As DeclarationModifiers = Nothing,
+                                                  Optional members As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
+            Dim underlyingTypeClause As AsClauseSyntax = Nothing
+
+            If underlyingType IsNot Nothing Then
+                underlyingTypeClause = SyntaxFactory.SimpleAsClause(DirectCast(underlyingType, TypeSyntax))
+            End If
+
             Return SyntaxFactory.EnumBlock(
                 enumStatement:=SyntaxFactory.EnumStatement(
                     attributeLists:=Nothing,
                     modifiers:=GetModifierList(accessibility, modifiers And GetAllowedModifiers(SyntaxKind.EnumStatement), DeclarationKind.Enum),
                     identifier:=name.ToIdentifierToken(),
-                    underlyingType:=Nothing),
+                    underlyingType:=underlyingTypeClause),
                     members:=AsEnumMembers(members))
         End Function
 

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -2275,12 +2275,21 @@ End Interface")
 
         <Fact>
         Public Sub TestEnumDeclarationFromSymbol()
-            Dim a As SyntaxNode = Generator.Declaration(_emptyCompilation.GetTypeByMetadataName("System.DateTimeKind"))
             VerifySyntax(Of EnumBlockSyntax)(Generator.Declaration(_emptyCompilation.GetTypeByMetadataName("System.DateTimeKind")),
 "Public Enum DateTimeKind
     Unspecified = 0
     Utc = 1
     Local = 2
+End Enum")
+        End Sub
+
+        <Fact>
+        Public Sub TestEnumWithUnderlyingTypeFromSymbol()
+            VerifySyntax(Of EnumBlockSyntax)(Generator.Declaration(_emptyCompilation.GetTypeByMetadataName("System.Security.SecurityRuleSet")),
+"Public Enum SecurityRuleSet As System.Byte
+    None = CByte(0)
+    Level1 = CByte(1)
+    Level2 = CByte(2)
 End Enum")
         End Sub
 #End Region

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -2286,7 +2286,7 @@ End Enum")
         <Fact>
         Public Sub TestEnumWithUnderlyingTypeFromSymbol()
             VerifySyntax(Of EnumBlockSyntax)(Generator.Declaration(_emptyCompilation.GetTypeByMetadataName("System.Security.SecurityRuleSet")),
-"Public Enum SecurityRuleSet As System.Byte
+"Public Enum SecurityRuleSet As Byte
     None = CByte(0)
     Level1 = CByte(1)
     Level2 = CByte(2)


### PR DESCRIPTION
Currently if an enum symbol contains an underlying type the generated syntax doesn't contain that information.

i.e:
```cs
public enum foo : byte { }
```
we would get back:
```cs
public enum foo { }
```

This fixes that but still doesn't return it if the underlying type is Int32.