### PR TITLE
Make navigation cancellable

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameService.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                             }
                         }
 
-                        if (!navigationService.CanNavigateToSpan(workspace, document.Id, documentSpan.SourceSpan))
+                        if (!navigationService.CanNavigateToSpan(workspace, document.Id, documentSpan.SourceSpan, cancellationToken))
                         {
                             return new InlineRenameSessionInfo(EditorFeaturesResources.You_cannot_rename_this_element_because_it_is_in_a_location_that_cannot_be_navigated_to);
                         }

--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveDocumentNavigationService.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveDocumentNavigationService.cs
@@ -13,24 +13,23 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 {
     internal sealed class InteractiveDocumentNavigationService : IDocumentNavigationService
     {
-        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
+        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
             => true;
 
-        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
+        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
             => false;
 
-        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0)
+        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
             => false;
 
-        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options)
+        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken)
         {
-            if (!(workspace is InteractiveWorkspace interactiveWorkspace))
+            if (workspace is not InteractiveWorkspace interactiveWorkspace)
             {
                 Debug.Fail("InteractiveDocumentNavigationService called with incorrect workspace!");
                 return false;
@@ -39,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             var textView = interactiveWorkspace.Window.TextView;
             var document = interactiveWorkspace.CurrentSolution.GetDocument(documentId);
 
-            var textSnapshot = document.GetTextSynchronously(CancellationToken.None).FindCorrespondingEditorTextSnapshot();
+            var textSnapshot = document.GetTextSynchronously(cancellationToken).FindCorrespondingEditorTextSnapshot();
             if (textSnapshot == null)
             {
                 return false;
@@ -67,10 +66,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             return true;
         }
 
-        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
+        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
+        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken)
             => throw new NotSupportedException();
     }
 }

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
@@ -60,7 +60,8 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                         _document.Project.Solution,
                         _definitions[0].NameDisplayParts.GetFullText(),
                         _threadingContext,
-                        _presenter));
+                        _presenter,
+                        context.CancellationToken));
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             // Document tabs opened by NavigateTo are carefully created as preview or regular
             // tabs by them; trying to specifically open them in a particular kind of tab here
             // has no effect.
-            navigationService.TryNavigateToSpan(workspace, document.Id, _searchResult.NavigableItem.SourceSpan);
+            navigationService.TryNavigateToSpan(workspace, document.Id, _searchResult.NavigableItem.SourceSpan, CancellationToken.None);
         }
 
         public int GetProvisionalViewingStatus()

--- a/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                 foreach (var item in navigableItems)
                 {
                     var document = item.Document;
-                    if (navigationService.CanNavigateToPosition(workspace, document.Id, item.SourceSpan.Start))
+                    if (navigationService.CanNavigateToPosition(workspace, document.Id, item.SourceSpan.Start, cancellationToken))
                     {
                         var text = document.GetTextSynchronously(cancellationToken);
                         var linePositionSpan = text.Lines.GetLinePositionSpan(item.SourceSpan);

--- a/src/EditorFeatures/Core/CommandHandlers/AbstractGoToCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/AbstractGoToCommandHandler.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 return context.Message;
 
             await _streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                _threadingContext, document.Project.Solution.Workspace, context.SearchTitle, context.GetDefinitions()).ConfigureAwait(false);
+                _threadingContext, document.Project.Solution.Workspace, context.SearchTitle, context.GetDefinitions(), cancellationToken).ConfigureAwait(false);
             return null;
         }
     }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractNavigationBarItemService.cs
@@ -45,19 +45,19 @@ namespace Microsoft.CodeAnalysis.Editor.Extensibility.NavigationBar
 
             if (navigationPoint.HasValue)
             {
-                NavigateToVirtualTreePoint(document.Project.Solution, navigationPoint.Value);
+                NavigateToVirtualTreePoint(document.Project.Solution, navigationPoint.Value, cancellationToken);
             }
         }
 
-        protected static void NavigateToVirtualTreePoint(Solution solution, VirtualTreePoint navigationPoint)
+        protected static void NavigateToVirtualTreePoint(Solution solution, VirtualTreePoint navigationPoint, CancellationToken cancellationToken)
         {
             var documentToNavigate = solution.GetDocument(navigationPoint.Tree);
             var workspace = solution.Workspace;
             var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
 
-            if (navigationService.CanNavigateToPosition(workspace, documentToNavigate.Id, navigationPoint.Position, navigationPoint.VirtualSpaces))
+            if (navigationService.CanNavigateToPosition(workspace, documentToNavigate.Id, navigationPoint.Position, navigationPoint.VirtualSpaces, cancellationToken))
             {
-                navigationService.TryNavigateToPosition(workspace, documentToNavigate.Id, navigationPoint.Position, navigationPoint.VirtualSpaces);
+                navigationService.TryNavigateToPosition(workspace, documentToNavigate.Id, navigationPoint.Position, navigationPoint.VirtualSpaces, options: null, cancellationToken);
             }
             else
             {

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return _threadingContext.JoinableTaskFactory.Run(() =>
                 _streamingPresenter.Value.TryNavigateToOrPresentItemsAsync(
-                    _threadingContext, solution.Workspace, title, definitions));
+                    _threadingContext, solution.Workspace, title, definitions, cancellationToken));
         }
 
         private static bool IsThirdPartyNavigationAllowed(ISymbol symbolToNavigateTo, int caretPosition, Document document, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             var solution = document.Project.Solution;
             var definitions = GoToDefinitionHelpers.GetDefinitions(symbol, solution, thirdPartyNavigationAllowed: true, cancellationToken)
-                .WhereAsArray(d => d.CanNavigateTo(solution.Workspace));
+                .WhereAsArray(d => d.CanNavigateTo(solution.Workspace, cancellationToken));
 
             await TaskScheduler.Default;
 

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return threadingContext.JoinableTaskFactory.Run(
                 () => streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                    threadingContext, solution.Workspace, title, definitions));
+                    threadingContext, solution.Workspace, title, definitions, cancellationToken));
         }
 
         public static bool TryGoToDefinition(
@@ -119,14 +119,15 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             Solution solution,
             string title,
             IThreadingContext threadingContext,
-            IStreamingFindUsagesPresenter streamingPresenter)
+            IStreamingFindUsagesPresenter streamingPresenter,
+            CancellationToken cancellationToken)
         {
             if (definitions.IsDefaultOrEmpty)
                 return false;
 
             return threadingContext.JoinableTaskFactory.Run(() =>
                 streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                    threadingContext, solution.Workspace, title, definitions));
+                    threadingContext, solution.Workspace, title, definitions, cancellationToken));
         }
     }
 }

--- a/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
+++ b/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.FindUsages;
@@ -60,10 +61,11 @@ namespace Microsoft.CodeAnalysis.Editor.Host
             IThreadingContext threadingContext,
             Workspace workspace,
             string title,
