### PR TITLE
Define CONTRACTS_FULL

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableHashMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableHashMap.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#define CONTRACTS_FULL
+
 using System;
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
`Pure` attribute is used for many methods in this file. It requires CONTRACTS_FULL to be defined as the attribute itself is conditionally compiled.