### PR TITLE
Fix race condition in records

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/FieldOrPropertyInitializer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldOrPropertyInitializer.cs
@@ -26,42 +26,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal readonly SyntaxReference Syntax;
 
-        /// <summary>
-        /// A sum of widths of spans of all preceding initializers 
-        /// (instance and static initializers are summed separately, and trivias are not counted).
-        /// </summary>
-        internal readonly int PrecedingInitializersLength;
-
-        public FieldOrPropertyInitializer(FieldSymbol fieldOpt, SyntaxNode syntax, int precedingInitializersLength)
+        public FieldOrPropertyInitializer(FieldSymbol fieldOpt, SyntaxNode syntax)
         {
             Debug.Assert(((syntax.IsKind(SyntaxKind.EqualsValueClause) || syntax.IsKind(SyntaxKind.Parameter)) && fieldOpt != null) || syntax is StatementSyntax);
 
             FieldOpt = fieldOpt;
             Syntax = syntax.GetReference();
-            PrecedingInitializersLength = precedingInitializersLength;
-        }
-
-        internal struct Builder
-        {
-            /// <summary>
-            /// The field being initialized (possibly a backing field of a property), or null if this is a top-level statement in script code.
-            /// </summary>
-            internal readonly FieldSymbol FieldOpt;
-
-            /// <summary>
-            /// A reference to <see cref="EqualsValueClauseSyntax"/>,
-            /// or top-level <see cref="StatementSyntax"/> in script code,
-            /// or <see cref="ParameterSyntax"/> for an initialization of a generated property based on record parameter.
-            /// </summary>
-            internal readonly SyntaxNode Syntax;
-
-            public Builder(FieldSymbol fieldOpt, SyntaxNode syntax)
-            {
-                Debug.Assert(((syntax.IsKind(SyntaxKind.EqualsValueClause) || syntax.IsKind(SyntaxKind.Parameter)) && fieldOpt != null) || syntax is StatementSyntax);
-
-                FieldOpt = fieldOpt;
-                Syntax = syntax;
-            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
-        protected override MembersAndInitializersBuilder BuildDeclaredMembersAndInitializers(DiagnosticBag diagnostics)
+        protected override MembersAndInitializers BuildMembersAndInitializers(DiagnosticBag diagnostics)
         {
             bool reportAnError = false;
             foreach (var singleDecl in declaration.Declarations)
@@ -212,15 +212,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            return new MembersAndInitializersBuilder();
-        }
-
-        protected override void AddSynthesizedMembers(MembersAndInitializersBuilder builder, DiagnosticBag diagnostics)
-        {
-            foreach (SingleTypeDeclaration singleDeclaration in declaration.Declarations)
-            {
-                builder.NonTypeNonIndexerMembers.Add(new SynthesizedSimpleProgramEntryPointSymbol(this, singleDeclaration, diagnostics));
-            }
+            return new MembersAndInitializers(nonTypeNonIndexerMembers: declaration.Declarations.SelectAsArray<SingleTypeDeclaration, Symbol>(singleDeclaration => new SynthesizedSimpleProgramEntryPointSymbol(this, singleDeclaration, diagnostics)),
+                                   staticInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
+                                   instanceInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
+                                   indexerDeclarations: ImmutableArray<SyntaxReference>.Empty,
+                                   staticInitializersSyntaxLength: 0,
+                                   instanceInitializersSyntaxLength: 0,
+                                   isNullableEnabledForInstanceConstructorsAndFields: false,
+                                   isNullableEnabledForStaticConstructorsAndFields: false);
         }
 
         public override bool IsImplicitlyDeclared => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
@@ -213,13 +213,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return new MembersAndInitializers(nonTypeNonIndexerMembers: declaration.Declarations.SelectAsArray<SingleTypeDeclaration, Symbol>(singleDeclaration => new SynthesizedSimpleProgramEntryPointSymbol(this, singleDeclaration, diagnostics)),
-                                   staticInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
-                                   instanceInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
-                                   indexerDeclarations: ImmutableArray<SyntaxReference>.Empty,
-                                   staticInitializersSyntaxLength: 0,
-                                   instanceInitializersSyntaxLength: 0,
-                                   isNullableEnabledForInstanceConstructorsAndFields: false,
-                                   isNullableEnabledForStaticConstructorsAndFields: false);
+                                              staticInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
+                                              instanceInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
+                                              indexerDeclarations: ImmutableArray<SyntaxReference>.Empty,
+                                              isNullableEnabledForInstanceConstructorsAndFields: false,
+                                              isNullableEnabledForStaticConstructorsAndFields: false);
         }
 
         public override bool IsImplicitlyDeclared => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
