### PR TITLE
Change storage api to not expose checksums directly

### DIFF
--- a/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var streamName1 = "TestReadChecksumReturnsNullWhenNeverWritten";
 
             using var storage = GetStorage(solution);
-            Assert.Null(await storage.ReadChecksumAsync(streamName1));
+            Assert.False(await storage.ChecksumMatchesAsync(streamName1, s_checksum1));
         }
 
         [Fact]
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Null(await storage.ReadChecksumAsync(streamName1));
+                Assert.False(await storage.ChecksumMatchesAsync(streamName1, s_checksum1));
             }
         }
 
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(streamName1, s_checksum1));
             }
         }
 
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Null(await storage.ReadChecksumAsync(streamName1));
+                Assert.False(await storage.ChecksumMatchesAsync(streamName1, s_checksum1));
             }
         }
 
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(streamName1, s_checksum1));
             }
         }
 
@@ -440,7 +440,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum2, await storage.ReadChecksumAsync(streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(streamName1, s_checksum2));
             }
         }
 
@@ -459,7 +459,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -499,7 +499,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }
@@ -519,7 +519,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -539,10 +539,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -562,10 +562,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }
@@ -585,10 +585,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -608,10 +608,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }
@@ -631,7 +631,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }
@@ -651,7 +651,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -671,7 +671,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }
@@ -691,7 +691,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -711,10 +711,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -734,10 +734,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }
@@ -757,10 +757,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
             }
         }
