### PR TITLE
Only use conditional expression conversion when no common type

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -8431,7 +8431,7 @@ class C
         => s is null ? (ushort)1234 : ushort.Parse(s);
 }
 ",
-                LanguageVersion = LanguageVersion.CSharp8,
+                LanguageVersion = LanguageVersion.CSharp9,
             }.RunAsync();
         }
 
@@ -8444,14 +8444,14 @@ class C
                 TestCode = @"
 class C
 {
-    ushort Goo(string s)
-        => s is null ? [|(ushort)|]1234 : ushort.Parse(s);
+    uint Goo(string s)
+        => s is null ? [|(uint)|]1234 : uint.Parse(s);
 }",
                 FixedCode = @"
 class C
 {
-    ushort Goo(string s)
-        => s is null ? 1234 : ushort.Parse(s);
+    uint Goo(string s)
+        => s is null ? 1234 : uint.Parse(s);
 }",
                 LanguageVersion = LanguageVersion.CSharp9,
             }.RunAsync();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3960,7 +3960,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors = constantValue != null && constantValue.IsBad;
             }
 
-            return new BoundConditionalOperator(node, isRef: false, condition, trueExpr, falseExpr, constantValue, naturalTypeOpt: null, wasTargetTyped: false, type, hasErrors);
+            return new BoundConditionalOperator(node, isRef: false, condition, trueExpr, falseExpr, constantValue, naturalTypeOpt: type, wasTargetTyped: false, type, hasErrors);
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3917,23 +3917,53 @@ namespace Microsoft.CodeAnalysis.CSharp
             return isRef ? BindRefConditionalOperator(node, whenTrue, whenFalse, diagnostics) : BindValueConditionalOperator(node, whenTrue, whenFalse, diagnostics);
         }
 
+#nullable enable
         private BoundExpression BindValueConditionalOperator(ConditionalExpressionSyntax node, ExpressionSyntax whenTrue, ExpressionSyntax whenFalse, DiagnosticBag diagnostics)
         {
-            ErrorCode noCommonTypeError = 0;
-
             BoundExpression condition = BindBooleanExpression(node.Condition, diagnostics);
             BoundExpression trueExpr = BindValue(whenTrue, diagnostics, BindValueKind.RValue);
             BoundExpression falseExpr = BindValue(whenFalse, diagnostics, BindValueKind.RValue);
-            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            TypeSymbol type = BestTypeInferrer.InferBestTypeForConditionalOperator(trueExpr, falseExpr, this.Conversions, out bool hadMultipleCandidates, ref useSiteDiagnostics);
+            HashSet<DiagnosticInfo>? useSiteDiagnostics = null;
+            ConstantValue? constantValue = null;
+            TypeSymbol? bestType = BestTypeInferrer.InferBestTypeForConditionalOperator(trueExpr, falseExpr, this.Conversions, out bool hadMultipleCandidates, ref useSiteDiagnostics);
             diagnostics.Add(node, useSiteDiagnostics);
-            if (type is null)
-                noCommonTypeError = hadMultipleCandidates ? ErrorCode.ERR_AmbigQM : ErrorCode.ERR_InvalidQM;
 
-            var constantValue = FoldConditionalOperator(condition, trueExpr, falseExpr);
-            bool hasErrors = type?.IsErrorType() == true || constantValue?.IsBad == true;
-            return new BoundUnconvertedConditionalOperator(node, condition, trueExpr, falseExpr, constantValue, noCommonTypeError, type, hasErrors);
+            if (bestType is null)
+            {
+                ErrorCode noCommonTypeError = hadMultipleCandidates ? ErrorCode.ERR_AmbigQM : ErrorCode.ERR_InvalidQM;
+                constantValue = FoldConditionalOperator(condition, trueExpr, falseExpr);
+                return new BoundUnconvertedConditionalOperator(node, condition, trueExpr, falseExpr, constantValue, noCommonTypeError, type: null, hasErrors: constantValue?.IsBad == true);
+            }
+
+            TypeSymbol type;
+            bool hasErrors;
+            if (bestType.IsErrorType())
+            {
+                type = bestType;
+                hasErrors = true;
+            }
+            else
+            {
+                trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
+                falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
+
+                hasErrors = trueExpr.HasAnyErrors || falseExpr.HasAnyErrors;
+                // If one of the conversions went wrong (e.g. return type of method group being converted
+                // didn't match), then we don't want to use bestType because it's not accurate.
+                type = hasErrors ? CreateErrorType() : bestType;
+            }
+
+            if (!hasErrors)
+            {
+                constantValue = FoldConditionalOperator(condition, trueExpr, falseExpr);
+                hasErrors = constantValue != null && constantValue.IsBad;
+            }
+
+            trueExpr = BindToNaturalType(trueExpr, diagnostics, reportNoTargetType: false);
+            falseExpr = BindToNaturalType(falseExpr, diagnostics, reportNoTargetType: false);
+            return new BoundConditionalOperator(node, isRef: false, condition, trueExpr, falseExpr, constantValue, naturalTypeOpt: null, wasTargetTyped: false, type, hasErrors);
         }