-            ImmutableArray<DefinitionItem> items)
+            ImmutableArray<DefinitionItem> items,
+            CancellationToken cancellationToken)
         {
             // Can only navigate or present items on UI thread.
-            await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             // Ignore any definitions that we can't navigate to.
             var definitions = items.WhereAsArray(d => d.CanNavigateTo(workspace));

--- a/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
+++ b/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Host
             await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             // Ignore any definitions that we can't navigate to.
-            var definitions = items.WhereAsArray(d => d.CanNavigateTo(workspace));
+            var definitions = items.WhereAsArray(d => d.CanNavigateTo(workspace, cancellationToken));
 
             // See if there's a third party external item we can navigate to.  If so, defer 
             // to that item and finish.
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Host
                 // If we're directly going to a location we need to activate the preview so
                 // that focus follows to the new cursor position. This behavior is expected
                 // because we are only going to navigate once successfully
-                if (item.TryNavigateTo(workspace, showInPreviewTab: true, activateTab: true))
+                if (item.TryNavigateTo(workspace, showInPreviewTab: true, activateTab: true, cancellationToken))
                 {
                     return true;
                 }
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.Host
                 // There was only one location to navigate to.  Just directly go to that location. If we're directly
                 // going to a location we need to activate the preview so that focus follows to the new cursor position.
 
-                return nonExternalItems[0].TryNavigateTo(workspace, showInPreviewTab: true, activateTab: true);
+                return nonExternalItems[0].TryNavigateTo(workspace, showInPreviewTab: true, activateTab: true, cancellationToken);
             }
 
             if (presenter != null)

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                 if (navigationTokenOpt.HasValue)
                 {
                     var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
-                    navigationService.TryNavigateToPosition(workspace, documentId, navigationTokenOpt.Value.SpanStart);
+                    navigationService.TryNavigateToPosition(workspace, documentId, navigationTokenOpt.Value.SpanStart, cancellationToken);
                     return;
                 }
 
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                     {
                         var editorWorkspace = workspace;
                         var navigationService = editorWorkspace.Services.GetService<IDocumentNavigationService>();
-                        if (navigationService.TryNavigateToSpan(editorWorkspace, documentId, resolvedRenameToken.Span))
+                        if (navigationService.TryNavigateToSpan(editorWorkspace, documentId, resolvedRenameToken.Span, cancellationToken))
                         {
                             var openDocument = workspace.CurrentSolution.GetDocument(documentId);
                             var openRoot = openDocument.GetSyntaxRootSynchronously(cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/ExtractInterface/AbstractExtractInterfaceCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/ExtractInterface/AbstractExtractInterfaceCommandHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ExtractInterface
                 }
 
                 var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
-                navigationService.TryNavigateToPosition(workspace, result.NavigationDocumentId, 0);
+                navigationService.TryNavigateToPosition(workspace, result.NavigationDocumentId, 0, CancellationToken.None);
 
                 return true;
             }

--- a/src/EditorFeatures/Core/Implementation/ExtractInterface/AbstractExtractInterfaceCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/ExtractInterface/AbstractExtractInterfaceCommandHandler.cs
@@ -76,6 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ExtractInterface
                     return true;
                 }
 
+                // TODO: Use a threaded-wait-dialog here so we can cancel navigation.
                 var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
                 navigationService.TryNavigateToPosition(workspace, result.NavigationDocumentId, 0, CancellationToken.None);
 

--- a/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockDocumentNavigationService.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockDocumentNavigationService.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.Navigation
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
@@ -26,19 +27,19 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
         Public _position As Integer = -1
         Public _positionVirtualSpace As Integer = -1
 
-        Public Function CanNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer) As Boolean Implements IDocumentNavigationService.CanNavigateToLineAndOffset
+        Public Function CanNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.CanNavigateToLineAndOffset
             Return _canNavigateToLineAndOffset
         End Function
 
-        Public Function CanNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, Optional virtualSpace As Integer = 0) As Boolean Implements IDocumentNavigationService.CanNavigateToPosition
+        Public Function CanNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.CanNavigateToPosition
             Return _canNavigateToPosition
         End Function
 
-        Public Function CanNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan) As Boolean Implements IDocumentNavigationService.CanNavigateToSpan
+        Public Function CanNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.CanNavigateToSpan
             Return _canNavigateToSpan
         End Function
 
-        Public Function TryNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, Optional options As OptionSet = Nothing) As Boolean Implements IDocumentNavigationService.TryNavigateToLineAndOffset
+        Public Function TryNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, options As OptionSet, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.TryNavigateToLineAndOffset
             _triedNavigationToLineAndOffset = True
             _documentId = documentId
             _options = options
@@ -48,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
             Return _canNavigateToLineAndOffset
         End Function
 
-        Public Function TryNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, Optional virtualSpace As Integer = 0, Optional options As OptionSet = Nothing) As Boolean Implements IDocumentNavigationService.TryNavigateToPosition
+        Public Function TryNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, options As OptionSet, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.TryNavigateToPosition
             _triedNavigationToPosition = True
             _documentId = documentId
             _options = options
@@ -58,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
             Return _canNavigateToPosition
         End Function
 
-        Public Function TryNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, Optional options As OptionSet = Nothing) As Boolean Implements IDocumentNavigationService.TryNavigateToSpan
+        Public Function TryNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, options As OptionSet, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.TryNavigateToSpan
             _triedNavigationToSpan = True
             _documentId = documentId
             _options = options

--- a/src/EditorFeatures/TestUtilities2/Utilities/MockDocumentNavigationServiceProvider.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/MockDocumentNavigationServiceProvider.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Composition
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Navigation
@@ -46,14 +47,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             Public TryNavigateToPositionReturnValue As Boolean = True
             Public TryNavigateToSpanReturnValue As Boolean = True
 
-            Public Function CanNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer) As Boolean Implements IDocumentNavigationService.CanNavigateToLineAndOffset
+            Public Function CanNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.CanNavigateToLineAndOffset
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedLineNumber = lineNumber
 
                 Return CanNavigateToLineAndOffsetReturnValue
             End Function
 
-            Public Function CanNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, Optional virtualSpace As Integer = 0) As Boolean Implements IDocumentNavigationService.CanNavigateToPosition
+            Public Function CanNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.CanNavigateToPosition
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedPosition = position
                 Me.ProvidedVirtualSpace = virtualSpace
@@ -61,14 +62,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
                 Return CanNavigateToPositionReturnValue
             End Function
 
-            Public Function CanNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan) As Boolean Implements IDocumentNavigationService.CanNavigateToSpan
+            Public Function CanNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.CanNavigateToSpan
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedTextSpan = textSpan
 
                 Return CanNavigateToSpanReturnValue
             End Function
 
-            Public Function TryNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, Optional options As OptionSet = Nothing) As Boolean Implements IDocumentNavigationService.TryNavigateToLineAndOffset
+            Public Function TryNavigateToLineAndOffset(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, options As OptionSet, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.TryNavigateToLineAndOffset
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedLineNumber = lineNumber
                 Me.ProvidedOffset = offset
@@ -77,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
                 Return TryNavigateToLineAndOffsetReturnValue
             End Function
 
-            Public Function TryNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, Optional virtualSpace As Integer = 0, Optional options As OptionSet = Nothing) As Boolean Implements IDocumentNavigationService.TryNavigateToPosition
+            Public Function TryNavigateToPosition(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, options As OptionSet, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.TryNavigateToPosition
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedPosition = position
                 Me.ProvidedVirtualSpace = virtualSpace
@@ -86,7 +87,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
                 Return TryNavigateToPositionReturnValue
             End Function
 
-            Public Function TryNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, Optional options As OptionSet = Nothing) As Boolean Implements IDocumentNavigationService.TryNavigateToSpan
+            Public Function TryNavigateToSpan(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, options As OptionSet, cancellationToken As CancellationToken) As Boolean Implements IDocumentNavigationService.TryNavigateToSpan
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedTextSpan = textSpan
                 Me.ProvidedOptions = options

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
@@ -527,7 +527,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
                 newDocument.Project.Solution.Workspace.ApplyDocumentChanges(newDocument, cancellationToken)
 
                 ' WARNING: now that we've edited, nothing can check the cancellation token from here
