### PR TITLE
Link ExternalAccess folder for TypeScript

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
+++ b/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
@@ -41,7 +41,7 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <RestrictedInternalsVisibleTo Include="TypeScriptAddIn" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
+    <RestrictedInternalsVisibleTo Include="TypeScriptAddin" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
   </ItemGroup>
   <ItemGroup>

--- a/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
+++ b/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Core.Wpf\ExternalAccess\**\*.cs" LinkBase="ExternalAccess" />
     <Compile Include="..\Core.Wpf\SignatureHelp\**\*.cs" LinkBase="SignatureHelp" />
     <Compile Include="..\Core.Wpf\IDebuggerTextView2.cs" Link="IDebuggerTextView2.cs" />
   </ItemGroup>
@@ -38,6 +39,10 @@
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.TypeScript" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
+    <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
   </ItemGroup>
   <ItemGroup>
     <!-- VS Mac has its own ExternalAccess.FSharp -->

--- a/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
+++ b/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Core.Wpf\ExternalAccess\**\*.cs" LinkBase="ExternalAccess" />
+    <Compile Include="..\Core.Wpf\ExternalAccess\VSTypeScript\**\*.cs" LinkBase="ExternalAccess\VSTypeScript" />
     <Compile Include="..\Core.Wpf\SignatureHelp\**\*.cs" LinkBase="SignatureHelp" />
     <Compile Include="..\Core.Wpf\IDebuggerTextView2.cs" Link="IDebuggerTextView2.cs" />
   </ItemGroup>
@@ -41,7 +41,7 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.TypeScript" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
+    <RestrictedInternalsVisibleTo Include="TypeScriptAddIn" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes the build break in xamarin/vsmac#3092

Replaces https://github.com/dotnet/roslyn/pull/50682

Code sharing now done via linked files, as discussed.