### PR TITLE
Capture telemetry on LSP requests sent to the server to enable dashbo…

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -382,7 +382,7 @@ namespace Roslyn.Test.Utilities
         {
             var workspace = (TestWorkspace)solution.Workspace;
             var registrationService = workspace.ExportProvider.GetExportedValue<ILspWorkspaceRegistrationService>();
-            return new RequestExecutionQueue(registrationService, "Tests");
+            return new RequestExecutionQueue(registrationService, "Tests", "TestClient");
         }
 
         private static string GetDocumentFilePathFromName(string documentName)

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Microsoft.CodeAnalysis.Internal.Log;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+{
+    internal partial class RequestExecutionQueue
+    {
+        /// <summary>
+        /// Logs metadata on how many / failure rate of requests
+        /// for this particular LSP server instance.
+        /// </summary>
+        internal class RequestTelemetryLogger : IDisposable
+        {
+            private readonly string _serverTypeName;
+
+            /// <summary>
+            /// Store request counters in a concurrent dictionary as non-mutating LSP requests can
+            /// run alongside other non-mutating requests.
+            /// </summary>
+            private readonly ConcurrentDictionary<string, Counter> _requestCounters;
+
+            public RequestTelemetryLogger(string serverTypeName)
+            {
+                _serverTypeName = serverTypeName;
+                _requestCounters = new ConcurrentDictionary<string, Counter>();
+            }
+
+            public void LogSuccess(string methodName)
+            {
+                Interlocked.Increment(ref _requestCounters.GetOrAdd(methodName, new Counter())._successfulCount);
+            }
+
+            public void LogFailure(string methodName)
+            {
+                Interlocked.Increment(ref _requestCounters.GetOrAdd(methodName, new Counter())._failedCount);
+            }
+
+            /// <summary>
+            /// Only output aggregate telemetry to the vs logger when the server instance is disposed
+            /// to avoid spamming the telemetry output with thousands of events
+            /// </summary>
+            public void Dispose()
+            {
+                foreach (var kvp in _requestCounters)
+                {
+                    Logger.Log(FunctionId.LSP_RequestCounter, KeyValueLogMessage.Create(LogType.Trace, m =>
+                    {
+                        m["server"] = _serverTypeName;
+                        m["method"] = kvp.Key;
+                        m["successful"] = kvp.Value._successfulCount;
+                        m["failed"] = kvp.Value._failedCount;
+                    }));
+                }
+
+                // Clear telemetry we've published in case dispose is called multiple times.
+                _requestCounters.Clear();
+            }
+
+            private class Counter
+            {
+                public int _successfulCount;
+                public int _failedCount;
+            }
+        }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
@@ -36,6 +36,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 Interlocked.Increment(ref _requestCounters.GetOrAdd(methodName, new Counter())._successfulCount);
             }
 
+            public void LogCancel(string methodName)
+            {
+                Interlocked.Increment(ref _requestCounters.GetOrAdd(methodName, new Counter())._cancelledCount);
+            }
+
             public void LogFailure(string methodName)
             {
                 Interlocked.Increment(ref _requestCounters.GetOrAdd(methodName, new Counter())._failedCount);
@@ -55,6 +60,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         m["method"] = kvp.Key;
                         m["successful"] = kvp.Value._successfulCount;
                         m["failed"] = kvp.Value._failedCount;
+                        m["cancelled"] = kvp.Value._cancelledCount;
                     }));
                 }
 
@@ -66,6 +72,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             {
                 public int _successfulCount;
                 public int _failedCount;
+                public int _cancelledCount;
             }
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -55,6 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly AsyncQueue<QueueItem> _queue;
         private readonly CancellationTokenSource _cancelSource;
         private readonly DocumentChangeTracker _documentChangeTracker;
+        private readonly RequestTelemetryLogger _requestTelemetryLogger;
 
         // This dictionary is used to cache our forked LSP solution so we don't have to
         // recompute it for each request. We don't need to worry about threading because they are only
