### PR TITLE
Delete confusing stuff from our packages

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -70,8 +70,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
                 this.RegisterService<ICSharpTempPECompilerService>(async ct =>
                 {
+                    var workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
                     await JoinableTaskFactory.SwitchToMainThreadAsync(ct);
-                    return new TempPECompilerService(this.Workspace.Services.GetService<IMetadataService>());
+                    return new TempPECompilerService(workspace.Services.GetService<IMetadataService>());
                 });
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
@@ -79,16 +80,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
         }
 
-        protected override VisualStudioWorkspaceImpl CreateWorkspace()
-            => this.ComponentModel.GetService<VisualStudioWorkspaceImpl>();
-
         protected override async Task RegisterObjectBrowserLibraryManagerAsync(CancellationToken cancellationToken)
         {
+            var workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
+
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             if (await GetServiceAsync(typeof(SVsObjectManager)).ConfigureAwait(true) is IVsObjectManager2 objectManager)
             {
-                _libraryManager = new ObjectBrowserLibraryManager(this, ComponentModel, Workspace);
+                _libraryManager = new ObjectBrowserLibraryManager(this, ComponentModel, workspace);
 
                 if (ErrorHandler.Failed(objectManager.RegisterSimpleLibrary(_libraryManager, out _libraryManagerCookie)))
                 {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             // This method should only contain calls to acquire services off of the component model
             // or service providers.  Anything else which is more complicated should go in Initialize
             // instead.
-            this.Workspace = this.Package.Workspace;
+            this.Workspace = this.Package.ComponentModel.GetService<VisualStudioWorkspaceImpl>();
             this.EditorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
             this.HostDiagnosticUpdateSource = this.Package.ComponentModel.GetService<HostDiagnosticUpdateSource>();
             this.AnalyzerFileWatcherService = this.Package.ComponentModel.GetService<AnalyzerFileWatcherService>();
@@ -335,7 +335,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             return new ContainedLanguage(
                 bufferCoordinator,
                 this.Package.ComponentModel,
-                this.Package.Workspace,
+                this.Workspace,
                 project.Id,
                 project,
                 filePath,

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -67,11 +67,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return _languageService.ComAggregate;
             });
 
-            // Okay, this is also a bit strange.  We need to get our Interop dll into our process,
-            // but we're in the GAC.  Ask the base Roslyn Package to load, and it will take care of
-            // it for us.
-            // * NOTE * workspace should never be created before loading roslyn package since roslyn package
-            //          installs a service roslyn visual studio workspace requires
             shell.LoadPackage(Guids.RoslynPackageId, out var setupPackage);
 
             var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 
             this.Workspace = this.CreateWorkspace();
-            if (IsInIdeMode(this.Workspace))
+            if (!IVsShellExtensions.IsInCommandLineMode)
             {
                 // not every derived package support object browser and for those languages
                 // this is a no op
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         {
             if (disposing)
             {
-                if (IsInIdeMode(Workspace))
+                if (!IVsShellExtensions.IsInCommandLineMode)
                 {
                     ThreadHelper.JoinableTaskFactory.Run(async () => await UnregisterObjectBrowserLibraryManagerAsync(CancellationToken.None).ConfigureAwait(true));
                 }
@@ -155,8 +155,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             // base package implementations
             return Task.CompletedTask;
         }
-
-        private static bool IsInIdeMode(Workspace workspace)
-            => workspace != null && !IVsShellExtensions.IsInCommandLineMode;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -85,8 +85,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            // Ensure the nuget package services are initialized after we've loaded
-            // the solution.
+            // Ensure the nuget package services are initialized. This initialization pass will only run
+            // once our package is loaded indirectly through a legacy COM service we proffer (like the legacy project systems
+            // loading us) or through something like the IVsEditorFactory or a debugger service. Right now it's fine
+            // we only load this there, because we only use these to provide code fixes. But we only show code fixes in
+            // open files, and so you would have had to open a file, which loads the editor factory, which loads our package,
+            // which will run this.
+            //
+            // This code will have to be moved elsewhere once any of that load path is changed such that the package
+            // no longer loads if a file is opened.
             _packageInstallerService = workspace.Services.GetService<IPackageInstallerService>() as PackageInstallerService;
             _symbolSearchService = workspace.Services.GetService<ISymbolSearchService>() as VisualStudioSymbolSearchService;
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.SymbolSearch;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -32,8 +31,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         private PackageInstallerService _packageInstallerService;
         private VisualStudioSymbolSearchService _symbolSearchService;
-
-        public VisualStudioWorkspaceImpl Workspace { get; private set; }
 
         protected AbstractPackage()
         {
@@ -72,7 +69,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             var miscellaneousFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>();
             RegisterMiscellaneousFilesWorkspaceInformation(miscellaneousFilesWorkspace);
 
-            this.Workspace = this.CreateWorkspace();
             if (!IVsShellExtensions.IsInCommandLineMode)
             {
                 // not every derived package support object browser and for those languages
@@ -85,18 +81,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         protected override async Task LoadComponentsAsync(CancellationToken cancellationToken)
         {
+            var workspace = ComponentModel.GetService<VisualStudioWorkspace>();
+
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             // Ensure the nuget package services are initialized after we've loaded
             // the solution.
-            _packageInstallerService = Workspace.Services.GetService<IPackageInstallerService>() as PackageInstallerService;
-            _symbolSearchService = Workspace.Services.GetService<ISymbolSearchService>() as VisualStudioSymbolSearchService;
+            _packageInstallerService = workspace.Services.GetService<IPackageInstallerService>() as PackageInstallerService;
+            _symbolSearchService = workspace.Services.GetService<ISymbolSearchService>() as VisualStudioSymbolSearchService;
 
             _packageInstallerService?.Connect(this.RoslynLanguageName);
             _symbolSearchService?.Connect(this.RoslynLanguageName);
         }
-
-        protected abstract VisualStudioWorkspaceImpl CreateWorkspace();
 
         internal IComponentModel ComponentModel
         {

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
                 RegisterService(Of IVbTempPECompilerFactory)(
                     Async Function(ct)
-                        Dim workspace = Me.ComponentModel.GetService(Of VisualStudioWorkspaceImpl)()
+                        Dim workspace = Me.ComponentModel.GetService(Of VisualStudioWorkspace)()
                         Await JoinableTaskFactory.SwitchToMainThreadAsync(ct)
                         Return New TempPECompilerFactory(workspace)
                     End Function)

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -58,10 +58,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
             _comAggregate = Interop.ComAggregate.CreateAggregatedObject(Me)
         End Sub
 
-        Protected Overrides Function CreateWorkspace() As VisualStudioWorkspaceImpl
-            Return Me.ComponentModel.GetService(Of VisualStudioWorkspaceImpl)
-        End Function
-
         Protected Overrides Async Function InitializeAsync(cancellationToken As CancellationToken, progress As IProgress(Of ServiceProgressData)) As Task
             Try
                 Await MyBase.InitializeAsync(cancellationToken, progress).ConfigureAwait(True)
@@ -69,9 +65,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
                 RegisterLanguageService(GetType(IVbCompilerService), Function() Task.FromResult(_comAggregate))
 
-                Dim workspace = Me.ComponentModel.GetService(Of VisualStudioWorkspaceImpl)()
                 RegisterService(Of IVbTempPECompilerFactory)(
                     Async Function(ct)
+                        Dim workspace = Me.ComponentModel.GetService(Of VisualStudioWorkspaceImpl)()
                         Await JoinableTaskFactory.SwitchToMainThreadAsync(ct)
                         Return New TempPECompilerFactory(workspace)
                     End Function)
@@ -81,11 +77,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Function
 
         Protected Overrides Async Function RegisterObjectBrowserLibraryManagerAsync(cancellationToken As CancellationToken) As Task
+            Dim workspace As VisualStudioWorkspace = ComponentModel.GetService(Of VisualStudioWorkspace)()
+
             Await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken)
 
             Dim objectManager = TryCast(Await GetServiceAsync(GetType(SVsObjectManager)).ConfigureAwait(True), IVsObjectManager2)
             If objectManager IsNot Nothing Then
-                Me._libraryManager = New ObjectBrowserLibraryManager(Me, ComponentModel, Workspace)
+                Me._libraryManager = New ObjectBrowserLibraryManager(Me, ComponentModel, workspace)
 
                 If ErrorHandler.Failed(objectManager.RegisterSimpleLibrary(Me._libraryManager, Me._libraryManagerCookie)) Then
                     Me._libraryManagerCookie = 0

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/TempPECompilerFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/TempPECompilerFactory.vb
@@ -2,16 +2,15 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
     Friend Class TempPECompilerFactory
         Implements IVbTempPECompilerFactory
 
-        Private ReadOnly _workspace As VisualStudioWorkspaceImpl
+        Private ReadOnly _workspace As VisualStudioWorkspace
 
-        Public Sub New(workspace As VisualStudioWorkspaceImpl)
+        Public Sub New(workspace As VisualStudioWorkspace)
             Me._workspace = workspace
         End Sub
 


### PR DESCRIPTION
Commit at a time might be easier; this is deleting some comments and methods that don't need to be there but led to some recent confusion.