### PR TITLE
Add IXamlLanguageServerFeedbackService interface

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLanguageServerProtocol.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLanguageServerProtocol.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public XamlLanguageServerProtocol(
-            [ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, 
+            [ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers,
             XamlProjectService projectService,
             [Import(AllowDefault = true)] IXamlLanguageServerFeedbackService? feedbackService)
             : base(requestHandlers, languageName: StringConstants.XamlLanguageName)
@@ -55,8 +55,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
                 {
                     return await base.ExecuteRequestAsync(queue, request, clientCapabilities, clientName, methodName, mutatesSolutionState, handler, cancellationToken).ConfigureAwait(false);
                 }
-                catch(Exception e) when (e is not OperationCanceledException)
+                catch (Exception e) when (e is not OperationCanceledException)
                 {
+                    // Inform Xaml language service that the RequestScope failed.
+                    // This doesn't send the exception to Telemetry or Watson
                     requestScope?.RecordFailure(e);
                     throw;
                 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLanguageServerProtocol.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlLanguageServerProtocol.cs
@@ -7,11 +7,13 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServices.Xaml.Telemetry;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
 {
@@ -23,25 +25,42 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
     internal sealed class XamlLanguageServerProtocol : AbstractRequestHandlerProvider
     {
         private readonly XamlProjectService _projectService;
+        private readonly IXamlLanguageServerFeedbackService? _feedbackService;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public XamlLanguageServerProtocol([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, XamlProjectService projectService)
+        public XamlLanguageServerProtocol(
+            [ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, 
+            XamlProjectService projectService,
+            [Import(AllowDefault = true)] IXamlLanguageServerFeedbackService? feedbackService)
             : base(requestHandlers, languageName: StringConstants.XamlLanguageName)
         {
             _projectService = projectService;
+            _feedbackService = feedbackService;
         }
 
-        protected override Task<ResponseType> ExecuteRequestAsync<RequestType, ResponseType>(RequestExecutionQueue queue, RequestType request, ClientCapabilities clientCapabilities, string? clientName, string methodName, bool mutatesSolutionState, IRequestHandler<RequestType, ResponseType> handler, CancellationToken cancellationToken)
+        protected override async Task<ResponseType> ExecuteRequestAsync<RequestType, ResponseType>(RequestExecutionQueue queue, RequestType request, ClientCapabilities clientCapabilities, string? clientName, string methodName, bool mutatesSolutionState, IRequestHandler<RequestType, ResponseType> handler, CancellationToken cancellationToken)
         {
             var textDocument = handler.GetTextDocumentIdentifier(request);
 
+            DocumentId? documentId = null;
             if (textDocument is { Uri: { IsAbsoluteUri: true } documentUri })
             {
-                _projectService.TrackOpenDocument(documentUri.LocalPath);
+                documentId = _projectService.TrackOpenDocument(documentUri.LocalPath);
             }
 
-            return base.ExecuteRequestAsync(queue, request, clientCapabilities, clientName, methodName, mutatesSolutionState, handler, cancellationToken);
+            using (var requestScope = _feedbackService?.CreateRequestScope(documentId, methodName))
+            {
+                try
+                {
+                    return await base.ExecuteRequestAsync(queue, request, clientCapabilities, clientName, methodName, mutatesSolutionState, handler, cancellationToken).ConfigureAwait(false);
+                }
+                catch(Exception e) when (e is not OperationCanceledException)
+                {
+                    requestScope?.RecordFailure(e);
+                    throw;
+                }
+            }
         }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
@@ -16,8 +16,10 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Xaml.Diagnostics.Analyzers;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServices.Xaml.Telemetry;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -60,30 +62,30 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
 
         public static IXamlDocumentAnalyzerService? AnalyzerService { get; private set; }
 
-        public void TrackOpenDocument(string filePath)
+        public DocumentId? TrackOpenDocument(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))
             {
                 // Can't track anything without a path (can happen while diffing)
-                return;
+                return null;
             }
 
             if (_threadingContext.JoinableTaskContext.IsOnMainThread)
             {
-                EnsureDocument(filePath);
+                return EnsureDocument(filePath);
             }
             else
             {
-                _threadingContext.JoinableTaskFactory.Run(async () =>
+                return _threadingContext.JoinableTaskFactory.Run(async () =>
                 {
                     await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    EnsureDocument(filePath);
+                    return EnsureDocument(filePath);
                 });
             }
         }
 
-        private void EnsureDocument(string filePath)
+        private DocumentId? EnsureDocument(string filePath)
         {
             if (_rdt == null)
             {
@@ -107,23 +109,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             catch (ArgumentException)
             {
                 // We only support open documents that are in the RDT already
+                return null;
             }
 
             if (hierarchy == null || docCookie == 0)
             {
-                return;
+                return null;
             }
 
             if (!_xamlProjects.TryGetValue(hierarchy, out var project))
             {
                 if (!hierarchy.TryGetName(out var name))
                 {
-                    return;
+                    return null;
                 }
 
                 if (!hierarchy.TryGetGuidProperty(__VSHPROPID.VSHPROPID_ProjectIDGuid, out var projectGuid))
                 {
-                    return;
+                    return null;
                 }
 
                 var projectInfo = new VisualStudioProjectCreationInfo
@@ -158,6 +161,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                     }
                 }
             }
+
+            if(_rdtDocumentIds.TryGetValue(docCookie, out DocumentId docId))
+            {
+                return docId;
+            }
+
+            return null;
         }
 
         private void OnProjectClosing(IVsHierarchy hierarchy)

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 }
             }
 
-            if(_rdtDocumentIds.TryGetValue(docCookie, out DocumentId docId))
+            if (_rdtDocumentIds.TryGetValue(docCookie, out var docId))
             {
                 return docId;
             }

--- a/src/VisualStudio/Xaml/Impl/Telemetry/IRequestScope.cs
+++ b/src/VisualStudio/Xaml/Impl/Telemetry/IRequestScope.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.Telemetry
+{
+    internal interface IRequestScope : IDisposable
+    {
+        /// <summary>
+        /// Record if any failure happens inside a RequestScope
+        /// </summary>
+        void RecordFailure(Exception? exception = null);
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Telemetry/IRequestScope.cs
+++ b/src/VisualStudio/Xaml/Impl/Telemetry/IRequestScope.cs
@@ -9,7 +9,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Telemetry
     internal interface IRequestScope : IDisposable
     {
         /// <summary>
-        /// Record if any failure happens inside a RequestScope
+        /// Record if any failure happens inside a RequestScope.
+        /// Please note that this call doesn't report the exception to Telemetry or watson. This is only used to imform Xaml language service that 
+        /// the RequestScope has failed, which is used to aggregate data for failure/success rates.
         /// </summary>
         void RecordFailure(Exception? exception = null);
     }

--- a/src/VisualStudio/Xaml/Impl/Telemetry/IXamlLanguageServerFeedbackService.cs
+++ b/src/VisualStudio/Xaml/Impl/Telemetry/IXamlLanguageServerFeedbackService.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.Telemetry
+{
+    /// <summary>
+    /// Service that collects data for Telemetry in XamlLanguageServer
+    /// </summary>
+    internal interface IXamlLanguageServerFeedbackService
+    {
+        /// <summary>
+        /// Create a RequestScope of a request of given documentId
+        /// </summary>
+        IRequestScope CreateRequestScope(DocumentId? documentId, string methodName);
+    }
+}


### PR DESCRIPTION
This PR mainly adds IXamlLanguageServerFeedbackService and IRequestScope to XAML project, which will be used to collect data of LSP request handled by XamlLanguageServer. Implementation will leave in Xaml language service which will aggregate the data and send telemetry if need.

This PR also changed TrackOpenDocument to return a DocumentId which is needed by IXamlLanguageServerFeedbackService.