-                NavigateToVirtualTreePoint(newDocument.Project.Solution, navigationPoint)
+                NavigateToVirtualTreePoint(newDocument.Project.Solution, navigationPoint, cancellationToken)
 
                 transaction.Complete()
             End Using

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
@@ -526,7 +526,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Using transaction = New CaretPreservingEditTransaction(VBEditorResources.Generate_Member, textView, _textUndoHistoryRegistry, _editorOperationsFactoryService)
                 newDocument.Project.Solution.Workspace.ApplyDocumentChanges(newDocument, cancellationToken)
 
-                ' WARNING: now that we've edited, nothing can check the cancellation token from here
                 NavigateToVirtualTreePoint(newDocument.Project.Solution, navigationPoint, cancellationToken)
 
                 transaction.Complete()

--- a/src/Features/Core/Portable/Common/NavigationOperation.cs
+++ b/src/Features/Core/Portable/Common/NavigationOperation.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
             if (workspace.CanOpenDocuments)
             {
                 var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
-                navigationService.TryNavigateToPosition(workspace, _documentId, _position);
+                navigationService.TryNavigateToPosition(workspace, _documentId, _position, cancellationToken);
             }
         }
     }

--- a/src/Features/Core/Portable/DocumentSpanExtensions.cs
+++ b/src/Features/Core/Portable/DocumentSpanExtensions.cs
@@ -12,14 +12,14 @@ namespace Microsoft.CodeAnalysis
 {
     internal static class DocumentSpanExtensions
     {
-        public static bool CanNavigateTo(this DocumentSpan documentSpan)
+        public static bool CanNavigateTo(this DocumentSpan documentSpan, CancellationToken cancellationToken)
         {
             var workspace = documentSpan.Document.Project.Solution.Workspace;
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.CanNavigateToSpan(workspace, documentSpan.Document.Id, documentSpan.SourceSpan);
+            return service.CanNavigateToSpan(workspace, documentSpan.Document.Id, documentSpan.SourceSpan, cancellationToken);
         }
 
-        public static bool TryNavigateTo(this DocumentSpan documentSpan, bool showInPreviewTab, bool activateTab)
+        public static bool TryNavigateTo(this DocumentSpan documentSpan, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
         {
             var solution = documentSpan.Document.Project.Solution;
             var workspace = solution.Workspace;
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
             var options = solution.Options.WithChangedOption(NavigationOptions.PreferProvisionalTab, showInPreviewTab);
             options = options.WithChangedOption(NavigationOptions.ActivateTab, activateTab);
 
-            return service.TryNavigateToSpan(workspace, documentSpan.Document.Id, documentSpan.SourceSpan, options);
+            return service.TryNavigateToSpan(workspace, documentSpan.Document.Id, documentSpan.SourceSpan, options, cancellationToken);
         }
 
         public static async Task<bool> IsHiddenAsync(

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Options;
@@ -18,6 +19,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         public static VSTypeScriptDocumentNavigationServiceWrapper Create(Workspace workspace)
             => new(workspace.Services.GetRequiredService<IDocumentNavigationService>());
 
+        [Obsolete("Call overload that takes a CancellationToken", error: false)]
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet? options = null)
             => this.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
 

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Options;
 
@@ -18,6 +19,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             => new(workspace.Services.GetRequiredService<IDocumentNavigationService>());
 
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet? options = null)
-            => _underlyingObject.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options);
+            => _underlyingObject.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
@@ -19,6 +19,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             => new(workspace.Services.GetRequiredService<IDocumentNavigationService>());
 
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet? options = null)
-            => _underlyingObject.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
+            => this.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
+
+        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet? options, CancellationToken cancellationToken)
+            => _underlyingObject.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet? options = null)
             => this.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
 
+        /// <inheritdoc cref="IDocumentNavigationService.TryNavigateToPosition"/>
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet? options, CancellationToken cancellationToken)
             => _underlyingObject.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, cancellationToken);
     }

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
             {
             }
 
-            public override bool CanNavigateTo(Workspace workspace)
+            public override bool CanNavigateTo(Workspace workspace, CancellationToken cancellationToken)
             {
                 if (Properties.ContainsKey(NonNavigable))
                 {
@@ -49,10 +49,10 @@ namespace Microsoft.CodeAnalysis.FindUsages
                     return CanNavigateToMetadataSymbol(workspace, symbolKey);
                 }
 
-                return SourceSpans[0].CanNavigateTo();
+                return SourceSpans[0].CanNavigateTo(cancellationToken);
             }
 
-            public override bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab)
+            public override bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
             {
                 if (Properties.ContainsKey(NonNavigable))
                 {
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
                     return TryNavigateToMetadataSymbol(workspace, symbolKey);
                 }
 
-                return SourceSpans[0].TryNavigateTo(showInPreviewTab, activateTab);
+                return SourceSpans[0].TryNavigateTo(showInPreviewTab, activateTab, cancellationToken);
             }
 
             private bool CanNavigateToMetadataSymbol(Workspace workspace, string symbolKey)

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis.Tags;
 using Roslyn.Utilities;
 
@@ -155,8 +156,8 @@ namespace Microsoft.CodeAnalysis.FindUsages
             }
         }
 
-        public abstract bool CanNavigateTo(Workspace workspace);
-        public abstract bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab);
+        public abstract bool CanNavigateTo(Workspace workspace, CancellationToken cancellationToken);
+        public abstract bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken);
 
         public static DefinitionItem Create(
             ImmutableArray<string> tags,

--- a/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Threading;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
@@ -11,22 +12,22 @@ namespace Microsoft.CodeAnalysis.Navigation
 {
     internal sealed class DefaultDocumentNavigationService : IDocumentNavigationService
     {
-        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
+        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
             => false;
 
-        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
+        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
             => false;
 
-        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace)
+        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
             => false;
 
-        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options)
+        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken)
             => false;
 
-        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
+        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken)
             => false;
 
-        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
+        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken)
             => false;
     }
 }

--- a/src/Features/Core/Portable/Navigation/IDocumentNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/IDocumentNavigationService.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
@@ -15,31 +16,46 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// <summary>
         /// Determines whether it is possible to navigate to the given position in the specified document.
         /// </summary>
-        bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan);
+        bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determines whether it is possible to navigate to the given line/offset in the specified document.
         /// </summary>
-        bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset);
+        bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determines whether it is possible to navigate to the given virtual position in the specified document.
         /// </summary>
-        bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0);
+        bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
 
         /// <summary>
         /// Navigates to the given position in the specified document, opening it if necessary.
         /// </summary>
-        bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null);
+        bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Navigates to the given line/offset in the specified document, opening it if necessary.
         /// </summary>
