### PR TITLE
Order PDB document table to match compiler arguments

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
@@ -50,7 +50,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
             pdbOptions.VerifyPdbOption("define", firstSyntaxTree.Options.PreprocessorSymbolNames, isDefault: v => v.IsEmpty(), toString: v => string.Join(",", v));
         }
 
-        private static void TestDeterministicCompilationCSharp(string langVersion, SyntaxTree[] syntaxTrees, CSharpCompilationOptions compilationOptions, EmitOptions emitOptions, params TestMetadataReferenceInfo[] metadataReferences)
+        private static void TestDeterministicCompilationCSharp(
+            string langVersion,
+            SyntaxTree[] syntaxTrees,
+            CSharpCompilationOptions compilationOptions,
+            EmitOptions emitOptions,
+            TestMetadataReferenceInfo[] metadataReferences,
+            int? debugDocumentsCount = null)
         {
             var originalCompilation = CreateCompilation(
                 syntaxTrees,
@@ -76,11 +82,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
                 using (var embeddedPdb = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embedded))
                 {
                     var pdbReader = embeddedPdb.GetMetadataReader();
-
                     var metadataReferenceReader = DeterministicBuildCompilationTestHelpers.GetSingleBlob(PortableCustomDebugInfoKinds.CompilationMetadataReferences, pdbReader);
                     var compilationOptionsReader = DeterministicBuildCompilationTestHelpers.GetSingleBlob(PortableCustomDebugInfoKinds.CompilationOptions, pdbReader);
 
-                    VerifyCompilationOptions(compilationOptions, originalCompilation, emitOptions, compilationOptionsReader, langVersion, sourceFileCount: syntaxTrees.Length);
+                    if (debugDocumentsCount is not null)
+                    {
+                        Assert.Equal(debugDocumentsCount, pdbReader.Documents.Count);
+                    }
+
+                    VerifyCompilationOptions(compilationOptions, originalCompilation, emitOptions, compilationOptionsReader, langVersion, syntaxTrees.Length);
                     DeterministicBuildCompilationTestHelpers.VerifyReferenceInfo(metadataReferences, metadataReferenceReader);
                 }
             }
@@ -138,7 +148,76 @@ public struct StructWithValue
                 emitOptions: emitOptions);
 
             var testSource = new[] { sourceOne, sourceTwo, sourceThree };
-            TestDeterministicCompilationCSharp(parseOptions.LanguageVersion.MapSpecifiedToEffectiveVersion().ToDisplayString(), testSource, compilationOptions, emitOptions, referenceOne, referenceTwo);
+            TestDeterministicCompilationCSharp(
+                parseOptions.LanguageVersion.MapSpecifiedToEffectiveVersion().ToDisplayString(),
+                testSource,
+                compilationOptions,
+                emitOptions,
+                new[] { referenceOne, referenceTwo });
+        }
+
+        [Theory]
+        [ClassData(typeof(CSharpDeterministicBuildCompilationTests))]
+        public void PortablePdb_DeterministicCompilation_DuplicateFilePaths(CSharpCompilationOptions compilationOptions, EmitOptions emitOptions, CSharpParseOptions parseOptions)
+        {
+            var sourceOne = Parse(@"
+using System;
+
+class MainType
+{
+    public static void Main()
+    {
+        Console.WriteLine();
+    }
+}
+", filename: "a.cs", options: parseOptions, encoding: Encoding.UTF8);
+
+            var sourceTwo = Parse(@"
+class TypeTwo
+{
+}", filename: "b.cs", options: parseOptions, encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            var sourceThree = Parse(@"
+class TypeThree
+{
+}", filename: "a.cs", options: parseOptions, encoding: Encoding.Unicode);
+
+            var referenceOneCompilation = CreateCompilation(
+@"public struct StructWithReference
+{
+    string PrivateData;
+}
+public struct StructWithValue
+{
+    int PrivateData;
+}", options: TestOptions.DebugDll);
+
+            var referenceTwoCompilation = CreateCompilation(
+@"public class ReferenceTwo
+{
+}", options: TestOptions.DebugDll);
+
+            using var referenceOne = TestMetadataReferenceInfo.Create(
+                referenceOneCompilation,
+                fullPath: "abcd.dll",
+                emitOptions: emitOptions);
+
+            using var referenceTwo = TestMetadataReferenceInfo.Create(
+                referenceTwoCompilation,
+                fullPath: "efgh.dll",
+                emitOptions: emitOptions);
+
+            var testSource = new[] { sourceOne, sourceTwo, sourceThree };
+
+            // Note that only one debug document can be present for each distinct source path.
+            // So if more than one syntax tree has the same file path, it won't be possible to do a rebuild from the DLL+PDB.
+            TestDeterministicCompilationCSharp(
+                parseOptions.LanguageVersion.MapSpecifiedToEffectiveVersion().ToDisplayString(),
+                testSource,
+                compilationOptions,
+                emitOptions,
+                new[] { referenceOne, referenceTwo },
+                debugDocumentsCount: 2);
         }
 
         [ConditionalTheory(typeof(DesktopOnly))]
@@ -193,7 +272,12 @@ public struct StructWithValue
                 emitOptions: emitOptions);
 
             var testSource = new[] { sourceOne, sourceTwo, sourceThree };
-            TestDeterministicCompilationCSharp(parseOptions.LanguageVersion.MapSpecifiedToEffectiveVersion().ToDisplayString(), testSource, compilationOptions, emitOptions, referenceOne, referenceTwo);
+            TestDeterministicCompilationCSharp(
+                parseOptions.LanguageVersion.MapSpecifiedToEffectiveVersion().ToDisplayString(),
+                testSource,
+                compilationOptions,
+                emitOptions,
+                new[] { referenceOne, referenceTwo });
         }
 
         public IEnumerator<object[]> GetEnumerator() => GetTestParameters().GetEnumerator();

--- a/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
@@ -85,10 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
                     var metadataReferenceReader = DeterministicBuildCompilationTestHelpers.GetSingleBlob(PortableCustomDebugInfoKinds.CompilationMetadataReferences, pdbReader);
                     var compilationOptionsReader = DeterministicBuildCompilationTestHelpers.GetSingleBlob(PortableCustomDebugInfoKinds.CompilationOptions, pdbReader);
 
-                    if (debugDocumentsCount is not null)
-                    {
-                        Assert.Equal(debugDocumentsCount, pdbReader.Documents.Count);
-                    }
+                    Assert.Equal(debugDocumentsCount ?? syntaxTrees.Length, pdbReader.Documents.Count);
 
                     VerifyCompilationOptions(compilationOptions, originalCompilation, emitOptions, compilationOptionsReader, langVersion, syntaxTrees.Length);
                     DeterministicBuildCompilationTestHelpers.VerifyReferenceInfo(metadataReferences, metadataReferenceReader);
@@ -110,17 +107,17 @@ class MainType
         Console.WriteLine();
     }
 }
-", options: parseOptions, encoding: Encoding.UTF8);
+", filename: "a.cs", options: parseOptions, encoding: Encoding.UTF8);
 
             var sourceTwo = Parse(@"
 class TypeTwo
 {
-}", options: parseOptions, encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+}", filename: "b.cs", options: parseOptions, encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
             var sourceThree = Parse(@"
 class TypeThree
 {
-}", options: parseOptions, encoding: Encoding.Unicode);
+}", filename: "c.cs", options: parseOptions, encoding: Encoding.Unicode);
 
             var referenceOneCompilation = CreateCompilation(
 @"public struct StructWithReference
@@ -234,17 +231,17 @@ class MainType
         Console.WriteLine();
     }
 }