+#nullable disable
 
         private BoundExpression BindRefConditionalOperator(ConditionalExpressionSyntax node, ExpressionSyntax whenTrue, ExpressionSyntax whenFalse, DiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3939,6 +3939,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors;
             if (bestType.IsErrorType())
             {
+                trueExpr = BindToNaturalType(trueExpr, diagnostics, reportNoTargetType: false);
+                falseExpr = BindToNaturalType(falseExpr, diagnostics, reportNoTargetType: false);
                 type = bestType;
                 hasErrors = true;
             }
@@ -3946,7 +3948,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
                 falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
-
                 hasErrors = trueExpr.HasAnyErrors || falseExpr.HasAnyErrors;
                 // If one of the conversions went wrong (e.g. return type of method group being converted
                 // didn't match), then we don't want to use bestType because it's not accurate.
@@ -3959,8 +3960,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors = constantValue != null && constantValue.IsBad;
             }
 
-            trueExpr = BindToNaturalType(trueExpr, diagnostics, reportNoTargetType: false);
-            falseExpr = BindToNaturalType(falseExpr, diagnostics, reportNoTargetType: false);
             return new BoundConditionalOperator(node, isRef: false, condition, trueExpr, falseExpr, constantValue, naturalTypeOpt: null, wasTargetTyped: false, type, hasErrors);
         }
 #nullable disable

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -50,10 +48,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// This method finds the best common type of a set of expressions as per section 7.5.2.14 of the specification.
         /// NOTE: If some or all of the expressions have error types, we return error type as the inference result.
         /// </remarks>
