### PR TITLE
Fix merge of 16.10 branch into master

### DIFF
--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -35,7 +35,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Protected ReadOnly SignatureHelpAfterCompletionCommandHandler As SignatureHelpAfterCompletionCommandHandler
         Protected ReadOnly CompleteStatementCommandHandler As CompleteStatementCommandHandler
         Private ReadOnly FormatCommandHandler As FormatCommandHandler
-        Protected ReadOnly CompleteStatementCommandHandler As CompleteStatementCommandHandler
 
         Public Shared ReadOnly CompositionWithoutCompletionTestParts As TestComposition = EditorTestCompositions.EditorFeaturesWpf.
             AddExcludedPartTypes(


### PR DESCRIPTION
the master branch will currently not build due to a duplicate field in TestState.vb
```
C:\Users\dabarbet\source\repos\roslyn\src\EditorFeatures\TestUtilities2\Intellisense\TestState.vb(38,28): error BC30260
: 'CompleteStatementCommandHandler' is already declared as 'Protected ReadOnly CompleteStatementCommandHandler As Compl
eteStatementCommandHandler' in this class. [C:\Users\dabarbet\source\repos\roslyn\src\EditorFeatures\TestUtilities2\Mic
rosoft.CodeAnalysis.EditorFeatures.Test.Utilities2.vbproj]
```

Looks like this was introduced by the merge from the 16.10 branch into master.