### PR TITLE
Add EA.Razor APIs for breakpoint & proximity expression resolution.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.Lines.cs
+++ b/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.Lines.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// using System.Collections.Generic;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 0);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 0, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// using Roslyn.Compilers.CSharp;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 35);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 35, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// using Roslyn.Services.CSharp.Utilities;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 67);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 67, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// using Roslyn.Services.Extensions;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 108);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 108, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 152);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 152, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// namespace Roslyn.Services.CSharp.Debugging
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 154);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 154, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 198);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 198, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////     internal partial class ProximityExpressionsGetter
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 201);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 201, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////     {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 256);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 256, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static string ConvertToString(ExpressionSyntax expression)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 263);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 263, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 339);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 339, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // TODO(cyrusn): Should we strip out comments?
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 350);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 350, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             return expression.GetFullText();
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 410);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 410, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 456);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 456, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 467);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 467, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectExpressionTerms(int position, ExpressionSyntax expression, List<string> terms)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 469);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 469, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 584);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 584, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms" }, terms);
         }
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Check here rather than at all the call sites...
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 595);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 595, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "position", "terms" }, terms);
         }
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression == null)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 659);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 659, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "position", "terms" }, terms);
         }
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 696);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 696, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 711);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 711, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 736);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 736, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 751);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 751, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expression", "expressionType" }, terms);
         }
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Collect terms from this expression, which returns flags indicating the validity
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 753);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 753, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expression", "expressionType" }, terms);
         }
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // of this expression as a whole.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 849);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 849, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expression", "expressionType" }, terms);
         }
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 896);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 896, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expression", "expressionType" }, terms);
         }
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 954);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 954, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectExpressionTerms", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1040);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1040, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "expression", "terms", "expressionType", "CollectExpressionTerms" }, terms);
         }
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((expressionType & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1042);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1042, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "expression", "terms", "expressionType", "CollectExpressionTerms" }, terms);
         }
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1132);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1132, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 // If this expression identified itself as a valid term, add it to the
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1147);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1147, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expressionType", "terms", "expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 // term table
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1235);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1235, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expressionType", "terms", "expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(expression));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1266);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1266, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expressionType", "terms", "expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1323);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1323, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "expression", "ConvertToString" }, terms);
         }
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1338);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1338, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm", "terms", "expression", "ConvertToString" }, terms);
         }
@@ -425,7 +425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1349);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1349, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -436,7 +436,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1351);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1351, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -447,7 +447,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1502);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1502, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -459,7 +459,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Check here rather than at all the call sites...
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1513);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1513, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "position", "terms", "expressionType" }, terms);
         }
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression == null)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1577);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1577, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "position", "terms", "expressionType" }, terms);
         }
@@ -483,7 +483,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1614);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1614, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -495,7 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1629);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1629, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1654);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1654, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -518,7 +518,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1669);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1669, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             switch (expression.Kind)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1671);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1671, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -542,7 +542,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1709);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1709, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.ThisExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1724);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1724, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.BaseExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1773);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1773, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -578,7 +578,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // an op term is ok if it's a "this" or "base" op it allows us to see
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1822);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1822, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -590,7 +590,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // "this.goo" in the autos window note: it's not a VALIDTERM since we don't
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1913);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1913, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -602,7 +602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // want "this" showing up in the auto's window twice.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2010);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2010, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2085);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2085, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -626,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2155);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2155, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -638,7 +638,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2184);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2184, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -650,7 +650,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.IdentifierName:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2186);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2186, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -662,7 +662,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // Name nodes are always valid terms
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2235);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2235, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm", "expression", "expression.Kind" }, terms);
         }
@@ -674,7 +674,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidTerm;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2293);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2293, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm", "expression", "expression.Kind" }, terms);
         }
@@ -686,7 +686,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2357);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2357, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -698,7 +698,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2386);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2386, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -710,7 +710,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.CharacterLiteralExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2388);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2388, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -722,7 +722,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.FalseLiteralExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2449);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2449, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -734,7 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.NullLiteralExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2506);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2506, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -746,7 +746,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.NumericLiteralExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2562);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2562, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -758,7 +758,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.StringLiteralExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2621);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2621, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -770,7 +770,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.TrueLiteralExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2679);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2679, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -782,7 +782,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // Constants can make up a valid term, but we don't consider them valid
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2735);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2735, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // terms themselves (since we don't want them to show up in the autos window
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2828);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2828, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -806,7 +806,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // on their own).
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2926);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2926, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2965);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2965, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -830,7 +830,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3035);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3035, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -842,7 +842,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3064);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3064, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -854,7 +854,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.CastExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3066);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3066, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -866,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // For a cast, just add the nested expression.  Note: this is technically
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3115);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3115, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "terms", "expressionType", "CollectExpressionTerms", "expression", "expression.Kind" }, terms);
         }
@@ -878,7 +878,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // unsafe as the cast *may* have side effects.  However, in practice this is
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3210);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3210, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "terms", "expressionType", "CollectExpressionTerms", "expression", "expression.Kind" }, terms);
         }
@@ -890,7 +890,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // extremely rare, so we allow for this since it's ok in the common case.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3308);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3308, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "terms", "expressionType", "CollectExpressionTerms", "expression", "expression.Kind" }, terms);
         }
@@ -902,7 +902,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectExpressionTerms(position, ((CastExpressionSyntax)expression).Expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3403);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3403, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "terms", "expressionType", "CollectExpressionTerms", "expression", "expression.Kind" }, terms);
         }
@@ -914,7 +914,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3532);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3532, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectExpressionTerms" }, terms);
         }
@@ -926,7 +926,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3561);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3561, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -938,7 +938,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.MemberAccessExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3563);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3563, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -950,7 +950,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.PointerMemberAccessExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3620);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3620, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -962,7 +962,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectMemberAccessExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3684);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3684, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectMemberAccessExpressionTerms", "expression.Kind" }, terms);
         }
@@ -974,7 +974,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3790);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3790, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectMemberAccessExpressionTerms" }, terms);
         }
@@ -986,7 +986,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3819);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3819, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -998,7 +998,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.ObjectCreationExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3821);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3821, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -1010,7 +1010,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectObjectCreationExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3880);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3880, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectObjectCreationExpressionTerms", "expression.Kind" }, terms);
         }
@@ -1022,7 +1022,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3988);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3988, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectObjectCreationExpressionTerms" }, terms);
         }
@@ -1034,7 +1034,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4017);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4017, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -1046,7 +1046,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.ArrayCreationExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4019);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4019, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -1058,7 +1058,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectArrayCreationExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4077);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4077, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectArrayCreationExpressionTerms", "expression.Kind" }, terms);
         }
@@ -1070,7 +1070,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4184);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4184, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectArrayCreationExpressionTerms" }, terms);
         }
@@ -1082,7 +1082,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4213);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4213, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -1094,7 +1094,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.InvocationExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4215);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4215, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -1106,7 +1106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectInvocationExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4270);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4270, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectInvocationExpressionTerms", "expression.Kind" }, terms);
         }
@@ -1118,7 +1118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4374);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4374, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectInvocationExpressionTerms" }, terms);
         }
@@ -1130,7 +1130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4403);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4403, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -1142,7 +1142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4418);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4418, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax", "expression.Kind" }, terms);
         }
@@ -1154,7 +1154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // +, -, ++, --, !, etc.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4420);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4420, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax", "expression.Kind" }, terms);
         }
@@ -1166,7 +1166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             //
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4458);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4458, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax", "expression.Kind" }, terms);
         }
@@ -1178,7 +1178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // This is a valid expression if it doesn't have obvious side effects (i.e. ++, --)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4474);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4474, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax", "expression.Kind" }, terms);
         }
@@ -1190,7 +1190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression is PrefixUnaryExpressionSyntax)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4571);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4571, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax", "expression.Kind" }, terms);
         }
