### PR TITLE
Allow access to semantic model during syntax walk (#50419)

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,10 +1,19 @@
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string firstLanguage, params string[] additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string[]
+Microsoft.CodeAnalysis.GeneratorExecutionContext.SyntaxContextReceiver.get -> Microsoft.CodeAnalysis.ISyntaxContextReceiver
+Microsoft.CodeAnalysis.GeneratorInitializationContext.RegisterForSyntaxNotifications(Microsoft.CodeAnalysis.SyntaxContextReceiverCreator receiverCreator) -> void
+Microsoft.CodeAnalysis.GeneratorSyntaxContext
+Microsoft.CodeAnalysis.GeneratorSyntaxContext.GeneratorSyntaxContext() -> void
+Microsoft.CodeAnalysis.GeneratorSyntaxContext.Node.get -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.GeneratorSyntaxContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel
+Microsoft.CodeAnalysis.ISyntaxContextReceiver
+Microsoft.CodeAnalysis.ISyntaxContextReceiver.OnVisitSyntaxNode(Microsoft.CodeAnalysis.GeneratorSyntaxContext context) -> void
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordClassName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string
+Microsoft.CodeAnalysis.SyntaxContextReceiverCreator
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Compare(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> int
 static Microsoft.CodeAnalysis.CaseInsensitiveComparison.Equals(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) -> bool
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGenerators(string language) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator>

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -19,13 +19,14 @@ namespace Microsoft.CodeAnalysis
 
         private readonly AdditionalSourcesCollection _additionalSources;
 
-        internal GeneratorExecutionContext(Compilation compilation, ParseOptions parseOptions, ImmutableArray<AdditionalText> additionalTexts, AnalyzerConfigOptionsProvider optionsProvider, ISyntaxReceiver? syntaxReceiver, AdditionalSourcesCollection additionalSources, CancellationToken cancellationToken = default)
+        internal GeneratorExecutionContext(Compilation compilation, ParseOptions parseOptions, ImmutableArray<AdditionalText> additionalTexts, AnalyzerConfigOptionsProvider optionsProvider, ISyntaxContextReceiver? syntaxReceiver, AdditionalSourcesCollection additionalSources, CancellationToken cancellationToken = default)
         {
             Compilation = compilation;
             ParseOptions = parseOptions;
             AdditionalFiles = additionalTexts;
             AnalyzerConfigOptions = optionsProvider;
-            SyntaxReceiver = syntaxReceiver;
+            SyntaxReceiver = (syntaxReceiver as SyntaxContextReceiverAdaptor)?.Receiver;
+            SyntaxContextReceiver = (syntaxReceiver is SyntaxContextReceiverAdaptor) ? null : syntaxReceiver;
             CancellationToken = cancellationToken;
             _additionalSources = additionalSources;
             _diagnostics = new DiagnosticBag();
@@ -60,6 +61,11 @@ namespace Microsoft.CodeAnalysis
         /// If the generator registered an <see cref="ISyntaxReceiver"/> during initialization, this will be the instance created for this generation pass.
         /// </summary>
         public ISyntaxReceiver? SyntaxReceiver { get; }
+
+        /// <summary>
+        /// If the generator registered an <see cref="ISyntaxContextReceiver"/> during initialization, this will be the instance created for this generation pass.
+        /// </summary>
+        public ISyntaxContextReceiver? SyntaxContextReceiver { get; }
 
         /// <summary>
         /// A <see cref="CancellationToken"/> that can be checked to see if the generation should be cancelled.
@@ -135,17 +141,61 @@ namespace Microsoft.CodeAnalysis
         /// <param name="receiverCreator">A <see cref="SyntaxReceiverCreator"/> that can be invoked to create an instance of <see cref="ISyntaxReceiver"/></param>
         public void RegisterForSyntaxNotifications(SyntaxReceiverCreator receiverCreator)
         {
-            CheckIsEmpty(InfoBuilder.SyntaxReceiverCreator);
-            InfoBuilder.SyntaxReceiverCreator = receiverCreator;
+            CheckIsEmpty(InfoBuilder.SyntaxContextReceiverCreator, $"{nameof(SyntaxReceiverCreator)} / {nameof(SyntaxContextReceiverCreator)}");
+            InfoBuilder.SyntaxContextReceiverCreator = SyntaxContextReceiverAdaptor.Create(receiverCreator);
         }
 
-        private static void CheckIsEmpty<T>(T x)
+        /// <summary>
+        /// Register a <see cref="SyntaxContextReceiverCreator"/> for this generator, which can be used to create an instance of an <see cref="ISyntaxContextReceiver"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method allows generators to be 'syntax aware'. Before each generation the <paramref name="receiverCreator"/> will be invoked to create
+        /// an instance of <see cref="ISyntaxContextReceiver"/>. This receiver will have its <see cref="ISyntaxContextReceiver.OnVisitSyntaxNode(GeneratorSyntaxContext)"/> 
+        /// invoked for each syntax node in the compilation, allowing the receiver to build up information about the compilation before generation occurs.
+        /// 
+        /// During <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the <see cref="ISyntaxContextReceiver"/> instance that was
+        /// created by accessing the <see cref="GeneratorExecutionContext.SyntaxContextReceiver"/> property. Any information that was collected by the receiver can be
+        /// used to generate the final output.
+        /// 
+        /// A new instance of <see cref="ISyntaxContextReceiver"/> is created prior to every call to <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/>, 
+        /// meaning there is no need to manage the lifetime of the receiver or its contents.
+        /// </remarks>
+        /// <param name="receiverCreator">A <see cref="SyntaxContextReceiverCreator"/> that can be invoked to create an instance of <see cref="ISyntaxContextReceiver"/></param>
+        public void RegisterForSyntaxNotifications(SyntaxContextReceiverCreator receiverCreator)
+        {
+            CheckIsEmpty(InfoBuilder.SyntaxContextReceiverCreator, $"{nameof(SyntaxReceiverCreator)} / {nameof(SyntaxContextReceiverCreator)}");
+            InfoBuilder.SyntaxContextReceiverCreator = receiverCreator;
+        }
+
+        private static void CheckIsEmpty<T>(T x, string? typeName = null) where T : class?
         {
             if (x is object)
             {
-                throw new InvalidOperationException(string.Format(CodeAnalysisResources.Single_type_per_generator_0, typeof(T).Name));
+                throw new InvalidOperationException(string.Format(CodeAnalysisResources.Single_type_per_generator_0, typeName ?? typeof(T).Name));
             }
         }
+    }
+
+    /// <summary>
+    /// Context passed to an <see cref="ISyntaxContextReceiver"/> when <see cref="ISyntaxContextReceiver.OnVisitSyntaxNode(GeneratorSyntaxContext)"/> is called
+    /// </summary>
+    public readonly struct GeneratorSyntaxContext
+    {
+        internal GeneratorSyntaxContext(SyntaxNode node, SemanticModel semanticModel)
+        {
+            Node = node;
+            SemanticModel = semanticModel;
+        }
+
+        /// <summary>
+        /// The <see cref="SyntaxNode"/> currently being visited
+        /// </summary>
+        public SyntaxNode Node { get; }
+
+        /// <summary>
+        /// The <see cref="SemanticModel" /> that can be queried to obtain information about <see cref="Node"/>.
+        /// </summary>
+        public SemanticModel SemanticModel { get; }
     }
 
     internal readonly struct GeneratorEditContext

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -8,14 +8,14 @@ namespace Microsoft.CodeAnalysis
     {
         internal EditCallback<AdditionalFileEdit>? EditCallback { get; }
 
-        internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; }
+        internal SyntaxContextReceiverCreator? SyntaxContextReceiverCreator { get; }
 
         internal bool Initialized { get; }
 
-        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxReceiverCreator? receiverCreator)
+        internal GeneratorInfo(EditCallback<AdditionalFileEdit>? editCallback, SyntaxContextReceiverCreator? receiverCreator)
         {
             EditCallback = editCallback;
-            SyntaxReceiverCreator = receiverCreator;
+            SyntaxContextReceiverCreator = receiverCreator;
             Initialized = true;
         }
 
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis
         {
             internal EditCallback<AdditionalFileEdit>? EditCallback { get; set; }
 
-            internal SyntaxReceiverCreator? SyntaxReceiverCreator { get; set; }
+            internal SyntaxContextReceiverCreator? SyntaxContextReceiverCreator { get; set; }
 
-            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxReceiverCreator);
+            public GeneratorInfo ToImmutable() => new GeneratorInfo(EditCallback, SyntaxContextReceiverCreator);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, ISyntaxReceiver? syntaxReceiver, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSourceText> sourceTexts, ImmutableArray<SyntaxTree> trees, ImmutableArray<Diagnostic> diagnostics, ISyntaxContextReceiver? syntaxReceiver, Exception? exception)
         {
             this.SourceTexts = sourceTexts;
             this.Trees = trees;
@@ -57,16 +57,16 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorInfo Info { get; }
 
-        internal ISyntaxReceiver? SyntaxReceiver { get; }
+        internal ISyntaxContextReceiver? SyntaxReceiver { get; }
 
         internal Exception? Exception { get; }
 
         internal ImmutableArray<Diagnostic> Diagnostics { get; }
 
         /// <summary>
-        /// Adds an <see cref="ISyntaxReceiver"/> to this generator state
+        /// Adds a syntax receiver to this generator state
         /// </summary>
-        internal GeneratorState WithReceiver(ISyntaxReceiver syntaxReceiver)
+        internal GeneratorState WithReceiver(ISyntaxContextReceiver syntaxReceiver)
         {
             Debug.Assert(this.Exception is null);
             return new GeneratorState(this.Info,

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorSyntaxWalker.cs
@@ -2,20 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace Microsoft.CodeAnalysis
 {
     internal sealed class GeneratorSyntaxWalker : SyntaxWalker
     {
-        private readonly ISyntaxReceiver _syntaxReceiver;
+        private readonly ISyntaxContextReceiver _syntaxReceiver;
 
-        internal GeneratorSyntaxWalker(ISyntaxReceiver syntaxReceiver)
+        private SemanticModel? _semanticModel;
+
+        internal GeneratorSyntaxWalker(ISyntaxContextReceiver syntaxReceiver)
         {
             _syntaxReceiver = syntaxReceiver;
         }
 
+        public void VisitWithModel(SemanticModel model, SyntaxNode node)
+        {
+            Debug.Assert(_semanticModel is null
+                         && model is not null
+                         && model.SyntaxTree == node.SyntaxTree);
+
+            _semanticModel = model;
+            Visit(node);
+            _semanticModel = null;
+        }
+
         public override void Visit(SyntaxNode node)
         {
-            _syntaxReceiver.OnVisitSyntaxNode(node);
+            Debug.Assert(_semanticModel is object && _semanticModel.SyntaxTree == node.SyntaxTree);
+            _syntaxReceiver.OnVisitSyntaxNode(new GeneratorSyntaxContext(node, _semanticModel));
             base.Visit(node);
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxReceiver.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
-    /// Receives notifications of each syntax node in the compilation before generation runs
+    /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation before generation runs
     /// </summary>
     /// <remarks>
     /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxReceiver"/>
@@ -22,6 +22,9 @@ namespace Microsoft.CodeAnalysis
     /// 
     /// A new instance of <see cref="ISyntaxReceiver"/> is created per-generation, meaning the instance
     /// is free to store state without worrying about lifetime or reuse.
+    /// 
+    /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
+    /// <see cref="ISyntaxContextReceiver" />, not both.
     /// </remarks>
     public interface ISyntaxReceiver
     {
@@ -37,4 +40,41 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     /// <returns>An instance of an <see cref="ISyntaxReceiver"/></returns>
     public delegate ISyntaxReceiver SyntaxReceiverCreator();
+
+    /// <summary>
+    /// Receives notifications of each <see cref="SyntaxNode"/> in the compilation, along with a  
+    /// <see cref="SemanticModel"/> that can be queried to obtain more information, before generation
+    /// runs.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="ISourceGenerator"/> can provide an instance of <see cref="ISyntaxContextReceiver"/>
+    /// via a <see cref="SyntaxReceiverCreator"/>.
+    /// 
+    /// The compiler will invoke the <see cref="SyntaxReceiverCreator"/> prior to generation to 
+    /// obtain an instance of <see cref="ISyntaxContextReceiver"/>. This instance will have its 
+    /// <see cref="OnVisitSyntaxNode(GeneratorSyntaxContext)"/> called for every syntax node
+    /// in the compilation.
+    /// 
+    /// The <see cref="ISyntaxContextReceiver"/> can record any information about the nodes visited. 
+    /// During <see cref="ISourceGenerator.Execute(GeneratorExecutionContext)"/> the generator can obtain the 
+    /// created instance via the <see cref="GeneratorExecutionContext.SyntaxContextReceiver"/> property. The
+    /// information contained can be used to perform final generation.
+    /// 
+    /// A new instance of <see cref="ISyntaxContextReceiver"/> is created per-generation, meaning the instance
+    /// is free to store state without worrying about lifetime or reuse. 
+    /// 
+    /// An <see cref="ISourceGenerator"/> may provide only a single <see cref="ISyntaxReceiver"/> or
+    /// <see cref="ISyntaxContextReceiver" />, not both.
+    /// </remarks>
+    public interface ISyntaxContextReceiver
+    {
+        void OnVisitSyntaxNode(GeneratorSyntaxContext context);
+    }
+
+    /// <summary>
+    /// Allows a generator to provide instances of an <see cref="ISyntaxContextReceiver"/>
+    /// </summary>
+    /// <returns>An instance of an <see cref="ISyntaxContextReceiver"/></returns>
+    public delegate ISyntaxContextReceiver? SyntaxContextReceiverCreator();
+
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SyntaxContextReceiverAdaptor.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Wraps an <see cref="ISyntaxReceiver"/> in an <see cref="ISyntaxContextReceiver"/>
+    /// </summary>
+    internal sealed class SyntaxContextReceiverAdaptor : ISyntaxContextReceiver
+    {
+        private SyntaxContextReceiverAdaptor(ISyntaxReceiver receiver)
+        {
+            Receiver = receiver ?? throw new ArgumentNullException(nameof(receiver));
+        }
+
+        public ISyntaxReceiver Receiver { get; }
+
+        public void OnVisitSyntaxNode(GeneratorSyntaxContext context) => Receiver.OnVisitSyntaxNode(context.Node);
+
+        public static SyntaxContextReceiverCreator Create(SyntaxReceiverCreator creator) => () =>
+        {
+            var rx = creator();
+            if (rx is object)
+            {
+                return new SyntaxContextReceiverAdaptor(rx);
+            }
+            // in the case that the creator function returns null, we'll also return a null adaptor
+            return null;
+        };
+    }
+}


### PR DESCRIPTION
Cherry pick of 089be987071b4d088dda1f5a1e35a9cf8d03d2b5 for 16.9 