### PR TITLE
Handle ImplicitObjectCreationExpressionSyntax in some places where ObjectCreationExpressionSyntax has special treatment.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2643,6 +2643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.AnonymousMethodExpression:
                 case SyntaxKind.InvocationExpression:
                 case SyntaxKind.ObjectCreationExpression:
+                case SyntaxKind.ImplicitObjectCreationExpression:
                 case SyntaxKind.ParenthesizedExpression: // this is never allowed in legacy compiler
                 case SyntaxKind.DeclarationExpression:
                     // A property/indexer is also invalid as it cannot be ref/out, but cannot be checked here. Assuming a bug in legacy compiler.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1152,7 +1152,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var token = syntax switch
             {
                 InvocationExpressionSyntax invocation => invocation.ArgumentList.OpenParenToken,
-                ObjectCreationExpressionSyntax objectCreation => objectCreation.NewKeyword,
+                BaseObjectCreationExpressionSyntax objectCreation => objectCreation.NewKeyword,
                 ConstructorInitializerSyntax constructorInitializer => constructorInitializer.ArgumentList.OpenParenToken,
                 PrimaryConstructorBaseTypeSyntax primaryConstructorBaseType => primaryConstructorBaseType.ArgumentList.OpenParenToken,
                 ElementAccessExpressionSyntax elementAccess => elementAccess.ArgumentList.OpenBracketToken,

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -504,7 +504,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Returns what 'Add' method symbol(s), if any, corresponds to the given expression syntax
-        /// within <see cref="ObjectCreationExpressionSyntax.Initializer"/>.
+        /// within <see cref="BaseObjectCreationExpressionSyntax.Initializer"/>.
         /// </summary>
         public static SymbolInfo GetCollectionInitializerSymbolInfo(this SemanticModel? semanticModel, ExpressionSyntax expression, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -603,7 +603,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Returns what 'Add' method symbol(s), if any, corresponds to the given expression syntax 
-        /// within <see cref="ObjectCreationExpressionSyntax.Initializer"/>.
+        /// within <see cref="BaseObjectCreationExpressionSyntax.Initializer"/>.
         /// </summary>
         public SymbolInfo GetCollectionInitializerSymbolInfo(ExpressionSyntax expression, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -626,9 +626,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
 
-                if (initializer.Parent != null && initializer.Parent.Kind() == SyntaxKind.ObjectCreationExpression &&
-                    ((ObjectCreationExpressionSyntax)initializer.Parent).Initializer == initializer &&
-                    CanGetSemanticInfo(initializer.Parent, allowNamedArgumentName: false))
+                if (initializer.Parent is BaseObjectCreationExpressionSyntax objectCreation &&
+                    objectCreation.Initializer == initializer &&
+                    CanGetSemanticInfo(objectCreation, allowNamedArgumentName: false))
                 {
                     return GetCollectionInitializerSymbolInfoWorker((InitializerExpressionSyntax)expression.Parent, expression, cancellationToken);
                 }
@@ -3288,7 +3288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var expr = (BoundBadExpression)boundNode;
                         resultKind = expr.ResultKind;
 
-                        if (expr.Syntax.Kind() == SyntaxKind.ObjectCreationExpression)
+                        if (expr.Syntax.Kind() is SyntaxKind.ObjectCreationExpression or SyntaxKind.ImplicitObjectCreationExpression)
                         {
                             if (resultKind == LookupResultKind.NotCreatable)
                             {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -314,6 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case InvocationExpression:
                 case TupleExpression:
                 case ObjectCreationExpression:
+                case ImplicitObjectCreationExpression:
                 case ObjectInitializerExpression:
                 case ElementAccessExpression:
                 case Attribute:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
@@ -4395,10 +4395,10 @@ public class Source
 using System;
 using System.Runtime.CompilerServices;
 
-class Foo
+class Test
 {
     public string Caller { get; set; }
-    public Foo([CallerMemberName] string caller = ""?"") => Caller = caller;
+    public Test([CallerMemberName] string caller = ""?"") => Caller = caller;
     public void PrintCaller() => Console.WriteLine(Caller);
 }
 
@@ -4406,20 +4406,132 @@ class Program
 {
     static void Main()
     {            
-        Foo f1 = new Foo();
+        Test f1 = new Test();
         f1.PrintCaller();
 
-        Foo f2 = new();
+        Test f2 = new();
         f2.PrintCaller();
     }
 }
 ";
 
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput:
 @"Main
-Main");
+Main").VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void CallerLineNumberAttributeWithImplicitObjectCreation()
+        {
+            string source = @"
+using System;
+using System.Runtime.CompilerServices;
+
+class Test
+{
+    public int LineNumber { get; set; }
+    public Test([CallerLineNumber] int lineNumber = -1) => LineNumber = lineNumber;
+    public void PrintLineNumber() => Console.WriteLine(LineNumber);
+}
+
+class Program
+{
+    static void Main()
+    {            
+        Test f1 = new Test();
+        f1.PrintLineNumber();
+
+        Test f2 = new();
+        f2.PrintLineNumber();
+    }
+}
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput:
+@"16
+19").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(50030, "https://github.com/dotnet/roslyn/issues/50030")]
+        public void GetCollectionInitializerSymbolInfo()
+        {
+            var source = @"
+using System;
+using System.Collections.Generic;
+ 
+class X : List<int>
+{
+    new void Add(int x) { }
+    void Add(string x) {}
+ 
+    static void Main()
+    {
+        X z = new() { String.Empty, 12 };
+    }
+}
+";
+            var compilation = CreateCompilation(source);
+            compilation.VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var nodes = (from node in tree.GetRoot().DescendantNodes()
+                         where node.IsKind(SyntaxKind.CollectionInitializerExpression)
+                         select (InitializerExpressionSyntax)node).Single().Expressions;
+
+            SymbolInfo symbolInfo;
+
+            symbolInfo = semanticModel.GetCollectionInitializerSymbolInfo(nodes[0]);
+
+            Assert.NotNull(symbolInfo.Symbol);
+            Assert.Equal("void X.Add(System.String x)", symbolInfo.Symbol.ToTestDisplayString());
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
+            Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
+
+            symbolInfo = semanticModel.GetCollectionInitializerSymbolInfo(nodes[1]);
+
+            Assert.NotNull(symbolInfo.Symbol);
+            Assert.Equal("void X.Add(System.Int32 x)", symbolInfo.Symbol.ToTestDisplayString());
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
+            Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
+        }
+
+        [Fact]
+        public void GetNamedParameterSymbolInfo()
+        {
+            var source = @"
+class X
+{
+
+    X(int aParameter)
+    {}
+
+    static void Main()
+    {
+        X z = new(aParameter: 1);
+    }
+}
+";
+            var compilation = CreateCompilation(source);
+            compilation.VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "aParameter").Single();
+
+            SymbolInfo symbolInfo;
+
+            symbolInfo = semanticModel.GetSymbolInfo(node);
+
+            Assert.NotNull(symbolInfo.Symbol);
+            Assert.Equal("System.Int32 aParameter", symbolInfo.Symbol.ToTestDisplayString());
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
+            Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -22626,6 +22626,7 @@ public class Program
         var z8 = new Func<string, string>(ref Program.BarP); 
         var z9 = new Func<string, string>(ref Program.Goo<string>(x => x));
         var z10 = new Func<string, string>(ref Id); // compat
+        var z11 = new Func<string, string>(ref new(x => x));
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
@@ -22646,7 +22647,11 @@ public class Program
                 Diagnostic(ErrorCode.ERR_RefProperty, "ref Program.BarP").WithArguments("Program.BarP").WithLocation(20, 43),
                 // (21,47): error CS1510: A ref or out argument must be an assignable variable
                 //         var z9 = new Func<string, string>(ref Program.Goo<string>(x => x));
-                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "Program.Goo<string>(x => x)").WithLocation(21, 47));
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "Program.Goo<string>(x => x)").WithLocation(21, 47),
+                // (23,48): error CS1510: A ref or out value must be an assignable variable
+                //         var z11 = new Func<string, string>(ref new(x => x));
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "new(x => x)").WithLocation(23, 48)
+                );
 
             CreateCompilation(source, parseOptions: TestOptions.Regular.WithStrictFeature()).VerifyDiagnostics(
                 // (13,47): error CS0149: Method name expected
@@ -22678,7 +22683,11 @@ public class Program
                 Diagnostic(ErrorCode.ERR_RefLvalueExpected, "Program.Goo<string>(x => x)").WithLocation(21, 47),
                 // (22,48): error CS1657: Cannot pass 'Id' as a ref or out argument because it is a 'method group'
                 //         var z10 = new Func<string, string>(ref Id); // compat
-                Diagnostic(ErrorCode.ERR_RefReadonlyLocalCause, "Id").WithArguments("Id", "method group").WithLocation(22, 48));
+                Diagnostic(ErrorCode.ERR_RefReadonlyLocalCause, "Id").WithArguments("Id", "method group").WithLocation(22, 48),
+                // (23,48): error CS1510: A ref or out value must be an assignable variable
+                //         var z11 = new Func<string, string>(ref new(x => x));
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "new(x => x)").WithLocation(23, 48)
+                );
         }
 
         [Fact, WorkItem(7359, "https://github.com/dotnet/roslyn/issues/7359")]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -4988,6 +4988,58 @@ class Class1
             Assert.False(semanticInfo.IsCompileTimeConstant);
         }
 