@@ -1202,7 +1202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4631);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4631, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax" }, terms);
         }
@@ -1214,7 +1214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectPrefixUnaryExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4646);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4646, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPrefixUnaryExpressionTerms", "PrefixUnaryExpressionSyntax" }, terms);
         }
@@ -1226,7 +1226,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4747);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4747, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPrefixUnaryExpressionTerms" }, terms);
         }
@@ -1238,7 +1238,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4772);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4772, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -1249,7 +1249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4787);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4787, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PostfixUnaryExpressionSyntax", "PrefixUnaryExpressionSyntax" }, terms);
         }
@@ -1261,7 +1261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression is PostfixUnaryExpressionSyntax)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4789);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4789, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PostfixUnaryExpressionSyntax", "PrefixUnaryExpressionSyntax" }, terms);
         }
@@ -1273,7 +1273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4850);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4850, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PostfixUnaryExpressionSyntax" }, terms);
         }
@@ -1285,7 +1285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectPostfixUnaryExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4865);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4865, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPostfixUnaryExpressionTerms", "PostfixUnaryExpressionSyntax" }, terms);
         }
@@ -1297,7 +1297,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4967);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4967, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPostfixUnaryExpressionTerms" }, terms);
         }
@@ -1309,7 +1309,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4992);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4992, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -1320,7 +1320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5007);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5007, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "BinaryExpressionSyntax", "PostfixUnaryExpressionSyntax" }, terms);
         }
@@ -1332,7 +1332,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression is BinaryExpressionSyntax)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5009);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5009, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "BinaryExpressionSyntax", "PostfixUnaryExpressionSyntax" }, terms);
         }
@@ -1344,7 +1344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5064);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5064, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "BinaryExpressionSyntax" }, terms);
         }
@@ -1356,7 +1356,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectBinaryExpressionTerms(position, expression, terms, ref expressionType);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5079);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5079, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectBinaryExpressionTerms", "BinaryExpressionSyntax" }, terms);
         }
@@ -1368,7 +1368,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5175);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5175, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectBinaryExpressionTerms" }, terms);
         }
@@ -1380,7 +1380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5200);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5200, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -1391,7 +1391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5215);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5215, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "expression", "BinaryExpressionSyntax" }, terms);
         }
@@ -1403,7 +1403,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5217);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5217, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "expression", "BinaryExpressionSyntax" }, terms);
         }
@@ -1415,7 +1415,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5271);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5271, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -1427,7 +1427,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5282);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5282, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -1438,7 +1438,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectMemberAccessExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5284);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5284, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -1449,7 +1449,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5447);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5447, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1461,7 +1461,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var flags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5458);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5458, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "flags", "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1473,7 +1473,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5507);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5507, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(MemberAccessExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "memberAccess" }, terms);
         }
@@ -1485,7 +1485,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // These operators always have a RHS of a name node, which we know would
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5509);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5509, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(MemberAccessExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "memberAccess" }, terms);
         }
@@ -1497,7 +1497,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // "claim" to be a valid term, but is not valid without the LHS present.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5595);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5595, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(MemberAccessExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "memberAccess" }, terms);
         }
@@ -1509,7 +1509,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // So, we don't bother collecting anything from the RHS...
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5681);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5681, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(MemberAccessExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "memberAccess" }, terms);
         }
@@ -1521,7 +1521,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var memberAccess = (MemberAccessExpressionSyntax)expression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5753);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5753, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(MemberAccessExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "memberAccess" }, terms);
         }
@@ -1533,7 +1533,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, memberAccess.Expression, terms, ref flags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5827);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5827, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "memberAccess", "memberAccess.Expression", "terms", "flags", "CollectExpressionTerms", "expression", "(MemberAccessExpressionSyntax)expression" }, terms);
         }
@@ -1545,7 +1545,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5917);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5917, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -1557,7 +1557,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // If the LHS says it's a valid term, then we add it ONLY if our PARENT
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5919);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5919, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -1569,7 +1569,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // is NOT another dot/arrow.  This allows the expression 'a.b.c.d' to
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6004);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6004, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -1581,7 +1581,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // add both 'a.b.c.d' and 'a.b.c', but not 'a.b' and 'a'.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6087);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6087, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -1593,7 +1593,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm &&
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6158);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6158, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -1605,7 +1605,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 !expression.IsParentKind(SyntaxKind.MemberAccessExpression) &&
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6241);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6241, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -1617,7 +1617,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 !expression.IsParentKind(SyntaxKind.PointerMemberAccessExpression))
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6321);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6321, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -1629,7 +1629,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6406);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6406, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression" }, terms);
         }
@@ -1641,7 +1641,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(memberAccess.Expression));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6421);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6421, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "memberAccess", "memberAccess.Expression", "ConvertToString", "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression" }, terms);
         }
@@ -1653,7 +1653,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6491);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6491, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -1665,7 +1665,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6506);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6506, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "ExpressionType.ValidTerm", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -1677,7 +1677,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // And this expression itself is a valid term if the LHS is a valid
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6508);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6508, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "ExpressionType.ValidTerm", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -1689,7 +1689,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // expression, and its PARENT is not an invocation.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6589);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6589, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "ExpressionType.ValidTerm", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -1701,7 +1701,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidExpression) == ExpressionType.ValidExpression &&
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6654);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6654, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "ExpressionType.ValidTerm", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -1713,7 +1713,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 !expression.IsParentKind(SyntaxKind.InvocationExpression))
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6749);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6749, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "ExpressionType.ValidTerm", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -1725,7 +1725,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6825);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6825, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -1737,7 +1737,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.ValidTerm;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6840);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6840, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "expressionType", "ExpressionType.ValidTerm", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -1749,7 +1749,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6900);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6900, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1761,7 +1761,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             else
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6915);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6915, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "ExpressionType.ValidTerm", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -1773,7 +1773,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6933);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6933, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -1785,7 +1785,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6948);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6948, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "flags", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -1797,7 +1797,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7014);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7014, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -1809,7 +1809,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7029);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7029, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "expressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1821,7 +1821,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7040);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7040, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -1832,7 +1832,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectObjectCreationExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7042);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7042, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -1843,7 +1843,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7207);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7207, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1855,7 +1855,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Object creation can *definitely* cause side effects.  So we initially
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7218);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7218, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -1867,7 +1867,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // mark this as something invalid.  We allow it as a valid expr if all
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7304);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7304, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -1879,7 +1879,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // the sub arguments are valid terms.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7388);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7388, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -1891,7 +1891,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7439);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7439, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -1903,7 +1903,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7493);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7493, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(ObjectCreationExpressionSyntax)expression", "ExpressionType", "expressionType", "ExpressionType.Invalid", "objectionCreation" }, terms);
         }
@@ -1915,7 +1915,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var objectionCreation = (ObjectCreationExpressionSyntax)expression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7495);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7495, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(ObjectCreationExpressionSyntax)expression", "ExpressionType", "expressionType", "ExpressionType.Invalid", "objectionCreation" }, terms);
         }
@@ -1927,7 +1927,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (objectionCreation.ArgumentListOpt != null)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7576);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7576, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "objectionCreation", "objectionCreation.ArgumentListOpt", "expression", "(ObjectCreationExpressionSyntax)expression" }, terms);
         }
@@ -1939,7 +1939,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7636);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7636, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "objectionCreation", "objectionCreation.ArgumentListOpt" }, terms);
         }
@@ -1951,7 +1951,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 var flags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7651);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7651, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "objectionCreation", "objectionCreation.ArgumentListOpt", "flags" }, terms);
         }
@@ -1963,7 +1963,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectArgumentTerms(position, objectionCreation.ArgumentList, terms, ref flags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7704);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7704, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "objectionCreation", "objectionCreation.ArgumentListOpt", "terms", "flags", "CollectArgumentTerms", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -1975,7 +1975,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7806);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7806, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "objectionCreation", "objectionCreation.ArgumentListOpt", "terms", "flags", "CollectArgumentTerms" }, terms);
         }
