### PR TITLE
Support converting anon types to records in C# 9 and up.

### DIFF
--- a/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
@@ -279,6 +279,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
 
             if (isRecord)
             {
+                // Create a record with a single primary constructor, containing a parameter for all the properties
+                // we're generating.
                 var constructor = CodeGenerationSymbolFactory.CreateConstructorSymbol(
                     attributes: default,
                     Accessibility.Public,

--- a/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
         {
             return CodeGenerationSymbolFactory.CreateNamedTypeSymbol(
                 attributes: default, Accessibility.Internal, modifiers: default,
-                isRecord: isRecord, TypeKind.Class, className, capturedTypeParameters, members: members);
+                isRecord, TypeKind.Class, className, capturedTypeParameters, members: members);
         }
 
         private static (ImmutableArray<IPropertySymbol> properties, ImmutableDictionary<IPropertySymbol, string> propertyMap) GenerateProperties(

--- a/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -49,9 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             var (anonymousObject, anonymousType) = await TryGetAnonymousObjectAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
 
             if (anonymousObject == null || anonymousType == null)
-            {
                 return;
-            }
 
             // Check if the anonymous type actually references another anonymous type inside of it.
             // If it does, we can't convert this.  There is no way to describe this anonymous type
@@ -60,16 +56,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
                                                      .OfType<IPropertySymbol>()
                                                      .Any(p => p.Type.ContainsAnonymousType());
             if (containsAnonymousType)
-            {
                 return;
-            }
 
             context.RegisterRefactoring(new MyCodeAction(
                 c => ConvertToClassAsync(document, textSpan, c)),
                 anonymousObject.Span);
         }
 
-        private static async Task<(TAnonymousObjectCreationExpressionSyntax, INamedTypeSymbol)> TryGetAnonymousObjectAsync(
+        private static async Task<(TAnonymousObjectCreationExpressionSyntax?, INamedTypeSymbol?)> TryGetAnonymousObjectAsync(
             Document document, TextSpan span, CancellationToken cancellationToken)
         {
             // Gets a `TAnonymousObjectCreationExpressionSyntax` for current selection.
@@ -79,11 +73,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             var anonymousObject = await document.TryGetRelevantNodeAsync<TAnonymousObjectCreationExpressionSyntax>(
                 span, cancellationToken).ConfigureAwait(false);
             if (anonymousObject == null)
-            {
                 return default;
-            }
 
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var anonymousType = semanticModel.GetTypeInfo(anonymousObject, cancellationToken).Type as INamedTypeSymbol;
 
             return (anonymousObject, anonymousType);
@@ -98,8 +90,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
 
             var position = span.Start;
             var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             // Generate a unique name for the class we're creating.  We'll also add a rename
             // annotation so the user can pick the right name for the type afterwards.
@@ -120,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             var generator = SyntaxGenerator.GetGenerator(document);
             var editor = new SyntaxEditor(root, generator);
 
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             var containingMember = anonymousObject.FirstAncestorOrSelf<SyntaxNode, ISyntaxFactsService>((node, syntaxFacts) => syntaxFacts.IsMethodLevelMember(node), syntaxFacts) ?? anonymousObject;
 
             // Next, go and update any references to these anonymous type properties to match
@@ -141,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             var container = anonymousObject.GetAncestor<TNamespaceDeclarationSyntax>() ?? root;
             editor.ReplaceNode(container, (currentContainer, _) =>
             {
-                var codeGenService = document.GetLanguageService<ICodeGenerationService>();
+                var codeGenService = document.GetRequiredLanguageService<ICodeGenerationService>();
                 var codeGenOptions = new CodeGenerationOptions(
                     generateMembers: true,
                     sortMembers: false,
@@ -157,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
 
             // Finally, format using the equals+getHashCode service so that our generated methods
             // follow any special formatting rules specific to them.
-            var equalsAndGetHashCodeService = document.GetLanguageService<IGenerateEqualsAndGetHashCodeService>();
+            var equalsAndGetHashCodeService = document.GetRequiredLanguageService<IGenerateEqualsAndGetHashCodeService>();
             return await equalsAndGetHashCodeService.FormatDocumentAsync(
                 updatedDocument, cancellationToken).ConfigureAwait(false);
         }
@@ -166,8 +158,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             Document document, SyntaxEditor editor, SyntaxNode containingMember,
             ImmutableDictionary<IPropertySymbol, string> propertyMap, CancellationToken cancellationToken)
         {
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var identifiers = containingMember.DescendantNodes().OfType<TIdentifierNameSyntax>();
 
             foreach (var identifier in identifiers)
@@ -178,10 +170,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
                     continue;
                 }
 
-                if (!(semanticModel.GetSymbolInfo(identifier, cancellationToken).GetAnySymbol() is IPropertySymbol symbol))
-                {
+                if (semanticModel.GetSymbolInfo(identifier, cancellationToken).GetAnySymbol() is not IPropertySymbol symbol)
                     continue;
-                }
 
                 if (propertyMap.TryGetValue(symbol, out var newName))
                 {
@@ -209,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             // Note: we could consider expanding this in the future (potentially with another
             // lightbulb action).  Specifically, we could look in the containing type and replace
             // any matches in any methods.
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var childCreationNodes = containingMember.DescendantNodesAndSelf()
                                                      .OfType<TAnonymousObjectCreationExpressionSyntax>();
@@ -224,9 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
                 }
 
                 if (anonymousType.Equals(childType))
-                {
                     ReplaceWithObjectCreation(editor, classSymbol, creationNode, childCreation);
-                }
             }
         }
 
@@ -263,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             Document document, string className,
             ImmutableArray<IPropertySymbol> properties, CancellationToken cancellationToken)
         {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             // Next, see if any of the properties ended up using any type parameters from the
             // containing method/named-type.  If so, we'll need to generate a generic type so we can
@@ -291,7 +279,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             var readonlyProperties = ImmutableArray<ISymbol>.CastUp(
                 properties.WhereAsArray(p => p.SetMethod == null));
 
-            var equalsAndGetHashCodeService = document.GetLanguageService<IGenerateEqualsAndGetHashCodeService>();
+            var equalsAndGetHashCodeService = document.GetRequiredLanguageService<IGenerateEqualsAndGetHashCodeService>();
 
             var equalsMethod = await equalsAndGetHashCodeService.GenerateEqualsMethodAsync(
                 document, namedTypeWithoutMembers, readonlyProperties,
@@ -333,9 +321,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
                 var newProperty = newProperties[i];
 
                 if (originalProperty.Name != newProperty.Name)
-                {
                     builder[originalProperty] = newProperty.Name;
-                }
             }
 
             return (newProperties, builder.ToImmutable());
@@ -363,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
 
         private static string GetLegalName(string name, Document document)
         {
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             return syntaxFacts.IsLegalIdentifier(name)
                 ? name
                 : "Item"; // Just a dummy name for the property.  Does not need to be localized.

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -2803,4 +2803,7 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="_0_dash_1" xml:space="preserve">
     <value>{0} - {1}</value>
   </data>
+  <data name="Convert_to_record" xml:space="preserve">
+    <value>Convert to record</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -245,6 +245,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Převést na LINQ (volání formuláře)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Převést na strukturu</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -245,6 +245,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">In LINQ konvertieren (Aufrufformular)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">In Struktur konvertieren</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -245,6 +245,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Convertir a LINQ (formulario de llamada)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Convertir a struct</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -245,6 +245,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Convertir en LINQ (formulaire d'appel)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Convertir en struct</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -245,6 +245,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Converti in LINQ (form di chiamata)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Converti in struct</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -245,6 +245,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">LINQ (呼び出し形式) へ変換</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">構造体に変換</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -245,6 +245,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">LINQ로 변환(통화 양식)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">구조체로 변환</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -245,6 +245,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Konwertuj na składnię LINQ (wywołaj formularz)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Konwertuj na strukturę</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -245,6 +245,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Converter para LINQ (formulário de chamada)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Converter para struct</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -245,6 +245,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Преобразовать в LINQ (форма вызова)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Преобразовать в структуру</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -245,6 +245,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">LINQ (görüşmesi formu) dönüştürmek</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">Yapıya dönüştür</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -245,6 +245,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">转换为 LINQ (调用表单)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">转换为结构</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -245,6 +245,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">轉換為 LINQ (呼叫表單)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_record">
+        <source>Convert to record</source>
+        <target state="new">Convert to record</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_struct">
         <source>Convert to struct</source>
         <target state="translated">轉換為結構</target>

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGeneration;
@@ -12,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationHelpers;
 using static Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpCodeGenerationHelpers;
 
@@ -72,22 +72,56 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             var declaration = GetDeclarationSyntaxWithoutMembers(namedType, destination, options);
 
-            if (namedType.IsComImport)
-            {
-                // If we're generating a ComImport type, then do not attempt to do any
-                // reordering of members.
-                options = options.With(autoInsertionLocation: false, sortMembers: false);
-            }
-
             // If we are generating members then make sure to exclude properties that cannot be generated.
             // Reason: Calling AddProperty on a propertysymbol that can't be generated (like one with params) causes
             // the getter and setter to get generated instead. Since the list of members is going to include
             // the method symbols for the getter and setter, we don't want to generate them twice.
+
+            var members = GetMembers(namedType).Where(s => s.Kind != SymbolKind.Property || PropertyGenerator.CanBeGenerated((IPropertySymbol)s))
+                                               .ToImmutableArray();
+            if (namedType.IsRecord)
+            {
+                var recordDeclaration = (RecordDeclarationSyntax)declaration;
+
+                // For a record, add record parameters if we have a primary constructor.
+                var primaryConstructor = members.OfType<IMethodSymbol>().FirstOrDefault(m => CodeGenerationConstructorInfo.GetIsPrimaryConstructor(m));
+                if (primaryConstructor != null)
+                {
+                    var parameterList = ParameterGenerator.GenerateParameterList(primaryConstructor.Parameters, isExplicit: false, options);
+                    recordDeclaration = recordDeclaration.WithParameterList(parameterList);
+
+                    // remove the primary constructor from the list of members to generate.
+                    members = members.Remove(primaryConstructor);
+
+                    // remove any properties that were created by the primary constructor
+                    members = members.WhereAsArray(m => m is not IPropertySymbol property || !primaryConstructor.Parameters.Any(p => p.Name == property.Name));
+                }
+
+                // remove any implicit overrides to generate.
+                members = members.WhereAsArray(m => !m.IsImplicitlyDeclared);
+
+                // If there are no members, just make a simple record with no body
+                if (members.Length == 0)
+                {
+                    declaration = recordDeclaration.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+                }
+                else
+                {
+                    // Otherwise, give the record a body.
+                    declaration = recordDeclaration.WithOpenBraceToken(SyntaxFactory.Token(SyntaxKind.OpenBraceToken))
+                                                   .WithCloseBraceToken(SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
+                }
+            }
+            else
+            {
+                // If we're generating a ComImport type, then do not attempt to do any
+                // reordering of members.
+                if (namedType.IsComImport)
+                    options = options.With(autoInsertionLocation: false, sortMembers: false);
+            }
+
             declaration = options.GenerateMembers && namedType.TypeKind != TypeKind.Delegate
-                ? service.AddMembers(declaration,
-                                     GetMembers(namedType).Where(s => s.Kind != SymbolKind.Property || PropertyGenerator.CanBeGenerated((IPropertySymbol)s)),
-                                     options,
-                                     cancellationToken)
+                ? service.AddMembers(declaration, members, options, cancellationToken)
                 : declaration;
 
             return AddFormatterAndCodeGeneratorAnnotationsTo(ConditionallyAddDocumentationCommentTo(declaration, namedType, options, cancellationToken));
@@ -111,12 +145,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             CodeGenerationOptions options)
         {
             var reusableDeclarationSyntax = GetReuseableSyntaxNodeForSymbol<MemberDeclarationSyntax>(namedType, options);
-            if (reusableDeclarationSyntax == null)
-            {
-                return GenerateNamedTypeDeclarationWorker(namedType, destination, options);
-            }
-
-            return RemoveAllMembers(reusableDeclarationSyntax);
+            return reusableDeclarationSyntax == null
+                ? GetDeclarationSyntaxWithoutMembersWorker(namedType, destination, options)
+                : RemoveAllMembers(reusableDeclarationSyntax);
         }
 
         private static MemberDeclarationSyntax RemoveAllMembers(MemberDeclarationSyntax declaration)
@@ -136,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private static MemberDeclarationSyntax GenerateNamedTypeDeclarationWorker(
+        private static MemberDeclarationSyntax GetDeclarationSyntaxWithoutMembersWorker(
             INamedTypeSymbol namedType,
             CodeGenerationDestination destination,
             CodeGenerationOptions options)
@@ -150,21 +181,27 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 return GenerateDelegateDeclaration(namedType, destination, options);
             }
 
-            var kind = namedType.TypeKind == TypeKind.Struct
-                ? SyntaxKind.StructDeclaration
-                : namedType.TypeKind == TypeKind.Interface
-                    ? SyntaxKind.InterfaceDeclaration
-                    : SyntaxKind.ClassDeclaration;
+            TypeDeclarationSyntax typeDeclaration;
+            if (namedType.IsRecord)
+            {
+                typeDeclaration = SyntaxFactory.RecordDeclaration(SyntaxFactory.Token(SyntaxKind.RecordKeyword), namedType.Name.ToIdentifierToken());
+            }
+            else
+            {
+                var kind = namedType.TypeKind == TypeKind.Struct ? SyntaxKind.StructDeclaration :
+                           namedType.TypeKind == TypeKind.Interface ? SyntaxKind.InterfaceDeclaration : SyntaxKind.ClassDeclaration;
 
-            var typeDeclaration =
-                SyntaxFactory.TypeDeclaration(kind, namedType.Name.ToIdentifierToken())
-                    .WithAttributeLists(GenerateAttributeDeclarations(namedType, options))
-                    .WithModifiers(GenerateModifiers(namedType, destination, options))
-                    .WithTypeParameterList(GenerateTypeParameterList(namedType, options))
-                    .WithBaseList(GenerateBaseList(namedType))
-                    .WithConstraintClauses(GenerateConstraintClauses(namedType));
+                typeDeclaration = SyntaxFactory.TypeDeclaration(kind, namedType.Name.ToIdentifierToken());
+            }
 
-            return typeDeclaration;
+            var result = typeDeclaration
+                .WithAttributeLists(GenerateAttributeDeclarations(namedType, options))
+                .WithModifiers(GenerateModifiers(namedType, destination, options))
+                .WithTypeParameterList(GenerateTypeParameterList(namedType, options))
+                .WithBaseList(GenerateBaseList(namedType))
+                .WithConstraintClauses(GenerateConstraintClauses(namedType));
+
+            return result;
         }
 
         private static DelegateDeclarationSyntax GenerateDelegateDeclaration(
@@ -173,6 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             CodeGenerationOptions options)
         {
             var invokeMethod = namedType.DelegateInvokeMethod;
+            Contract.ThrowIfNull(invokeMethod);
 
             return SyntaxFactory.DelegateDeclaration(
                 GenerateAttributeDeclarations(namedType, options),
@@ -259,23 +297,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return TypeParameterGenerator.GenerateTypeParameterList(namedType.TypeParameters, options);
         }
 
-        private static BaseListSyntax GenerateBaseList(INamedTypeSymbol namedType)
+        private static BaseListSyntax? GenerateBaseList(INamedTypeSymbol namedType)
         {
             var types = new List<BaseTypeSyntax>();
             if (namedType.TypeKind == TypeKind.Class && namedType.BaseType != null && namedType.BaseType.SpecialType != Microsoft.CodeAnalysis.SpecialType.System_Object)
-            {
                 types.Add(SyntaxFactory.SimpleBaseType(namedType.BaseType.GenerateTypeSyntax()));
-            }
 
             foreach (var type in namedType.Interfaces)
-            {
                 types.Add(SyntaxFactory.SimpleBaseType(type.GenerateTypeSyntax()));
-            }
 
             if (types.Count == 0)
-            {
                 return null;
-            }
 
             return SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(types));
         }

--- a/src/Workspaces/Core/Portable/CodeGeneration/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/INamedTypeSymbolExtensions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 namedType.GetAttributes(),
                 namedType.DeclaredAccessibility,
                 namedType.GetSymbolModifiers(),
+                namedType.IsRecord,
                 namedType.TypeKind,
                 namedType.Name,
                 namedType.TypeParameters,

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorInfo.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 
@@ -11,9 +9,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationConstructorInfo
     {
-        private static readonly ConditionalWeakTable<IMethodSymbol, CodeGenerationConstructorInfo> s_constructorToInfoMap =
-            new();
+        private static readonly ConditionalWeakTable<IMethodSymbol, CodeGenerationConstructorInfo> s_constructorToInfoMap = new();
 
+        private readonly bool _isPrimaryConstructor;
         private readonly bool _isUnsafe;
         private readonly string _typeName;
         private readonly ImmutableArray<SyntaxNode> _baseConstructorArguments;
@@ -21,12 +19,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private readonly ImmutableArray<SyntaxNode> _statements;
 
         private CodeGenerationConstructorInfo(
+            bool isPrimaryConstructor,
             bool isUnsafe,
             string typeName,
             ImmutableArray<SyntaxNode> statements,
             ImmutableArray<SyntaxNode> baseConstructorArguments,
             ImmutableArray<SyntaxNode> thisConstructorArguments)
         {
+            _isPrimaryConstructor = isPrimaryConstructor;
             _isUnsafe = isUnsafe;
             _typeName = typeName;
             _statements = statements;
@@ -36,17 +36,18 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public static void Attach(
             IMethodSymbol constructor,
+            bool isPrimaryConstructor,
             bool isUnsafe,
             string typeName,
             ImmutableArray<SyntaxNode> statements,
             ImmutableArray<SyntaxNode> baseConstructorArguments,
             ImmutableArray<SyntaxNode> thisConstructorArguments)
         {
-            var info = new CodeGenerationConstructorInfo(isUnsafe, typeName, statements, baseConstructorArguments, thisConstructorArguments);
+            var info = new CodeGenerationConstructorInfo(isPrimaryConstructor, isUnsafe, typeName, statements, baseConstructorArguments, thisConstructorArguments);
             s_constructorToInfoMap.Add(constructor, info);
         }
 
-        private static CodeGenerationConstructorInfo GetInfo(IMethodSymbol method)
+        private static CodeGenerationConstructorInfo? GetInfo(IMethodSymbol method)
         {
             s_constructorToInfoMap.TryGetValue(method, out var info);
             return info;
@@ -67,19 +68,25 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public static bool GetIsUnsafe(IMethodSymbol constructor)
             => GetIsUnsafe(GetInfo(constructor));
 
-        private static ImmutableArray<SyntaxNode> GetThisConstructorArgumentsOpt(CodeGenerationConstructorInfo info)
+        public static bool GetIsPrimaryConstructor(IMethodSymbol constructor)
+            => GetIsPrimaryConstructor(GetInfo(constructor));
+
+        private static ImmutableArray<SyntaxNode> GetThisConstructorArgumentsOpt(CodeGenerationConstructorInfo? info)
             => info?._thisConstructorArguments ?? default;
 
-        private static ImmutableArray<SyntaxNode> GetBaseConstructorArgumentsOpt(CodeGenerationConstructorInfo info)
+        private static ImmutableArray<SyntaxNode> GetBaseConstructorArgumentsOpt(CodeGenerationConstructorInfo? info)
             => info?._baseConstructorArguments ?? default;
 
-        private static ImmutableArray<SyntaxNode> GetStatements(CodeGenerationConstructorInfo info)
+        private static ImmutableArray<SyntaxNode> GetStatements(CodeGenerationConstructorInfo? info)
             => info?._statements ?? default;
 
-        private static string GetTypeName(CodeGenerationConstructorInfo info, IMethodSymbol constructor)
+        private static string GetTypeName(CodeGenerationConstructorInfo? info, IMethodSymbol constructor)
             => info == null ? constructor.ContainingType.Name : info._typeName;
 
-        private static bool GetIsUnsafe(CodeGenerationConstructorInfo info)
+        private static bool GetIsUnsafe(CodeGenerationConstructorInfo? info)
             => info?._isUnsafe ?? false;
+
+        private static bool GetIsPrimaryConstructor(CodeGenerationConstructorInfo? info)
+            => info?._isPrimaryConstructor ?? false;
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             var result = new CodeGenerationConstructorSymbol(this.ContainingType, this.GetAttributes(), this.DeclaredAccessibility, this.Modifiers, this.Parameters);
 
             CodeGenerationConstructorInfo.Attach(result,
+                CodeGenerationConstructorInfo.GetIsPrimaryConstructor(this),
                 CodeGenerationConstructorInfo.GetIsUnsafe(this),
                 CodeGenerationConstructorInfo.GetTypeName(this),
                 CodeGenerationConstructorInfo.GetStatements(this),

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
@@ -15,12 +15,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 {
     internal class CodeGenerationNamedTypeSymbol : CodeGenerationAbstractNamedTypeSymbol
     {
-        private readonly TypeKind _typeKind;
         private readonly ImmutableArray<ITypeParameterSymbol> _typeParameters;
-        private readonly INamedTypeSymbol _baseType;
         private readonly ImmutableArray<INamedTypeSymbol> _interfaces;
         private readonly ImmutableArray<ISymbol> _members;
-        private readonly INamedTypeSymbol _enumUnderlyingType;
 
         public CodeGenerationNamedTypeSymbol(
             IAssemblySymbol containingAssembly,
@@ -28,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ImmutableArray<AttributeData> attributes,
             Accessibility declaredAccessibility,
             DeclarationModifiers modifiers,
+            bool isRecord,
             TypeKind typeKind,
             string name,
             ImmutableArray<ITypeParameterSymbol> typeParameters,
@@ -40,12 +38,13 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             INamedTypeSymbol enumUnderlyingType)
             : base(containingAssembly, containingType, attributes, declaredAccessibility, modifiers, name, specialType, nullableAnnotation, typeMembers)
         {
-            _typeKind = typeKind;
+            IsRecord = isRecord;
+            TypeKind = typeKind;
             _typeParameters = typeParameters.NullToEmpty();
-            _baseType = baseType;
+            BaseType = baseType;
             _interfaces = interfaces.NullToEmpty();
             _members = members.NullToEmpty();
-            _enumUnderlyingType = enumUnderlyingType;
+            EnumUnderlyingType = enumUnderlyingType;
 
             this.OriginalDefinition = this;
         }
@@ -54,12 +53,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             return new CodeGenerationNamedTypeSymbol(
                 this.ContainingAssembly, this.ContainingType, this.GetAttributes(), this.DeclaredAccessibility,
-                this.Modifiers, this.TypeKind, this.Name, _typeParameters, _baseType,
+                this.Modifiers, this.IsRecord, this.TypeKind, this.Name, _typeParameters, this.BaseType,
                 _interfaces, this.SpecialType, nullableAnnotation, _members, this.TypeMembers,
                 this.EnumUnderlyingType);
         }
 
-        public override TypeKind TypeKind => _typeKind;
+        public override bool IsRecord { get; }
+
+        public override TypeKind TypeKind { get; }
 
         public override SymbolKind Kind => SymbolKind.NamedType;
 
@@ -97,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override INamedTypeSymbol EnumUnderlyingType => _enumUnderlyingType;
+        public override INamedTypeSymbol EnumUnderlyingType { get; }
 
         protected override CodeGenerationNamedTypeSymbol ConstructedFrom
         {
@@ -143,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override INamedTypeSymbol BaseType => _baseType;
+        public override INamedTypeSymbol BaseType { get; }
 
         public override ImmutableArray<INamedTypeSymbol> Interfaces
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         bool ITypeSymbol.IsReadOnly => Modifiers.IsReadOnly;
 
-        bool ITypeSymbol.IsRecord => throw new System.NotImplementedException();
+        public virtual bool IsRecord => false;
 
         public NullableAnnotation NullableAnnotation { get; }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -61,6 +61,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool SupportsLocalFunctionDeclaration(ParseOptions options)
             => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp7;
 
+        public bool SupportsRecord(ParseOptions options)
+            => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp9;
+
         public SyntaxToken ParseToken(string text)
             => SyntaxFactory.ParseToken(text);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -28,9 +28,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         ISyntaxKinds SyntaxKinds { get; }
 
         bool SupportsIndexingInitializer(ParseOptions options);
-        bool SupportsNotPattern(ParseOptions options);
-        bool SupportsThrowExpression(ParseOptions options);
         bool SupportsLocalFunctionDeclaration(ParseOptions options);
+        bool SupportsNotPattern(ParseOptions options);
+        bool SupportsRecord(ParseOptions options);
+        bool SupportsThrowExpression(ParseOptions options);
 
         SyntaxToken ParseToken(string text);
         SyntaxTriviaList ParseLeadingTrivia(string text);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -72,6 +72,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return False
         End Function
 
+        Public Function SupportsRecord(options As ParseOptions) As Boolean Implements ISyntaxFacts.SupportsRecord
+            Return False
+        End Function
+
         Public Function ParseToken(text As String) As SyntaxToken Implements ISyntaxFacts.ParseToken
             Return SyntaxFactory.ParseToken(text, startStatement:=True)
         End Function


### PR DESCRIPTION
Enhancement to the previous feature we did to convert anon-types to classes.  Now that we have records, we can also offer to directly convert to a much simpler record.

First commit is just minor cleanup, the rest are the bulk of the change.

Review with whitespace changes off.