### PR TITLE
Move tests to net5.0 reference assemblies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -100,7 +100,7 @@
     <MicrosoftMSXMLVersion>8.0.0</MicrosoftMSXMLVersion>
     <MicrosoftNETBuildExtensionsVersion>2.2.101</MicrosoftNETBuildExtensionsVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNETCoreAppRefVersion>3.1.0</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRefVersion>5.0.0</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETFrameworkReferenceAssembliesnet461Version>1.0.0</MicrosoftNETFrameworkReferenceAssembliesnet461Version>
     <MicrosoftNETFrameworkReferenceAssembliesnet451Version>1.0.0</MicrosoftNETFrameworkReferenceAssembliesnet451Version>
     <MicrosoftNETFrameworkReferenceAssembliesnet40Version>1.0.0</MicrosoftNETFrameworkReferenceAssembliesnet40Version>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -2079,7 +2079,7 @@ interface I
 
             CheckEncLog(reader2,
                 Row(3, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(8, TableIndex.TypeRef, EditAndContinueOperation.Default),
+                Row(10, TableIndex.TypeRef, EditAndContinueOperation.Default),
                 Row(2, TableIndex.Event, EditAndContinueOperation.Default),
                 Row(3, TableIndex.Event, EditAndContinueOperation.Default),
                 Row(1, TableIndex.Field, EditAndContinueOperation.Default),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
@@ -55,7 +55,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
 
             var knownMissingTypes = new HashSet<int>()
             {
-                (int)SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute
             };
 
             for (int i = 1; i <= (int)SpecialType.Count; i++)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -55068,7 +55068,7 @@ class C1 : I1, Interface<int>
 ";
             foreach (var options in new[] { TestOptions.DebugDll, TestOptions.DebugWinMD })
             {
-                var comp = CreateCompilationWithIL(source, ilSource, options: options, targetFramework: TargetFramework.NetCoreApp, references: new[] { windowsRuntimeRef });;
+                var comp = CreateCompilationWithIL(source, ilSource, options: options, targetFramework: TargetFramework.NetCoreApp, references: new[] { windowsRuntimeRef });
 
                 void Validate(ModuleSymbol m)
                 {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -55194,7 +55194,7 @@ interface I1 : Interface
 class C1 : I1, Interface
 {}
 ";
-            var comp = CreateCompilation(source, options: TestOptions.DebugWinMD, targetFramework: TargetFramework.NetCoreApp, references: new[] { CompilationExtensions.CreateWindowsRuntimeMetadataReference() });;
+            var comp = CreateCompilation(source, options: TestOptions.DebugWinMD, targetFramework: TargetFramework.NetCoreApp, references: new[] { CompilationExtensions.CreateWindowsRuntimeMetadataReference() });
 
             void Validate(ModuleSymbol m)
             {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ModuleInitializers/SignatureTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ModuleInitializers/SignatureTests.cs
@@ -52,8 +52,6 @@ interface i
     [ModuleInitializer]
     internal void M2() { }
 }
-
-namespace System.Runtime.CompilerServices { class ModuleInitializerAttribute : System.Attribute { } }
 ";
             var compilation = CreateCompilation(source, parseOptions: s_parseOptions, targetFramework: TargetFramework.NetCoreApp);
             compilation.VerifyEmitDiagnostics(

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -70,7 +70,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var knownMissingTypes = new HashSet<SpecialType>()
             {
-                SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute
             };
 
             for (var specialType = SpecialType.None + 1; specialType <= SpecialType.Count; specialType++)

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -1005,24 +1005,6 @@ DoneWithSequence:
 
         internal static bool IsValidPublicKey(ImmutableArray<byte> bytes) => CryptoBlobParser.IsValidPublicKey(bytes);
 
-        internal static ImmutableArray<byte> ConvertPublicKeyStringToBytes(string publicKey)
-        {
-            Debug.Assert(publicKey.Length % 2 == 0);
-            var builder = ArrayBuilder<byte>.GetInstance(publicKey.Length / 2);
-            var span = publicKey.AsSpan();
-            for (int i = 0; i < publicKey.Length; i += 2)
-            {
-#if NETCOREAPP
-                var b = byte.Parse(publicKey.AsSpan().Slice(i, length: 2), style: NumberStyles.HexNumber, provider: null);
-#else
-                var b = byte.Parse(publicKey.Substring(i, length: 2), style: NumberStyles.HexNumber, provider: null);
-#endif
-                builder.Add(b);
-            }
-
-            return builder.ToImmutableAndFree();
-        }
-
         /// <summary>
         /// Given an input string changes it to be acceptable as a part of a type name.
         /// </summary>

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -1005,6 +1005,24 @@ DoneWithSequence:
 
         internal static bool IsValidPublicKey(ImmutableArray<byte> bytes) => CryptoBlobParser.IsValidPublicKey(bytes);
 
+        internal static ImmutableArray<byte> ConvertPublicKeyStringToBytes(string publicKey)
+        {
+            Debug.Assert(publicKey.Length % 2 == 0);
+            var builder = ArrayBuilder<byte>.GetInstance(publicKey.Length / 2);
+            var span = publicKey.AsSpan();
+            for (int i = 0; i < publicKey.Length; i += 2)
+            {
+#if NETCOREAPP
+                var b = byte.Parse(publicKey.AsSpan().Slice(i, length: 2), style: NumberStyles.HexNumber, provider: null);
+#else
+                var b = byte.Parse(publicKey.Substring(i, length: 2), style: NumberStyles.HexNumber, provider: null);
+#endif
+                builder.Add(b);
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
         /// <summary>
         /// Given an input string changes it to be acceptable as a part of a type name.
         /// </summary>

--- a/src/Compilers/Test/Core/Generate.ps1
+++ b/src/Compilers/Test/Core/Generate.ps1
@@ -144,7 +144,7 @@ Add-TargetFramework "Net461" '$(PkgMicrosoft_NETFramework_ReferenceAssemblies_ne
   'Microsoft.VisualBasic.dll'
 )
 
-Add-TargetFramework "NetCoreApp" '$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1' @(
+Add-TargetFramework "NetCoreApp" '$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0' @(
   'mscorlib.dll',
   'System.dll',
   'System.Core.dll',
@@ -154,7 +154,6 @@ Add-TargetFramework "NetCoreApp" '$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp
   'System.Linq.Expressions.dll',
   'System.Runtime.dll',
   'System.Runtime.InteropServices.dll',
-  'System.Runtime.InteropServices.WindowsRuntime.dll',
   'System.Threading.Tasks.dll',
   'netstandard.dll',
   'Microsoft.CSharp.dll',

--- a/src/Compilers/Test/Core/Generated.cs
+++ b/src/Compilers/Test/Core/Generated.cs
@@ -176,8 +176,6 @@ namespace Roslyn.Test.Utilities
             public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netcoreapp.System.Runtime.dll");
             private static byte[] _SystemRuntimeInteropServices;
             public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netcoreapp.System.Runtime.InteropServices.dll");
-            private static byte[] _SystemRuntimeInteropServicesWindowsRuntime;
-            public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "netcoreapp.System.Runtime.InteropServices.WindowsRuntime.dll");
             private static byte[] _SystemThreadingTasks;
             public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netcoreapp.System.Threading.Tasks.dll");
             private static byte[] _netstandard;
@@ -198,7 +196,6 @@ namespace Roslyn.Test.Utilities
             public static PortableExecutableReference SystemLinqExpressions { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemLinqExpressions).GetReference(display: "System.Linq.Expressions.dll (netcoreapp)");
             public static PortableExecutableReference SystemRuntime { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemRuntime).GetReference(display: "System.Runtime.dll (netcoreapp)");
             public static PortableExecutableReference SystemRuntimeInteropServices { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemRuntimeInteropServices).GetReference(display: "System.Runtime.InteropServices.dll (netcoreapp)");
-            public static PortableExecutableReference SystemRuntimeInteropServicesWindowsRuntime { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemRuntimeInteropServicesWindowsRuntime).GetReference(display: "System.Runtime.InteropServices.WindowsRuntime.dll (netcoreapp)");
             public static PortableExecutableReference SystemThreadingTasks { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemThreadingTasks).GetReference(display: "System.Threading.Tasks.dll (netcoreapp)");
             public static PortableExecutableReference netstandard { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.netstandard).GetReference(display: "netstandard.dll (netcoreapp)");
             public static PortableExecutableReference MicrosoftCSharp { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.MicrosoftCSharp).GetReference(display: "Microsoft.CSharp.dll (netcoreapp)");

--- a/src/Compilers/Test/Core/Generated.targets
+++ b/src/Compilers/Test/Core/Generated.targets
@@ -152,59 +152,55 @@
           <LogicalName>net461.Microsoft.VisualBasic.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\net461\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\mscorlib.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\mscorlib.dll">
           <LogicalName>netcoreapp.mscorlib.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.dll">
           <LogicalName>netcoreapp.System.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Core.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Core.dll">
           <LogicalName>netcoreapp.System.Core.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Collections.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Collections.dll">
           <LogicalName>netcoreapp.System.Collections.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Console.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Console.dll">
           <LogicalName>netcoreapp.System.Console.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Linq.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Linq.dll">
           <LogicalName>netcoreapp.System.Linq.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Linq.Expressions.dll">
           <LogicalName>netcoreapp.System.Linq.Expressions.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Runtime.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Runtime.dll">
           <LogicalName>netcoreapp.System.Runtime.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Runtime.InteropServices.dll">
           <LogicalName>netcoreapp.System.Runtime.InteropServices.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Runtime.InteropServices.WindowsRuntime.dll">
-          <LogicalName>netcoreapp.System.Runtime.InteropServices.WindowsRuntime.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Runtime.InteropServices.WindowsRuntime.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Threading.Tasks.dll">
           <LogicalName>netcoreapp.System.Threading.Tasks.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\netstandard.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\netstandard.dll">
           <LogicalName>netcoreapp.netstandard.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\Microsoft.CSharp.dll">
           <LogicalName>netcoreapp.Microsoft.CSharp.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\netcoreapp3.1\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\Microsoft.VisualBasic.dll">
           <LogicalName>netcoreapp.Microsoft.VisualBasic.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\netcoreapp\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>

--- a/src/Compilers/Test/Core/TargetFrameworkUtil.cs
+++ b/src/Compilers/Test/Core/TargetFrameworkUtil.cs
@@ -96,7 +96,7 @@ namespace Roslyn.Test.Utilities
         public static ImmutableArray<MetadataReference> NetStandard20References => ImmutableArray.Create<MetadataReference>(NetStandard20.netstandard, NetStandard20.mscorlib, NetStandard20.SystemRuntime, NetStandard20.SystemCore, NetStandard20.SystemDynamicRuntime, NetStandard20.SystemLinq, NetStandard20.SystemLinqExpressions);
         public static ImmutableArray<MetadataReference> NetCoreAppReferences => ImmutableArray.Create<MetadataReference>(NetCoreApp.netstandard, NetCoreApp.mscorlib, NetCoreApp.SystemRuntime, NetCoreApp.SystemCore,
                                                                                                                            NetCoreApp.SystemConsole, NetCoreApp.SystemLinq, NetCoreApp.SystemLinqExpressions, NetCoreApp.SystemThreadingTasks,
-                                                                                                                           NetCoreApp.SystemCollections, NetCoreApp.SystemRuntimeInteropServicesWindowsRuntime);
+                                                                                                                           NetCoreApp.SystemCollections);
         public static ImmutableArray<MetadataReference> WinRTReferences => ImmutableArray.Create(TestBase.WinRtRefs);
         public static ImmutableArray<MetadataReference> StandardReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References : Mscorlib46ExtendedReferences;
         public static ImmutableArray<MetadataReference> StandardLatestReferences => RuntimeUtilities.IsCoreClrRuntime ? NetCoreAppReferences : Mscorlib46ExtendedReferences;

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
@@ -38,7 +38,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
             Dim msCorLibRef As MetadataOrSourceAssemblySymbol = DirectCast(assemblies(0), MetadataOrSourceAssemblySymbol)
 
             Dim knownMissingTypes As HashSet(Of Integer) = New HashSet(Of Integer)
-            knownMissingTypes.Add(SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute)
 
             For i As Integer = 1 To SpecialType.Count
                 Dim t = msCorLibRef.GetSpecialType(CType(i, SpecialType))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -11805,7 +11805,11 @@ public interface I2 : I1
     }
 }
 "
-            Dim csCompilation = GetCSharpCompilation(csSource, compilationOptions:=New CSharp.CSharpCompilationOptions(OutputKind.WindowsRuntimeMetadata)).EmitToImageReference()
+            Dim csCompilation = GetCSharpCompilation(
+                csSource,
+                compilationOptions:=New CSharp.CSharpCompilationOptions(OutputKind.WindowsRuntimeMetadata),
+                targetFramework:=TargetFramework.NetCoreApp,
+                additionalReferences:=New MetadataReference() {CompilationExtensions.CreateWindowsRuntimeMetadataReference()}).EmitToImageReference()
 
             Dim source1 =
 <compilation>
@@ -11840,7 +11844,7 @@ End Class
 ]]></file>
 </compilation>
 
-            Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetCoreApp, references:={csCompilation})
+            Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetCoreApp, references:={csCompilation, CompilationExtensions.CreateWindowsRuntimeMetadataReference()})
 
             Dim validator = Sub(m As ModuleSymbol)
                                 Dim c1 = m.GlobalNamespace.GetTypeMember("C1")


### PR DESCRIPTION
This moves our tests to use the net5.0 reference assemblies.