-        public static TypeSymbol InferBestType(
+        public static TypeSymbol? InferBestType(
             ImmutableArray<BoundExpression> exprs,
             ConversionsBase conversions,
-            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+            ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
         {
             // SPEC:    7.5.2.14 Finding the best common type of a set of expressions
             // SPEC:    In some cases, a common type needs to be inferred for a set of expressions. In particular, the element types of implicitly typed arrays and
@@ -70,9 +68,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             HashSet<TypeSymbol> candidateTypes = new HashSet<TypeSymbol>(comparer);
             foreach (BoundExpression expr in exprs)
             {
-                TypeSymbol type = expr.Type;
+                TypeSymbol? type = expr.Type;
 
-                if ((object)type != null)
+                if (type is { })
                 {
                     if (type.IsErrorType())
                     {
@@ -95,12 +93,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// This method implements best type inference for the conditional operator ?:.
         /// NOTE: If either expression is an error type, we return error type as the inference result.
         /// </remarks>
-        public static TypeSymbol InferBestTypeForConditionalOperator(
+        public static TypeSymbol? InferBestTypeForConditionalOperator(
             BoundExpression expr1,
             BoundExpression expr2,
             ConversionsBase conversions,
             out bool hadMultipleCandidates,
-            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+            ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
         {
             // SPEC:    The second and third operands, x and y, of the ?: operator control the type of the conditional expression. 
             // SPEC:    •	If x has type X and y has type Y then
@@ -115,9 +113,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             try
             {
                 var conversionsWithoutNullability = conversions.WithNullability(false);
-                TypeSymbol type1 = expr1.Type;
+                TypeSymbol? type1 = expr1.Type;
 
-                if ((object)type1 != null)
+                if (type1 is { })
                 {
                     if (type1.IsErrorType())
                     {
@@ -131,9 +129,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                TypeSymbol type2 = expr2.Type;
+                TypeSymbol? type2 = expr2.Type;
 
-                if ((object)type2 != null)
+                if (type2 is { })
                 {
                     if (type2.IsErrorType())
                     {
@@ -157,10 +155,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal static TypeSymbol GetBestType(
+        internal static TypeSymbol? GetBestType(
             ArrayBuilder<TypeSymbol> types,
             ConversionsBase conversions,
-            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+            ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
         {
             // This code assumes that the types in the list are unique. 
 
@@ -177,12 +175,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return types[0];
             }
 
-            TypeSymbol best = null;
+            TypeSymbol? best = null;
             int bestIndex = -1;
             for (int i = 0; i < types.Count; i++)
             {
                 TypeSymbol type = types[i];
-                if ((object)best == null)
+                if (best is null)
                 {
                     best = type;
                     bestIndex = i;
@@ -191,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var better = Better(best, type, conversions, ref useSiteDiagnostics);
 
-                    if ((object)better == null)
+                    if (better is null)
                     {
                         best = null;
                     }
@@ -203,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if ((object)best == null)
+            if (best is null)
             {
                 return null;
             }
@@ -213,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < bestIndex; i++)
             {
                 TypeSymbol type = types[i];
-                TypeSymbol better = Better(best, type, conversions, ref useSiteDiagnostics);
+                TypeSymbol? better = Better(best, type, conversions, ref useSiteDiagnostics);
                 if (!best.Equals(better, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
                 {
                     return null;
@@ -226,11 +224,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Returns the better type amongst the two, with some possible modifications (dynamic/object or tuple names).
         /// </summary>
-        private static TypeSymbol Better(
+        private static TypeSymbol? Better(
             TypeSymbol type1,
-            TypeSymbol type2,
+            TypeSymbol? type2,
             ConversionsBase conversions,
-            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+            ref HashSet<DiagnosticInfo>? useSiteDiagnostics)
         {
             // Anything is better than an error sym.
             if (type1.IsErrorType())
@@ -238,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return type2;
             }
 
-            if ((object)type2 == null || type2.IsErrorType())
+            if (type2 is null || type2.IsErrorType())
             {
                 return type1;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3472,10 +3472,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             HashSet<DiagnosticInfo>? useSiteDiagnostics = null;
             var placeholders = placeholdersBuilder.ToImmutableAndFree();
-            TypeSymbol bestType = BestTypeInferrer.InferBestType(placeholders, walker._conversions, ref useSiteDiagnostics);
+            TypeSymbol? bestType = BestTypeInferrer.InferBestType(placeholders, walker._conversions, ref useSiteDiagnostics);
 
             TypeWithAnnotations inferredType;
-            if ((object)bestType != null)
+            if (bestType is { })
             {
                 // Note: so long as we have a best type, we can proceed.
                 var bestTypeWithObliviousAnnotation = TypeWithAnnotations.Create(bestType);

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IDeclarationExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IDeclarationExpression.cs
@@ -57,7 +57,6 @@ Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
         Entering: {R1}
-
 .locals {R1}
 {
     Locals: [var i1] [var i2]
@@ -67,7 +66,6 @@ Block[B0] - Entry
         Statements (0)
         Jump if False (Regular) to Block[B3]
             IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
-
         Next (Regular) Block[B2]
     Block[B2] - Block
         Predecessors: [B1]
@@ -76,7 +74,6 @@ Block[B0] - Entry
               Value: 
                 IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: '')
                   Children(0)
-
         Next (Regular) Block[B4]
     Block[B3] - Block
         Predecessors: [B1]
@@ -85,7 +82,6 @@ Block[B0] - Entry
               Value: 
                 IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: '')
                   Children(0)
-
         Next (Regular) Block[B4]
     Block[B4] - Block
         Predecessors: [B2] [B3]
@@ -94,20 +90,14 @@ Block[B0] - Entry
               Expression: 
                 IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'M2(b ? out  ... out var i2)')
                   Children(3):
-                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'b ? ')
-                        Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                          (NoConversion)
-                        Operand: 
-                          IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: ?, IsInvalid, IsImplicit) (Syntax: 'b ? ')
+                      IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: ?, IsInvalid, IsImplicit) (Syntax: 'b ? ')
                       IDeclarationExpressionOperation (OperationKind.DeclarationExpression, Type: var) (Syntax: 'var i1')
                         ILocalReferenceOperation: i1 (IsDeclaration: True) (OperationKind.LocalReference, Type: var) (Syntax: 'i1')
                       IDeclarationExpressionOperation (OperationKind.DeclarationExpression, Type: var) (Syntax: 'var i2')
                         ILocalReferenceOperation: i2 (IsDeclaration: True) (OperationKind.LocalReference, Type: var) (Syntax: 'i2')
-
         Next (Regular) Block[B5]
             Leaving: {R1}
 }
-
 Block[B5] - Exit
     Predecessors: [B4]
     Statements (0)

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFixedStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFixedStatement.cs
@@ -645,7 +645,7 @@ Block[B0] - Entry
                   Left: 
                     ILocalReferenceOperation: p (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32*, IsInvalid, IsImplicit) (Syntax: 'p = b ? &i1 : &i2')
                   Right: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32*, IsInvalid, IsImplicit) (Syntax: 'b ? &i1 : &i2')
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: ?, IsInvalid, IsImplicit) (Syntax: 'b ? &i1 : &i2')
 
             Next (Regular) Block[B5]
                 Leaving: {R2}

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringExpression.cs
@@ -1360,7 +1360,7 @@ Block[B0] - Entry
                 IParameterReferenceOperation: c2 (OperationKind.ParameterReference, Type: System.String) (Syntax: 'c2')
 
         Jump if False (Regular) to Block[B3]
-            IParameterReferenceOperation: a (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'a')
+            IParameterReferenceOperation: a (OperationKind.ParameterReference, Type: System.Boolean, IsInvalid) (Syntax: 'a')
 
         Next (Regular) Block[B2]
     Block[B2] - Block
@@ -1411,12 +1411,9 @@ Block[B5] - Exit
     Statements (0)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // file.cs(8,24): error CS0029: Cannot implicitly convert type 'string' to 'int'
+                // file.cs(8,20): error CS0029: Cannot implicitly convert type 'string' to 'int'
                 //         p = $"{c2,(a ? b : c):D3}";
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "b").WithArguments("string", "int").WithLocation(8, 24),
-                // file.cs(8,28): error CS0029: Cannot implicitly convert type 'string' to 'int'
-                //         p = $"{c2,(a ? b : c):D3}";
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "c").WithArguments("string", "int").WithLocation(8, 28)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "a ? b : c").WithArguments("string", "int").WithLocation(8, 20)
             };
 
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2360,8 +2360,7 @@ b --> False
             // Duplicate "(byte)2" is because there's an implicit conversion to uint.
             // Duplicate "b ? (uint)1 : (byte)2" is because there's an implicit conversion to int.
             var expected =
-@"true ? 1 + i : (int)4u --> BAD
-1 + i --> BAD
+@"1 + i --> BAD
 i --> BAD
 (int)4u --> 4
 b ? (uint)1 : (byte)2 --> BAD

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -1512,9 +1512,9 @@ class C
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (6,9): error CS0127: Since 'C.M1()' returns void, a return keyword must not be followed by an object expression
+                // (6,23): error CS0029: Cannot implicitly convert type '<throw expression>' to 'void'
                 //         return true ? throw null : M2();
-                Diagnostic(ErrorCode.ERR_RetNoObjectRequired, "return").WithArguments("C.M1()").WithLocation(6, 9));
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "throw null").WithArguments("<throw expression>", "void").WithLocation(6, 23));
         }
 
         [Fact, WorkItem(40405, "https://github.com/dotnet/roslyn/issues/40405")]
@@ -1532,9 +1532,9 @@ class C
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (6,42): error CS0029: Cannot implicitly convert type 'void' to 'object'
+                // (6,29): error CS0029: Cannot implicitly convert type '<throw expression>' to 'void'
                 //         object obj = true ? throw null : M2();
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "M2()").WithArguments("void", "object").WithLocation(6, 42));
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "throw null").WithArguments("<throw expression>", "void").WithLocation(6, 29));
         }
 
         [Fact, WorkItem(40405, "https://github.com/dotnet/roslyn/issues/40405")]
@@ -1573,12 +1573,9 @@ class C
 }
 ";
             CreateCompilation(text).VerifyDiagnostics(
-                // (6,29): error CS0029: Cannot implicitly convert type 'void' to 'object'
+                // (6,22): error CS0029: Cannot implicitly convert type 'void' to 'object'
                 //         object obj = true ? M2() : M2();
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "M2()").WithArguments("void", "object").WithLocation(6, 29),
-                // (6,36): error CS0029: Cannot implicitly convert type 'void' to 'object'
-                //         object obj = true ? M2() : M2();
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "M2()").WithArguments("void", "object").WithLocation(6, 36));
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "true ? M2() : M2()").WithArguments("void", "object").WithLocation(6, 22));
         }
 
         [Fact, WorkItem(40405, "https://github.com/dotnet/roslyn/issues/40405")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedConditionalOperatorTests.cs
@@ -648,5 +648,47 @@ class Program
                 //         return (b ? a : 0) + a;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "(b ? a : 0) + a").WithArguments("A", "B").WithLocation(15, 16));
         }