@@ -1987,7 +1987,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 // If all arguments are terms, then this is possibly a valid expr
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7808);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7808, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "objectionCreation", "objectionCreation.ArgumentListOpt", "terms", "flags", "CollectArgumentTerms" }, terms);
         }
@@ -1999,7 +1999,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 // that can be used somewhere higher in the stack.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7891);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7891, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "objectionCreation", "objectionCreation.ArgumentListOpt", "terms", "flags", "CollectArgumentTerms" }, terms);
         }
@@ -2011,7 +2011,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7959);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7959, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "objectionCreation", "objectionCreation.ArgumentListOpt", "terms", "flags", "CollectArgumentTerms" }, terms);
         }
@@ -2023,7 +2023,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8044);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8044, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2035,7 +2035,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8063);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8063, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2047,7 +2047,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8133);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8133, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -2059,7 +2059,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8152);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8152, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -2071,7 +2071,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8167);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8167, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "objectionCreation", "objectionCreation.ArgumentListOpt", "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -2083,7 +2083,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8178);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8178, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2094,7 +2094,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectArrayCreationExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8180);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8180, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2105,7 +2105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8344);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8344, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -2117,7 +2117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var validTerm = true;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8355);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8355, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm", "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -2129,7 +2129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var arrayCreation = (ArrayCreationExpressionSyntax)expression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8390);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8390, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(ArrayCreationExpressionSyntax)expression", "validTerm", "arrayCreation" }, terms);
         }
@@ -2141,7 +2141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8466);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8466, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arrayCreation", "arrayCreation.InitializerOpt", "expression", "(ArrayCreationExpressionSyntax)expression" }, terms);
         }
@@ -2153,7 +2153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (arrayCreation.InitializerOpt != null)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8468);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8468, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arrayCreation", "arrayCreation.InitializerOpt", "expression", "(ArrayCreationExpressionSyntax)expression" }, terms);
         }
@@ -2165,7 +2165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8523);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8523, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arrayCreation", "arrayCreation.InitializerOpt" }, terms);
         }
@@ -2177,7 +2177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 var flags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8538);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8538, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "arrayCreation", "arrayCreation.InitializerOpt", "flags" }, terms);
         }
@@ -2189,7 +2189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 arrayCreation.Initializer.Expressions.Do(e => CollectExpressionTerms(position, e, terms, ref flags));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8591);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8591, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arrayCreation.InitializerOpt.Expressions", "flags", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -2201,7 +2201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8713);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8713, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "validTerm", "arrayCreation.InitializerOpt.Expressions" }, terms);
         }
@@ -2213,7 +2213,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 validTerm &= (flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8715);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8715, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "validTerm", "arrayCreation.InitializerOpt.Expressions" }, terms);
         }
@@ -2225,7 +2225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8809);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8809, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "validTerm" }, terms);
         }
@@ -2237,7 +2237,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8824);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8824, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm", "arrayCreation", "arrayCreation.InitializerOpt", "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2249,7 +2249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (validTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8826);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8826, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm", "arrayCreation", "arrayCreation.InitializerOpt", "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2261,7 +2261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8854);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8854, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm" }, terms);
         }
@@ -2273,7 +2273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8869);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8869, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "validTerm" }, terms);
         }
@@ -2285,7 +2285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8935);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8935, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -2297,7 +2297,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             else
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8950);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8950, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm", "arrayCreation", "arrayCreation.InitializerOpt", "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2309,7 +2309,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8968);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8968, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm" }, terms);
         }
@@ -2321,7 +2321,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8983);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8983, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "validTerm" }, terms);
         }
@@ -2333,7 +2333,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9041);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9041, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -2345,7 +2345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9056);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9056, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm", "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "ExpressionType.Invalid" }, terms);
         }
@@ -2357,7 +2357,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9067);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9067, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2368,7 +2368,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectInvocationExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9069);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9069, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2379,7 +2379,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9230);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9230, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -2391,7 +2391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Invocations definitely have side effects.  So we assume this
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9241);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9241, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -2403,7 +2403,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // is invalid initially
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9318);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9318, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -2415,7 +2415,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9355);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9355, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -2427,7 +2427,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             ExpressionType leftFlags = ExpressionType.Invalid, rightFlags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9409);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9409, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expressionType", "leftFlags", "rightFlags" }, terms);
         }
@@ -2439,7 +2439,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9510);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9510, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(InvocationExpressionSyntax)expression", "leftFlags", "ExpressionType", "ExpressionType.Invalid", "rightFlags", "invocation" }, terms);
         }
@@ -2451,7 +2451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var invocation = (InvocationExpressionSyntax)expression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9512);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9512, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(InvocationExpressionSyntax)expression", "leftFlags", "ExpressionType", "ExpressionType.Invalid", "rightFlags", "invocation" }, terms);
         }
@@ -2463,7 +2463,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, invocation.Expression, terms, ref leftFlags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9582);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9582, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "invocation", "invocation.Expression", "terms", "leftFlags", "CollectExpressionTerms", "expression", "(InvocationExpressionSyntax)expression" }, terms);
         }
@@ -2475,7 +2475,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectArgumentTerms(position, invocation.ArgumentList, terms, ref rightFlags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9674);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9674, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "invocation", "invocation.ArgumentList", "terms", "rightFlags", "CollectArgumentTerms", "invocation.Expression", "leftFlags", "CollectExpressionTerms" }, terms);
         }
@@ -2487,7 +2487,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9767);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9767, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm", "position", "invocation", "invocation.ArgumentList", "terms", "rightFlags", "CollectArgumentTerms" }, terms);
         }
@@ -2499,7 +2499,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((leftFlags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9769);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9769, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm", "position", "invocation", "invocation.ArgumentList", "terms", "rightFlags", "CollectArgumentTerms" }, terms);
         }
@@ -2511,7 +2511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9854);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9854, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2523,7 +2523,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(invocation.Expression));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9869);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9869, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "invocation", "invocation.Expression", "ConvertToString", "ExpressionType", "leftFlags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2535,7 +2535,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9937);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9937, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "invocation", "invocation.Expression", "ConvertToString" }, terms);
         }
@@ -2547,7 +2547,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9952);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9952, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "rightFlags", "ExpressionType.ValidExpression", "expressionType", "ExpressionType.ValidTerm", "terms", "invocation", "invocation.Expression", "ConvertToString" }, terms);
         }
@@ -2559,7 +2559,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // We're valid if both children are...
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9954);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9954, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType", "ExpressionType.ValidTerm", "terms", "invocation", "invocation.Expression", "ConvertToString" }, terms);
         }
@@ -2571,7 +2571,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = (leftFlags & rightFlags) & ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10006);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10006, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType", "ExpressionType.ValidTerm", "terms", "invocation", "invocation.Expression", "ConvertToString" }, terms);
         }
@@ -2583,7 +2583,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10095);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10095, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType" }, terms);
         }
@@ -2595,7 +2595,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10106);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10106, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2606,7 +2606,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectPrefixUnaryExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10108);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10108, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2617,7 +2617,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10270);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10270, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -2629,7 +2629,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10281);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10281, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -2641,7 +2641,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var flags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10335);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10335, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expressionType", "flags" }, terms);
         }
@@ -2653,7 +2653,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var prefixUnaryExpression = (PrefixUnaryExpressionSyntax)expression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10384);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10384, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(PrefixUnaryExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "prefixUnaryExpression" }, terms);
         }