-        protected override MembersAndInitializers BuildMembersAndInitializers(DiagnosticBag diagnostics)
+        protected override MembersAndInitializersBuilder BuildDeclaredMembersAndInitializers(DiagnosticBag diagnostics)
         {
             bool reportAnError = false;
             foreach (var singleDecl in declaration.Declarations)
@@ -212,14 +212,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            return new MembersAndInitializers(nonTypeNonIndexerMembers: declaration.Declarations.SelectAsArray<SingleTypeDeclaration, Symbol>(singleDeclaration => new SynthesizedSimpleProgramEntryPointSymbol(this, singleDeclaration, diagnostics)),
-                                              staticInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
-                                              instanceInitializers: ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>>.Empty,
-                                              indexerDeclarations: ImmutableArray<SyntaxReference>.Empty,
-                                              staticInitializersSyntaxLength: 0,
-                                              instanceInitializersSyntaxLength: 0,
-                                              isNullableEnabledForInstanceConstructorsAndFields: false,
-                                              isNullableEnabledForStaticConstructorsAndFields: false);
+            return new MembersAndInitializersBuilder();
+        }
+
+        protected override void AddSynthesizedMembers(MembersAndInitializersBuilder builder, DiagnosticBag diagnostics)
+        {
+            foreach (SingleTypeDeclaration singleDeclaration in declaration.Declarations)
+            {
+                builder.NonTypeNonIndexerMembers.Add(new SynthesizedSimpleProgramEntryPointSymbol(this, singleDeclaration, diagnostics));
+            }
         }
 
         public override bool IsImplicitlyDeclared => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2468,8 +2468,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public void Free()
             {
                 NonTypeNonIndexerMembers.Free();
+
+                foreach (var group in StaticInitializers)
+                {
+                    group.Free();
+                }
                 StaticInitializers.Free();
+
+                foreach (var group in InstanceInitializers)
+                {
+                    group.Free();
+                }
                 InstanceInitializers.Free();
+
                 IndexerDeclarations.Free();
             }
 
@@ -2649,6 +2660,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public void Free()
             {
                 NonTypeNonIndexerMembers.Free();
+                foreach (var group in InstanceInitializers)
+                {
+                    group.Free();
+                }
                 InstanceInitializers.Free();
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1428,7 +1428,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             AddDeclarationDiagnostics(diagnostics);
             diagnostics.Free();
-            Interlocked.Exchange(ref _lazyDeclaredMembersAndInitializers, null);
+            _lazyDeclaredMembersAndInitializers = null;
 
             return membersAndInitializers!;
         }
@@ -2542,7 +2542,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public readonly bool IsNullableEnabledForInstanceConstructorsAndFields;
             public readonly bool IsNullableEnabledForStaticConstructorsAndFields;
 
