### PR TITLE
VB: Make behavior of FindImplementationForInterfaceMember API on an interface consistent across source and metadata

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -2711,5 +2711,53 @@ $@"public class A<T> : I
             var implementingMember = derivedType.FindImplementationForInterfaceMember(interfaceMember);
             Assert.Equal(expectedImplementingMember, implementingMember.ToTestDisplayString());
         }
+
+        [Fact]
+        [WorkItem(50713, "https://github.com/dotnet/roslyn/issues/50713")]
+        public void Issue50713_1()
+        {
+            var text1 = @"
+public interface I1
+{
+    void M();
+}
+
+public interface I2 : I1
+{
+    new void M();
+}
+";
+
+            var comp1 = CreateCompilation(text1);
+            comp1.VerifyDiagnostics();
+
+            var i1M = comp1.GetMember("I1.M");
+            var i2 = comp1.GetMember<NamedTypeSymbol>("I2");
+            Assert.Null(i2.FindImplementationForInterfaceMember(i1M));
+        }
+
+        [Fact]
+        [WorkItem(50713, "https://github.com/dotnet/roslyn/issues/50713")]
+        public void Issue50713_2()
+        {
+            var text0 = @"
+public interface I1
+{
+    void M();
+}
+
+public interface I2 : I1
+{
+    new void M();
+}
+";
+            var comp0 = CreateCompilation(text0);
+
+            var comp1 = CreateCompilation("", references: new[] { comp0.EmitToImageReference() });
+
+            var i1M = comp1.GetMember("I1.M");
+            var i2 = comp1.GetMember<NamedTypeSymbol>("I2");
+            Assert.Null(i2.FindImplementationForInterfaceMember(i1M));
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -643,7 +643,8 @@ Done:
                 Throw New ArgumentNullException(NameOf(interfaceMember))
             End If
 
-            If Not interfaceMember.ContainingType.IsInterfaceType() OrElse
+            If Not interfaceMember.RequiresImplementation() OrElse
+               Me.IsInterfaceType() OrElse ' In VB interfaces do not implement anything
                Not Me.ImplementsInterface(interfaceMember.ContainingType, comparer:=EqualsIgnoringComparer.InstanceCLRSignatureCompare, useSiteDiagnostics:=Nothing) Then
                 Return Nothing
             End If

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -68,6 +68,10 @@ BC30149: Class 'C' must implement 'Sub M1()' for interface 'I1'.
                ~~
 </errors>
             )
+
+            Dim i1M1 = comp1.GetMember(Of MethodSymbol)("I1.M1")
+            Assert.Empty(i1M1.ExplicitInterfaceImplementations)
+            Assert.Null(i1M1.ContainingType.FindImplementationForInterfaceMember(i1M1))
         End Sub
 
         <Fact>
@@ -142,6 +146,12 @@ BC30149: Class 'C' must implement 'Sub M1()' for interface 'I1'.
                ~~
 </errors>
             )
+
+            Dim i1M1 = comp1.GetMember(Of MethodSymbol)("I1.M1")
+            Dim i2 = comp1.GetMember(Of NamedTypeSymbol)("I2")
+            Dim i2i1M1 = i2.GetMembers().OfType(Of MethodSymbol)().Single()
+            Assert.Same(i1M1, i2i1M1.ExplicitInterfaceImplementations.Single())
+            Assert.Null(i2.FindImplementationForInterfaceMember(i1M1))
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/InterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/InterfaceImplementationTests.vb
@@ -107,6 +107,126 @@ End Class"
             Assert.Equal(expectedImplementingMember, implementingMember.ToTestDisplayString())
         End Sub
 
+        <Fact()>
+        <WorkItem(50713, "https://github.com/dotnet/roslyn/issues/50713")>
+        Public Sub Issue50713_1()
+            Dim vbSource1 =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+Interface I1
+    Sub M()
+End Interface
+
+Interface I2
+    Inherits I1
+    Overloads Sub M()
+End Interface
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation1 = CreateCompilation(vbSource1, options:=TestOptions.ReleaseDll)
+            compilation1.AssertNoDiagnostics()
+
+            Dim i1M = compilation1.GetMember("I1.M")
+            Dim i2 = compilation1.GetMember(Of NamedTypeSymbol)("I2")
+            Assert.Null(i2.FindImplementationForInterfaceMember(i1M))
+        End Sub
+
+        <Fact()>
+        <WorkItem(50713, "https://github.com/dotnet/roslyn/issues/50713")>
+        Public Sub Issue50713_2()
+            Dim vbSource0 =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+Interface I1
+    Sub M()
+End Interface
+
+Interface I2
+    Inherits I1
+    Overloads Sub M()
+End Interface
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation0 = CreateCompilation(vbSource0, options:=TestOptions.ReleaseDll)
+
+            Dim vbSource1 =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation1 = CreateCompilation(vbSource1, options:=TestOptions.ReleaseDll, references:={compilation0.EmitToImageReference()})
+
+            Dim i1M = compilation1.GetMember("I1.M")
+            Dim i2 = compilation1.GetMember(Of NamedTypeSymbol)("I2")
+            Assert.Null(i2.FindImplementationForInterfaceMember(i1M))
+        End Sub
+
+        <Fact()>
+        <WorkItem(50713, "https://github.com/dotnet/roslyn/issues/50713")>
+        Public Sub Issue50713_3()
+            Dim vbSource1 =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+Interface I1
+    Sub M()
+End Interface
+
+Interface I2
+    Inherits I1
+    Shadows Sub M()
+End Interface
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation1 = CreateCompilation(vbSource1, options:=TestOptions.ReleaseDll)
+            compilation1.AssertNoDiagnostics()
+
+            Dim i1M = compilation1.GetMember("I1.M")
+            Dim i2 = compilation1.GetMember(Of NamedTypeSymbol)("I2")
+            Assert.Null(i2.FindImplementationForInterfaceMember(i1M))
+        End Sub
+
+        <Fact()>
+        <WorkItem(50713, "https://github.com/dotnet/roslyn/issues/50713")>
+        Public Sub Issue50713_4()
+            Dim vbSource0 =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+Interface I1
+    Sub M()
+End Interface
+
+Interface I2
+    Inherits I1
+    Shadows Sub M()
+End Interface
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation0 = CreateCompilation(vbSource0, options:=TestOptions.ReleaseDll)
+
+            Dim vbSource1 =
+                <compilation>
+                    <file name="c.vb"><![CDATA[
+]]>
+                    </file>
+                </compilation>
+
+            Dim compilation1 = CreateCompilation(vbSource1, options:=TestOptions.ReleaseDll, references:={compilation0.EmitToImageReference()})
+
+            Dim i1M = compilation1.GetMember("I1.M")
+            Dim i2 = compilation1.GetMember(Of NamedTypeSymbol)("I2")
+            Assert.Null(i2.FindImplementationForInterfaceMember(i1M))
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #50713.