@@ -780,10 +780,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorageFromKey(solution.Workspace, (SolutionKey)solution))
             {
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync(document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync(document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync(document, streamName1)));
 
-                Assert.Equal(s_checksum1, await storage.ReadChecksumAsync((DocumentKey)document, streamName1));
+                Assert.True(await storage.ChecksumMatchesAsync((DocumentKey)document, streamName1, s_checksum1));
                 Assert.Equal(GetData1(Size.Small), ReadStringToEnd(await storage.ReadStreamAsync((DocumentKey)document, streamName1)));
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -106,8 +106,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 // expect.  If so, we're already precalculated and don't have to recompute
                 // this index.  Otherwise if we don't have a checksum, or the checksums don't
                 // match, go ahead and recompute it.
-                var persistedChecksum = await storage.ReadChecksumAsync(document, PersistenceName, cancellationToken).ConfigureAwait(false);
-                return persistedChecksum == checksum;
+                return await storage.ChecksumMatchesAsync(document, PersistenceName, checksum, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (IOUtilities.IsNormalIOException(e))
             {

--- a/src/Workspaces/Core/Portable/Storage/AbstractPersistentStorageService.cs
+++ b/src/Workspaces/Core/Portable/Storage/AbstractPersistentStorageService.cs
@@ -237,20 +237,20 @@ namespace Microsoft.CodeAnalysis.Storage
             public void Dispose()
                 => _storage.Dispose();
 
-            public Task<Checksum> ReadChecksumAsync(string name, CancellationToken cancellationToken)
-                => _storage.Target.ReadChecksumAsync(name, cancellationToken);
+            public Task<bool> ChecksumMatchesAsync(string name, Checksum checksum, CancellationToken cancellationToken)
+                => _storage.Target.ChecksumMatchesAsync(name, checksum, cancellationToken);
 
-            public Task<Checksum> ReadChecksumAsync(Project project, string name, CancellationToken cancellationToken)
-                => _storage.Target.ReadChecksumAsync(project, name, cancellationToken);
+            public Task<bool> ChecksumMatchesAsync(Project project, string name, Checksum checksum, CancellationToken cancellationToken)
+                => _storage.Target.ChecksumMatchesAsync(project, name, checksum, cancellationToken);
 
-            public Task<Checksum> ReadChecksumAsync(Document document, string name, CancellationToken cancellationToken)
-                => _storage.Target.ReadChecksumAsync(document, name, cancellationToken);
+            public Task<bool> ChecksumMatchesAsync(Document document, string name, Checksum checksum, CancellationToken cancellationToken)
+                => _storage.Target.ChecksumMatchesAsync(document, name, checksum, cancellationToken);
 
-            public Task<Checksum> ReadChecksumAsync(ProjectKey project, string name, CancellationToken cancellationToken)
-                => _storage.Target.ReadChecksumAsync(project, name, cancellationToken);
+            public Task<bool> ChecksumMatchesAsync(ProjectKey project, string name, Checksum checksum, CancellationToken cancellationToken)
+                => _storage.Target.ChecksumMatchesAsync(project, name, checksum, cancellationToken);
 
-            public Task<Checksum> ReadChecksumAsync(DocumentKey document, string name, CancellationToken cancellationToken)
-                => _storage.Target.ReadChecksumAsync(document, name, cancellationToken);
+            public Task<bool> ChecksumMatchesAsync(DocumentKey document, string name, Checksum checksum, CancellationToken cancellationToken)
+                => _storage.Target.ChecksumMatchesAsync(document, name, checksum, cancellationToken);
 
             public Task<Stream> ReadStreamAsync(string name, CancellationToken cancellationToken)
                 => _storage.Target.ReadStreamAsync(name, cancellationToken);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -70,14 +70,11 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             private bool ChecksumMatches(TKey key, Checksum checksum, CancellationToken cancellationToken)
             {
-                using (var stream = ReadBlobColumn(key, ChecksumColumnName, checksum: null, cancellationToken))
-                using (var reader = ObjectReader.TryGetReader(stream, leaveOpen: false, cancellationToken))
-                {
-                    if (reader != null)
-                    {
-                        return checksum.GetHashData() == Checksum.HashData.ReadFrom(reader);
-                    }
-                }
+                using var stream = ReadBlobColumn(key, ChecksumColumnName, checksum: null, cancellationToken);
+                using var reader = ObjectReader.TryGetReader(stream, leaveOpen: false, cancellationToken);
+                
+                if (reader != null)
+                    return checksum == Checksum.HashData.ReadFrom(reader);
 
                 return false;
             }

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -72,11 +72,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             {
                 using var stream = ReadBlobColumn(key, ChecksumColumnName, checksum: null, cancellationToken);
                 using var reader = ObjectReader.TryGetReader(stream, leaveOpen: false, cancellationToken);
-                
-                if (reader != null)
-                    return checksum == Checksum.HashData.ReadFrom(reader);
 
-                return false;
+                return reader != null && checksum == Checksum.HashData.ReadFrom(reader);
             }
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentSerialization.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentSerialization.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 {
     internal partial class SQLitePersistentStorage
     {
-        protected override Task<Checksum?> ReadChecksumAsync(DocumentKey documentKey, Document? bulkLoadSnapshot, string name, CancellationToken cancellationToken)
-            => _documentAccessor.ReadChecksumAsync((documentKey, bulkLoadSnapshot, name), cancellationToken);
+        protected override Task<bool> ChecksumMatchesAsync(DocumentKey documentKey, Document? bulkLoadSnapshot, string name, Checksum checksum, CancellationToken cancellationToken)
+            => _documentAccessor.ChecksumMatchesAsync((documentKey, bulkLoadSnapshot, name), checksum, cancellationToken);
 
         protected override Task<Stream?> ReadStreamAsync(DocumentKey documentKey, Document? bulkLoadSnapshot, string name, Checksum? checksum, CancellationToken cancellationToken)
             => _documentAccessor.ReadStreamAsync((documentKey, bulkLoadSnapshot, name), checksum, cancellationToken);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectSerialization.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectSerialization.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 {
     internal partial class SQLitePersistentStorage
     {
-        protected override Task<Checksum?> ReadChecksumAsync(ProjectKey projectKey, Project? bulkLoadSnapshot, string name, CancellationToken cancellationToken)
-            => _projectAccessor.ReadChecksumAsync((projectKey, bulkLoadSnapshot, name), cancellationToken);
+        protected override Task<bool> ChecksumMatchesAsync(ProjectKey projectKey, Project? bulkLoadSnapshot, string name, Checksum checksum, CancellationToken cancellationToken)
+            => _projectAccessor.ChecksumMatchesAsync((projectKey, bulkLoadSnapshot, name), checksum, cancellationToken);
 
         protected override Task<Stream?> ReadStreamAsync(ProjectKey projectKey, Project? bulkLoadSnapshot, string name, Checksum? checksum, CancellationToken cancellationToken)
             => _projectAccessor.ReadStreamAsync((projectKey, bulkLoadSnapshot, name), checksum, cancellationToken);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_SolutionSerialization.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_SolutionSerialization.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 {
     internal partial class SQLitePersistentStorage
     {
-        public override Task<Checksum?> ReadChecksumAsync(string name, CancellationToken cancellationToken)
-            => _solutionAccessor.ReadChecksumAsync(name, cancellationToken);
+        public override Task<bool> ChecksumMatchesAsync(string name, Checksum checksum, CancellationToken cancellationToken)
+            => _solutionAccessor.ChecksumMatchesAsync(name, checksum, cancellationToken);
 
         public override Task<Stream?> ReadStreamAsync(string name, Checksum? checksum, CancellationToken cancellationToken)
             => _solutionAccessor.ReadStreamAsync(name, checksum, cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/AbstractPersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/AbstractPersistentStorage.cs
@@ -35,22 +35,22 @@ namespace Microsoft.CodeAnalysis.Host
 
         public abstract void Dispose();
 
-        public abstract Task<Checksum?> ReadChecksumAsync(string name, CancellationToken cancellationToken);
+        public abstract Task<bool> ChecksumMatchesAsync(string name, Checksum checksum, CancellationToken cancellationToken);
 
-        protected abstract Task<Checksum?> ReadChecksumAsync(ProjectKey projectKey, Project? bulkLoadSnapshot, string name, CancellationToken cancellationToken);
-        protected abstract Task<Checksum?> ReadChecksumAsync(DocumentKey documentKey, Document? bulkLoadSnapshot, string name, CancellationToken cancellationToken);
+        protected abstract Task<bool> ChecksumMatchesAsync(ProjectKey projectKey, Project? bulkLoadSnapshot, string name, Checksum checksum, CancellationToken cancellationToken);
+        protected abstract Task<bool> ChecksumMatchesAsync(DocumentKey documentKey, Document? bulkLoadSnapshot, string name, Checksum checksum, CancellationToken cancellationToken);
 
-        public Task<Checksum?> ReadChecksumAsync(ProjectKey projectKey, string name, CancellationToken cancellationToken)
-            => ReadChecksumAsync(projectKey, bulkLoadSnapshot: null, name, cancellationToken);
+        public Task<bool> ChecksumMatchesAsync(ProjectKey projectKey, string name, Checksum checksum, CancellationToken cancellationToken)
+            => ChecksumMatchesAsync(projectKey, bulkLoadSnapshot: null, name, checksum, cancellationToken);
 
-        public Task<Checksum?> ReadChecksumAsync(DocumentKey documentKey, string name, CancellationToken cancellationToken)
-            => ReadChecksumAsync(documentKey, bulkLoadSnapshot: null, name, cancellationToken);
+        public Task<bool> ChecksumMatchesAsync(DocumentKey documentKey, string name, Checksum checksum, CancellationToken cancellationToken)
+            => ChecksumMatchesAsync(documentKey, bulkLoadSnapshot: null, name, checksum, cancellationToken);
 
-        public Task<Checksum?> ReadChecksumAsync(Project project, string name, CancellationToken cancellationToken)
-            => ReadChecksumAsync((ProjectKey)project, project, name, cancellationToken);
+        public Task<bool> ChecksumMatchesAsync(Project project, string name, Checksum checksum, CancellationToken cancellationToken)
+            => ChecksumMatchesAsync((ProjectKey)project, project, name, checksum, cancellationToken);
 
-        public Task<Checksum?> ReadChecksumAsync(Document document, string name, CancellationToken cancellationToken)
-            => ReadChecksumAsync((DocumentKey)document, document, name, cancellationToken);
+        public Task<bool> ChecksumMatchesAsync(Document document, string name, Checksum checksum, CancellationToken cancellationToken)
+            => ChecksumMatchesAsync((DocumentKey)document, document, name, checksum, cancellationToken);
 
         public abstract Task<Stream?> ReadStreamAsync(string name, Checksum? checksum, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IChecksummedPersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IChecksummedPersistentStorage.cs
@@ -15,25 +15,25 @@ namespace Microsoft.CodeAnalysis.Host
     internal interface IChecksummedPersistentStorage : IPersistentStorage
     {
         /// <summary>
-        /// Reads the existing checksum we have for the solution with the given <paramref name="name"/>,
-        /// or <see langword="null"/> if we do not have a checksum persisted.
+        /// <see langword="true"/> if the data we have for the solution with the given <paramref name="name"/> has the
+        /// provided <paramref name="checksum"/>.
         /// </summary>
-        Task<Checksum> ReadChecksumAsync(string name, CancellationToken cancellationToken = default);
+        Task<bool> ChecksumMatchesAsync(string name, Checksum checksum, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Reads the existing checksum we have for the given <paramref name="project"/> with the given <paramref name="name"/>,
-        /// or <see langword="null"/> if we do not have a checksum persisted.
+        /// <see langword="true"/> if the data we have for the given <paramref name="project"/> with the given <paramref
+        /// name="name"/> has the provided <paramref name="checksum"/>.
         /// </summary>
-        Task<Checksum> ReadChecksumAsync(Project project, string name, CancellationToken cancellationToken = default);
+        Task<bool> ChecksumMatchesAsync(Project project, string name, Checksum checksum, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Reads the existing checksum we have for the given <paramref name="document"/> with the given <paramref name="name"/>,
-        /// or <see langword="null"/> if we do not have a checksum persisted.
+        /// <see langword="true"/> if the data we have for the given <paramref name="document"/> with the given <paramref
+        /// name="name"/> has the provided <paramref name="checksum"/>.
         /// </summary>
-        Task<Checksum> ReadChecksumAsync(Document document, string name, CancellationToken cancellationToken = default);
+        Task<bool> ChecksumMatchesAsync(Document document, string name, Checksum checksum, CancellationToken cancellationToken = default);
 
-        Task<Checksum> ReadChecksumAsync(ProjectKey project, string name, CancellationToken cancellationToken = default);
-        Task<Checksum> ReadChecksumAsync(DocumentKey document, string name, CancellationToken cancellationToken = default);
+        Task<bool> ChecksumMatchesAsync(ProjectKey project, string name, Checksum checksum, CancellationToken cancellationToken = default);
+        Task<bool> ChecksumMatchesAsync(DocumentKey document, string name, Checksum checksum, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Reads the stream for the solution with the given <paramref name="name"/>.  If <paramref name="checksum"/>

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/NoOpPersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/NoOpPersistentStorage.cs
@@ -24,20 +24,20 @@ namespace Microsoft.CodeAnalysis.Host
         {
         }
 
-        public Task<Checksum> ReadChecksumAsync(string name, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<Checksum>();
+        public Task<bool> ChecksumMatchesAsync(string name, Checksum checksum, CancellationToken cancellationToken)
+            => SpecializedTasks.False;
 
-        public Task<Checksum> ReadChecksumAsync(Project project, string name, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<Checksum>();
+        public Task<bool> ChecksumMatchesAsync(Project project, string name, Checksum checksum, CancellationToken cancellationToken)
+            => SpecializedTasks.False;
 
-        public Task<Checksum> ReadChecksumAsync(Document document, string name, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<Checksum>();
+        public Task<bool> ChecksumMatchesAsync(Document document, string name, Checksum checksum, CancellationToken cancellationToken)
+            => SpecializedTasks.False;
 
-        public Task<Checksum> ReadChecksumAsync(ProjectKey project, string name, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<Checksum>();
+        public Task<bool> ChecksumMatchesAsync(ProjectKey project, string name, Checksum checksum, CancellationToken cancellationToken)
+            => SpecializedTasks.False;
 
-        public Task<Checksum> ReadChecksumAsync(DocumentKey document, string name, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<Checksum>();
+        public Task<bool> ChecksumMatchesAsync(DocumentKey document, string name, Checksum checksum, CancellationToken cancellationToken)
+            => SpecializedTasks.False;
 
         public Task<Stream> ReadStreamAsync(Document document, string name, CancellationToken cancellationToken)
             => SpecializedTasks.Null<Stream>();

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis
         public Checksum(HashData hash)
             => _checksum = hash;
 
+        public HashData GetHashData() => _checksum;
+
         /// <summary>
         /// Create Checksum from given byte array. if byte array is bigger than
         /// <see cref="HashSize"/>, it will be truncated to the size

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -34,8 +34,6 @@ namespace Microsoft.CodeAnalysis
         public Checksum(HashData hash)
             => _checksum = hash;
 
-        public HashData GetHashData() => _checksum;
-
         /// <summary>
         /// Create Checksum from given byte array. if byte array is bigger than
         /// <see cref="HashSize"/>, it will be truncated to the size
@@ -136,6 +134,12 @@ namespace Microsoft.CodeAnalysis
             => EqualityComparer<Checksum>.Default.Equals(left, right);
 
         public static bool operator !=(Checksum left, Checksum right)
+            => !(left == right);
+
+        public static bool operator ==(Checksum left, HashData right)
+            => left._checksum == right;
+
+        public static bool operator !=(Checksum left, HashData right)
             => !(left == right);
 
         bool IObjectWritable.ShouldReuseInSerialization => true;

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
@@ -105,8 +105,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
             // Don't need to do anything if the information we've persisted matches the checksum of this doc.
             var checksum = await GetChecksumAsync(document, cancellationToken).ConfigureAwait(false);
-            var persistedChecksum = await storage.ReadChecksumAsync(document, PersistenceName, cancellationToken).ConfigureAwait(false);
-            if (checksum == persistedChecksum)
+            var matches = await storage.ChecksumMatchesAsync(document, PersistenceName, checksum, cancellationToken).ConfigureAwait(false);
+            if (matches)
                 return;
 
             var classifiedSpans = ClassificationUtilities.GetOrCreateClassifiedSpanList();


### PR DESCRIPTION
The storage API the platform is exposing does not support this functionality.  It does support asking if there is a key with a particular checksum, and that's all the functionality we need in roslyn itself.  So this switches to have the same form to make porting easier.