+        [Fact]
+        public void InaccessibleMethodGroup_Constructors_ImplicitObjectCreationExpressionSyntax()
+        {
+            string sourceCode = @"
+using System;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        Class1 x = /*<bind>*/new(3, 7)/*</bind>*/;
+    }
+}
+
+class Class1
+{
+    protected Class1() { }
+    protected Class1(int x) { }
+    private Class1(int a, long b) { }
+}
+";
+            var semanticInfo = GetSemanticInfoForTest<ImplicitObjectCreationExpressionSyntax>(sourceCode);
+
+            Assert.Equal("Class1", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal(TypeKind.Class, semanticInfo.Type.TypeKind);
+            Assert.Equal("Class1", semanticInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
+            Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
+
+            Assert.Null(semanticInfo.Symbol);
+            Assert.Equal(CandidateReason.Inaccessible, semanticInfo.CandidateReason);
+            Assert.Equal(3, semanticInfo.CandidateSymbols.Length);
+            var sortedCandidates = semanticInfo.CandidateSymbols.OrderBy(s => s.ToTestDisplayString(), StringComparer.Ordinal).ToArray();
+            Assert.Equal("Class1..ctor()", sortedCandidates[0].ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, sortedCandidates[0].Kind);
+            Assert.Equal("Class1..ctor(System.Int32 a, System.Int64 b)", sortedCandidates[1].ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, sortedCandidates[1].Kind);
+            Assert.Equal("Class1..ctor(System.Int32 x)", sortedCandidates[2].ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, sortedCandidates[2].Kind);
+
+            Assert.Equal(3, semanticInfo.MethodGroup.Length);
+            sortedCandidates = semanticInfo.MethodGroup.OrderBy(s => s.ToTestDisplayString(), StringComparer.Ordinal).ToArray();
+            Assert.Equal("Class1..ctor()", sortedCandidates[0].ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, sortedCandidates[0].Kind);
+            Assert.Equal("Class1..ctor(System.Int32 a, System.Int64 b)", sortedCandidates[1].ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, sortedCandidates[1].Kind);
+            Assert.Equal("Class1..ctor(System.Int32 x)", sortedCandidates[2].ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, sortedCandidates[2].Kind);
+
+            Assert.False(semanticInfo.IsCompileTimeConstant);
+        }
+
         [WorkItem(542782, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542782")]
         [Fact]
         public void InaccessibleMethodGroup_Constructors_IdentifierNameSyntax()


### PR DESCRIPTION
Also fixes #50030.