### PR TITLE
Error on malformed IAsyncEnumerable await foreach

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
@@ -137,3 +137,5 @@ class C
     static Func<Func<int, object>, IEnumerable<object>> Select = null;
 }
 ```
+
+21. https://github.com/dotnet/roslyn/issues/50182 In *Visual Studio 2019 version 16.9* and greater, the compiler will no longer allow `await foreach` over variables that implement a malformed version of `IAsyncEnumerable` that has a non-optional `CancellationToken` parameter.

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -858,14 +858,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Well-known members are matched by signature: we shouldn't find it if it doesn't have exactly 1 parameter.
                     Debug.Assert(getEnumeratorMethod is null or { ParameterCount: 1 });
 
-                    // C# 8 shipped allowing the CancellationToken of `IAsyncEnumerable.GetAsyncEnumerator` to be non-optional.
-                    // https://github.com/dotnet/roslyn/issues/50182 tracks enabling this error and breaking the scenario.
-                    // if (getEnumeratorMethod?.Parameters[0].IsOptional == false)
-                    // {
-                    //     // This indicates a problem with the well-known IAsyncEnumerable type - it should have an optional cancellation token.
-                    //     diagnostics.Add(ErrorCode.ERR_AwaitForEachMissingMember, _syntax.Expression.Location, unwrappedCollectionExprType, GetAsyncEnumeratorMethodName);
-                    //     return EnumeratorResult.FailedAndReported;
-                    // }
+                    if (getEnumeratorMethod?.Parameters[0].IsOptional == false)
+                    {
+                        // This indicates a problem with the well-known IAsyncEnumerable type - it should have an optional cancellation token.
+                        diagnostics.Add(ErrorCode.ERR_AwaitForEachMissingMember, _syntax.Expression.Location, unwrappedCollectionExprType, GetAsyncEnumeratorMethodName);
+                        return EnumeratorResult.FailedAndReported;
+                    }
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -4464,10 +4464,9 @@ namespace System
 ";
             var comp = CreateCompilationWithTasksExtensions(source);
             comp.VerifyEmitDiagnostics(
-                // https://github.com/dotnet/roslyn/issues/50182 tracks erroring here
                 // (8,33): error CS8411: Asynchronous foreach statement cannot operate on variables of type 'C' because 'C' does not contain a suitable public instance or extension definition for 'GetAsyncEnumerator'
                 //         await foreach (var i in c)
-                //Diagnostic(ErrorCode.ERR_AwaitForEachMissingMember, "c").WithArguments("C", "GetAsyncEnumerator").WithLocation(8, 33)
+                Diagnostic(ErrorCode.ERR_AwaitForEachMissingMember, "c").WithArguments("C", "GetAsyncEnumerator").WithLocation(8, 33)
                 );
         }
 
@@ -4511,10 +4510,9 @@ namespace System
 ";
             var comp = CreateCompilationWithTasksExtensions(source);
             comp.VerifyEmitDiagnostics(
-                // https://github.com/dotnet/roslyn/issues/50182 tracks erroring here
                 // (8,33): error CS8411: Asynchronous foreach statement cannot operate on variables of type 'C' because 'C' does not contain a suitable public instance or extension definition for 'GetAsyncEnumerator'
                 //         await foreach (var i in c)
-                //Diagnostic(ErrorCode.ERR_AwaitForEachMissingMember, "c").WithArguments("C", "GetAsyncEnumerator").WithLocation(8, 33)
+                Diagnostic(ErrorCode.ERR_AwaitForEachMissingMember, "c").WithArguments("C", "GetAsyncEnumerator").WithLocation(8, 33)
                 );
         }
 


### PR DESCRIPTION
The compiler would allow await foreaching over a variable of a type that implements `IAsyncEnumerable` when `IAsyncEnumerable.GetEnumerator`'s `CancellationToken` parameter was non-optional. This was in violation of the spec, and compat council has approved breaking the scenario. Fixes https://github.com/dotnet/roslyn/issues/50182.