-        bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null);
+        bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Navigates to the given virtual position in the specified document, opening it if necessary.
         /// </summary>
-        bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null);
+        bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken);
+    }
+
+    internal static class IDocumentNavigationServiceExtensions
+    {
+        public static bool CanNavigateToPosition(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
+            => service.CanNavigateToPosition(workspace, documentId, position, virtualSpace: 0, cancellationToken);
+
+        public static bool TryNavigateToSpan(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
+            => service.TryNavigateToSpan(workspace, documentId, textSpan, options: null, cancellationToken);
+
+        public static bool TryNavigateToLineAndOffset(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
+            => service.TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, options: null, cancellationToken);
+
+        public static bool TryNavigateToPosition(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
+            => service.TryNavigateToPosition(workspace, documentId, position, virtualSpace: 0, options: null, cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -48,9 +48,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
                 var workspace = document.Project.Solution.Workspace;
                 var navigationService = workspace.Services.GetService<IFSharpDocumentNavigationService>();
 
-                if (navigationService.CanNavigateToPosition(workspace, document.Id, span.Start))
+                if (navigationService.CanNavigateToPosition(workspace, document.Id, span.Start, virtualSpace: 0, cancellationToken))
                 {
-                    navigationService.TryNavigateToPosition(workspace, document.Id, span.Start);
+                    navigationService.TryNavigateToPosition(workspace, document.Id, span.Start, virtualSpace: 0, options: null, cancellationToken);
                 }
                 else
                 {

--- a/src/Tools/ExternalAccess/FSharp/Navigation/FSharpDocumentNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/FSharpDocumentNavigationService.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Options;
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.CanNavigateToSpan(workspace, documentId, textSpan);
+            return service.CanNavigateToSpan(workspace, documentId, textSpan, CancellationToken.None);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.CanNavigateToLineAndOffset(workspace, documentId, lineNumber, offset);
+            return service.CanNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, CancellationToken.None);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.CanNavigateToPosition(workspace, documentId, position, virtualSpace);
+            return service.CanNavigateToPosition(workspace, documentId, position, virtualSpace, CancellationToken.None);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.TryNavigateToSpan(workspace, documentId, textSpan, options);
+            return service.TryNavigateToSpan(workspace, documentId, textSpan, options, CancellationToken.None);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, options);
+            return service.TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, options, CancellationToken.None);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options);
+            return service.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
         }
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Navigation/FSharpDocumentNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/FSharpDocumentNavigationService.cs
@@ -23,58 +23,58 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         {
         }
 
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given position in the specified document.
-        /// </summary>
         public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
+            => CanNavigateToSpan(workspace, documentId, textSpan, CancellationToken.None);
+
+        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.CanNavigateToSpan(workspace, documentId, textSpan, CancellationToken.None);
+            return service.CanNavigateToSpan(workspace, documentId, textSpan, cancellationToken);
         }
 
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given line/offset in the specified document.
-        /// </summary>
         public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
+            => CanNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, CancellationToken.None);
+
+        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.CanNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, CancellationToken.None);
+            return service.CanNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, cancellationToken);
         }
 
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given virtual position in the specified document.
-        /// </summary>
-        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0)
+        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace)
+            => CanNavigateToPosition(workspace, documentId, position, virtualSpace, CancellationToken.None);
+
+        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.CanNavigateToPosition(workspace, documentId, position, virtualSpace, CancellationToken.None);
+            return service.CanNavigateToPosition(workspace, documentId, position, virtualSpace, cancellationToken);
         }
 
-        /// <summary>
-        /// Navigates to the given position in the specified document, opening it if necessary.
-        /// </summary>
-        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null)
+        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options)
+            => TryNavigateToSpan(workspace, documentId, textSpan, options, CancellationToken.None);
+
+        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.TryNavigateToSpan(workspace, documentId, textSpan, options, CancellationToken.None);
+            return service.TryNavigateToSpan(workspace, documentId, textSpan, options, cancellationToken);
         }
 
-        /// <summary>
-        /// Navigates to the given line/offset in the specified document, opening it if necessary.
-        /// </summary>
-        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null)
+        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
+            => TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, options, CancellationToken.None);
+
+        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, options, CancellationToken.None);
+            return service.TryNavigateToLineAndOffset(workspace, documentId, lineNumber, offset, options, cancellationToken);
         }
 
-        /// <summary>
-        /// Navigates to the given virtual position in the specified document, opening it if necessary.
-        /// </summary>
-        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null)
+        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
+            => TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
+
+        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken)
         {
             var service = workspace.Services.GetService<IDocumentNavigationService>();
-            return service.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, CancellationToken.None);
+            return service.TryNavigateToPosition(workspace, documentId, position, virtualSpace, options, cancellationToken);
         }
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
@@ -16,30 +17,36 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
         /// Determines whether it is possible to navigate to the given position in the specified document.
         /// </summary>
         bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan);
+        bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determines whether it is possible to navigate to the given line/offset in the specified document.
         /// </summary>
         bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset);
+        bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determines whether it is possible to navigate to the given virtual position in the specified document.
         /// </summary>
         bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0);
+        bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
 
         /// <summary>
         /// Navigates to the given position in the specified document, opening it if necessary.
         /// </summary>
         bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null);
+        bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Navigates to the given line/offset in the specified document, opening it if necessary.
         /// </summary>
         bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null);
+        bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Navigates to the given virtual position in the specified document, opening it if necessary.
         /// </summary>
         bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null);
+        bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
@@ -6,6 +6,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
@@ -13,40 +14,28 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
 {
     internal interface IFSharpDocumentNavigationService : IWorkspaceService
     {
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given position in the specified document.
-        /// </summary>
         bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan);
+        /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToSpan"/>
         bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given line/offset in the specified document.
-        /// </summary>
         bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset);
+        /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToLineAndOffset"/>
         bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Determines whether it is possible to navigate to the given virtual position in the specified document.
-        /// </summary>
         bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0);
+        /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToPosition"/>
         bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Navigates to the given position in the specified document, opening it if necessary.
-        /// </summary>
         bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null);
+        /// <inheritdoc cref="IDocumentNavigationService.TryNavigateToSpan"/>
         bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Navigates to the given line/offset in the specified document, opening it if necessary.
-        /// </summary>
         bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null);
+        /// <inheritdoc cref="IDocumentNavigationService.TryNavigateToLineAndOffset"/>
         bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Navigates to the given virtual position in the specified document, opening it if necessary.
-        /// </summary>
         bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null);
+        /// <inheritdoc cref="IDocumentNavigationService.TryNavigateToPosition"/>
         bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpDocumentNavigationService.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Navigation;
@@ -14,27 +15,30 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
 {
     internal interface IFSharpDocumentNavigationService : IWorkspaceService
     {
+        [Obsolete("Call overload that takes a CancellationToken", error: false)]
         bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan);
+        [Obsolete("Call overload that takes a CancellationToken", error: false)]
+        bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset);
+        [Obsolete("Call overload that takes a CancellationToken", error: false)]
+        bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0);
+        [Obsolete("Call overload that takes a CancellationToken", error: false)]
+        bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null);
+        [Obsolete("Call overload that takes a CancellationToken", error: false)]
+        bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null);
+        [Obsolete("Call overload that takes a CancellationToken", error: false)]
+        bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null);
+
         /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToSpan"/>
         bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
