### PR TITLE
Fix parsing of generatedfilesout option

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -615,6 +615,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             continue;
 
                         case "generatedfilesout":
+                            value = RemoveQuotesAndSlashes(value);
                             if (string.IsNullOrWhiteSpace(value))
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, MessageID.IDS_Text.Localize(), arg);

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12771,20 +12771,20 @@ class C
         }
 
         [Fact]
-        public void ParseCompilerGeneratedFilesOut()
+        public void ParseGeneratedFilesOut()
         {
             string root = PathUtilities.IsUnixLikePlatform ? "/" : "c:\\";
             string baseDirectory = Path.Combine(root, "abc", "def");
 
             var parsedArgs = DefaultParse(new[] { @"/generatedfilesout:", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
-                // error CS2006: Command-line syntax error: Missing '<text>' for '/compilergeneratedfilesout:' option
+                // error CS2006: Command-line syntax error: Missing '<text>' for '/generatedfilesout:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/generatedfilesout:"));
             Assert.Null(parsedArgs.GeneratedFilesOutputDirectory);
 
             parsedArgs = DefaultParse(new[] { @"/generatedfilesout:""""", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
-                // error CS2006: Command-line syntax error: Missing '<text>' for '/compilergeneratedfilesout:' option
+                // error CS2006: Command-line syntax error: Missing '<text>' for '/generatedfilesout:' option
                 Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/generatedfilesout:\"\""));
             Assert.Null(parsedArgs.GeneratedFilesOutputDirectory);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49981

We were failing to remove extra quotes from the `generatedfilesout` argument. It worked fine when passed directly via the commandline as the OS removed them for us, but failed in response file scenarios such as when compiling via the build server.