### PR TITLE
Make SourceGeneratedDocument.SourceGenerator internal

### DIFF
--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -8,7 +8,6 @@ Microsoft.CodeAnalysis.Editing.DeclarationKind.Record = 29 -> Microsoft.CodeAnal
 Microsoft.CodeAnalysis.Solution.GetSourceGeneratedDocumentAsync(Microsoft.CodeAnalysis.DocumentId documentId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Microsoft.CodeAnalysis.SourceGeneratedDocument>
 Microsoft.CodeAnalysis.SourceGeneratedDocument
 Microsoft.CodeAnalysis.SourceGeneratedDocument.HintName.get -> string
-Microsoft.CodeAnalysis.SourceGeneratedDocument.SourceGenerator.get -> Microsoft.CodeAnalysis.ISourceGenerator
 override sealed Microsoft.CodeAnalysis.CodeFixes.DocumentBasedFixAllProvider.GetFixAsync(Microsoft.CodeAnalysis.CodeFixes.FixAllContext fixAllContext) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.CodeActions.CodeAction>
 override sealed Microsoft.CodeAnalysis.CodeFixes.DocumentBasedFixAllProvider.GetSupportedFixAllScopes() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeFixes.FixAllScope>
 virtual Microsoft.CodeAnalysis.CodeFixes.DocumentBasedFixAllProvider.GetFixAllTitle(Microsoft.CodeAnalysis.CodeFixes.FixAllContext fixAllContext) -> string

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis
 
         private new SourceGeneratedDocumentState State => (SourceGeneratedDocumentState)base.State;
 
-        public ISourceGenerator SourceGenerator => State.SourceGenerator;
+        // TODO: make this public. Tracked by https://github.com/dotnet/roslyn/issues/50546
+        internal ISourceGenerator SourceGenerator => State.SourceGenerator;
         public string HintName => State.HintName;
     }
 }


### PR DESCRIPTION
If we expose the instance directory this will cause problems for things like OOP mirroring since we won't have an instance for the other side. Just hide this while we sort out a better API.

I'm doing this ASAP so we don't accidentally lose this in the other bugs to work on and end up shipping 16.9 this way by accident.