-            public static DeclaredMembersAndInitializers UninitializedSentinel = new DeclaredMembersAndInitializers();
+            public static readonly DeclaredMembersAndInitializers UninitializedSentinel = new DeclaredMembersAndInitializers();
 
             private DeclaredMembersAndInitializers()
             {
@@ -2727,8 +2727,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DeclaredMembersAndInitializers? getDeclaredMembersAndInitializers()
             {
                 var declaredMembersAndInitializers = _lazyDeclaredMembersAndInitializers;
-                if (declaredMembersAndInitializers != DeclaredMembersAndInitializers.UninitializedSentinel &&
-                    declaredMembersAndInitializers != null)
+                if (declaredMembersAndInitializers != DeclaredMembersAndInitializers.UninitializedSentinel)
                 {
                     return declaredMembersAndInitializers;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2786,12 +2786,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     builder.AddOrWrapTupleMembers(this);
                 }
 
-                // We already built the explicitly declared members and initializers on another thread, we might have detected that condition
-                // during member building on this thread and bailed, which results in incomplete data in the builder.
-                // In such case we have to avoid creating the instance of MemberAndInitializers since it checks the consistency
-                // of the data in the builder and would fail in an assertion if we tried to construct it from incomplete builder.
                 if (Volatile.Read(ref _lazyDeclaredMembersAndInitializers) != DeclaredMembersAndInitializers.UninitializedSentinel)
                 {
+                    // _lazyDeclaredMembersAndInitializers is already computed. no point to continue.
                     builder.Free();
                     return null;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3354,6 +3354,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We put synthesized record members first so that errors about conflicts show up on user-defined members rather than all
             // going to the record declaration
             members.AddRange(builder.NonTypeNonIndexerMembers);
+            builder.NonTypeNonIndexerMembers.Free();
             builder.NonTypeNonIndexerMembers = members;
 
             return;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1042,9 +1042,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 out FieldOrPropertyInitializer found, out int precedingLength)
             {
                 precedingLength = 0;
-                for (var groupIndex = 0; groupIndex < initializers.Length; groupIndex++)
+                foreach (var group in initializers)
                 {
-                    var group = initializers[groupIndex];
                     if (!group.IsEmpty &&
                         group[0].Syntax.SyntaxTree == tree &&
                         position < group.Last().Syntax.Span.End)
@@ -1095,10 +1094,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 int length = 0;
                 foreach (var group in initializers)
                 {
-                    foreach (var initializer in group)
-                    {
-                        length += getInitializerLength(initializer);
-                    }
+                    length += getGroupLength(group);
                 }
 
                 return length;
@@ -2615,10 +2611,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var groupsBuilder = ArrayBuilder<ImmutableArray<FieldOrPropertyInitializer>>.GetInstance(groupCount);
                     for (int i = 0; i < groupCount; i++)
                     {
+                        var declaredInitializers = declaredMembers.InstanceInitializers[i];
                         if (i == declaredMembers.InstanceInitializersIndexForRecordDeclarationWithParameters)
                         {
                             var insertedInitializers = InstanceInitializersForPositionalMembers;
-                            var declaredInitializers = declaredMembers.InstanceInitializers[i];
 #if DEBUG
                             if (declaredInitializers.Length > 0)
                             {
@@ -2633,7 +2629,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
                         else
                         {
-                            groupsBuilder.Add(declaredMembers.InstanceInitializers[i]);
+                            groupsBuilder.Add(declaredInitializers);
                         }
                     }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -27260,7 +27260,7 @@ public sealed class Hamster : Document
 }
 ";
 
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < 100; i++)
             {
                 var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, options: TestOptions.DebugExe);
                 comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -27224,6 +27224,50 @@ public class Outer
         }
 
         [Fact]
+        [WorkItem(50040, "https://github.com/dotnet/roslyn/issues/50040")]
+        public void RaceConditionInAddMembers()
+        {
+            var src = @"
+#nullable enable
+using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+var collection = new Collection<Hamster>();
+Hamster h = null!;
+await collection.MethodAsync(entity => entity.Name! == ""bar"", h);
+
+public record Collection<T> where T : Document
+{
+    public Task MethodAsync<TDerived>(Expression<Func<TDerived, bool>> filter, TDerived td) where TDerived : T
+        => throw new NotImplementedException();
+
+    public Task MethodAsync<TDerived2>(Task<TDerived2> filterDefinition, TDerived2 td) where TDerived2 : T
+        => throw new NotImplementedException();
+}
+
+public sealed record HamsterCollection : Collection<Hamster>
+{
+}
+
+public abstract class Document
+{
+}
+
+public sealed class Hamster : Document
+{
+    public string? Name { get; private set; }
+}
+";
+
+            for (int i = 0; i < 10; i++)
+            {
+                var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, options: TestOptions.DebugExe);
+                comp.VerifyDiagnostics();
+            }
+        }
+
+        [Fact]
         [WorkItem(44571, "https://github.com/dotnet/roslyn/issues/44571")]
         public void XmlDoc()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/50040

The design for this PR is to add a separate builder to collect all the explicitly declared members and persist that builder. Then we clone that builder (to avoid mutating the first builder) and add the synthesized members. That's safe because we can rely on the explicit members (those are locked in) and they can go into the binder cache.

Note: I didn't try to clean up and free the first builder after we're done with it, because another thread may still be using it. This is unfortunate (removed usage of pooled builders) but I don't see a reliable/safe way to improve on that. Ideas are welcome.

Note: We have a mechanism to keep track of which array of instance initializers should be patched once we generate record properties. I've changed that to use an index rather than a reference, so that it's easier to clone.

----

Summary of investigation: 
When multiple threads call `GetMembersByNameSlow` on a record type, we add synthesized members (`AddSynthesizedRecordMembersIfNecessary`) but this realizes the parameters of the methods (to compare signatures) which causes the binder cache to store methods which have not yet been reified as the official members of the type. 
If done concurrently, a second identical method is instantiated whose parameter references the type symbol of the first instance instead of its own.
This results in a broken object structure (duplicate method instance survives without being a member of its containing type, so doesn't get properly completed).
This causes assertions in debug mode and likely the above symptoms in release mode (I will confirm after fixing).


References:
- caching of method symbols in binder: [BinderFactory.VisitMethodDeclaration](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs#L131)
- the method symbol that is cached is `this` method when binding parameters: [SourceOrdinaryMethodSymbol.MakeParametersAndBindReturnType](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs#L123)
- the stacktrace below shows how the comparison of symbols while computing members of records realizes parameters:

```
   at Microsoft.CodeAnalysis.CSharp.BinderFactory.BinderFactoryVisitor.Initialize(Int32 position, CSharpSyntaxNode memberDeclarationOpt, Symbol memberOpt)
   at Microsoft.CodeAnalysis.CSharp.BinderFactory.GetBinder(SyntaxNode node, Int32 position, CSharpSyntaxNode memberDeclarationOpt, Symbol memberOpt)
   at Microsoft.CodeAnalysis.CSharp.BinderFactory.GetBinder(SyntaxNode node, CSharpSyntaxNode memberDeclarationOpt, Symbol memberOpt)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol.MakeParametersAndBindReturnType(DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbolBase.MethodChecks(DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol.LazyMethodChecks()
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbolBase.get_Parameters()
   at Microsoft.CodeAnalysis.CSharp.Symbols.SymbolExtensions.GetParameters(Symbol member)
   at Microsoft.CodeAnalysis.CSharp.Symbols.MemberSignatureComparer.Equals(Symbol member1, Symbol member2)
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.AddSynthesizedRecordMembersIfNecessary(MembersAndInitializersBuilder builder, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.BuildMembersAndInitializers(DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.GetMembersAndInitializers()
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.MakeAllMembers(DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.GetMembersByNameSlow()
```