### PR TITLE
Fix null annotation

### DIFF
--- a/src/Compilers/Core/Portable/Text/TextLine.cs
+++ b/src/Compilers/Core/Portable/Text/TextLine.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Text
         {
             get
             {
-                return _text?.Lines.IndexOf(_start) ?? 0;
+                return _text.Lines.IndexOf(_start);
             }
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Text
         {
             get
             {
-                if (_text == null || _text.Length == 0 || _endIncludingBreaks == _start)
+                if (_text.Length == 0 || _endIncludingBreaks == _start)
                 {
                     return 0;
                 }
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Text
 
         public override string ToString()
         {
-            if (_text == null || _text.Length == 0)
+            if (_text.Length == 0)
             {
                 return string.Empty;
             }

--- a/src/Compilers/Core/Portable/Text/TextLine.cs
+++ b/src/Compilers/Core/Portable/Text/TextLine.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Text
     /// </summary>
     public readonly struct TextLine : IEquatable<TextLine>
     {
-        private readonly SourceText? _text;
+        private readonly SourceText _text;
         private readonly int _start;
         private readonly int _endIncludingBreaks;
 
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// Gets the source text.
         /// </summary>
-        public SourceText? Text
+        public SourceText Text
         {
             get { return _text; }
         }


### PR DESCRIPTION
The constructor of `TextLine` is private and is only called in `FromSpan` method, which throws for a null `text`. It seems that `_text` can never be null.