### PR TITLE
Binder.DecodeTextBinary - handle an invalid syntax.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
@@ -791,6 +791,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Decode an option "Text" or "Binary" value into true or false. The syntax is not optional.
         ''' </summary>
         Public Shared Function DecodeTextBinary(keywordSyntax As SyntaxToken) As Boolean?
+            If keywordSyntax.Node Is Nothing Then
+                Return Nothing ' Must be a syntax error, an error is reported elsewhere
+            End If
 
             Select Case keywordSyntax.Kind
                 Case SyntaxKind.TextKeyword

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OptionApis.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OptionApis.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
     Public Class OptionApis
@@ -51,6 +52,281 @@ Option Compare Binary
             Assert.Equal(False, semanticModelEmpty.OptionInfer)
             Assert.Equal(True, semanticModelEmpty.OptionExplicit)
             Assert.Equal(False, semanticModelEmpty.OptionCompareText)
+        End Sub
+
+        <Fact>
+        <WorkItem(50610, "https://github.com/dotnet/roslyn/issues/50610")>
+        Public Sub MissingParts_01()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option Text
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.CompareKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.True(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30208: 'Compare' expected.
+Option Text
+       ~~~~
+</expected>)
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub MissingParts_02()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option Compare
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.CompareKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.BinaryKeyword, stmt.ValueKeyword.Kind)
+            Assert.False(stmt.NameKeyword.IsMissing)
+            Assert.True(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30207: 'Option Compare' must be followed by 'Text' or 'Binary'.
+Option Compare
+~~~~~~~~~~~~~~
+</expected>)
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub MissingParts_03()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option Strict
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.StrictKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.False(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertNoDiagnostics()
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub MissingParts_04()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option Infer
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.InferKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.False(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertNoDiagnostics()
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub MissingParts_05()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option Explicit
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.ExplicitKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.False(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertNoDiagnostics()
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub MissingParts_06()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option On
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.StrictKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.True(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30206: 'Option' must be followed by 'Compare', 'Explicit', 'Infer', or 'Strict'.
+Option On
+       ~~
+</expected>)
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub MissingParts_07()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option Off
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.StrictKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.True(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30206: 'Option' must be followed by 'Compare', 'Explicit', 'Infer', or 'Strict'.
+Option Off
+       ~~~
+</expected>)
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub MissingParts_08()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.StrictKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.True(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30206: 'Option' must be followed by 'Compare', 'Explicit', 'Infer', or 'Strict'.
+Option
+~~~~~~
+</expected>)
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
+        End Sub
+
+        <Fact>
+        <WorkItem(50610, "https://github.com/dotnet/roslyn/issues/50610")>
+        Public Sub MissingParts_09()
+            Dim compilation = CreateCompilation(
+<compilation name="GetSemanticInfo">
+    <file name="a.vb">
+Option Binary
+    </file>
+</compilation>)
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim root = tree.GetRoot()
+
+            Dim stmt = root.DescendantNodes().OfType(Of OptionStatementSyntax)().Single()
+
+            Assert.Equal(SyntaxKind.CompareKeyword, stmt.NameKeyword.Kind)
+            Assert.Equal(SyntaxKind.None, stmt.ValueKeyword.Kind)
+            Assert.True(stmt.NameKeyword.IsMissing)
+            Assert.False(stmt.ValueKeyword.IsMissing)
+
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30208: 'Compare' expected.
+Option Binary
+       ~~~~~~
+</expected>)
+
+            Dim model = compilation.GetSemanticModel(tree)
+            For i As Integer = 0 To root.Span.End
+                model.GetEnclosingSymbol(i)
+            Next
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #50610.