### PR TITLE
Support finding generated documents in Navigate To

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -222,6 +222,22 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
+
+        /// <summary>
+        /// Maps an immutable array through a function that returns ValueTasks, returning the new ImmutableArray.
+        /// </summary>
+        public static async ValueTask<ImmutableArray<TResult>> SelectAsArrayAsync<TItem, TResult>(this ImmutableArray<TItem> array, Func<TItem, ValueTask<TResult>> selector)
+        {
+            var builder = ArrayBuilder<TResult>.GetInstance(array.Length);
+
+            foreach (var item in array)
+            {
+                builder.Add(await selector(item).ConfigureAwait(false));
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
         /// <summary>
         /// Zips two immutable arrays together through a mapping function, producing another immutable array.
         /// </summary>

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -1386,6 +1386,32 @@ testHost, @"class C
                 },
                 await _aggregator.GetItemsAsync("Outer"));
         }
+
+        [Fact]
+        public async Task DoIncludeSymbolsFromSourceGeneratedFiles()
+        {
+            using var workspace = TestWorkspace.Create(@"
+<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"">
+        <DocumentFromSourceGenerator>
+            public class C
+            {
+            }
+        </DocumentFromSourceGenerator>
+    </Project>
+</Workspace>
+", composition: EditorTestCompositions.EditorFeatures);
+
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _aggregator = new NavigateToTestAggregator(_provider);
+
+            VerifyNavigateToResultItems(
+                new()
+                {
+                    new NavigateToItem("C", NavigateToItemKind.Class, "csharp", null, null, s_emptyExactPatternMatch, null),
+                },
+                await _aggregator.GetItemsAsync("C"));
+        }
     }
 }
 #pragma warning restore CS0618 // MatchKind is obsolete

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -244,15 +244,14 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
         public async ValueTask<DefinitionItem> RehydrateAsync(Solution solution, CancellationToken cancellationToken)
         {
-            var sourceSpansTasks = SourceSpans.SelectAsArray(ss => ss.RehydrateAsync(solution, cancellationToken).AsTask());
-            var sourceSpans = await Task.WhenAll(sourceSpansTasks).ConfigureAwait(false);
+            var sourceSpans = await SourceSpans.SelectAsArrayAsync(ss => ss.RehydrateAsync(solution, cancellationToken)).ConfigureAwait(false);
 
             return new DefinitionItem.DefaultDefinitionItem(
                 Tags,
                 DisplayParts,
                 NameDisplayParts,
                 OriginationParts,
-                sourceSpans.ToImmutableArray(),
+                sourceSpans,
                 Properties,
                 DisplayableProperties,
                 DisplayIfNoReferences);

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -91,12 +91,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             var highPriDocs = priorityDocuments.WhereAsArray(d => project.ContainsDocument(d.Id));
 
             var highPriDocsSet = highPriDocs.ToSet();
-            var lowPriDocs = project.Documents.Where(d => !highPriDocsSet.Contains(d));
+            var lowPriDocs = (await project.GetAllRegularAndSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false))
+                              .Where(d => !highPriDocsSet.Contains(d));
 
             var orderedDocs = highPriDocs.AddRange(lowPriDocs);
 
             Debug.Assert(priorityDocuments.All(d => project.ContainsDocument(d.Id)), "Priority docs included doc not from project.");
-            Debug.Assert(orderedDocs.Length == project.Documents.Count(), "Didn't have the same number of project after ordering them!");
             Debug.Assert(orderedDocs.Distinct().Length == orderedDocs.Length, "Ordered list contained a duplicate!");
             Debug.Assert(project.Documents.All(d => orderedDocs.Contains(d)), "At least one document from the project was missing from the ordered list!");
 

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {
@@ -68,19 +69,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 project, priorityDocuments, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<ImmutableArray<INavigateToSearchResult>> RehydrateAsync(
+        private static ValueTask<ImmutableArray<INavigateToSearchResult>> RehydrateAsync(
             Optional<ImmutableArray<SerializableNavigateToSearchResult>> result,
             Solution solution,
             CancellationToken cancellationToken)
         {
             if (result.HasValue)
             {
-                var resultTasks = result.Value.SelectAsArray(r => r.RehydrateAsync(solution, cancellationToken).AsTask());
-                return (await Task.WhenAll(resultTasks).ConfigureAwait(false)).ToImmutableArray();
+                return result.Value.SelectAsArrayAsync(r => r.RehydrateAsync(solution, cancellationToken));
             }
             else
             {
-                return ImmutableArray<INavigateToSearchResult>.Empty;
+                return ValueTaskFactory.FromResult(ImmutableArray<INavigateToSearchResult>.Empty);
             }
         }
     }

--- a/src/Features/Core/Portable/Remote/RemoteArguments.cs
+++ b/src/Features/Core/Portable/Remote/RemoteArguments.cs
@@ -178,9 +178,7 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             var childItems = ChildItems == null
                 ? ImmutableArray<INavigableItem>.Empty
-                : ImmutableArray.Create(
-                    await Task.WhenAll(
-                        ChildItems.SelectAsArray(c => c.RehydrateAsync(solution, cancellationToken).AsTask())).ConfigureAwait(false));
+                : await ChildItems.SelectAsArrayAsync(c => c.RehydrateAsync(solution, cancellationToken)).ConfigureAwait(false);
 
             return new NavigableItem(
                 Glyph, DisplayTaggedParts,

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -122,5 +122,13 @@ internal static class Program
             Assert.Equal($"{HelloWorldGenerator.GeneratedEnglishClassName}.cs {ServicesVSResources.generated_suffix}", VisualStudio.Shell.GetActiveWindowCaption());
             Assert.Equal(isPreview, VisualStudio.Shell.IsActiveTabProvisional());
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SourceGenerators)]
+        public void InvokeNavigateToForGeneratedFile()
+        {
+            VisualStudio.Editor.InvokeNavigateTo(HelloWorldGenerator.GeneratedEnglishClassName, VirtualKey.Enter);
+            VisualStudio.Editor.WaitForActiveView(HelloWorldGenerator.GeneratedEnglishClassName + ".cs");
+            Assert.Equal("HelloWorld", VisualStudio.Editor.GetSelectedText());
+        }
     }
 }


### PR DESCRIPTION
Updating the search algorithm was trivial -- the only "interesting" bit of work here was ensuring the dehydration/rehydration logic for bringing the results back in-proc is async so we can fetch generated documents.

Fixes https://github.com/dotnet/roslyn/issues/49581