-
-        bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset);
         /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToLineAndOffset"/>
         bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
-
-        bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0);
         /// <inheritdoc cref="IDocumentNavigationService.CanNavigateToPosition"/>
         bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
 
-        bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null);
         /// <inheritdoc cref="IDocumentNavigationService.TryNavigateToSpan"/>
         bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken);
-
-        bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null);
         /// <inheritdoc cref="IDocumentNavigationService.TryNavigateToLineAndOffset"/>
         bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken);
-
-        bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null);
         /// <inheritdoc cref="IDocumentNavigationService.TryNavigateToPosition"/>
         bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken);
     }

--- a/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyDetail.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyDetail.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Threading;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.CallHierarchy;
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
                 var navigator = _workspace.Services.GetService<IDocumentNavigationService>();
                 var options = _workspace.Options.WithChangedOption(NavigationOptions.PreferProvisionalTab, true)
                                                 .WithChangedOption(NavigationOptions.ActivateTab, false);
-                navigator.TryNavigateToSpan(_workspace, document.Id, _span, options);
+                navigator.TryNavigateToSpan(_workspace, document.Id, _span, options, CancellationToken.None);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/DocumentSpanEntry.cs
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     sourceText.Lines[lastLineNumber].End);
             }
 
-            bool ISupportsNavigation.TryNavigateTo(bool isPreview)
+            bool ISupportsNavigation.TryNavigateTo(bool isPreview, CancellationToken cancellationToken)
             {
                 // If the document is a source generated document, we need to do the navigation ourselves;
                 // this is because the file path given to the table control isn't a real file path to a file
@@ -218,7 +218,8 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                             workspace,
                             _excerptResult.Document.Id,
                             _excerptResult.Span,
-                            workspace.Options.WithChangedOption(NavigationOptions.PreferProvisionalTab, isPreview));
+                            workspace.Options.WithChangedOption(NavigationOptions.PreferProvisionalTab, isPreview),
+                            cancellationToken);
                     }
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/MetadataDefinitionItemEntry.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/MetadataDefinitionItemEntry.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Windows.Documents;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -32,9 +33,9 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 return null;
             }
 
