### PR TITLE
Update regex used to remove version number in publish assets

### DIFF
--- a/eng/publish-assets.ps1
+++ b/eng/publish-assets.ps1
@@ -52,7 +52,7 @@ function Publish-Nuget($publishData, [string]$packageDir) {
       }
 
       # Lookup the feed name from the packages map using the package name without the version or extension.
-      $nupkgWithoutVersion = $nupkg -replace '(\.\d){3}-.*.nupkg', ''
+      $nupkgWithoutVersion = $nupkg -replace '(\.\d+){3}-.*.nupkg', ''
       if (-not (Get-Member -InputObject $packagesData -Name $nupkgWithoutVersion)) {
         throw "$nupkg has no configured feed (looked for $nupkgWithoutVersion)"
       }


### PR DESCRIPTION
Before this change the regex used to remove version number from a nupkg file name was expecting single digits. Now that we are publishing version 3.10 packages this regex was failing.

This should fix signed builds of the dev16.10 branch. (see failure https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4408787&view=logs&j=20fcf628-b65c-5865-625a-1cef81cda63b&t=7efdce5b-215a-5afd-980e-58e9cb1ef7e6)