### PR TITLE
Don't include namespace symbol in LSP goto definition result

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -80,6 +80,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // local functions
             static bool ShouldInclude(INavigableItem item, bool typeOnly)
             {
+                if (item.Glyph is Glyph.Namespace)
+                {
+                    // Never return namespace symbols as part of the go to definition result.
+                    return false;
+                }
+
                 if (!typeOnly)
                 {
                     return true;

--- a/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -104,6 +104,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Definitions
             Assert.Empty(results);
         }
 
+        [Fact, WorkItem(1264627, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1264627")]
+        public async Task TestGotoDefinitionAsync_NoResultsOnNamespace()
+        {
+            var markup =
+@"namespace {|caret:M|}
+{
+    class A
+    {
+    }
+}";
+            using var workspace = CreateTestWorkspace(markup, out var locations);
+
+            var results = await RunGotoDefinitionAsync(workspace.CurrentSolution, locations["caret"].Single());
+            Assert.Empty(results);
+        }
+
         private static async Task<LSP.Location[]> RunGotoDefinitionAsync(Solution solution, LSP.Location caret)
         {
             var queue = CreateRequestQueue(solution);


### PR DESCRIPTION
Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1264627

Locally, this is handled here - http://sourceroslyn.io/#Microsoft.CodeAnalysis.EditorFeatures/FindUsages/IDefinitionsAndReferencesFactory.cs,121 in TryGotoDefinition. 