@@ -2665,7 +2665,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10466);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10466, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PrefixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -2677,7 +2677,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Ask our subexpression for terms
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10468);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10468, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PrefixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -2689,7 +2689,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, prefixUnaryExpression.Operand, terms, ref flags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10516);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10516, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PrefixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -2701,7 +2701,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10612);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10612, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -2713,7 +2713,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Is our expression a valid term?
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10614);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10614, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -2725,7 +2725,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10662);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10662, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -2737,7 +2737,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10743);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10743, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2749,7 +2749,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(prefixUnaryExpression.Operand));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10758);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10758, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "terms", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -2761,7 +2761,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10834);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10834, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "ConvertToString" }, terms);
         }
@@ -2773,7 +2773,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10849);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10849, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression", "ExpressionType", "ExpressionType.ValidTerm", "terms", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "ConvertToString" }, terms);
         }
@@ -2785,7 +2785,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression.MatchesKind(SyntaxKind.LogicalNotExpression, SyntaxKind.BitwiseNotExpression, SyntaxKind.NegateExpression, SyntaxKind.PlusExpression))
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10851);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10851, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression", "ExpressionType", "ExpressionType.ValidTerm", "terms", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "ConvertToString" }, terms);
         }
@@ -2797,7 +2797,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11014);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11014, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression" }, terms);
         }
@@ -2809,7 +2809,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 // We're a valid expression if our subexpression is...
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11029);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11029, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expressionType", "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression" }, terms);
         }
@@ -2821,7 +2821,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = flags & ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11101);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11101, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expressionType", "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression" }, terms);
         }
@@ -2833,7 +2833,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11175);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11175, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expressionType" }, terms);
         }
@@ -2845,7 +2845,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11190);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11190, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression", "ExpressionType", "flags", "ExpressionType.ValidExpression", "expressionType" }, terms);
         }
@@ -2857,7 +2857,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11201);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11201, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2868,7 +2868,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectPostfixUnaryExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11203);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11203, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -2879,7 +2879,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11366);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11366, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -2891,7 +2891,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // ++ and -- are the only postfix operators.  Since they always have side
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11377);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11377, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -2903,7 +2903,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // effects, we never consider this an expression.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11464);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11464, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -2915,7 +2915,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11527);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11527, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -2927,7 +2927,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11581);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11581, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expressionType", "flags" }, terms);
         }
@@ -2939,7 +2939,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var flags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11583);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11583, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expressionType", "flags" }, terms);
         }
@@ -2951,7 +2951,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var postfixUnaryExpression = (PostfixUnaryExpressionSyntax)expression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11632);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11632, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(PostfixUnaryExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "postfixUnaryExpression" }, terms);
         }
@@ -2963,7 +2963,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11716);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11716, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PostfixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -2975,7 +2975,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Ask our subexpression for terms
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11718);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11718, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PostfixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -2987,7 +2987,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, postfixUnaryExpression.Operand, terms, ref flags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11766);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11766, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PostfixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -2999,7 +2999,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11863);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11863, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -3011,7 +3011,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Is our expression a valid term?
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11865);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11865, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -3023,7 +3023,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11913);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11913, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -3035,7 +3035,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11994);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11994, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3047,7 +3047,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(postfixUnaryExpression.Operand));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12009);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12009, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "terms", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3059,7 +3059,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12086);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12086, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "ConvertToString" }, terms);
         }
@@ -3071,7 +3071,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12101);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12101, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "ExpressionType.ValidTerm", "terms", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "ConvertToString" }, terms);
         }
@@ -3083,7 +3083,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12112);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12112, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3094,7 +3094,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectBinaryExpressionTerms(int position, ExpressionSyntax expression, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12114);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12114, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3105,7 +3105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12271);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12271, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -3117,7 +3117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             ExpressionType leftFlags = ExpressionType.Invalid, rightFlags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12282);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12282, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "leftFlags", "rightFlags", "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -3129,7 +3129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12383);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12383, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(BinaryExpressionSyntax)expression", "leftFlags", "ExpressionType", "ExpressionType.Invalid", "rightFlags", "binaryExpression" }, terms);
         }
@@ -3141,7 +3141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var binaryExpression = (BinaryExpressionSyntax)expression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12385);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12385, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(BinaryExpressionSyntax)expression", "leftFlags", "ExpressionType", "ExpressionType.Invalid", "rightFlags", "binaryExpression" }, terms);
         }
@@ -3153,7 +3153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, binaryExpression.Left, terms, ref leftFlags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12457);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12457, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "binaryExpression", "binaryExpression.Left", "terms", "leftFlags", "CollectExpressionTerms", "expression", "(BinaryExpressionSyntax)expression" }, terms);
         }
@@ -3165,7 +3165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, binaryExpression.Right, terms, ref rightFlags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12549);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12549, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "binaryExpression", "binaryExpression.Right", "terms", "rightFlags", "CollectExpressionTerms", "binaryExpression.Left", "leftFlags" }, terms);
         }
@@ -3177,7 +3177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12643);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12643, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm", "position", "binaryExpression", "binaryExpression.Right", "terms", "rightFlags", "CollectExpressionTerms" }, terms);
         }
@@ -3189,7 +3189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((leftFlags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12645);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12645, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm", "position", "binaryExpression", "binaryExpression.Right", "terms", "rightFlags", "CollectExpressionTerms" }, terms);
         }
@@ -3201,7 +3201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12730);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12730, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3213,7 +3213,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(binaryExpression.Left));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12745);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12745, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "terms", "binaryExpression", "binaryExpression.Left", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3225,7 +3225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12813);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12813, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "binaryExpression", "binaryExpression.Left", "ConvertToString" }, terms);
         }
@@ -3237,7 +3237,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12828);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12828, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression", "binaryExpression.Left", "ConvertToString" }, terms);
         }
@@ -3249,7 +3249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((rightFlags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12830);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12830, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression", "binaryExpression.Left", "ConvertToString" }, terms);
         }
@@ -3261,7 +3261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12916);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12916, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3273,7 +3273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(binaryExpression.Right));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12931);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12931, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "terms", "binaryExpression", "binaryExpression.Right", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3285,7 +3285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13000);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13000, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "binaryExpression", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3297,7 +3297,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13015);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13015, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3309,7 +3309,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Many sorts of binops (like +=) will definitely have side effects.  We only
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13017);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13017, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3321,7 +3321,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // consider this valid if it's a simple expression like +, -, etc.
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13108);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13108, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3333,7 +3333,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13188);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13188, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3345,7 +3345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             switch (binaryExpression.Kind)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13190);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13190, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3357,7 +3357,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13234);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13234, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3369,7 +3369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.AddExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13249);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13249, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3381,7 +3381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.SubtractExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13297);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13297, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3394,7 +3394,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 case SyntaxKind.CoalesceExpression:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14319);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14319, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3406,7 +3406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     // We're valid if both children are...
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14372);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14372, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType", "binaryExpression", "binaryExpression.Kind" }, terms);
         }
@@ -3418,7 +3418,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = (leftFlags & rightFlags) & ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14432);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14432, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType", "binaryExpression", "binaryExpression.Kind" }, terms);
         }
@@ -3430,7 +3430,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14529);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14529, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType" }, terms);
         }
@@ -3442,7 +3442,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14558);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14558, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3454,7 +3454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 default:
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14560);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14560, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3466,7 +3466,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14586);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14586, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "binaryExpression", "binaryExpression.Kind" }, terms);
         }
@@ -3478,7 +3478,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14648);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14648, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -3490,7 +3490,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14677);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14677, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -3502,7 +3502,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14692);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14692, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "binaryExpression", "binaryExpression.Kind" }, terms);
         }
@@ -3514,7 +3514,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14703);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14703, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3525,7 +3525,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectArgumentTerms(int position, ArgumentListSyntax argumentList, IList<string> terms, ref ExpressionType expressionType)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14705);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14705, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3536,7 +3536,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14858);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14858, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "argumentList", "terms", "expressionType" }, terms);
         }
@@ -3548,7 +3548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var validExpr = true;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14869);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14869, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validExpr", "position", "argumentList", "terms", "expressionType" }, terms);
         }
