### PR TITLE
[VisualBasic] Fix the analyzer to add MustInherit correctly

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/MakeTypeAbstract/MakeTypeAbstractTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MakeTypeAbstract/MakeTypeAbstractTests.vb
@@ -22,7 +22,7 @@ Public Class [|Foo|]
     Public MustOverride Sub M()
 End Class",
 "
-Public MustOverride Class Foo
+Public MustInherit Class Foo
     Public MustOverride Sub M()
 End Class")
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -2173,6 +2173,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
                     Return DeclarationKind.NamespaceImport
                 Case SyntaxKind.ClassBlock
                     Return DeclarationKind.Class
+                Case SyntaxKind.ClassStatement
+                    If Not IsChildOf(declaration, SyntaxKind.ClassBlock) Then
+                        Return DeclarationKind.Class
+                    End If
                 Case SyntaxKind.StructureBlock
                     Return DeclarationKind.Struct
                 Case SyntaxKind.InterfaceBlock


### PR DESCRIPTION
Correct GetDeclarationKind implementation to consider ClassStatement. Resolves #50003