-            bool ISupportsNavigation.TryNavigateTo(bool isPreview)
+            bool ISupportsNavigation.TryNavigateTo(bool isPreview, CancellationToken cancellationToken)
                 => DefinitionBucket.DefinitionItem.TryNavigateTo(
-                    Presenter._workspace, showInPreviewTab: isPreview, activateTab: !isPreview); // Only activate the tab if not opening in preview
+                    Presenter._workspace, showInPreviewTab: isPreview, activateTab: !isPreview, cancellationToken); // Only activate the tab if not opening in preview
 
             protected override IList<Inline> CreateLineTextInlines()
                 => DefinitionBucket.DefinitionItem.DisplayParts

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/FindReferencesTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/FindReferencesTableControlEventProcessorProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             {
                 if (entry.Identity is ISupportsNavigation supportsNavigation)
                 {
-                    // TODO: Use a TWD here so we can cancel navigation.
+                    // TODO: Use a Threaded-Wait Dialog here so we can cancel navigation.
                     if (supportsNavigation.TryNavigateTo(e.IsPreview, CancellationToken.None))
                     {
                         e.Handled = true;

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/FindReferencesTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/FindReferencesTableControlEventProcessorProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             {
                 if (entry.Identity is ISupportsNavigation supportsNavigation)
                 {
-                    // TODO: Use a Threaded-Wait Dialog here so we can cancel navigation.
+                    // TODO: Use a threaded-wait-dialog here so we can cancel navigation.
                     if (supportsNavigation.TryNavigateTo(e.IsPreview, CancellationToken.None))
                     {
                         e.Handled = true;
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
                 if (entry.TryGetValue(StreamingFindUsagesPresenter.SelfKeyName, out var item) && item is ISupportsNavigation itemSupportsNavigation)
                 {
-                    // TODO: Use a TWD here so we can cancel navigation.
+                    // TODO: Use a threaded-wait-dialog here so we can cancel navigation.
                     if (itemSupportsNavigation.TryNavigateTo(e.IsPreview, CancellationToken.None))
                     {
                         e.Handled = true;

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/FindReferencesTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/FindReferencesTableControlEventProcessorProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Text.Classification;
 using System;
 using Microsoft.CodeAnalysis.Host.Mef;
+using System.Threading;
 
 namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 {
@@ -42,7 +43,8 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             {
                 if (entry.Identity is ISupportsNavigation supportsNavigation)
                 {
-                    if (supportsNavigation.TryNavigateTo(e.IsPreview))
+                    // TODO: Use a TWD here so we can cancel navigation.
+                    if (supportsNavigation.TryNavigateTo(e.IsPreview, CancellationToken.None))
                     {
                         e.Handled = true;
                         return;
@@ -51,7 +53,8 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
                 if (entry.TryGetValue(StreamingFindUsagesPresenter.SelfKeyName, out var item) && item is ISupportsNavigation itemSupportsNavigation)
                 {
-                    if (itemSupportsNavigation.TryNavigateTo(e.IsPreview))
+                    // TODO: Use a TWD here so we can cancel navigation.
+                    if (itemSupportsNavigation.TryNavigateTo(e.IsPreview, CancellationToken.None))
                     {
                         e.Handled = true;
                         return;

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/ISupportsNavigation.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/ISupportsNavigation.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+
 namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 {
     internal interface ISupportsNavigation
     {
-        bool TryNavigateTo(bool isPreview);
+        bool TryNavigateTo(bool isPreview, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/RoslynDefinitionBucket.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/RoslynDefinitionBucket.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Windows;
 using System.Windows.Documents;
 using Microsoft.CodeAnalysis;
@@ -52,9 +53,9 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     name, expandedByDefault: true, presenter, context, definitionItem);
             }
 
-            public bool TryNavigateTo(bool isPreview)
+            public bool TryNavigateTo(bool isPreview, CancellationToken cancellationToken)
                 => DefinitionItem.TryNavigateTo(
-                    _presenter._workspace, showInPreviewTab: isPreview, activateTab: !isPreview); // Only activate the tab if not opening in preview
+                    _presenter._workspace, showInPreviewTab: isPreview, activateTab: !isPreview, cancellationToken); // Only activate the tab if not opening in preview
 
             public override bool TryGetValue(string key, out object? content)
             {

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
@@ -104,9 +104,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.FindReferences
                 _charOffset = charOffset;
             }
 
-            public override bool CanNavigateTo(Workspace workspace) => true;
+            public override bool CanNavigateTo(Workspace workspace, CancellationToken cancellationToken) => true;
 
-            public override bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab)
+            public override bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
                 => TryOpenFile() && TryNavigateToPosition();
 
             private bool TryOpenFile()

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
@@ -126,7 +126,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                         editorWorkspace,
                         document.Id,
                         sourceLocation.StartPosition.Line,
-                        sourceLocation.StartPosition.Character);
+                        sourceLocation.StartPosition.Character,
+                        CancellationToken.None);
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
@@ -122,6 +122,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 {
                     var editorWorkspace = document.Project.Solution.Workspace;
                     var navigationService = editorWorkspace.Services.GetService<IDocumentNavigationService>();
+
+                    // TODO: Get the platform to use and pass us an operation context, or create one ourselves.
                     navigationService.TryNavigateToLineAndOffset(
                         editorWorkspace,
                         document.Id,

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Threading;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
 
@@ -46,7 +47,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 // we might fail to navigate if we don't see the document in our solution anymore.
                 // that can happen if error is staled build error or user used #line pragma in C#
                 // to point to some random file in error or more.
-                e.Handled = roslynSnapshot.TryNavigateTo(index, e.IsPreview, e.ShouldActivate);
+
+                // TODO: Use a TWD here so we can cancel navigation.
+                e.Handled = roslynSnapshot.TryNavigateTo(index, e.IsPreview, e.ShouldActivate, CancellationToken.None);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 // that can happen if error is staled build error or user used #line pragma in C#
                 // to point to some random file in error or more.
 
-                // TODO: Use a TWD here so we can cancel navigation.
+                // TODO: Use a threaded-wait-dialog here so we can cancel navigation.
                 e.Handled = roslynSnapshot.TryNavigateTo(index, e.IsPreview, e.ShouldActivate, CancellationToken.None);
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableEntriesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableEntriesFactory.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.VisualStudio.Shell.TableManager;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -198,7 +199,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 {
                 }
 
-                public override bool TryNavigateTo(int index, bool previewTab, bool activate) => false;
+                public override bool TryNavigateTo(int index, bool previewTab, bool activate, CancellationToken cancellationToken) => false;
 
                 public override bool TryGetValue(int index, string columnName, out object content)
                 {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -458,8 +458,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     }
                 }
 
-                public override bool TryNavigateTo(int index, bool previewTab, bool activate)
-                    => TryNavigateToItem(index, previewTab, activate);
+                public override bool TryNavigateTo(int index, bool previewTab, bool activate, CancellationToken cancellationToken)
+                    => TryNavigateToItem(index, previewTab, activate, cancellationToken);
 
                 #region IWpfTableEntriesSnapshot
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -268,8 +268,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                         item.Data.MappedColumn);
                 }
 
-                public override bool TryNavigateTo(int index, bool previewTab, bool activate)
-                    => TryNavigateToItem(index, previewTab, activate);
+                public override bool TryNavigateTo(int index, bool previewTab, bool activate, CancellationToken cancellationToken)
+                    => TryNavigateToItem(index, previewTab, activate, cancellationToken);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
@@ -209,7 +210,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                         }
                     }
 
-                    public override bool TryNavigateTo(int index, bool previewTab, bool activate)
+                    public override bool TryNavigateTo(int index, bool previewTab, bool activate, CancellationToken cancellationToken)
                     {
                         var item = GetItem(index);
                         if (item?.DocumentId == null)
@@ -221,7 +222,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                         var solution = item.Workspace.CurrentSolution;
 
                         return solution.ContainsDocument(documentId) &&
-                            TryNavigateTo(item.Workspace, documentId, item.GetOriginalPosition(), previewTab, activate);
+                            TryNavigateTo(item.Workspace, documentId, item.GetOriginalPosition(), previewTab, activate, cancellationToken);
                     }
 
                     private DocumentId GetProperDocumentId(DiagnosticTableItem item)

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 this);
         }
 
-        public void NavigateToSourceGeneratedFile(SourceGeneratedDocument document, TextSpan sourceSpan)
+        public void NavigateToSourceGeneratedFile(SourceGeneratedDocument document, TextSpan sourceSpan, CancellationToken cancellationToken)
         {
             _foregroundThreadAffintizedObject.AssertIsForeground();
 
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             // We should have the file now, so navigate to the right span
             if (_openFiles.TryGetValue(temporaryFilePath, out var openFile))
             {
-                openFile.NavigateToSpan(sourceSpan);
+                openFile.NavigateToSpan(sourceSpan, cancellationToken);
             }
         }
 
@@ -481,10 +481,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 _currentWindowFrameInfoBarElement = infoBarUI;
             }
 
-            public void NavigateToSpan(TextSpan sourceSpan)
+            public void NavigateToSpan(TextSpan sourceSpan, CancellationToken cancellationToken)
             {
                 var sourceText = _textBuffer.CurrentSnapshot.AsText();
-                _fileManager._visualStudioDocumentNavigationService.NavigateTo(_textBuffer, sourceText.GetVsTextSpanForSpan(sourceSpan));
+                _fileManager._visualStudioDocumentNavigationService.NavigateTo(_textBuffer, sourceText.GetVsTextSpanForSpan(sourceSpan), cancellationToken);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Linq;
@@ -61,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _sourceGeneratedFileManager = sourceGeneratedFileManager;
         }
 
-        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan)
+        public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
             // Navigation should not change the context of linked files and Shared Projects.
             documentId = workspace.GetDocumentIdInCurrentContext(documentId);
@@ -72,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             var document = workspace.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextSynchronously(CancellationToken.None);
+            var text = document.GetTextSynchronously(cancellationToken);
 
             var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
             if (boundedTextSpan != textSpan)
@@ -93,7 +92,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return CanMapFromSecondaryBufferToPrimaryBuffer(workspace, documentId, vsTextSpan);
         }
 
-        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset)
+        public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
         {
             // Navigation should not change the context of linked files and Shared Projects.
             documentId = workspace.GetDocumentIdInCurrentContext(documentId);
@@ -104,13 +103,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             var document = workspace.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextSynchronously(CancellationToken.None);
+            var text = document.GetTextSynchronously(cancellationToken);
             var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
 
             return CanMapFromSecondaryBufferToPrimaryBuffer(workspace, documentId, vsTextSpan);
         }
 
-        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0)
+        public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
         {
             // Navigation should not change the context of linked files and Shared Projects.
             documentId = workspace.GetDocumentIdInCurrentContext(documentId);
@@ -121,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             var document = workspace.CurrentSolution.GetDocument(documentId);
-            var text = document.GetTextSynchronously(CancellationToken.None);
+            var text = document.GetTextSynchronously(cancellationToken);
 
             var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
             if (boundedPosition != position)
@@ -142,13 +141,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return CanMapFromSecondaryBufferToPrimaryBuffer(workspace, documentId, vsTextSpan);
         }
 
-        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options)
+        public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken)
         {
             return TryNavigateToLocation(workspace,
                 documentId,
                 _ => textSpan,
                 text => GetVsTextSpan(text, textSpan),
-                options);
+                options,
+                cancellationToken);
 
             static VsTextSpan GetVsTextSpan(SourceText text, TextSpan textSpan)
             {
@@ -168,17 +168,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
+        public bool TryNavigateToLineAndOffset(
+            Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken)
         {
             return TryNavigateToLocation(workspace,
                 documentId,
-                (document) => GetTextSpanFromLineAndOffset(document, lineNumber, offset),
-                (text) => GetVsTextSpan(text, lineNumber, offset),
-                options);
+                document => GetTextSpanFromLineAndOffset(document, lineNumber, offset, cancellationToken),
+                text => GetVsTextSpan(text, lineNumber, offset),
+                options,
+                cancellationToken);
 
-            static TextSpan GetTextSpanFromLineAndOffset(Document document, int lineNumber, int offset)
+            static TextSpan GetTextSpanFromLineAndOffset(Document document, int lineNumber, int offset, CancellationToken cancellationToken)
             {
-                var text = document.GetTextSynchronously(CancellationToken.None);
+                var text = document.GetTextSynchronously(cancellationToken);
 
                 var linePosition = new LinePosition(lineNumber, offset);
                 return text.Lines.GetTextSpan(new LinePositionSpan(linePosition, linePosition));
@@ -190,17 +192,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
+        public bool TryNavigateToPosition(
+            Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken)
         {
             return TryNavigateToLocation(workspace,
                 documentId,
-                (document) => GetTextSpanFromPosition(document, position, virtualSpace),
-                (text) => GetVsTextSpan(text, position, virtualSpace),
-                options);
+                document => GetTextSpanFromPosition(document, position, virtualSpace, cancellationToken),
+                text => GetVsTextSpan(text, position, virtualSpace),
+                options,
+                cancellationToken);
 
-            static TextSpan GetTextSpanFromPosition(Document document, int position, int virtualSpace)
+            static TextSpan GetTextSpanFromPosition(Document document, int position, int virtualSpace, CancellationToken cancellationToken)
             {
-                var text = document.GetTextSynchronously(CancellationToken.None);
+                var text = document.GetTextSynchronously(cancellationToken);
                 text.GetLineAndOffset(position, out var lineNumber, out var offset);
 
                 offset += virtualSpace;
@@ -227,7 +231,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        private bool TryNavigateToLocation(Workspace workspace, DocumentId documentId, Func<Document, TextSpan> getTextSpanForMapping, Func<SourceText, VsTextSpan> getVsTextSpan, OptionSet options)
+        private bool TryNavigateToLocation(
+            Workspace workspace,
+            DocumentId documentId,
+            Func<Document, TextSpan> getTextSpanForMapping,
+            Func<SourceText, VsTextSpan> getVsTextSpan,
+            OptionSet options,
+            CancellationToken cancellationToken)
         {
             // Navigation should not change the context of linked files and Shared Projects.
             documentId = workspace.GetDocumentIdInCurrentContext(documentId);
@@ -241,12 +251,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 if (workspace.CurrentSolution.GetDocument(documentId) == null)
                 {
-                    // We unfortunately don't have a cancellation token to pass here right now; we don't expect this to be expensive though,
-                    // because if a feature is asking to navigate to this file, it's because they already know this file contains something interesting;
-                    // that probably means generators have already ran so this should be a no-op. If this proves to be wrong, we may want to refactor
-                    // this further to have the SourceGeneratedFileManager instead open the file asynchronously.
+                    // We unfortunately don't have a cancellation token to pass here right now; we don't expect this to
+                    // be expensive though, because if a feature is asking to navigate to this file, it's because they
+                    // already know this file contains something interesting; that probably means generators have
+                    // already ran so this should be a no-op. If this proves to be wrong, we may want to refactor this
+                    // further to have the SourceGeneratedFileManager instead open the file asynchronously.
                     var generatedDocument = workspace.CurrentSolution.GetProject(documentId.ProjectId)
-                                                                     .GetSourceGeneratedDocumentAsync(documentId, CancellationToken.None)
+                                                                     .GetSourceGeneratedDocumentAsync(documentId, cancellationToken)
                                                                      .GetAwaiter().GetResult();
 
                     if (generatedDocument != null)
@@ -261,7 +272,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 var spanMappingService = document?.Services.GetService<ISpanMappingService>();
                 if (spanMappingService != null)
                 {
-                    var mappedSpan = GetMappedSpan(spanMappingService, document, getTextSpanForMapping(document));
+                    var mappedSpan = GetMappedSpan(spanMappingService, document, getTextSpanForMapping(document), cancellationToken);
                     if (mappedSpan.HasValue)
                     {
                         // Check if the mapped file matches one already in the workspace.
@@ -272,18 +283,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                             // If the mapped file maps to the same document that was passed in, then re-use the documentId to preserve context.
                             // Otherwise, just pick one of the ids to use for navigation.
                             var documentIdToNavigate = documentIdsForFilePath.Contains(documentId) ? documentId : documentIdsForFilePath.First();
-                            return NavigateToFileInWorkspace(documentIdToNavigate, workspace, getVsTextSpan);
+                            return NavigateToFileInWorkspace(documentIdToNavigate, workspace, getVsTextSpan, cancellationToken);
                         }
 
-                        return TryNavigateToMappedFile(workspace, document, mappedSpan.Value);
+                        return TryNavigateToMappedFile(workspace, document, mappedSpan.Value, cancellationToken);
                     }
                 }
 
-                return NavigateToFileInWorkspace(documentId, workspace, getVsTextSpan);
+                return NavigateToFileInWorkspace(documentId, workspace, getVsTextSpan, cancellationToken);
             }
         }
 
-        private bool NavigateToFileInWorkspace(DocumentId documentId, Workspace workspace, Func<SourceText, VsTextSpan> getVsTextSpan)
+        private bool NavigateToFileInWorkspace(
+            DocumentId documentId,
+            Workspace workspace,
+            Func<SourceText, VsTextSpan> getVsTextSpan,
+            CancellationToken cancellationToken)
         {
             var document = OpenDocument(workspace, documentId);
             if (document == null)
@@ -291,7 +306,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return false;
             }
 
-            var text = document.GetTextSynchronously(CancellationToken.None);
+            var text = document.GetTextSynchronously(cancellationToken);
             var textBuffer = text.Container.GetTextBuffer();
 
             var vsTextSpan = getVsTextSpan(text);
@@ -301,10 +316,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return false;
             }
 
-            return NavigateTo(textBuffer, vsTextSpan);
+            return NavigateTo(textBuffer, vsTextSpan, cancellationToken);
         }
 
