### PR TITLE
Remove non-external-access types from TS external access API

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
+++ b/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
@@ -41,7 +41,7 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <RestrictedInternalsVisibleTo Include="TypeScriptAddin" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
+    <RestrictedInternalsVisibleTo Include="TypeScriptAddin" Key="$(MonoDevelopKey)" Partner="VSTypeScript" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" Key="$(TypeScriptKey)" Partner="VSTypeScript" />
   </ItemGroup>
   <ItemGroup>

--- a/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/IVSTypeScriptInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/IVSTypeScriptInlineRenameInfo.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         /// <summary>
         /// The locations of the symbol being renamed.
         /// </summary>
-        ImmutableArray<DocumentSpan> DefinitionLocations { get; }
+        ImmutableArray<VSTypeScriptDocumentSpanWrapper> DefinitionLocations { get; }
 
         /// <summary>
         /// Gets the final name of the symbol if the user has typed the provided replacement text

--- a/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentSpanWrapper.cs
+++ b/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentSpanWrapper.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
+{
+    internal sealed class VSTypeScriptDocumentSpanWrapper
+    {
+        public VSTypeScriptDocumentSpanWrapper(Document document, TextSpan sourceSpan)
+            : this(document, sourceSpan, properties: null)
+        {
+        }
+
+        public VSTypeScriptDocumentSpanWrapper(Document document, TextSpan sourceSpan, ImmutableDictionary<string, object>? properties)
+        {
+            UnderlyingObject = new DocumentSpan(document, sourceSpan, properties);
+        }
+
+        internal DocumentSpan UnderlyingObject { get; }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
+++ b/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameInfo.cs
@@ -18,11 +18,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
     internal sealed class VSTypeScriptInlineRenameInfo : IInlineRenameInfo
     {
         private readonly IVSTypeScriptInlineRenameInfo _info;
+        private readonly ImmutableArray<DocumentSpan> _definitionLocations;
 
         public VSTypeScriptInlineRenameInfo(IVSTypeScriptInlineRenameInfo info)
         {
             Contract.ThrowIfNull(info);
             _info = info;
+            _definitionLocations = info.DefinitionLocations.SelectAsArray(loc => loc.UnderlyingObject);
         }
 
         public bool CanRename => _info.CanRename;
@@ -41,7 +43,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 
         public Glyph Glyph => VSTypeScriptGlyphHelpers.ConvertTo(_info.Glyph);
 
-        public ImmutableArray<DocumentSpan> DefinitionLocations => _info.DefinitionLocations;
+        public ImmutableArray<DocumentSpan> DefinitionLocations => _definitionLocations;
 
         public async Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameLocationWrapper.cs
+++ b/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptInlineRenameLocationWrapper.cs
@@ -16,6 +16,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         public VSTypeScriptInlineRenameLocationWrapper(InlineRenameLocation underlyingObject)
             => _underlyingObject = underlyingObject;
 
+        public VSTypeScriptInlineRenameLocationWrapper(Document document, TextSpan textSpan)
+            => _underlyingObject = new InlineRenameLocation(document, textSpan);
+
         public Document Document => _underlyingObject.Document;
         public TextSpan TextSpan => _underlyingObject.TextSpan;
     }

--- a/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptSignatureHelpClassifierFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/ExternalAccess/VSTypeScript/Api/VSTypeScriptSignatureHelpClassifierFactory.cs
@@ -2,16 +2,29 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.VisualStudio.Text.Classification;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.VisualStudio.Text;
+using System;
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp.Presentation;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
-    internal static class VSTypeScriptSignatureHelpClassifierFactory
+    [Export]
+    internal class VSTypeScriptSignatureHelpClassifierFactory
     {
-        public static IClassifier Create(ITextBuffer textBuffer, ClassificationTypeMap typeMap)
-            => new SignatureHelpClassifier(textBuffer, typeMap);
+        private readonly ClassificationTypeMap _typeMap;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public VSTypeScriptSignatureHelpClassifierFactory(ClassificationTypeMap typeMap)
+        {
+            _typeMap = typeMap;
+        }
+
+        public IClassifier Create(ITextBuffer textBuffer)
+            => new SignatureHelpClassifier(textBuffer, _typeMap);
     }
 }


### PR DESCRIPTION
Follow up to #50709 that removes internal, non-external-access types from the TS external access API types.
This is because our VSMac-specific assembly now only has (restricted)IVT to MS.CA.EF.Cocoa, so any other internal types are inaccessible.

I've also updated the IVT key for the reference to our VSMac-specific assembly to match its usage of the MonoDevelop key.

Built locally, so I've confirmed these changes allow us to build.