@@ -75,7 +74,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// </remarks>
         public event EventHandler<RequestShutdownEventArgs>? RequestServerShutdown;
 
-        public RequestExecutionQueue(ILspWorkspaceRegistrationService workspaceRegistrationService, string serverName)
+        public RequestExecutionQueue(ILspWorkspaceRegistrationService workspaceRegistrationService, string serverName, string serverTypeName)
         {
             _workspaceRegistrationService = workspaceRegistrationService;
             _serverName = serverName;
@@ -83,6 +82,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _queue = new AsyncQueue<QueueItem>();
             _cancelSource = new CancellationTokenSource();
             _documentChangeTracker = new DocumentChangeTracker();
+
+            // Pass the language client instance type name to the telemetry logger to ensure we can
+            // differentiate between the different C# LSP servers that have the same client name.
+            // We also don't use the language client's name property as it is a localized user facing string
+            // which is difficult to write telemetry queries for.
+            _requestTelemetryLogger = new RequestTelemetryLogger(serverTypeName);
 
             // Start the queue processing
             _ = ProcessQueueAsync();
@@ -96,6 +101,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
             _cancelSource.Cancel();
             DrainQueue();
+            _requestTelemetryLogger.Dispose();
         }
 
         /// <summary>
@@ -143,6 +149,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     {
                         var result = await handler.HandleRequestAsync(request, context, cancellationToken).ConfigureAwait(false);
                         completion.SetResult(result);
+
+                        // Update success count for the request
+                        _requestTelemetryLogger.LogSuccess(methodName);
                     }
                     catch (OperationCanceledException ex)
                     {
@@ -152,6 +161,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     {
                         // Pass the exception to the task completion source, so the caller of the ExecuteAsync method can react
                         completion.SetException(exception);
+
+                        // Update the failure count for the request.
+                        // Failure details are captured separately in a non fatal watson report.
+                        _requestTelemetryLogger.LogFailure(methodName);
 
                         // Also allow the exception to flow back to the request queue to handle as appropriate
                         throw new InvalidOperationException($"Error handling '{methodName}' request: {exception.Message}", exception);

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -156,6 +156,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     catch (OperationCanceledException ex)
                     {
                         completion.TrySetCanceled(ex.CancellationToken);
+                        _requestTelemetryLogger.LogCancel(methodName);
                     }
                     catch (Exception exception)
                     {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             _listener = listenerProvider.GetListener(FeatureAttribute.LanguageServer);
             _clientName = clientName;
 
-            _queue = new RequestExecutionQueue(lspWorkspaceRegistrationService, languageClient.Name);
+            _queue = new RequestExecutionQueue(lspWorkspaceRegistrationService, languageClient.Name, _languageClient.GetType().Name);
             _queue.RequestServerShutdown += RequestExecutionQueue_Errored;
 
             // Dedupe on DocumentId.  If we hear about the same document multiple times, we only need to process that id once.
@@ -144,10 +144,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         [JsonRpcMethod(Methods.ExitName)]
         public Task ExitAsync(CancellationToken _)
         {
-            Contract.ThrowIfFalse(_shuttingDown, "Shutdown has not been called yet.");
-
             try
             {
+                ShutdownRequestQueue();
                 _jsonRpc.Dispose();
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -505,5 +505,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         FindDocumentInWorkspace = 480,
         RegisterWorkspace = 481,
+
+        LSP_RequestCounter = 482,
     }
 }


### PR DESCRIPTION
…ards

We've been asked to have a dashboard displaying an overall health of codespaces.  Most of the telemetry is being collected client side as server telemetry is not necessarily representative of what the client sees.  However, I'm also adding server side telemetry here so we can see
a) which lsp requests are failing
b) at what rate lsp requests are failing (broken down by method)

Note that the actual failure details are being capture by nfw reports, but we can't extract the failure rate or easily break down by lsp request.