-        private bool TryNavigateToMappedFile(Workspace workspace, Document generatedDocument, MappedSpanResult mappedSpanResult)
+        private bool TryNavigateToMappedFile(Workspace workspace, Document generatedDocument, MappedSpanResult mappedSpanResult, CancellationToken cancellationToken)
         {
             var vsWorkspace = (VisualStudioWorkspaceImpl)workspace;
             // TODO - Move to IOpenDocumentService - https://github.com/dotnet/roslyn/issues/45954
@@ -321,13 +336,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     iEndLine = mappedSpanResult.LinePositionSpan.End.Line
                 };
 
-                return NavigateTo(textBuffer, vsTextSpan);
+                return NavigateTo(textBuffer, vsTextSpan, cancellationToken);
             }
 
             return false;
         }
 
-        private MappedSpanResult? GetMappedSpan(ISpanMappingService spanMappingService, Document generatedDocument, TextSpan textSpan)
+        private MappedSpanResult? GetMappedSpan(ISpanMappingService spanMappingService, Document generatedDocument, TextSpan textSpan, CancellationToken cancellationToken)
         {
             // Mappings for opened razor files are retrieved via the LSP client making a request to the razor server.
             // If we wait for the result on the UI thread, we will hit a bug in the LSP client that brings us to a code path
@@ -335,7 +350,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             // Instead, we invoke this in JTF run which will mitigate deadlocks when the ConfigureAwait(true)
             // tries to switch back to the main thread in the LSP client.
             // Link to LSP client bug for ConfigureAwait(true) - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1216657
-            var results = _threadingContext.JoinableTaskFactory.Run(() => spanMappingService.MapSpansAsync(generatedDocument, SpecializedCollections.SingletonEnumerable(textSpan), CancellationToken.None));
+            var results = _threadingContext.JoinableTaskFactory.Run(() => spanMappingService.MapSpansAsync(generatedDocument, SpecializedCollections.SingletonEnumerable(textSpan), cancellationToken));
 
             if (!results.IsDefaultOrEmpty)
             {
@@ -389,9 +404,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return workspace.CurrentSolution.GetDocument(documentId);
         }
 
-        public bool NavigateTo(ITextBuffer textBuffer, VsTextSpan vsTextSpan)
+        public bool NavigateTo(ITextBuffer textBuffer, VsTextSpan vsTextSpan, CancellationToken cancellationToken)
         {
-            using (Logger.LogBlock(FunctionId.NavigationService_VSDocumentNavigationService_NavigateTo, CancellationToken.None))
+            using (Logger.LogBlock(FunctionId.NavigationService_VSDocumentNavigationService_NavigateTo, cancellationToken))
             {
                 var vsTextBuffer = _editorAdaptersFactoryService.GetBufferAdapter(textBuffer);
                 if (vsTextBuffer == null)
@@ -419,9 +434,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        private bool IsSecondaryBuffer(Workspace workspace, DocumentId documentId)
+        private static bool IsSecondaryBuffer(Workspace workspace, DocumentId documentId)
         {
-            if (!(workspace is VisualStudioWorkspaceImpl visualStudioWorkspace))
+            if (workspace is not VisualStudioWorkspaceImpl visualStudioWorkspace)
             {
                 return false;
             }
@@ -435,10 +450,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return true;
         }
 
-        private bool CanMapFromSecondaryBufferToPrimaryBuffer(Workspace workspace, DocumentId documentId, VsTextSpan spanInSecondaryBuffer)
+        private static bool CanMapFromSecondaryBufferToPrimaryBuffer(Workspace workspace, DocumentId documentId, VsTextSpan spanInSecondaryBuffer)
             => spanInSecondaryBuffer.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out _);
 
-        private IDisposable OpenNewDocumentStateScope(OptionSet options)
+        private static IDisposable OpenNewDocumentStateScope(OptionSet options)
         {
             var state = options.GetOption(NavigationOptions.PreferProvisionalTab)
                 ? __VSNEWDOCUMENTSTATE.NDS_Provisional

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                     if (generatedDocument != null)
                     {
-                        _sourceGeneratedFileManager.Value.NavigateToSourceGeneratedFile(generatedDocument, getTextSpanForMapping(generatedDocument));
+                        _sourceGeneratedFileManager.Value.NavigateToSourceGeneratedFile(generatedDocument, getTextSpanForMapping(generatedDocument), cancellationToken);
                         return true;
                     }
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -251,11 +251,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 if (workspace.CurrentSolution.GetDocument(documentId) == null)
                 {
-                    // We unfortunately don't have a cancellation token to pass here right now; we don't expect this to
-                    // be expensive though, because if a feature is asking to navigate to this file, it's because they
-                    // already know this file contains something interesting; that probably means generators have
-                    // already ran so this should be a no-op. If this proves to be wrong, we may want to refactor this
-                    // further to have the SourceGeneratedFileManager instead open the file asynchronously.
                     var generatedDocument = workspace.CurrentSolution.GetProject(documentId.ProjectId)
                                                                      .GetSourceGeneratedDocumentAsync(documentId, cancellationToken)
                                                                      .GetAwaiter().GetResult();

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     var editorWorkspace = targetDocument.Project.Solution.Workspace;
                     var navigationService = editorWorkspace.Services.GetRequiredService<IDocumentNavigationService>();
-                    return navigationService.TryNavigateToSpan(editorWorkspace, targetDocument.Id, sourceLocation.SourceSpan, options);
+                    return navigationService.TryNavigateToSpan(editorWorkspace, targetDocument.Id, sourceLocation.SourceSpan, options, cancellationToken);
                 }
             }
 
@@ -162,10 +162,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 var navigationService = editorWorkspace.Services.GetRequiredService<IDocumentNavigationService>();
 
                 return navigationService.TryNavigateToSpan(
-                    workspace: editorWorkspace,
-                    documentId: openedDocument.Id,
-                    textSpan: result.IdentifierLocation.SourceSpan,
-                    options: options.WithChangedOption(NavigationOptions.PreferProvisionalTab, true));
+                    editorWorkspace,
+                    openedDocument.Id,
+                    result.IdentifierLocation.SourceSpan,
+                    options.WithChangedOption(NavigationOptions.PreferProvisionalTab, true),
+                    cancellationToken);
             }
 
             return true;

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItem.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItem.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                     if (documentNavigationService != null)
                     {
                         // TODO: we're navigating back to the top of the file, do we have a way to just bring it to the focus and that's it?
-                        // TODO: Use a TWD here so the user can cancel navigation.
+                        // TODO: Use a threaded-wait-dialog here so we can cancel navigation.
                         didNavigate |= documentNavigationService.TryNavigateToPosition(item.Workspace, item.DocumentId, position: 0, CancellationToken.None);
                     }
                 }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItem.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItem.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.Internal.VisualStudio.PlatformUI;
