### PR TITLE
Make analyzer non-configurable

### DIFF
--- a/src/Analyzers/Core/Analyzers/ConvertAnonymousTypeToTuple/AbstractConvertAnonymousTypeToTupleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/ConvertAnonymousTypeToTuple/AbstractConvertAnonymousTypeToTupleDiagnosticAnalyzer.cs
@@ -22,7 +22,9 @@ namespace Microsoft.CodeAnalysis.ConvertAnonymousTypeToTuple
                    EnforceOnBuildValues.ConvertAnonymousTypeToTuple,
                    option: null,
                    new LocalizableResourceString(nameof(AnalyzersResources.Convert_to_tuple), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
-                   new LocalizableResourceString(nameof(AnalyzersResources.Convert_to_tuple), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
+                   new LocalizableResourceString(nameof(AnalyzersResources.Convert_to_tuple), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+                   // This analyzer is not configurable.  The intent is just to act as a refactoring, just benefiting from fix-all
+                   configurable: false)
         {
             _syntaxKinds = syntaxKinds;
         }

--- a/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
+++ b/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
@@ -53,7 +53,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const EnforceOnBuild UseConditionalExpressionForAssignment = /*IDE0045*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild UseConditionalExpressionForReturn = /*IDE0046*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild RemoveUnnecessaryParentheses = /*IDE0047*/ EnforceOnBuild.Recommended;
-        public const EnforceOnBuild ConvertAnonymousTypeToTuple = /*IDE0050*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild UseExpressionBodyForLambdaExpressions = /*IDE0053*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild UseCompoundAssignment = /*IDE0054*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild UseIndexOperator = /*IDE0056*/ EnforceOnBuild.Recommended;
@@ -96,6 +95,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const EnforceOnBuild RemoveQualification = /*IDE0003*/ EnforceOnBuild.Never;
         public const EnforceOnBuild AddQualification = /*IDE0009*/ EnforceOnBuild.Never;
         public const EnforceOnBuild PreferBuiltInOrFrameworkType = /*IDE0049*/ EnforceOnBuild.Never;
+        public const EnforceOnBuild ConvertAnonymousTypeToTuple = /*IDE0050*/ EnforceOnBuild.Never;
         public const EnforceOnBuild RemoveUnreachableCode = /*IDE0035*/ EnforceOnBuild.Never; // Non-configurable fading diagnostic corresponding to CS0162.
         public const EnforceOnBuild RemoveUnnecessarySuppression = /*IDE0079*/ EnforceOnBuild.Never; // IDE-only analyzer.
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/50468

This analyzer was never intended to be something could "turn on to enforce".  Anonymous types are a standard part of the language and are used in many APIs as *the* way to communicate data.  It's not sensical for a rule to blanket ban them in a non-intelligent fashion.

This is a simpler approach that we can get in while discussing: https://github.com/dotnet/roslyn/pull/50536