@@ -3560,7 +3560,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14904);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14904, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arg", "argumentList", "argumentList.Arguments", "validExpr" }, terms);
         }
@@ -3572,7 +3572,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // Process the list of expressions.  This is probably a list of
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14906);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14906, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arg", "argumentList", "argumentList.Arguments", "validExpr" }, terms);
         }
@@ -3584,7 +3584,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // arguments to a function call(or a list of array index expressions)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14983);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14983, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arg", "argumentList", "argumentList.Arguments", "validExpr" }, terms);
         }
@@ -3596,7 +3596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             foreach (var arg in argumentList.Arguments)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15066);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15066, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arg", "argumentList", "argumentList.Arguments", "validExpr" }, terms);
         }
@@ -3608,7 +3608,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15123);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15123, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arg", "argumentList", "argumentList.Arguments" }, terms);
         }
@@ -3620,7 +3620,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 var flags = ExpressionType.Invalid;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15138);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15138, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "arg", "argumentList", "argumentList.Arguments", "flags" }, terms);
         }
@@ -3632,7 +3632,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15191);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15191, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "arg", "arg.Expression", "terms", "flags", "CollectExpressionTerms", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -3644,7 +3644,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectExpressionTerms(position, arg.Expression, terms, ref flags);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15193);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15193, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "arg", "arg.Expression", "terms", "flags", "CollectExpressionTerms", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -3656,7 +3656,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15278);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15278, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "arg", "arg.Expression", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -3668,7 +3668,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15363);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15363, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3680,7 +3680,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     terms.Add(ConvertToString(arg.Expression));
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15382);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15382, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "terms", "arg", "arg.Expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -3692,7 +3692,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15447);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15447, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "arg", "arg.Expression", "ConvertToString" }, terms);
         }
@@ -3704,7 +3704,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15466);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15466, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "ExpressionType.ValidExpression", "validExpr", "ExpressionType.ValidTerm", "terms", "arg", "arg.Expression", "ConvertToString" }, terms);
         }
@@ -3716,7 +3716,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 validExpr &= (flags & ExpressionType.ValidExpression) == ExpressionType.ValidExpression;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15468);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15468, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "ExpressionType.ValidExpression", "validExpr", "ExpressionType.ValidTerm", "terms", "arg", "arg.Expression", "ConvertToString" }, terms);
         }
@@ -3728,7 +3728,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15574);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15574, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "ExpressionType.ValidExpression", "validExpr" }, terms);
         }
@@ -3740,7 +3740,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15589);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15589, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "validExpr", "ExpressionType.ValidExpression", "expressionType", "arg", "argumentList", "argumentList.Arguments" }, terms);
         }
@@ -3752,7 +3752,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // We're never a valid term, but we're a valid expression if all
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15591);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15591, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "validExpr", "ExpressionType.ValidExpression", "expressionType", "arg", "argumentList", "argumentList.Arguments" }, terms);
         }
@@ -3764,7 +3764,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             // the list elements are...
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15669);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15669, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "validExpr", "ExpressionType.ValidExpression", "expressionType", "arg", "argumentList", "argumentList.Arguments" }, terms);
         }
@@ -3776,7 +3776,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = validExpr ? ExpressionType.ValidExpression : 0;
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15710);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15710, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "validExpr", "ExpressionType.ValidExpression", "expressionType", "arg", "argumentList", "argumentList.Arguments" }, terms);
         }
@@ -3788,7 +3788,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15788);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15788, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "validExpr", "ExpressionType.ValidExpression", "expressionType" }, terms);
         }
@@ -3800,7 +3800,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15799);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15799, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3811,7 +3811,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         private static void CollectVariableTerms(int position, SeparatedSyntaxList<VariableDeclaratorSyntax> declarators, List<string> terms)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15801);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15801, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3822,7 +3822,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15944);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15944, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "declarators", "terms" }, terms);
         }
@@ -3834,7 +3834,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             foreach (var declarator in declarators)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15955);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15955, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarators", "position", "terms" }, terms);
         }
@@ -3846,7 +3846,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16008);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16008, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarators" }, terms);
         }
@@ -3858,7 +3858,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 if (declarator.InitializerOpt != null)
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16023);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16023, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarator.InitializerOpt", "declarators" }, terms);
         }
@@ -3870,7 +3870,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 {
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16079);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16079, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarator.InitializerOpt" }, terms);
         }
@@ -3882,7 +3882,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectExpressionTerms(position, declarator.Initializer.Value, terms);
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16098);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16098, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "declarator.InitializerOpt", "declarator.InitializerOpt.Value", "terms", "CollectExpressionTerms", "declarator" }, terms);
         }
@@ -3894,7 +3894,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16193);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16193, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "declarator.InitializerOpt", "declarator.InitializerOpt.Value", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -3906,7 +3906,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16212);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16212, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarator.InitializerOpt", "position", "declarator.InitializerOpt.Value", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -3918,7 +3918,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16227);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16227, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarators", "position", "declarator.InitializerOpt", "declarator.InitializerOpt.Value", "terms", "CollectExpressionTerms" }, terms);
         }
@@ -3930,7 +3930,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////     }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16238);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16238, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3941,7 +3941,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// }
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16245);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16245, cancellationToken: default);
             Assert.Null(terms);
         }
 
@@ -3952,7 +3952,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             //// 
             //// ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16248);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16248, cancellationToken: default);
             Assert.Null(terms);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.Statements.cs
+++ b/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.Statements.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 347);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 347, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             return expression.GetFullText();
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 422);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 422, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 592);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 592, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms" }, terms);
         }
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression == null)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 671);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 671, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "position", "terms" }, terms);
         }
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 708);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 708, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 727);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 727, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var expressionType = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 908);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 908, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expression", "expressionType" }, terms);
         }
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, expression, terms, ref expressionType);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 966);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 966, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectExpressionTerms", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((expressionType & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1054);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1054, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "expression", "terms", "expressionType", "CollectExpressionTerms" }, terms);
         }
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1144);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1144, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(expression));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1282);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1282, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "expressionType", "expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1510);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1510, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression == null)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1589);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1589, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "position", "terms", "expressionType" }, terms);
         }
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1626);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1626, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1645);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1645, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression" }, terms);
         }
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             switch (expression.Kind)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 1683);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 1683, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "expression.Kind" }, terms);
         }
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidExpression;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2105);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2105, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2175);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2175, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidTerm;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2313);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2313, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm", "expression", "expression.Kind" }, terms);
         }
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2377);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2377, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidExpression;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 2985);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 2985, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "expression", "expression.Kind" }, terms);
         }
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3055);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3055, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression" }, terms);
         }
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectExpressionTerms(position, ((CastExpressionSyntax)expression).Expression, terms, ref expressionType);
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3423);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3423, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "terms", "expressionType", "CollectExpressionTerms", "expression", "expression.Kind" }, terms);
         }
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3552);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3552, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "position", "terms", "expressionType", "CollectExpressionTerms" }, terms);
         }
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectMemberAccessExpressionTerms(position, expression, terms, ref expressionType);
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3704);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3704, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectMemberAccessExpressionTerms", "expression.Kind" }, terms);
         }
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3810);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3810, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectMemberAccessExpressionTerms" }, terms);
         }
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectObjectCreationExpressionTerms(position, expression, terms, ref expressionType);
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 3900);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 3900, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectObjectCreationExpressionTerms", "expression.Kind" }, terms);
         }
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4008);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4008, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectObjectCreationExpressionTerms" }, terms);
         }
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectArrayCreationExpressionTerms(position, expression, terms, ref expressionType);
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4097);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4097, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectArrayCreationExpressionTerms", "expression.Kind" }, terms);
         }
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4204);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4204, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectArrayCreationExpressionTerms" }, terms);
         }
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectInvocationExpressionTerms(position, expression, terms, ref expressionType);
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4290);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4290, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectInvocationExpressionTerms", "expression.Kind" }, terms);
         }
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4394);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4394, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectInvocationExpressionTerms" }, terms);
         }
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression is PrefixUnaryExpressionSyntax)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4583);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4583, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax", "expression.Kind" }, terms);
         }