@@ -50,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
             public bool Invoke(IEnumerable<object> items, InputSource inputSource, bool preview)
             {
-                bool didNavigate = false;
+                var didNavigate = false;
 
                 foreach (var item in items.OfType<SourceGeneratedFileItem>())
                 {
@@ -58,7 +59,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                     if (documentNavigationService != null)
                     {
                         // TODO: we're navigating back to the top of the file, do we have a way to just bring it to the focus and that's it?
-                        didNavigate |= documentNavigationService.TryNavigateToPosition(item.Workspace, item.DocumentId, 0);
+                        // TODO: Use a TWD here so the user can cancel navigation.
+                        didNavigate |= documentNavigationService.TryNavigateToPosition(item.Workspace, item.DocumentId, position: 0, CancellationToken.None);
                     }
                 }
 

--- a/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
+++ b/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -33,17 +34,17 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
 
         private class MockDocumentNavigationService : IDocumentNavigationService
         {
-            public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset) => true;
+            public bool CanNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken) => true;
 
-            public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0) => true;
+            public bool CanNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken) => true;
 
-            public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan) => true;
+            public bool CanNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken) => true;
 
-            public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options = null) => true;
+            public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options, CancellationToken cancellationToken) => true;
 
-            public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace = 0, OptionSet options = null) => true;
+            public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options, CancellationToken cancellationToken) => true;
 
-            public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options = null) => true;
+            public bool TryNavigateToSpan(Workspace workspace, DocumentId documentId, TextSpan textSpan, OptionSet options, CancellationToken cancellationToken) => true;
         }
     }
 }


### PR DESCRIPTION
For a while i've noticed several operations cause a TWD to pop up, but i can end up in a non-cancellable state where hitting cancel does nothing.  Breaking into the debugger i coudl see this was due to us being in a codepath where we were passing along CancellationToken.None because there was no way to pass along the TWD token.

This allows us to thread the token through.  There are still some codepaths where we don't have a TWD, but we can address those separately.