-", options: parseOptions, encoding: Encoding.UTF8);
+", filename: "a.cs", options: parseOptions, encoding: Encoding.UTF8);
 
             var sourceTwo = Parse(@"
 class TypeTwo
 {
-}", options: parseOptions, encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+}", filename: "b.cs", options: parseOptions, encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
             var sourceThree = Parse(@"
 class TypeThree
 {
-}", options: parseOptions, encoding: Encoding.GetEncoding(932)); // SJIS encoding
+}", filename: "c.cs", options: parseOptions, encoding: Encoding.GetEncoding(932)); // SJIS encoding
 
             var referenceOneCompilation = CreateCompilation(
 @"public struct StructWithReference

--- a/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CSharpDeterministicBuildCompilationTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
             Compilation compilation,
             EmitOptions emitOptions,
             BlobReader compilationOptionsBlobReader,
-            string langVersion)
+            string langVersion,
+            int sourceFileCount)
         {
             var pdbOptions = DeterministicBuildCompilationTestHelpers.ParseCompilationOptions(compilationOptionsBlobReader);
 
@@ -43,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
             pdbOptions.VerifyPdbOption("unsafe", originalOptions.AllowUnsafe);
 
             Assert.Equal(langVersion, pdbOptions["language-version"]);
+            Assert.Equal(sourceFileCount.ToString(), pdbOptions["source-file-count"]);
 
             var firstSyntaxTree = (CSharpSyntaxTree)compilation.SyntaxTrees.FirstOrDefault();
             pdbOptions.VerifyPdbOption("define", firstSyntaxTree.Options.PreprocessorSymbolNames, isDefault: v => v.IsEmpty(), toString: v => string.Join(",", v));
@@ -78,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
                     var metadataReferenceReader = DeterministicBuildCompilationTestHelpers.GetSingleBlob(PortableCustomDebugInfoKinds.CompilationMetadataReferences, pdbReader);
                     var compilationOptionsReader = DeterministicBuildCompilationTestHelpers.GetSingleBlob(PortableCustomDebugInfoKinds.CompilationOptions, pdbReader);
 
-                    VerifyCompilationOptions(compilationOptions, originalCompilation, emitOptions, compilationOptionsReader, langVersion);
+                    VerifyCompilationOptions(compilationOptions, originalCompilation, emitOptions, compilationOptionsReader, langVersion, sourceFileCount: syntaxTrees.Length);
                     DeterministicBuildCompilationTestHelpers.VerifyReferenceInfo(metadataReferences, metadataReferenceReader);
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
@@ -232,27 +233,22 @@ int y = 1;
             compilation.VerifyPdb("C.Main", @"
 <symbols>
   <files>
-    <file id=""1"" name=""USED1.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
-    <file id=""2"" name=""USED2.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
-    <file id=""3"" name=""b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""C0-51-F0-6F-D3-ED-44-A2-11-4D-03-70-89-20-A6-05-11-62-14-BE"" />
-    <file id=""4"" name=""a.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""F0-C4-23-63-A5-89-B9-29-AF-94-07-85-2F-3A-40-D3-70-14-8F-9B"" />
+    <file id=""1"" name=""a.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""F0-C4-23-63-A5-89-B9-29-AF-94-07-85-2F-3A-40-D3-70-14-8F-9B"" />
+    <file id=""2"" name=""b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""C0-51-F0-6F-D3-ED-44-A2-11-4D-03-70-89-20-A6-05-11-62-14-BE"" />
+    <file id=""3"" name=""USED1.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
+    <file id=""4"" name=""USED2.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
     <file id=""5"" name=""UNUSED.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
   </files>
   <methods>
     <method containingType=""C"" name=""Main"">
-      <customDebugInfo>
-        <using>
-          <namespace usingCount=""0"" />
-        </using>
-      </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""112"" startColumn=""9"" endLine=""112"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x6"" startLine=""112"" startColumn=""9"" endLine=""112"" endColumn=""24"" document=""2"" />
-        <entry offset=""0xc"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""3"" />
+        <entry offset=""0x0"" startLine=""112"" startColumn=""9"" endLine=""112"" endColumn=""23"" document=""3"" />
+        <entry offset=""0x6"" startLine=""112"" startColumn=""9"" endLine=""112"" endColumn=""24"" document=""4"" />
+        <entry offset=""0xc"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""2"" />
       </sequencePoints>
     </method>
   </methods>
-</symbols>");
+</symbols>", format: DebugInformationFormat.PortablePdb);
         }
 
         [WorkItem(729235, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/729235")]
@@ -309,23 +305,18 @@ class C { void M() { } }
             comp.VerifyPdb(@"
 <symbols>
   <files>
-    <file id=""1"" name=""a\..\a.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D5"" />
-    <file id=""2"" name=""C:\a\..\b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""36-39-3C-83-56-97-F2-F0-60-95-A4-A0-32-C6-32-C7-B2-4B-16-92"" />
+    <file id=""1"" name=""C:\a\..\b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""36-39-3C-83-56-97-F2-F0-60-95-A4-A0-32-C6-32-C7-B2-4B-16-92"" />
+    <file id=""2"" name=""a\..\a.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D5"" />
   </files>
   <methods>
     <method containingType=""C"" name=""M"">
-      <customDebugInfo>
-        <using>
-          <namespace usingCount=""0"" />
-        </using>
-      </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""20"" endLine=""10"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""22"" endLine=""10"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""20"" endLine=""10"" endColumn=""21"" document=""2"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""22"" endLine=""10"" endColumn=""23"" document=""2"" />
       </sequencePoints>
     </method>
   </methods>
-</symbols>");
+</symbols>", format: DebugInformationFormat.PortablePdb);
         }
 
         [WorkItem(729235, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/729235")]

--- a/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
@@ -194,6 +194,7 @@ class C1
         }
 
         [Fact]
+        [WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")]
         public void TestPartialClassFieldInitializers()
         {
             var text1 = WithWindowsLineBreaks(@"
@@ -288,6 +289,7 @@ class C
         }
 
         [ConditionalFact(typeof(WindowsOnly))]
+        [WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")]
         public void NoResolver()
         {
             var comp = CSharpCompilation.Create(

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -67,6 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
             var hash3 = CryptographicHashProvider.ComputeSha1(new UTF8Encoding(true, false).GetBytesWithPreamble(tree3.ToString())).ToArray();
             var hash4 = CryptographicHashProvider.ComputeSha1(new UTF8Encoding(false, false).GetBytesWithPreamble(tree4.ToString())).ToArray();
 
+            // TODO: try to change implementation to avoid the need to adjust this baseline.
             comp.VerifyPdb(@"
 <symbols>
   <files>
@@ -4683,7 +4684,23 @@ public partial class C
       </sequencePoints>
     </method>
   </methods>
-</symbols>");
+</symbols>", format: DebugInformationFormat.Pdb);
+
+            compilation.VerifyPdb("C..ctor", @"
+<symbols>
+  <files>
+    <file id=""1"" name=""a.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""B4-EA-18-73-D2-0E-7F-15-51-4C-68-86-40-DF-E3-C3-97-9D-F6-B7"" />
+    <file id=""2"" name=""b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""BB-7A-A6-D2-B2-32-59-43-8C-98-7F-E1-98-8D-F0-94-68-E9-EB-80"" />
+  </files>
+  <methods>
+    <method containingType=""C"" name="".ctor"">
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""15"" document=""1"" />
+        <entry offset=""0x7"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""15"" document=""2"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>", format: DebugInformationFormat.PortablePdb);
         }
 
         [Fact]
@@ -4744,31 +4761,25 @@ public partial class C
             //loads the assembly into the ReflectionOnlyLoadFrom context.
             //So it's probably a good idea to have a new name for each assembly.
             var compilation = CreateCompilation(new[] { Parse(text1, "a.cs"), Parse(text2, "b.cs"), Parse(text3, "a.cs") }, options: TestOptions.DebugDll);
-
             compilation.VerifyPdb("C..ctor", @"
 <symbols>
-<files>
-  <file id=""1"" name=""a.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""E2-3B-47-02-DC-E4-8D-B4-FF-00-67-90-31-68-74-C0-06-D7-39-0E"" />
-  <file id=""2"" name=""foo.cs"" language=""C#"" />
-  <file id=""3"" name=""bar.cs"" language=""C#"" />
-  <file id=""4"" name=""b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""DB-CE-E5-E9-CB-53-E5-EF-C1-7F-2C-53-EC-02-FE-5C-34-2C-EF-94"" />
-  <file id=""5"" name=""foo2.cs"" language=""C#"" />
-  <file id=""6"" name=""mah.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
-</files>
+  <files>
+    <file id=""1"" name=""a.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""E2-3B-47-02-DC-E4-8D-B4-FF-00-67-90-31-68-74-C0-06-D7-39-0E"" />
+    <file id=""2"" name=""b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""DB-CE-E5-E9-CB-53-E5-EF-C1-7F-2C-53-EC-02-FE-5C-34-2C-EF-94"" />
+    <file id=""3"" name=""foo.cs"" language=""C#"" />
+    <file id=""4"" name=""bar.cs"" language=""C#"" />
+    <file id=""5"" name=""foo2.cs"" language=""C#"" />
+    <file id=""6"" name=""mah.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
-      <customDebugInfo>
-        <using>
-          <namespace usingCount=""1"" />
-        </using>
-      </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""15"" document=""1"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""26"" document=""2"" />
-        <entry offset=""0x14"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""25"" document=""2"" />
-        <entry offset=""0x20"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""30"" document=""3"" />
-        <entry offset=""0x34"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""15"" document=""4"" />
-        <entry offset=""0x3b"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""16"" document=""4"" />
+        <entry offset=""0x7"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""26"" document=""3"" />
+        <entry offset=""0x14"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""25"" document=""3"" />
+        <entry offset=""0x20"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""30"" document=""4"" />
+        <entry offset=""0x34"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""15"" document=""2"" />
+        <entry offset=""0x3b"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""16"" document=""2"" />
         <entry offset=""0x42"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""27"" document=""5"" />
         <entry offset=""0x4f"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""26"" document=""5"" />
         <entry offset=""0x5b"" startLine=""112"" startColumn=""5"" endLine=""112"" endColumn=""16"" document=""6"" />
@@ -4781,12 +4792,9 @@ public partial class C
         <entry offset=""0x9e"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""33"" document=""1"" />
         <entry offset=""0xa9"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xaa"">
-        <namespace name=""System"" />
-      </scope>
     </method>
   </methods>
-</symbols>");
+</symbols>", format: DebugInformationFormat.PortablePdb);
         }
 
         [WorkItem(543313, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543313")]
@@ -11628,7 +11636,36 @@ public class C
     </method>
   </methods>
 </symbols>
-");
+", format: DebugInformationFormat.Pdb);
+
+            c.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name=""HIDDEN.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""8A-92-EE-2F-D6-6F-C0-69-F4-A8-54-CB-11-BE-A3-06-76-2C-9C-98"" />
+    <file id=""2"" name=""C:\Async.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""DB-EB-2A-06-7B-2F-0E-0D-67-8A-00-2C-58-7A-28-06-05-6C-3D-CE"" />
+  </files>
+  <methods>
+    <method containingType=""C+&lt;M1&gt;d__0"" name=""MoveNext"">
+      <customDebugInfo>
+        <encLocalSlotMap>
+          <slot kind=""27"" offset=""0"" />
+          <slot kind=""temp"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" document=""2"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""2"" />
+        <entry offset=""0xa"" hidden=""true"" document=""2"" />
+        <entry offset=""0x22"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""2"" />
+        <entry offset=""0x2a"" hidden=""true"" document=""2"" />
+      </sequencePoints>
+      <asyncInfo>
+        <catchHandler offset=""0xa"" />
+        <kickoffMethod declaringType=""C"" methodName=""M1"" />
+      </asyncInfo>
+    </method>
+  </methods>
+</symbols>", format: DebugInformationFormat.PortablePdb);
         }
 
         [WorkItem(12923, "https://github.com/dotnet/roslyn/issues/12923")]
@@ -11678,7 +11715,25 @@ partial class C
     </method>
   </methods>
 </symbols>
-");
+", format: DebugInformationFormat.Pdb);
+
+            c.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name=""initializer.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""84-32-24-D7-FE-32-63-BA-41-D5-17-A2-D5-90-23-B8-12-3C-AF-D5"" />
+    <file id=""2"" name=""constructor.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""EA-D6-0A-16-6C-6A-BC-C1-5D-98-0F-B7-4B-78-13-93-FB-C7-C2-5A"" />
+  </files>
+  <methods>
+    <method containingType=""C"" name="".ctor"">
+      <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" document=""2"" />
+        <entry offset=""0x8"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""8"" document=""2"" />
+        <entry offset=""0xf"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""2"" />
+        <entry offset=""0x10"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""2"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>", format: DebugInformationFormat.PortablePdb);
         }
 
         [WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
             var hash3 = CryptographicHashProvider.ComputeSha1(new UTF8Encoding(true, false).GetBytesWithPreamble(tree3.ToString())).ToArray();
             var hash4 = CryptographicHashProvider.ComputeSha1(new UTF8Encoding(false, false).GetBytesWithPreamble(tree4.ToString())).ToArray();
 
-            // TODO: try to change implementation to avoid the need to adjust this baseline.
             comp.VerifyPdb(@"
 <symbols>
   <files>
@@ -4642,6 +4641,7 @@ public class Derived : Base
         #region Field and Property Initializers
 
         [Fact]
+        [WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")]
         public void TestPartialClassFieldInitializers()
         {
             var text1 = WithWindowsLineBreaks(@"
@@ -4704,6 +4704,7 @@ public partial class C
         }
 
         [Fact]
+        [WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")]
         public void TestPartialClassFieldInitializersWithLineDirectives()
         {
             var text1 = WithWindowsLineBreaks(@"

--- a/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Cci
     /// </remarks>
     internal static class CompilationOptionNames
     {
+        public const string CompilationOptionsVersion = "compilation-options-version";
         public const string CompilerVersion = "compiler-version";
         public const string FallbackEncoding = "fallback-encoding";
         public const string DefaultEncoding = "default-encoding";

--- a/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Cci
     /// </remarks>
     internal static class CompilationOptionNames
     {
-        public const string CompilationOptionsVersion = "compilation-options-version";
+        public const string CompilationOptionsVersion = "version";
         public const string CompilerVersion = "compiler-version";
         public const string FallbackEncoding = "fallback-encoding";
         public const string DefaultEncoding = "default-encoding";

--- a/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
@@ -28,5 +28,6 @@ namespace Microsoft.Cci
         public const string Nullable = "nullable";
         public const string Define = "define";
         public const string Strict = "strict";
+        public const string SourceFileCount = "source-file-count";
     }
 }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -835,6 +835,9 @@ namespace Microsoft.Cci
                 value: _debugMetadataOpt.GetOrAddBlob(bytes));
         }
 
+        ///<summary>The version of the compilation options schema to be written to the PDB.</summary>
+        public const int CompilationOptionsVersion = 1;
+
         /// <summary>
         /// Capture the set of compilation options to allow a compilation 
         /// to be reconstructed from the pdb
@@ -844,6 +847,7 @@ namespace Microsoft.Cci
             var builder = new BlobBuilder();
 
             var compilerVersion = typeof(Compilation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            WriteValue(CompilationOptionNames.CompilationOptionsVersion, CompilationOptionsVersion.ToString());
             WriteValue(CompilationOptionNames.CompilerVersion, compilerVersion);
 
             WriteValue(CompilationOptionNames.Language, module.CommonCompilation.Options.Language);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -836,7 +836,7 @@ namespace Microsoft.Cci
         }
 
         ///<summary>The version of the compilation options schema to be written to the PDB.</summary>
-        public const int CompilationOptionsVersion = 1;
+        public const int Version = 1;
 
         /// <summary>
         /// Capture the set of compilation options to allow a compilation 
@@ -847,7 +847,7 @@ namespace Microsoft.Cci
             var builder = new BlobBuilder();
 
             var compilerVersion = typeof(Compilation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-            WriteValue(CompilationOptionNames.CompilationOptionsVersion, CompilationOptionsVersion.ToString());
+            WriteValue(CompilationOptionNames.CompilationOptionsVersion, Version.ToString());
             WriteValue(CompilationOptionNames.CompilerVersion, compilerVersion);
 
             WriteValue(CompilationOptionNames.Language, module.CommonCompilation.Options.Language);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -836,7 +836,7 @@ namespace Microsoft.Cci
         }
 
         ///<summary>The version of the compilation options schema to be written to the PDB.</summary>
-        public const int Version = 1;
+        public const int CompilationOptionsSchemaVersion = 1;
 
         /// <summary>
         /// Capture the set of compilation options to allow a compilation 
@@ -847,7 +847,7 @@ namespace Microsoft.Cci
             var builder = new BlobBuilder();
 
             var compilerVersion = typeof(Compilation).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-            WriteValue(CompilationOptionNames.CompilationOptionsVersion, Version.ToString());
+            WriteValue(CompilationOptionNames.CompilationOptionsVersion, CompilationOptionsSchemaVersion.ToString());
             WriteValue(CompilationOptionNames.CompilerVersion, compilerVersion);
 
             WriteValue(CompilationOptionNames.Language, module.CommonCompilation.Options.Language);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -847,6 +847,7 @@ namespace Microsoft.Cci
             WriteValue(CompilationOptionNames.CompilerVersion, compilerVersion);
 
             WriteValue(CompilationOptionNames.Language, module.CommonCompilation.Options.Language);
+            WriteValue(CompilationOptionNames.SourceFileCount, module.CommonCompilation.SyntaxTrees.Count().ToString());
 
             if (module.EmitOptions.FallbackSourceFileEncoding != null)
             {

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1788,6 +1788,7 @@ namespace Microsoft.Cci
             if (_debugMetadataOpt != null)
             {
                 // Ensure document table lists files in command line order
+                // This is key for us to be able to accurately rebuild a binary from a PDB.
                 var documentsBuilder = Module.DebugDocumentsBuilder;
                 var documents = documentsBuilder.DebugDocuments;
                 foreach (var tree in Module.CommonCompilation.SyntaxTrees)
@@ -1798,7 +1799,6 @@ namespace Microsoft.Cci
                         AddDocument(doc, _documentIndex);
                     }
                 }
-
 
                 DefineModuleImportScope();
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1790,11 +1790,9 @@ namespace Microsoft.Cci
                 // Ensure document table lists files in command line order
                 // This is key for us to be able to accurately rebuild a binary from a PDB.
                 var documentsBuilder = Module.DebugDocumentsBuilder;
-                var documents = documentsBuilder.DebugDocuments;
                 foreach (var tree in Module.CommonCompilation.SyntaxTrees)
                 {
-                    string normalizedPath = documentsBuilder.NormalizeDebugDocumentPath(tree.FilePath, basePath: null);
-                    if (documents.TryGetValue(normalizedPath, out var doc) && !_documentIndex.ContainsKey(doc))
+                    if (documentsBuilder.TryGetDebugDocument(tree.FilePath, basePath: null) is { } doc && !_documentIndex.ContainsKey(doc))
                     {
                         AddDocument(doc, _documentIndex);
                     }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1787,6 +1787,19 @@ namespace Microsoft.Cci
 
             if (_debugMetadataOpt != null)
             {
+                // Ensure document table lists files in command line order
+                var documentsBuilder = Module.DebugDocumentsBuilder;
+                var documents = documentsBuilder.DebugDocuments;
+                foreach (var tree in Module.CommonCompilation.SyntaxTrees)
+                {
+                    string normalizedPath = documentsBuilder.NormalizeDebugDocumentPath(tree.FilePath, basePath: null);
+                    if (documents.TryGetValue(normalizedPath, out var doc) && !_documentIndex.ContainsKey(doc))
+                    {
+                        AddDocument(doc, _documentIndex);
+                    }
+                }
+
+
                 DefineModuleImportScope();
 
                 if (module.SourceLinkStreamOpt != null)

--- a/src/Compilers/Test/Core/PDB/DeterministicBuildCompilationTestHelpers.cs
+++ b/src/Compilers/Test/Core/PDB/DeterministicBuildCompilationTestHelpers.cs
@@ -45,7 +45,7 @@ namespace Roslyn.Test.Utilities.PDB
 
         internal static void AssertCommonOptions(EmitOptions emitOptions, CompilationOptions compilationOptions, Compilation compilation, ImmutableDictionary<string, string> pdbOptions)
         {
-            pdbOptions.VerifyPdbOption("version", MetadataWriter.Version);
+            pdbOptions.VerifyPdbOption("version", MetadataWriter.CompilationOptionsSchemaVersion);
             pdbOptions.VerifyPdbOption("fallback-encoding", emitOptions.FallbackSourceFileEncoding, toString: v => v.WebName);
             pdbOptions.VerifyPdbOption("default-encoding", emitOptions.DefaultSourceFileEncoding, toString: v => v.WebName);
 

--- a/src/Compilers/Test/Core/PDB/DeterministicBuildCompilationTestHelpers.cs
+++ b/src/Compilers/Test/Core/PDB/DeterministicBuildCompilationTestHelpers.cs
@@ -45,6 +45,7 @@ namespace Roslyn.Test.Utilities.PDB
 
         internal static void AssertCommonOptions(EmitOptions emitOptions, CompilationOptions compilationOptions, Compilation compilation, ImmutableDictionary<string, string> pdbOptions)
         {
+            pdbOptions.VerifyPdbOption("compilation-options-version", MetadataWriter.CompilationOptionsVersion);
             pdbOptions.VerifyPdbOption("fallback-encoding", emitOptions.FallbackSourceFileEncoding, toString: v => v.WebName);
             pdbOptions.VerifyPdbOption("default-encoding", emitOptions.DefaultSourceFileEncoding, toString: v => v.WebName);
 

--- a/src/Compilers/Test/Core/PDB/DeterministicBuildCompilationTestHelpers.cs
+++ b/src/Compilers/Test/Core/PDB/DeterministicBuildCompilationTestHelpers.cs
@@ -45,7 +45,7 @@ namespace Roslyn.Test.Utilities.PDB
 
         internal static void AssertCommonOptions(EmitOptions emitOptions, CompilationOptions compilationOptions, Compilation compilation, ImmutableDictionary<string, string> pdbOptions)
         {
-            pdbOptions.VerifyPdbOption("compilation-options-version", MetadataWriter.CompilationOptionsVersion);
+            pdbOptions.VerifyPdbOption("version", MetadataWriter.Version);
             pdbOptions.VerifyPdbOption("fallback-encoding", emitOptions.FallbackSourceFileEncoding, toString: v => v.WebName);
             pdbOptions.VerifyPdbOption("default-encoding", emitOptions.DefaultSourceFileEncoding, toString: v => v.WebName);
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinuePdbTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinuePdbTests.vb
@@ -16,7 +16,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
         Inherits EditAndContinueTestBase
 
         <ConditionalTheory(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
-        <MemberData(NameOf(ExternalPdbFormats))>
+        <InlineData(DebugInformationFormat.PortablePdb)> '<MemberData(NameOf(ExternalPdbFormats))>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         Public Sub MethodExtents(format As DebugInformationFormat)
             Dim source0 = MarkedSource("
 Imports System
@@ -185,80 +186,65 @@ End Class", fileName:="C:\Enc1.vb")
             End If
 
             diff1.VerifyPdb(Enumerable.Range(&H6000001, 20),
-<symbols>
-    <files>
-        <file id="1" name="C:\F\A.vb" language="VB"/>
-        <file id="2" name="C:\F\C.vb" language="VB"/>
-        <file id="3" name="C:\Enc1.vb" language="VB" checksumAlgorithm="SHA1" checksum="E2-3A-75-D7-B2-2D-78-1C-0E-F7-75-E2-8C-09-4B-4E-E1-68-2E-9D"/>
-    </files>
-    <methods>
-        <method token="0x600000b">
-            <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" startLine="10" startColumn="9" endLine="10" endColumn="28" document="1"/>
-                <entry offset="0x7" startLine="10" startColumn="9" endLine="10" endColumn="28" document="2"/>
-                <entry offset="0xd" hidden="true" document="2"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0xe">
-                <namespace name="System" importlevel="file"/>
-                <currentnamespace name=""/>
-            </scope>
-        </method>
-        <method token="0x600000d">
-            <sequencePoints>
-                <entry offset="0x0" startLine="20" startColumn="5" endLine="20" endColumn="12" document="3"/>
-                <entry offset="0x1" startLine="21" startColumn="13" endLine="21" endColumn="35" document="3"/>
-                <entry offset="0x26" startLine="23" startColumn="13" endLine="26" endColumn="16" document="3"/>
-                <entry offset="0x4b" startLine="27" startColumn="5" endLine="27" endColumn="12" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x4c">
-                <importsforward token="0x600000b"/>
-                <local name="H1" il_index="2" il_start="0x0" il_end="0x4c" attributes="0"/>
-                <local name="H2" il_index="3" il_start="0x0" il_end="0x4c" attributes="0"/>
-            </scope>
-        </method>
-        <method token="0x6000010">
-            <sequencePoints>
-                <entry offset="0x0" startLine="21" startColumn="23" endLine="21" endColumn="33" document="3"/>
-                <entry offset="0x1" startLine="21" startColumn="34" endLine="21" endColumn="35" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x7">
-                <importsforward token="0x600000b"/>
-            </scope>
-        </method>
-        <method token="0x6000011">
-            <sequencePoints>
-                <entry offset="0x0" startLine="23" startColumn="23" endLine="23" endColumn="28" document="3"/>
-                <entry offset="0x1" startLine="24" startColumn="17" endLine="24" endColumn="39" document="3"/>
-                <entry offset="0x26" startLine="25" startColumn="17" endLine="25" endColumn="39" document="3"/>
-                <entry offset="0x4b" startLine="26" startColumn="9" endLine="26" endColumn="16" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x4c">
-                <importsforward token="0x600000b"/>
-                <local name="H3" il_index="0" il_start="0x0" il_end="0x4c" attributes="0"/>
-                <local name="H4" il_index="1" il_start="0x0" il_end="0x4c" attributes="0"/>
-            </scope>
-        </method>
-        <method token="0x6000012">
-            <sequencePoints>
-                <entry offset="0x0" startLine="24" startColumn="27" endLine="24" endColumn="37" document="3"/>
-                <entry offset="0x1" startLine="24" startColumn="38" endLine="24" endColumn="39" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x7">
-                <importsforward token="0x600000b"/>
-            </scope>
-        </method>
-        <method token="0x6000013">
-            <sequencePoints>
-                <entry offset="0x0" startLine="25" startColumn="27" endLine="25" endColumn="37" document="3"/>
-                <entry offset="0x1" startLine="25" startColumn="38" endLine="25" endColumn="39" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x7">
-                <importsforward token="0x600000b"/>
-            </scope>
-        </method>
-    </methods>
-</symbols>)
+    <symbols>
+        <files>
+            <file id="1" name="C:\Enc1.vb" language="VB" checksumAlgorithm="SHA1" checksum="E2-3A-75-D7-B2-2D-78-1C-0E-F7-75-E2-8C-09-4B-4E-E1-68-2E-9D"/>
+            <file id="2" name="C:\F\A.vb" language="VB"/>
+            <file id="3" name="C:\F\C.vb" language="VB"/>
+        </files>
+        <methods>
+            <method token="0x600000b">
+                <sequencePoints>
+                    <entry offset="0x0" hidden="true" document="2"/>
+                    <entry offset="0x1" startLine="10" startColumn="9" endLine="10" endColumn="28" document="2"/>
+                    <entry offset="0x7" startLine="10" startColumn="9" endLine="10" endColumn="28" document="3"/>
+                    <entry offset="0xd" hidden="true" document="3"/>
+                </sequencePoints>
+            </method>
+            <method token="0x600000d">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="20" startColumn="5" endLine="20" endColumn="12" document="1"/>
+                    <entry offset="0x1" startLine="21" startColumn="13" endLine="21" endColumn="35" document="1"/>
+                    <entry offset="0x26" startLine="23" startColumn="13" endLine="26" endColumn="16" document="1"/>
+                    <entry offset="0x4b" startLine="27" startColumn="5" endLine="27" endColumn="12" document="1"/>
+                </sequencePoints>
+                <scope startOffset="0x0" endOffset="0x4c">
+                    <local name="H1" il_index="2" il_start="0x0" il_end="0x4c" attributes="0"/>
+                    <local name="H2" il_index="3" il_start="0x0" il_end="0x4c" attributes="0"/>
+                </scope>
+            </method>
+            <method token="0x6000010">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="21" startColumn="23" endLine="21" endColumn="33" document="1"/>
+                    <entry offset="0x1" startLine="21" startColumn="34" endLine="21" endColumn="35" document="1"/>
+                </sequencePoints>
+            </method>
+            <method token="0x6000011">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="23" startColumn="23" endLine="23" endColumn="28" document="1"/>
+                    <entry offset="0x1" startLine="24" startColumn="17" endLine="24" endColumn="39" document="1"/>
+                    <entry offset="0x26" startLine="25" startColumn="17" endLine="25" endColumn="39" document="1"/>
+                    <entry offset="0x4b" startLine="26" startColumn="9" endLine="26" endColumn="16" document="1"/>
+                </sequencePoints>
+                <scope startOffset="0x0" endOffset="0x4c">
+                    <local name="H3" il_index="0" il_start="0x0" il_end="0x4c" attributes="0"/>
+                    <local name="H4" il_index="1" il_start="0x0" il_end="0x4c" attributes="0"/>
+                </scope>
+            </method>
+            <method token="0x6000012">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="24" startColumn="27" endLine="24" endColumn="37" document="1"/>
+                    <entry offset="0x1" startLine="24" startColumn="38" endLine="24" endColumn="39" document="1"/>
+                </sequencePoints>
+            </method>
+            <method token="0x6000013">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="25" startColumn="27" endLine="25" endColumn="37" document="1"/>
+                    <entry offset="0x1" startLine="25" startColumn="38" endLine="25" endColumn="39" document="1"/>
+                </sequencePoints>
+            </method>
+        </methods>
+    </symbols>, format:=DebugInformationFormat.PortablePdb)
 
             Dim syntaxMap2 = GetSyntaxMapFromMarkers(source1, source2)
             Dim diff2 = compilation2.EmitDifference(diff1.NextGeneration,
@@ -298,58 +284,49 @@ End Class", fileName:="C:\Enc1.vb")
             End If
 
             diff2.VerifyPdb(Enumerable.Range(&H6000001, 20),
-<symbols>
-    <files>
-        <file id="1" name="C:\F\A.vb" language="VB"/>
-        <file id="2" name="C:\F\E.vb" language="VB"/>
-        <file id="3" name="C:\Enc1.vb" language="VB" checksumAlgorithm="SHA1" checksum="DB-81-EA-11-DD-DE-3B-51-F3-07-C3-A7-7E-0B-41-D3-D4-12-86-93"/>
-    </files>
-    <methods>
-        <method token="0x600000b">
-            <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" startLine="10" startColumn="9" endLine="10" endColumn="28" document="1"/>
-                <entry offset="0x7" startLine="10" startColumn="9" endLine="10" endColumn="28" document="2"/>
-                <entry offset="0xd" hidden="true" document="2"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0xe">
-                <namespace name="System" importlevel="file"/>
-                <currentnamespace name=""/>
-            </scope>
-        </method>
-        <method token="0x600000d">
-            <sequencePoints>
-                <entry offset="0x0" startLine="20" startColumn="5" endLine="20" endColumn="12" document="3"/>
-                <entry offset="0x1" startLine="23" startColumn="13" endLine="26" endColumn="16" document="3"/>
-                <entry offset="0x27" startLine="27" startColumn="5" endLine="27" endColumn="12" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x28">
-                <importsforward token="0x600000b"/>
-                <local name="H2" il_index="4" il_start="0x0" il_end="0x28" attributes="0"/>
-            </scope>
-        </method>
-        <method token="0x6000011">
-            <sequencePoints>
-                <entry offset="0x0" startLine="23" startColumn="23" endLine="23" endColumn="28" document="3"/>
-                <entry offset="0x1" startLine="25" startColumn="17" endLine="25" endColumn="39" document="3"/>
-                <entry offset="0x26" startLine="26" startColumn="9" endLine="26" endColumn="16" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x27">
-                <importsforward token="0x600000b"/>
-                <local name="H4" il_index="0" il_start="0x0" il_end="0x27" attributes="0"/>
-            </scope>
-        </method>
-        <method token="0x6000013">
-            <sequencePoints>
-                <entry offset="0x0" startLine="25" startColumn="27" endLine="25" endColumn="37" document="3"/>
-                <entry offset="0x1" startLine="25" startColumn="38" endLine="25" endColumn="39" document="3"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x7">
-                <importsforward token="0x600000b"/>
-            </scope>
-        </method>
-    </methods>
-</symbols>)
+    <symbols>
+        <files>
+            <file id="1" name="C:\Enc1.vb" language="VB" checksumAlgorithm="SHA1" checksum="DB-81-EA-11-DD-DE-3B-51-F3-07-C3-A7-7E-0B-41-D3-D4-12-86-93"/>
+            <file id="2" name="C:\F\A.vb" language="VB"/>
+            <file id="3" name="C:\F\E.vb" language="VB"/>
+        </files>
+        <methods>
+            <method token="0x600000b">
+                <sequencePoints>
+                    <entry offset="0x0" hidden="true" document="2"/>
+                    <entry offset="0x1" startLine="10" startColumn="9" endLine="10" endColumn="28" document="2"/>
+                    <entry offset="0x7" startLine="10" startColumn="9" endLine="10" endColumn="28" document="3"/>
+                    <entry offset="0xd" hidden="true" document="3"/>
+                </sequencePoints>
+            </method>
+            <method token="0x600000d">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="20" startColumn="5" endLine="20" endColumn="12" document="1"/>
+                    <entry offset="0x1" startLine="23" startColumn="13" endLine="26" endColumn="16" document="1"/>
+                    <entry offset="0x27" startLine="27" startColumn="5" endLine="27" endColumn="12" document="1"/>
+                </sequencePoints>
+                <scope startOffset="0x0" endOffset="0x28">
+                    <local name="H2" il_index="4" il_start="0x0" il_end="0x28" attributes="0"/>
+                </scope>
+            </method>
+            <method token="0x6000011">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="23" startColumn="23" endLine="23" endColumn="28" document="1"/>
+                    <entry offset="0x1" startLine="25" startColumn="17" endLine="25" endColumn="39" document="1"/>
+                    <entry offset="0x26" startLine="26" startColumn="9" endLine="26" endColumn="16" document="1"/>
+                </sequencePoints>
+                <scope startOffset="0x0" endOffset="0x27">
+                    <local name="H4" il_index="0" il_start="0x0" il_end="0x27" attributes="0"/>
+                </scope>
+            </method>
+            <method token="0x6000013">
+                <sequencePoints>
+                    <entry offset="0x0" startLine="25" startColumn="27" endLine="25" endColumn="37" document="1"/>
+                    <entry offset="0x1" startLine="25" startColumn="38" endLine="25" endColumn="39" document="1"/>
+                </sequencePoints>
+            </method>
+        </methods>
+    </symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
@@ -216,6 +216,7 @@ End Class
         End Sub
 
         <WorkItem(729235, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/729235")>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.TestHasWindowsPaths)>
         Public Sub NormalizedPath_ExternalSource()
             Dim source = <![CDATA[
@@ -333,6 +334,7 @@ End Class
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.TestHasWindowsPaths)>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         Public Sub NormalizedPath_NoBaseDirectory()
             Dim source = <![CDATA[
 Class C

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
@@ -8,6 +8,7 @@ Imports System.Collections.Immutable
 Imports System.IO
 Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.Emit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB
 
@@ -248,28 +249,25 @@ End Class
             comp.VerifyPdb("C.M",
 <symbols>
     <files>
-        <file id="1" name="b:\base\line.vb" language="VB"/>
-        <file id="2" name="q:\absolute\line.vb" language="VB"/>
-        <file id="3" name="b:\base\b.vb" language="VB" checksumAlgorithm="SHA1" checksum="F9-90-00-9D-9E-45-97-F2-3D-67-1C-D8-47-A8-9B-DA-4A-91-AA-7F"/>
+        <file id="1" name="b:\base\b.vb" language="VB" checksumAlgorithm="SHA1" checksum="F9-90-00-9D-9E-45-97-F2-3D-67-1C-D8-47-A8-9B-DA-4A-91-AA-7F"/>
+        <file id="2" name="b:\base\line.vb" language="VB"/>
+        <file id="3" name="q:\absolute\line.vb" language="VB"/>
     </files>
     <methods>
         <method containingType="C" name="M">
             <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" hidden="true" document="1"/>
-                <entry offset="0x8" startLine="1" startColumn="9" endLine="1" endColumn="12" document="1"/>
-                <entry offset="0xf" startLine="2" startColumn="9" endLine="2" endColumn="12" document="1"/>
-                <entry offset="0x16" startLine="3" startColumn="9" endLine="3" endColumn="12" document="1"/>
-                <entry offset="0x1d" startLine="4" startColumn="9" endLine="4" endColumn="12" document="1"/>
-                <entry offset="0x24" startLine="5" startColumn="9" endLine="5" endColumn="12" document="2"/>
-                <entry offset="0x2b" hidden="true" document="2"/>
+                <entry offset="0x0" hidden="true" document="2"/>
+                <entry offset="0x1" hidden="true" document="2"/>
+                <entry offset="0x8" startLine="1" startColumn="9" endLine="1" endColumn="12" document="2"/>
+                <entry offset="0xf" startLine="2" startColumn="9" endLine="2" endColumn="12" document="2"/>
+                <entry offset="0x16" startLine="3" startColumn="9" endLine="3" endColumn="12" document="2"/>
+                <entry offset="0x1d" startLine="4" startColumn="9" endLine="4" endColumn="12" document="2"/>
+                <entry offset="0x24" startLine="5" startColumn="9" endLine="5" endColumn="12" document="3"/>
+                <entry offset="0x2b" hidden="true" document="3"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x2c">
-                <currentnamespace name=""/>
-            </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
         <WorkItem(729235, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/729235")>
@@ -310,31 +308,28 @@ End Class
             comp.VerifyPdb("C.M",
 <symbols>
     <files>
-        <file id="1" name="b:\base\a.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DA"/>
-        <file id="2" name="b:\base\b.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DB"/>
-        <file id="3" name="b:\base\c.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DC"/>
-        <file id="4" name="b:\base\d.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DD"/>
-        <file id="5" name="b:\base\e.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DE"/>
-        <file id="6" name="b:\base\file.vb" language="VB" checksumAlgorithm="SHA1" checksum="C2-46-C6-34-F6-20-D3-FE-28-B9-D8-62-0F-A9-FB-2F-89-E7-48-23"/>
+        <file id="1" name="b:\base\file.vb" language="VB" checksumAlgorithm="SHA1" checksum="C2-46-C6-34-F6-20-D3-FE-28-B9-D8-62-0F-A9-FB-2F-89-E7-48-23"/>
+        <file id="2" name="b:\base\a.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DA"/>
+        <file id="3" name="b:\base\b.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DB"/>
+        <file id="4" name="b:\base\c.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DC"/>
+        <file id="5" name="b:\base\d.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DD"/>
+        <file id="6" name="b:\base\e.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DE"/>
     </files>
     <methods>
         <method containingType="C" name="M">
             <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" hidden="true" document="1"/>
-                <entry offset="0x8" startLine="1" startColumn="9" endLine="1" endColumn="12" document="1"/>
-                <entry offset="0xf" startLine="2" startColumn="9" endLine="2" endColumn="12" document="2"/>
-                <entry offset="0x16" startLine="3" startColumn="9" endLine="3" endColumn="12" document="3"/>
-                <entry offset="0x1d" startLine="4" startColumn="9" endLine="4" endColumn="12" document="4"/>
-                <entry offset="0x24" startLine="5" startColumn="9" endLine="5" endColumn="12" document="5"/>
-                <entry offset="0x2b" hidden="true" document="5"/>
+                <entry offset="0x0" hidden="true" document="2"/>
+                <entry offset="0x1" hidden="true" document="2"/>
+                <entry offset="0x8" startLine="1" startColumn="9" endLine="1" endColumn="12" document="2"/>
+                <entry offset="0xf" startLine="2" startColumn="9" endLine="2" endColumn="12" document="3"/>
+                <entry offset="0x16" startLine="3" startColumn="9" endLine="3" endColumn="12" document="4"/>
+                <entry offset="0x1d" startLine="4" startColumn="9" endLine="4" endColumn="12" document="5"/>
+                <entry offset="0x24" startLine="5" startColumn="9" endLine="5" endColumn="12" document="6"/>
+                <entry offset="0x2b" hidden="true" document="6"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x2c">
-                <currentnamespace name=""/>
-            </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.TestHasWindowsPaths)>
@@ -364,27 +359,24 @@ End Class
             comp.VerifyPdb("C.M",
 <symbols>
     <files>
-        <file id="1" name="a.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DA"/>
-        <file id="2" name="./a.vb" language="VB"/>
-        <file id="3" name="b.vb" language="VB"/>
-        <file id="4" name="file.vb" language="VB" checksumAlgorithm="SHA1" checksum="23-C1-6B-94-B0-D4-06-26-C8-D2-82-21-63-07-53-11-4D-5A-02-BC"/>
+        <file id="1" name="file.vb" language="VB" checksumAlgorithm="SHA1" checksum="23-C1-6B-94-B0-D4-06-26-C8-D2-82-21-63-07-53-11-4D-5A-02-BC"/>
+        <file id="2" name="a.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DA"/>
+        <file id="3" name="./a.vb" language="VB"/>
+        <file id="4" name="b.vb" language="VB"/>
     </files>
     <methods>
         <method containingType="C" name="M">
             <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" hidden="true" document="1"/>
-                <entry offset="0x8" startLine="1" startColumn="9" endLine="1" endColumn="12" document="1"/>
-                <entry offset="0xf" startLine="2" startColumn="9" endLine="2" endColumn="12" document="2"/>
-                <entry offset="0x16" startLine="3" startColumn="9" endLine="3" endColumn="12" document="3"/>
-                <entry offset="0x1d" hidden="true" document="3"/>
+                <entry offset="0x0" hidden="true" document="2"/>
+                <entry offset="0x1" hidden="true" document="2"/>
+                <entry offset="0x8" startLine="1" startColumn="9" endLine="1" endColumn="12" document="2"/>
+                <entry offset="0xf" startLine="2" startColumn="9" endLine="2" endColumn="12" document="3"/>
+                <entry offset="0x16" startLine="3" startColumn="9" endLine="3" endColumn="12" document="4"/>
+                <entry offset="0x1d" hidden="true" document="4"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x1e">
-                <currentnamespace name=""/>
-            </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
@@ -47,27 +47,22 @@ End Class
             compilation.VerifyPdb(
 <symbols>
     <files>
-        <file id="1" name="C:\abc\def.vb" language="VB"/>
-        <file id="2" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="70-82-DD-9A-57-B3-BE-57-7E-E8-B4-AE-B8-1E-1B-75-38-9D-13-C9"/>
+        <file id="1" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="70-82-DD-9A-57-B3-BE-57-7E-E8-B4-AE-B8-1E-1B-75-38-9D-13-C9"/>
+        <file id="2" name="C:\abc\def.vb" language="VB"/>
     </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
             <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" hidden="true" document="1"/>
-                <entry offset="0xc" startLine="23" startColumn="9" endLine="23" endColumn="41" document="1"/>
-                <entry offset="0x17" hidden="true" document="1"/>
-                <entry offset="0x22" hidden="true" document="1"/>
+                <entry offset="0x0" hidden="true" document="2"/>
+                <entry offset="0x1" hidden="true" document="2"/>
+                <entry offset="0xc" startLine="23" startColumn="9" endLine="23" endColumn="41" document="2"/>
+                <entry offset="0x17" hidden="true" document="2"/>
+                <entry offset="0x22" hidden="true" document="2"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x23">
-                <namespace name="System" importlevel="file"/>
-                <namespace name="System.Collections.Generic" importlevel="file"/>
-                <currentnamespace name=""/>
-            </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
@@ -121,9 +116,9 @@ End Class
             compilation.VerifyPdb(
 <symbols>
     <files>
-        <file id="1" name="C:\abc\def.vb" language="VB"/>
-        <file id="2" name="C:\abc\def2.vb" language="VB"/>
-        <file id="3" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="DB-A9-94-EF-BC-DF-10-C9-60-0F-C0-C4-9F-E4-77-F9-37-CF-E1-CE"/>
+        <file id="1" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="DB-A9-94-EF-BC-DF-10-C9-60-0F-C0-C4-9F-E4-77-F9-37-CF-E1-CE"/>
+        <file id="2" name="C:\abc\def.vb" language="VB"/>
+        <file id="3" name="C:\abc\def2.vb" language="VB"/>
     </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
@@ -140,36 +135,33 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" hidden="true" document="1"/>
-                <entry offset="0xc" startLine="23" startColumn="9" endLine="23" endColumn="41" document="1"/>
-                <entry offset="0x17" startLine="24" startColumn="9" endLine="24" endColumn="41" document="1"/>
-                <entry offset="0x22" startLine="44" startColumn="9" endLine="44" endColumn="46" document="2"/>
-                <entry offset="0x36" hidden="true" document="2"/>
-                <entry offset="0x41" startLine="45" startColumn="13" endLine="45" endColumn="33" document="2"/>
-                <entry offset="0x4d" startLine="46" startColumn="9" endLine="46" endColumn="15" document="2"/>
-                <entry offset="0x4e" hidden="true" document="2"/>
-                <entry offset="0x52" hidden="true" document="2"/>
-                <entry offset="0x59" hidden="true" document="2"/>
-                <entry offset="0x5c" hidden="true" document="2"/>
-                <entry offset="0x67" hidden="true" document="2"/>
-                <entry offset="0x7d" hidden="true" document="2"/>
-                <entry offset="0x8a" hidden="true" document="2"/>
-                <entry offset="0x96" hidden="true" document="2"/>
-                <entry offset="0x97" hidden="true" document="2"/>
-                <entry offset="0x9d" hidden="true" document="2"/>
-                <entry offset="0xa7" hidden="true" document="2"/>
-                <entry offset="0xab" hidden="true" document="2"/>
+                <entry offset="0x0" hidden="true" document="2"/>
+                <entry offset="0x1" hidden="true" document="2"/>
+                <entry offset="0xc" startLine="23" startColumn="9" endLine="23" endColumn="41" document="2"/>
+                <entry offset="0x17" startLine="24" startColumn="9" endLine="24" endColumn="41" document="2"/>
+                <entry offset="0x22" startLine="44" startColumn="9" endLine="44" endColumn="46" document="3"/>
+                <entry offset="0x36" hidden="true" document="3"/>
+                <entry offset="0x41" startLine="45" startColumn="13" endLine="45" endColumn="33" document="3"/>
+                <entry offset="0x4d" startLine="46" startColumn="9" endLine="46" endColumn="15" document="3"/>
+                <entry offset="0x4e" hidden="true" document="3"/>
+                <entry offset="0x52" hidden="true" document="3"/>
+                <entry offset="0x59" hidden="true" document="3"/>
+                <entry offset="0x5c" hidden="true" document="3"/>
+                <entry offset="0x67" hidden="true" document="3"/>
+                <entry offset="0x7d" hidden="true" document="3"/>
+                <entry offset="0x8a" hidden="true" document="3"/>
+                <entry offset="0x96" hidden="true" document="3"/>
+                <entry offset="0x97" hidden="true" document="3"/>
+                <entry offset="0x9d" hidden="true" document="3"/>
+                <entry offset="0xa7" hidden="true" document="3"/>
+                <entry offset="0xab" hidden="true" document="3"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xac">
-                <namespace name="System" importlevel="file"/>
-                <namespace name="System.Collections.Generic" importlevel="file"/>
-                <currentnamespace name=""/>
                 <local name="i" il_index="0" il_start="0x0" il_end="0xac" attributes="0"/>
             </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
@@ -511,35 +503,28 @@ End Class
             compilation.VerifyPdb(
 <symbols>
     <files>
-        <file id="1" name="C:\abc\def1.vb" language="VB"/>
-        <file id="2" name="C:\abc\def2.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="12-34"/>
-        <file id="3" name="b.vb" language="VB" checksumAlgorithm="SHA1" checksum="7F-D8-35-3F-B4-08-17-37-3E-37-30-26-2A-3F-0C-20-6F-48-2A-7A"/>
-        <file id="4" name="BOGUS.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="12-34"/>
-        <file id="5" name="C:\Abc\ACTUAL.vb" language="VB" checksumAlgorithm="SHA1" checksum="27-52-E9-85-5A-AC-31-05-A5-6F-70-40-55-3A-9C-43-D2-07-0D-4B"/>
+        <file id="1" name="C:\Abc\ACTUAL.vb" language="VB" checksumAlgorithm="SHA1" checksum="27-52-E9-85-5A-AC-31-05-A5-6F-70-40-55-3A-9C-43-D2-07-0D-4B"/>
+        <file id="2" name="b.vb" language="VB" checksumAlgorithm="SHA1" checksum="7F-D8-35-3F-B4-08-17-37-3E-37-30-26-2A-3F-0C-20-6F-48-2A-7A"/>
+        <file id="3" name="C:\abc\def1.vb" language="VB"/>
+        <file id="4" name="C:\abc\def2.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="12-34"/>
+        <file id="5" name="BOGUS.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="12-34"/>
     </files>
     <entryPoint declaringType="C1" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="C1" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x7" startLine="46" startColumn="12" endLine="46" endColumn="30" document="1"/>
-                <entry offset="0xf" startLine="27" startColumn="36" endLine="27" endColumn="54" document="2"/>
+                <entry offset="0x0" hidden="true" document="3"/>
+                <entry offset="0x7" startLine="46" startColumn="12" endLine="46" endColumn="30" document="3"/>
+                <entry offset="0xf" startLine="27" startColumn="36" endLine="27" endColumn="54" document="4"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x18">
-                <namespace name="System" importlevel="file"/>
-                <currentnamespace name=""/>
-            </scope>
         </method>
         <method containingType="C1" name="DumpFields">
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="28" document="1"/>
-                <entry offset="0x1" startLine="11" startColumn="9" endLine="11" endColumn="30" document="1"/>
-                <entry offset="0xd" startLine="12" startColumn="9" endLine="12" endColumn="30" document="1"/>
-                <entry offset="0x19" startLine="13" startColumn="5" endLine="13" endColumn="12" document="1"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="28" document="3"/>
+                <entry offset="0x1" startLine="11" startColumn="9" endLine="11" endColumn="30" document="3"/>
+                <entry offset="0xd" startLine="12" startColumn="9" endLine="12" endColumn="30" document="3"/>
+                <entry offset="0x19" startLine="13" startColumn="5" endLine="13" endColumn="12" document="3"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x1a">
-                <importsforward declaringType="C1" methodName=".ctor"/>
-            </scope>
         </method>
         <method containingType="C1" name="Main" parameterNames="args">
             <customDebugInfo>
@@ -548,18 +533,17 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="1" startColumn="5" endLine="1" endColumn="45" document="1"/>
-                <entry offset="0x1" startLine="2" startColumn="13" endLine="2" endColumn="24" document="1"/>
-                <entry offset="0x7" startLine="3" startColumn="9" endLine="3" endColumn="23" document="1"/>
-                <entry offset="0xe" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x0" startLine="1" startColumn="5" endLine="1" endColumn="45" document="3"/>
+                <entry offset="0x1" startLine="2" startColumn="13" endLine="2" endColumn="24" document="3"/>
+                <entry offset="0x7" startLine="3" startColumn="9" endLine="3" endColumn="23" document="3"/>
+                <entry offset="0xe" startLine="4" startColumn="5" endLine="4" endColumn="12" document="3"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xf">
-                <importsforward declaringType="C1" methodName=".ctor"/>
                 <local name="c" il_index="0" il_start="0x0" il_end="0xf" attributes="0"/>
             </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
@@ -770,22 +754,19 @@ End Class
             compilation.VerifyPdb(
 <symbols>
     <files>
-        <file id="1" name="C:\Folder1\Test2.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="DB-78-88-82-72-1B-2B-27-C9-05-79-D5-FE-2A-04-18"/>
-        <file id="2" name="C:\Folder1\Folder2\Test1.vb" language="VB" checksumAlgorithm="SHA1" checksum="B9-49-3D-62-89-9B-B2-2F-B6-72-90-A1-2D-01-11-89-B4-C2-83-B4"/>
+        <file id="1" name="C:\Folder1\Folder2\Test1.vb" language="VB" checksumAlgorithm="SHA1" checksum="B9-49-3D-62-89-9B-B2-2F-B6-72-90-A1-2D-01-11-89-B4-C2-83-B4"/>
+        <file id="2" name="C:\Folder1\Test2.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="DB-78-88-82-72-1B-2B-27-C9-05-79-D5-FE-2A-04-18"/>
     </files>
     <methods>
         <method containingType="Test1" name="Main">
             <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x1" startLine="4" startColumn="2" endLine="4" endColumn="8" document="1"/>
-                <entry offset="0x8" hidden="true" document="1"/>
+                <entry offset="0x0" hidden="true" document="2"/>
+                <entry offset="0x1" startLine="4" startColumn="2" endLine="4" endColumn="8" document="2"/>
+                <entry offset="0x8" hidden="true" document="2"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x9">
-                <currentnamespace name=""/>
-            </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
@@ -11,6 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB
         Inherits BasicTestBase
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         Public Sub TwoMethodsOnlyOneWithMapping()
             Dim source =
 <compilation>
@@ -66,6 +67,7 @@ End Class
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         Public Sub TwoMethodsOnlyOneWithMultipleMappingsAndRewriting()
             Dim source =
 <compilation>
@@ -436,6 +438,7 @@ End Class
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         Public Sub TestPartialClassFieldInitializersWithExternalSource()
             Dim source =
 <compilation>
@@ -729,6 +732,7 @@ End Module
         End Sub
 
         <WorkItem(846584, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/846584")>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
         Public Sub RelativePathForExternalSource()
             Dim source =

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
@@ -478,6 +478,7 @@ End Class
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
+        <WorkItem(50611, "https://github.com/dotnet/roslyn/issues/50611")>
         Public Sub PartiallyDefinedClass_3()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 Imports System.Xml.Linq
@@ -502,8 +503,8 @@ End Class
             compilation.VerifyPdb(
 <symbols>
     <files>
-        <file id="1" name="b.vb" language="VB" checksumAlgorithm="SHA1" checksum="37-E0-06-E1-03-09-97-5A-F5-8F-79-EE-92-BC-7C-63-A6-EB-FF-D4"/>
-        <file id="2" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="D2-29-EA-DE-F7-E6-E9-BC-A0-CE-E4-FB-93-74-05-37-16-D8-89-F1"/>
+        <file id="1" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="D2-29-EA-DE-F7-E6-E9-BC-A0-CE-E4-FB-93-74-05-37-16-D8-89-F1"/>
+        <file id="2" name="b.vb" language="VB" checksumAlgorithm="SHA1" checksum="37-E0-06-E1-03-09-97-5A-F5-8F-79-EE-92-BC-7C-63-A6-EB-FF-D4"/>
     </files>
     <methods>
         <method containingType="C2" name=".cctor">
@@ -514,14 +515,10 @@ End Class
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="21" document="1"/>
-                <entry offset="0x1" startLine="3" startColumn="19" endLine="3" endColumn="56" document="2"/>
-                <entry offset="0x16" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="21" document="2"/>
+                <entry offset="0x1" startLine="3" startColumn="19" endLine="3" endColumn="56" document="1"/>
+                <entry offset="0x16" startLine="4" startColumn="5" endLine="4" endColumn="12" document="2"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x17">
-                <namespace name="System" importlevel="file"/>
-                <currentnamespace name=""/>
-            </scope>
         </method>
         <method containingType="C2+_Closure$__" name="_Lambda$__2-0">
             <customDebugInfo>
@@ -530,15 +527,12 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="44" endLine="3" endColumn="54" document="2"/>
-                <entry offset="0x1" startLine="3" startColumn="55" endLine="3" endColumn="56" document="2"/>
+                <entry offset="0x0" startLine="3" startColumn="44" endLine="3" endColumn="54" document="1"/>
+                <entry offset="0x1" startLine="3" startColumn="55" endLine="3" endColumn="56" document="1"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x7">
-                <importsforward declaringType="C2" methodName=".cctor"/>
-            </scope>
         </method>
     </methods>
-</symbols>)
+</symbols>, format:=DebugInformationFormat.PortablePdb)
         End Sub
 
         <WorkItem(824944, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/824944")>


### PR DESCRIPTION
PTAL @tmat @jaredpar

@ryzngard are there tests for the compilation options embedded in the PDBs? or would it be practical to add any?

Have filed #50611 to follow up on fixing the document order in native PDBs.