+
+        [Fact]
+        public void NaturalType_01()
+        {
+            var source =
+@"class Program
+{
+    static void F(bool b, object x, string y)
+    {
+        _ = b ? x : y;
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var expr = tree.GetRoot().DescendantNodes().OfType<ConditionalExpressionSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(expr);
+            Assert.Equal("System.Object", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Object", typeInfo.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void NaturalType_02()
+        {
+            var source =
+@"class Program
+{
+    static void F(bool b, int x)
+    {
+        int? y = b ? x : null;
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var expr = tree.GetRoot().DescendantNodes().OfType<ConditionalExpressionSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(expr);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal("System.Int32?", typeInfo.ConvertedType.ToTestDisplayString());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedConditionalOperatorTests.cs
@@ -24,7 +24,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // they are error cases but included here for convenience.
 
             // Implicit constant expression conversions
-            TestConditional("b ? 1 : 2", "System.Int16", "System.Int32");
+            TestConditional("b ? 1 : 2", "System.Int16", "System.Int32",
+                // (6,26): error CS0266: Cannot implicitly convert type 'int' to 'short'. An explicit conversion exists (are you missing a cast?)
+                //         System.Int16 t = b ? 1 : 2;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "b ? 1 : 2").WithArguments("int", "short").WithLocation(6, 26));
             TestConditional("b ? -1L : 1UL", "System.Double", null);
 
             // Implicit reference conversions
@@ -38,10 +41,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestConditional("b ? GetUInt() : GetInt()", "System.Int64", null);
 
             // Implicit enumeration conversions
-            TestConditional("b ? 0 : 0", "color", "System.Int32");
+            TestConditional("b ? 0 : 0", "color", "System.Int32",
+                // (6,19): error CS0266: Cannot implicitly convert type 'int' to 'color'. An explicit conversion exists (are you missing a cast?)
+                //         color t = b ? 0 : 0;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "b ? 0 : 0").WithArguments("int", "color").WithLocation(6, 19));
 
             // Implicit interpolated string conversions
-            TestConditional(@"b ? $""x"" : $""x""", "System.FormattableString", "System.String");
+            TestConditional(@"b ? $""x"" : $""x""", "System.FormattableString", "System.String",
+                // (6,38): error CS0029: Cannot implicitly convert type 'string' to 'System.FormattableString'
+                //         System.FormattableString t = b ? $"x" : $"x";
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"b ? $""x"" : $""x""").WithArguments("string", "System.FormattableString").WithLocation(6, 38));
 
             // Implicit nullable conversions
             // Null literal conversions
@@ -69,9 +78,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             // Implicit constant expression conversions
             TestConditional("b ? 1000000 : 2", "System.Int16", "System.Int32",
-                // (6,30): error CS0029: Cannot implicitly convert type 'int' to 'short'
+                // (6,26): error CS0266: Cannot implicitly convert type 'int' to 'short'. An explicit conversion exists (are you missing a cast?)
                 //         System.Int16 t = b ? 1000000 : 2;
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "1000000").WithArguments("int", "short").WithLocation(6, 30)
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "b ? 1000000 : 2").WithArguments("int", "short").WithLocation(6, 26)
                 );
 
             // Implicit reference conversions
@@ -93,24 +102,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             // Implicit enumeration conversions
             TestConditional("b ? 1 : 0", "color", "System.Int32",
-                // (6,23): error CS0029: Cannot implicitly convert type 'int' to 'color'
+                // (6,19): error CS0266: Cannot implicitly convert type 'int' to 'color'. An explicit conversion exists (are you missing a cast?)
                 //         color t = b ? 1 : 0;
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "1").WithArguments("int", "color").WithLocation(6, 23)
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "b ? 1 : 0").WithArguments("int", "color").WithLocation(6, 19)
                 );
 
             // Implicit interpolated string conversions
             TestConditional(@"b ? $""x"" : ""x""", "System.FormattableString", "System.String",
-                // (6,49): error CS0029: Cannot implicitly convert type 'string' to 'System.FormattableString'
+                // (6,38): error CS0029: Cannot implicitly convert type 'string' to 'System.FormattableString'
                 //         System.FormattableString t = b ? $"x" : "x";
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""x""").WithArguments("string", "System.FormattableString").WithLocation(6, 49)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"b ? $""x"" : ""x""").WithArguments("string", "System.FormattableString").WithLocation(6, 38)
                 );
 
             // Implicit nullable conversions
             // Null literal conversions
             TestConditional(@"b ? """" : null", "System.Int64?", "System.String",
-                // (6,31): error CS0029: Cannot implicitly convert type 'string' to 'long?'
+                // (6,27): error CS0029: Cannot implicitly convert type 'string' to 'long?'
                 //         System.Int64? t = b ? "" : null;
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""""").WithArguments("string", "long?").WithLocation(6, 31)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"b ? """" : null").WithArguments("string", "long?").WithLocation(6, 27)
                 );
             TestConditional(@"b ? 1 : """"", "System.Int64?", null,
                 // (6,35): error CS0029: Cannot implicitly convert type 'string' to 'long?'
@@ -154,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void NonbreakingChange()
+        public void NonBreakingChange_01()
         {
             var source = @"
 class C
@@ -179,11 +188,8 @@ class C
         }
 
         [Fact]
-        public void BreakingChange_02()
+        public void NonBreakingChange_02()
         {
-            // Prior to C# 9.0, this program compiles without error, as only the overload M(long, long)
-            // is a candidate. With the semantic changes in C# 9.0, both are candidates, but neither is
-            // more specific.
             var source = @"
 class C
 {
@@ -201,16 +207,12 @@ class C
                 var comp = CreateCompilation(
                     source, options: TestOptions.ReleaseExe,
                     parseOptions: TestOptions.Regular.WithLanguageVersion(langVersion))
-                    .VerifyDiagnostics(
-                        // (9,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(short, short)' and 'C.M(long, long)'
-                        //         M(b ? 1 : 2, 1);
-                        Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(short, short)", "C.M(long, long)").WithLocation(9, 9)
-                    );
+                    .VerifyDiagnostics();
             }
         }
 
         [Fact]
-        public void NonBreakingChange_01()
+        public void NonBreakingChange_03()
         {
             var source = @"
 class C
@@ -233,7 +235,7 @@ class C
         }
 
         [Fact]
-        public void NonBreakingChange_02()
+        public void NonBreakingChange_04()
         {
             var source = @"
 class Program
@@ -450,6 +452,140 @@ public class Program {
                 .VerifyEmitDiagnostics();
             CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(MessageID.IDS_FeatureTargetTypedConditional.RequiredVersion()), options: TestOptions.DebugDll)
                 .VerifyEmitDiagnostics();
+        }
+
+        [Theory]
+        [InlineData("sbyte", "System.Int32", "System.SByte")]
+        [InlineData("short", "System.Int32", "System.Int16")]
+        [InlineData("int", "System.Int32", "System.Int32")]
+        [InlineData("long", "System.Int64", "System.Int64")]
+        [InlineData("byte", "System.Int32", "System.Byte")]
+        [InlineData("ushort", "System.Int32", "System.UInt16")]
+        [WorkItem(49598, "https://github.com/dotnet/roslyn/issues/49598")]
+        public void IntType_01(string sourceType, string resultType1, string resultType2)
+        {
+            var source =
+$@"class Program
+{{
+    static void Main()
+    {{
+        {sourceType}? a = 1;
+        var b = true;
+        var c1 = a ?? (b ? 2 : 3);
+        var c2 = a ?? (true ? 2 : 3);
+        var c3 = a ?? (false ? 2 : 3);
+        Report(c1);
+        Report(c2);
+        Report(c3);
+    }}
+    static void Report(object obj)
+    {{
+        System.Console.WriteLine(""{{0}}: {{1}}"", obj.GetType().FullName, obj);
+    }}
+}}";
+            var expectedOutput =
+$@"{resultType1}: 1
+{resultType2}: 1
+{resultType2}: 1";
+            CompileAndVerify(source, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp3), expectedOutput: expectedOutput);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular.WithLanguageVersion(MessageID.IDS_FeatureTargetTypedConditional.RequiredVersion()), expectedOutput: expectedOutput);
+        }
+
+        [Theory]
+        [InlineData("uint")]
+        [InlineData("ulong")]
+        [WorkItem(49598, "https://github.com/dotnet/roslyn/issues/49598")]
+        public void IntType_02(string sourceType)
+        {
+            var source =
+$@"class Program
+{{
+    static void Main()
+    {{
+        {sourceType}? a = 1;
+        var b = true;
+        var c1 = a ?? (b ? 2 : 3);
+        var c2 = a ?? (true ? 2 : 3);
+        var c3 = a ?? (false ? 2 : 3);
+        Report(c1);
+        Report(c2);
+        Report(c3);
+    }}
+    static void Report(object obj)
+    {{
+        System.Console.WriteLine(""{{0}}: {{1}}"", obj.GetType().FullName, obj);
+    }}
+}}";
+            var expectedDiagnostics = new DiagnosticDescription[]
+            {
+                // (7,18): error CS0019: Operator '??' cannot be applied to operands of type 'uint?' and 'int'
+                //         var c1 = a ?? (b ? 2 : 3);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "a ?? (b ? 2 : 3)").WithArguments("??", $"{sourceType}?", "int").WithLocation(7, 18)
+            };
+            CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp3)).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(MessageID.IDS_FeatureTargetTypedConditional.RequiredVersion())).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        [WorkItem(49598, "https://github.com/dotnet/roslyn/issues/49598")]
+        public void IntType_03()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        char? a = 'A';
+        var b = true;
+        var c1 = a ?? (b ? 'B' : 'C');
+        var c2 = a ?? (true ? 'B' : 'C');
+        var c3 = a ?? (false ? 'B' : 'C');
+        Report(c1);
+        Report(c2);
+        Report(c3);
+    }
+    static void Report(object obj)
+    {
+        System.Console.WriteLine(""{0}: {1}"", obj.GetType().FullName, obj);
+    }
+}";
+            var expectedOutput =
+@"System.Char: A
+System.Char: A
+System.Char: A";
+            CompileAndVerify(source, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp3), expectedOutput: expectedOutput);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular.WithLanguageVersion(MessageID.IDS_FeatureTargetTypedConditional.RequiredVersion()), expectedOutput: expectedOutput);
+        }
+
+        [Fact]
+        [WorkItem(49598, "https://github.com/dotnet/roslyn/issues/49598")]
+        public void IntType_04()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        char? a = 'A';
+        var b = true;
+        var c1 = a ?? (b ? 0 : 0);
+        var c2 = a ?? (true ? 0 : 0);
+        var c3 = a ?? (false ? 0 : 0);
+        Report(c1);
+        Report(c2);
+        Report(c3);
+    }
+    static void Report(object obj)
+    {
+        System.Console.WriteLine(""{0}: {1}"", obj.GetType().FullName, obj);
+    }
+}";
+            var expectedOutput =
+@"System.Int32: 65
+System.Int32: 65
+System.Int32: 65";
+            CompileAndVerify(source, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp3), expectedOutput: expectedOutput);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular.WithLanguageVersion(MessageID.IDS_FeatureTargetTypedConditional.RequiredVersion()), expectedOutput: expectedOutput);
         }
     }
 }


### PR DESCRIPTION
Target-typed conditional expression conversion should only be used when there is no common type between the sub-expressions - see [conditional-expression-conversion](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-9.0/target-typed-conditional-expression.md#conditional-expression-conversion).

For example, in the following methods, `b ? 1 : 2` should be treated as an expression of type `int` rather than treated as target-typed because `1` and `2` have a common type. (The comments include the behavior in 16.8 compiling with `-langversion:8` and `-langversion:9` and the expected behavior for both matching 16.7.)

```C#
static short F1(bool b)
{
    // -langversion:8: CS8400: 'target-typed conditional expression' is not available
    // -langversion:9: ok
    //       expected: CS0266: cannot convert type 'int' to 'short'.
    return b ? 1 : 2;
}

static object F2(bool b, short? a)
{
    // -langversion:8: CS8400: 'target-typed conditional expression' is not available
    // -langversion:9: short
    //       expected: int
    return a ?? (b ? 1 : 2);
}
```

Fixes #49598