@@ -484,7 +484,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4643);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4643, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PrefixUnaryExpressionSyntax" }, terms);
         }
@@ -498,7 +498,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectPrefixUnaryExpressionTerms(position, expression, terms, ref expressionType);
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4662);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4662, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPrefixUnaryExpressionTerms", "PrefixUnaryExpressionSyntax" }, terms);
         }
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4763);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4763, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPrefixUnaryExpressionTerms" }, terms);
         }
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression is PostfixUnaryExpressionSyntax)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4801);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4801, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PostfixUnaryExpressionSyntax", "PrefixUnaryExpressionSyntax" }, terms);
         }
@@ -540,7 +540,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4862);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4862, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "PostfixUnaryExpressionSyntax" }, terms);
         }
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectPostfixUnaryExpressionTerms(position, expression, terms, ref expressionType);
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4881);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4881, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPostfixUnaryExpressionTerms", "PostfixUnaryExpressionSyntax" }, terms);
         }
@@ -568,7 +568,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 4983);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 4983, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectPostfixUnaryExpressionTerms" }, terms);
         }
@@ -582,7 +582,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression is BinaryExpressionSyntax)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5021);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5021, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "BinaryExpressionSyntax", "PostfixUnaryExpressionSyntax" }, terms);
         }
@@ -596,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5076);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5076, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "BinaryExpressionSyntax" }, terms);
         }
@@ -610,7 +610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectBinaryExpressionTerms(position, expression, terms, ref expressionType);
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5095);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5095, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectBinaryExpressionTerms", "BinaryExpressionSyntax" }, terms);
         }
@@ -624,7 +624,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 return;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5191);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5191, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType", "CollectBinaryExpressionTerms" }, terms);
         }
@@ -638,7 +638,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5229);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5229, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "expression", "BinaryExpressionSyntax" }, terms);
         }
@@ -652,7 +652,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5455);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5455, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -666,7 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var flags = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5470);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5470, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "flags", "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -680,7 +680,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var memberAccess = (MemberAccessExpressionSyntax)expression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5765);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5765, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(MemberAccessExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "memberAccess" }, terms);
         }
@@ -694,7 +694,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, memberAccess.Expression, terms, ref flags);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 5839);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 5839, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "memberAccess", "memberAccess.Expression", "terms", "flags", "CollectExpressionTerms", "expression", "(MemberAccessExpressionSyntax)expression" }, terms);
         }
@@ -708,7 +708,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm &&
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6170);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6170, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "position", "memberAccess", "memberAccess.Expression", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -722,7 +722,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6418);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6418, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression" }, terms);
         }
@@ -736,7 +736,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(memberAccess.Expression));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6437);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6437, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm", "expression", "SyntaxKind", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression" }, terms);
         }
@@ -750,7 +750,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidExpression) == ExpressionType.ValidExpression &&
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6666);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6666, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression", "ExpressionType.ValidTerm", "SyntaxKind.MemberAccessExpression", "SyntaxKind.PointerMemberAccessExpression", "terms", "memberAccess", "memberAccess.Expression", "ConvertToString" }, terms);
         }
@@ -764,7 +764,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6837);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6837, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -778,7 +778,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.ValidTerm;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6856);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6856, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "expressionType", "ExpressionType.ValidTerm", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -792,7 +792,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6945);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6945, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -806,7 +806,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.ValidExpression;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 6964);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 6964, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "expressionType", "ExpressionType.ValidExpression", "expression", "SyntaxKind", "SyntaxKind.InvocationExpression" }, terms);
         }
@@ -820,7 +820,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7215);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7215, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7451);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7451, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -848,7 +848,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var objectionCreation = (ObjectCreationExpressionSyntax)expression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7507);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7507, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(ObjectCreationExpressionSyntax)expression", "ExpressionType", "expressionType", "ExpressionType.Invalid", "objectionCreation" }, terms);
         }
@@ -862,7 +862,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (objectionCreation.ArgumentListOpt != null)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7588);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7588, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "objectionCreation", "objectionCreation.ArgumentListOpt", "expression", "(ObjectCreationExpressionSyntax)expression" }, terms);
         }
@@ -876,7 +876,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7648);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7648, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "objectionCreation", "objectionCreation.ArgumentListOpt" }, terms);
         }
@@ -890,7 +890,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 var flags = ExpressionType.Invalid;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7667);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7667, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "objectionCreation", "objectionCreation.ArgumentListOpt", "flags" }, terms);
         }
@@ -904,7 +904,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectArgumentTerms(position, objectionCreation.ArgumentList, terms, ref flags);
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7720);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7720, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "objectionCreation", "objectionCreation.ArgumentListOpt", "terms", "flags", "CollectArgumentTerms", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -918,7 +918,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 7975);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 7975, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "objectionCreation", "objectionCreation.ArgumentListOpt", "terms", "flags", "CollectArgumentTerms" }, terms);
         }
@@ -932,7 +932,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 {
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8060);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8060, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -946,7 +946,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.ValidExpression;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8083);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8083, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "expressionType", "ExpressionType.ValidExpression", "ExpressionType.ValidTerm" }, terms);
         }
@@ -960,7 +960,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8352);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8352, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -974,7 +974,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var validTerm = true;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8367);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8367, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm", "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -988,7 +988,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var arrayCreation = (ArrayCreationExpressionSyntax)expression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8402);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8402, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(ArrayCreationExpressionSyntax)expression", "validTerm", "arrayCreation" }, terms);
         }
@@ -1002,7 +1002,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (arrayCreation.InitializerOpt != null)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8480);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8480, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arrayCreation", "arrayCreation.InitializerOpt", "expression", "(ArrayCreationExpressionSyntax)expression" }, terms);
         }
@@ -1016,7 +1016,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8535);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8535, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arrayCreation", "arrayCreation.InitializerOpt" }, terms);
         }
@@ -1030,7 +1030,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 var flags = ExpressionType.Invalid;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8554);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8554, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "arrayCreation", "arrayCreation.InitializerOpt", "flags" }, terms);
         }
@@ -1044,7 +1044,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 arrayCreation.Initializer.Expressions.Do(e => CollectExpressionTerms(position, e, terms, ref flags));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8607);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8607, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arrayCreation.InitializerOpt.Expressions", "flags", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -1058,7 +1058,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 validTerm &= (flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8731);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8731, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm", "validTerm", "arrayCreation.InitializerOpt.Expressions" }, terms);
         }
@@ -1072,7 +1072,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (validTerm)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8838);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8838, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "validTerm", "arrayCreation", "arrayCreation.InitializerOpt", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1086,7 +1086,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8866);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8866, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm" }, terms);
         }
@@ -1100,7 +1100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.ValidExpression;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8885);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8885, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.ValidExpression", "validTerm" }, terms);
         }
@@ -1114,7 +1114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8980);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8980, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validTerm" }, terms);
         }
@@ -1128,7 +1128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = ExpressionType.Invalid;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 8999);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 8999, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "validTerm" }, terms);
         }
@@ -1142,7 +1142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9238);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9238, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1156,7 +1156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9367);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9367, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -1170,7 +1170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             ExpressionType leftFlags = ExpressionType.Invalid, rightFlags = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9421);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9421, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expressionType", "leftFlags", "rightFlags" }, terms);
         }
@@ -1184,7 +1184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var invocation = (InvocationExpressionSyntax)expression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9524);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9524, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(InvocationExpressionSyntax)expression", "leftFlags", "ExpressionType", "ExpressionType.Invalid", "rightFlags", "invocation" }, terms);
         }
