### PR TITLE
Fix cursor location on enter inside razor brace completion

### DIFF
--- a/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
@@ -284,16 +284,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.OnAutoInsert
         {|type:|}
     }
 }";
-            var expected =
+            await VerifyNoResult("\n", markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
+        [WorkItem(1260219, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1260219")]
+        public async Task OnAutoInsert_BraceFormattingDoesNotMoveCaretOnEnterInsideBraces()
+        {
+            // The test starts with the closing brace already on a new line.
+            // In LSP, hitting enter will first trigger a didChange event for the new line character
+            // (bringing the server text to the form below) and then trigger OnAutoInsert
+            // for the new line character.
+            var markup =
 @"class A
 {
     void M()
-    {
+    {{|type:|}
 
-        $0
+
     }
 }";
-            await VerifyMarkupAndExpected("\n", markup, expected);
+            await VerifyNoResult("\n", markup);
         }
 
         private async Task VerifyMarkupAndExpected(string characterTyped, string markup, string expected, bool useTabs = false)


### PR DESCRIPTION
This ensures that when enter is typed inside a pair of already completed + newline + formatted pair of braces, we do not attempt to do any kind of formatting on brace completion.  Previously, we would attempt to move the caret to the line before the closing brace after formatting, which resulted in weird caret moving behavior.
![adffb2a5-d78c-4bf3-8d54-a06469cb2e6a](https://user-images.githubusercontent.com/5749229/105241534-ab8b9780-5b22-11eb-902c-631358a7826d.gif)

Now we just don't attempt to do any formatting at all if there are already multiple lines between the braces.  We need to support a single line between the braces as razor language configuration inserts one.