@@ -1198,7 +1198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, invocation.Expression, terms, ref leftFlags);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9594);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9594, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "invocation", "invocation.Expression", "terms", "leftFlags", "CollectExpressionTerms", "expression", "(InvocationExpressionSyntax)expression" }, terms);
         }
@@ -1212,7 +1212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectArgumentTerms(position, invocation.ArgumentList, terms, ref rightFlags);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9686);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9686, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "invocation", "invocation.ArgumentList", "terms", "rightFlags", "CollectArgumentTerms", "invocation.Expression", "leftFlags", "CollectExpressionTerms" }, terms);
         }
@@ -1226,7 +1226,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((leftFlags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9781);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9781, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm", "position", "invocation", "invocation.ArgumentList", "terms", "rightFlags", "CollectArgumentTerms" }, terms);
         }
@@ -1240,7 +1240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9866);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9866, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1254,7 +1254,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(invocation.Expression));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 9885);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 9885, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "terms", "invocation", "invocation.Expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1268,7 +1268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = (leftFlags & rightFlags) & ExpressionType.ValidExpression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10018);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10018, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType", "ExpressionType.ValidTerm", "terms", "invocation", "invocation.Expression", "ConvertToString" }, terms);
         }
@@ -1282,7 +1282,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10278);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10278, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1296,7 +1296,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10293);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10293, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -1310,7 +1310,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var flags = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10347);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10347, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expressionType", "flags" }, terms);
         }
@@ -1324,7 +1324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var prefixUnaryExpression = (PrefixUnaryExpressionSyntax)expression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10396);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10396, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(PrefixUnaryExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "prefixUnaryExpression" }, terms);
         }
@@ -1338,7 +1338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, prefixUnaryExpression.Operand, terms, ref flags);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10528);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10528, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PrefixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -1352,7 +1352,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10674);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10674, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -1366,7 +1366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10755);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10755, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1380,7 +1380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(prefixUnaryExpression.Operand));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10774);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10774, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "terms", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1394,7 +1394,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if (expression.MatchesKind(SyntaxKind.LogicalNotExpression, SyntaxKind.BitwiseNotExpression, SyntaxKind.NegateExpression, SyntaxKind.PlusExpression))
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 10863);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 10863, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression", "ExpressionType", "ExpressionType.ValidTerm", "terms", "prefixUnaryExpression", "prefixUnaryExpression.Operand", "ConvertToString" }, terms);
         }
@@ -1408,7 +1408,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11026);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11026, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression" }, terms);
         }
@@ -1422,7 +1422,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 expressionType = flags & ExpressionType.ValidExpression;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11117);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11117, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType", "expression", "SyntaxKind", "SyntaxKind.LogicalNotExpression", "SyntaxKind.BitwiseNotExpression", "SyntaxKind.NegateExpression", "SyntaxKind.PlusExpression" }, terms);
         }
@@ -1436,7 +1436,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11374);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11374, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1450,7 +1450,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11539);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11539, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "position", "expression", "terms" }, terms);
         }
@@ -1464,7 +1464,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var flags = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11595);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11595, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "expressionType", "flags" }, terms);
         }
@@ -1478,7 +1478,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var postfixUnaryExpression = (PostfixUnaryExpressionSyntax)expression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11644);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11644, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(PostfixUnaryExpressionSyntax)expression", "flags", "ExpressionType", "ExpressionType.Invalid", "postfixUnaryExpression" }, terms);
         }
@@ -1492,7 +1492,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, postfixUnaryExpression.Operand, terms, ref flags);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11778);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11778, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms", "expression", "(PostfixUnaryExpressionSyntax)expression" }, terms);
         }
@@ -1506,7 +1506,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 11925);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 11925, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -1520,7 +1520,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12006);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12006, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1534,7 +1534,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(postfixUnaryExpression.Operand));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12025);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12025, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "terms", "postfixUnaryExpression", "postfixUnaryExpression.Operand", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1548,7 +1548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12279);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12279, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1562,7 +1562,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             ExpressionType leftFlags = ExpressionType.Invalid, rightFlags = ExpressionType.Invalid;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12294);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12294, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "leftFlags", "rightFlags", "position", "expression", "terms", "expressionType" }, terms);
         }
@@ -1576,7 +1576,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var binaryExpression = (BinaryExpressionSyntax)expression;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12397);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12397, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "expression", "(BinaryExpressionSyntax)expression", "leftFlags", "ExpressionType", "ExpressionType.Invalid", "rightFlags", "binaryExpression" }, terms);
         }
@@ -1590,7 +1590,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, binaryExpression.Left, terms, ref leftFlags);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12469);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12469, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "binaryExpression", "binaryExpression.Left", "terms", "leftFlags", "CollectExpressionTerms", "expression", "(BinaryExpressionSyntax)expression" }, terms);
         }
@@ -1604,7 +1604,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             CollectExpressionTerms(position, binaryExpression.Right, terms, ref rightFlags);
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12561);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12561, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "binaryExpression", "binaryExpression.Right", "terms", "rightFlags", "CollectExpressionTerms", "binaryExpression.Left", "leftFlags" }, terms);
         }
@@ -1618,7 +1618,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((leftFlags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12657);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12657, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm", "position", "binaryExpression", "binaryExpression.Right", "terms", "rightFlags", "CollectExpressionTerms" }, terms);
         }
@@ -1632,7 +1632,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12742);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12742, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "leftFlags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1646,7 +1646,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(binaryExpression.Left));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12761);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12761, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "terms", "binaryExpression", "binaryExpression.Left", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1660,7 +1660,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             if ((rightFlags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12842);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12842, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression", "binaryExpression.Left", "ConvertToString" }, terms);
         }
@@ -1674,7 +1674,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12928);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12928, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1688,7 +1688,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 terms.Add(ConvertToString(binaryExpression.Right));
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 12947);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 12947, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "terms", "rightFlags", "binaryExpression", "binaryExpression.Right", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1702,7 +1702,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             switch (binaryExpression.Kind)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 13202);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 13202, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "rightFlags", "binaryExpression", "binaryExpression.Kind", "ExpressionType", "ExpressionType.ValidTerm", "terms", "binaryExpression.Right", "ConvertToString" }, terms);
         }
@@ -1716,7 +1716,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = (leftFlags & rightFlags) & ExpressionType.ValidExpression;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14452);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14452, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType", "binaryExpression", "binaryExpression.Kind" }, terms);
         }
@@ -1730,7 +1730,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14549);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14549, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "leftFlags", "rightFlags", "ExpressionType", "ExpressionType.ValidExpression", "expressionType" }, terms);
         }
@@ -1744,7 +1744,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     expressionType = ExpressionType.Invalid;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14606);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14606, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid", "binaryExpression", "binaryExpression.Kind" }, terms);
         }
@@ -1758,7 +1758,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     return;
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14668);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14668, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "expressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -1772,7 +1772,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14866);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14866, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "argumentList", "terms", "expressionType" }, terms);
         }
@@ -1786,7 +1786,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             var validExpr = true;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 14881);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 14881, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "validExpr", "position", "argumentList", "terms", "expressionType" }, terms);
         }
@@ -1800,7 +1800,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             foreach (var arg in argumentList.Arguments)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15078);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15078, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arg", "argumentList", "argumentList.Arguments", "validExpr" }, terms);
         }
@@ -1814,7 +1814,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15135);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15135, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "arg", "argumentList", "argumentList.Arguments" }, terms);
         }
@@ -1828,7 +1828,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 var flags = ExpressionType.Invalid;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15154);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15154, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.Invalid", "arg", "argumentList", "argumentList.Arguments", "flags" }, terms);
         }
@@ -1842,7 +1842,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 CollectExpressionTerms(position, arg.Expression, terms, ref flags);
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15209);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15209, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "arg", "arg.Expression", "terms", "flags", "CollectExpressionTerms", "ExpressionType", "ExpressionType.Invalid" }, terms);
         }
@@ -1856,7 +1856,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 if ((flags & ExpressionType.ValidTerm) == ExpressionType.ValidTerm)
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15294);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15294, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "ExpressionType.ValidTerm", "position", "arg", "arg.Expression", "terms", "flags", "CollectExpressionTerms" }, terms);
         }
@@ -1870,7 +1870,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 {
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15379);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15379, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1884,7 +1884,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     terms.Add(ConvertToString(arg.Expression));
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15402);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15402, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "terms", "arg", "arg.Expression", "ConvertToString", "ExpressionType", "ExpressionType.ValidTerm" }, terms);
         }
@@ -1898,7 +1898,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 validExpr &= (flags & ExpressionType.ValidExpression) == ExpressionType.ValidExpression;
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15484);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15484, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "ExpressionType", "flags", "ExpressionType.ValidExpression", "validExpr", "ExpressionType.ValidTerm", "terms", "arg", "arg.Expression", "ConvertToString" }, terms);
         }
@@ -1912,7 +1912,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             expressionType = validExpr ? ExpressionType.ValidExpression : 0;
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15722);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15722, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "flags", "ExpressionType", "validExpr", "ExpressionType.ValidExpression", "expressionType", "arg", "argumentList", "argumentList.Arguments" }, terms);
         }
@@ -1926,7 +1926,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////         {
             ////         ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15952);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15952, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "declarators", "terms" }, terms);
         }
@@ -1940,7 +1940,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             foreach (var declarator in declarators)
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 15967);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 15967, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarators", "position", "terms" }, terms);
         }
@@ -1954,7 +1954,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////             {
             ////             ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16020);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16020, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarators" }, terms);
         }
@@ -1968,7 +1968,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 if (declarator.InitializerOpt != null)
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16039);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16039, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarator.InitializerOpt", "declarators" }, terms);
         }
@@ -1982,7 +1982,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                 {
             ////                 ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16095);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16095, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "declarator", "declarator.InitializerOpt" }, terms);
         }
@@ -1996,7 +1996,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Debugging
             ////                     CollectExpressionTerms(position, declarator.Initializer.Value, terms);
             ////                     ^
             var tree = GetTree();
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 16118);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 16118, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.SetEqual(new[] { "position", "declarator.InitializerOpt", "declarator.InitializerOpt.Value", "terms", "CollectExpressionTerms", "declarator" }, terms);
         }

--- a/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Debugging/ProximityExpressionsGetterTests.cs
@@ -62,7 +62,7 @@ namespace ConsoleApplication1
         }
     }
 }");
-            var terms = CSharpProximityExpressionsService.TestAccessor.Do(tree, 245);
+            var terms = CSharpProximityExpressionsService.GetProximityExpressions(tree, 245, cancellationToken: default);
             Assert.NotNull(terms);
             AssertEx.Equal(new[] { "yy", "xx" }, terms);
         }

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
@@ -100,6 +100,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             }
         }
 
+        public static IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int position) => Do(syntaxTree, position, cancellationToken: default);
+
         private static IList<string> Do(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
             => new Worker(syntaxTree, position).Do(cancellationToken);
 

--- a/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
+++ b/src/Features/CSharp/Portable/Debugging/CSharpProximityExpressionsService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             try
             {
                 var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                return Do(tree, position, cancellationToken);
+                return GetProximityExpressions(tree, position, cancellationToken);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
@@ -100,8 +100,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             }
         }
 
-        public static IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int position) => Do(syntaxTree, position, cancellationToken: default);
+        public static IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
+            => new Worker(syntaxTree, position).Do(cancellationToken);
 
+        [Obsolete($"Use {nameof(GetProximityExpressions)}.")]
         private static IList<string> Do(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
             => new Worker(syntaxTree, position).Do(cancellationToken);
 
@@ -111,12 +113,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Debugging
             bool includeDeclarations)
         {
             new RelevantExpressionsCollector(includeDeclarations, expressions).Visit(statement);
-        }
-
-        internal static class TestAccessor
-        {
-            public static IList<string> Do(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken = default)
-                => CSharpProximityExpressionsService.Do(syntaxTree, position, cancellationToken);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
+++ b/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
@@ -26,6 +26,9 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures.Wpf" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Workspaces" />
+    <!-- BEGIN External Access -->
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" />
+    <!-- END External Access -->
     <!-- BEGIN MONODEVELOP
     These MonoDevelop dependencies don't ship with Visual Studio, so can't break our
     binary insertions and are exempted from the ExternalAccess adapter assembly policies.

--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
+    <ProjectReference Include="..\..\..\Features\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Remote\Core\Microsoft.CodeAnalysis.Remote.Workspaces.csproj" />
   </ItemGroup>

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpBreakpointResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpBreakpointResolver.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal class RazorCSharpBreakpointResolver
+    {
+        public bool TryGetBreakpointSpan(SyntaxTree tree, int position, CancellationToken cancellationToken, out TextSpan breakpointSpan)
+            => BreakpointSpans.TryGetBreakpointSpan(tree, position, cancellationToken, out breakpointSpan);
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpBreakpointResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpBreakpointResolver.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    internal class RazorCSharpBreakpointResolver
+    internal static class RazorBreakpointSpans
     {
         public static bool TryGetBreakpointSpan(SyntaxTree tree, int position, CancellationToken cancellationToken, out TextSpan breakpointSpan)
             => BreakpointSpans.TryGetBreakpointSpan(tree, position, cancellationToken, out breakpointSpan);

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpBreakpointResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpBreakpointResolver.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     internal class RazorCSharpBreakpointResolver
     {
-        public bool TryGetBreakpointSpan(SyntaxTree tree, int position, CancellationToken cancellationToken, out TextSpan breakpointSpan)
+        public static bool TryGetBreakpointSpan(SyntaxTree tree, int position, CancellationToken cancellationToken, out TextSpan breakpointSpan)
             => BreakpointSpans.TryGetBreakpointSpan(tree, position, cancellationToken, out breakpointSpan);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Debugging;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal class RazorCSharpProximityExpressionResolver
+    {
+        public IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex)
+            => CSharpProximityExpressionsService.Do(syntaxTree, absoluteIndex);
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Debugging;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    internal class RazorCSharpProximityExpressionResolver
+    internal static class RazorCSharpProximityExpressionResolverService
     {
         public IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex)
             => CSharpProximityExpressionsService.Do(syntaxTree, absoluteIndex);

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     internal static class RazorCSharpProximityExpressionResolverService
     {
-        public IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex)
-            => CSharpProximityExpressionsService.Do(syntaxTree, absoluteIndex);
+        public static IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex)
+            => CSharpProximityExpressionsService.GetProximityExpressions(syntaxTree, absoluteIndex);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpProximityExpressionResolver.cs
@@ -5,13 +5,14 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Debugging;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     internal static class RazorCSharpProximityExpressionResolverService
     {
-        public static IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex)
-            => CSharpProximityExpressionsService.GetProximityExpressions(syntaxTree, absoluteIndex);
+        public static IList<string> GetProximityExpressions(SyntaxTree syntaxTree, int absoluteIndex, CancellationToken cancellationToken)
+            => CSharpProximityExpressionsService.GetProximityExpressions(syntaxTree, absoluteIndex, cancellationToken);
     }
 }


### PR DESCRIPTION
- Had to add add a project reference to the corresponding editor APIs in Microsoft.CodeAnalysis.CSharp.Features.csproj.
- Prefixed our ExternalAccess API's with "Razor" to not conflict in symbol recognition when working in the Roslyn solution.
- Added a non-test method to the `CSharpProximityExpressionService` (which is already internal) to expose a more first class way in getting proximity expressiosn from a syntax tree (doesn't need to be async). This API still isn't accessible on the `IProximityExpressionService` since Razor doesn't want to actually be in the business of resolving full on services and in this case doesn't actually need to.

Fixes dotnet/aspnetcore#29547