### PR TITLE
 Fix issue with GetSimpleNonTypeMembers on records

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1320,7 +1320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<Symbol> GetSimpleNonTypeMembers(string name)
         {
-            if (_lazyMembersDictionary != null || declaration.MemberNames.Contains(name))
+            if (_lazyMembersDictionary != null || declaration.MemberNames.Contains(name) || declaration.Kind == DeclarationKind.Record)
             {
                 return GetMembers(name);
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -280,9 +280,7 @@ class C
         public void GetSimpleNonTypeMembers_DirectApiCheck()
         {
             var src = @"
-public record RecordA(RecordB B);
-
-public record RecordB(int C);
+public record RecordB();
 ";
             var comp = CreateCompilation(src);
             var b = comp.GlobalNamespace.GetTypeMember("RecordB");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -228,6 +228,33 @@ class E
             comp.VerifyDiagnostics();
         }
 
+        
+        [Fact, WorkItem(49263, "https://github.com/dotnet/roslyn/issues/49263")]
+        public void DeriveFromSelf()
+        {
+            var src = @"
+record R : R;
+";
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics(
+                // (2,8): error CS0146: Circular base type dependency involving 'R' and 'R'
+                // record R : R;
+                Diagnostic(ErrorCode.ERR_CircularBase, "R").WithArguments("R", "R").WithLocation(2, 8),
+                // (2,8): error CS0115: 'R.ToString()': no suitable method found to override
+                // record R : R;
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.ToString()").WithLocation(2, 8),
+                // (2,8): error CS0115: 'R.EqualityContract': no suitable method found to override
+                // record R : R;
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.EqualityContract").WithLocation(2, 8),
+                // (2,8): error CS0115: 'R.Equals(object?)': no suitable method found to override
+                // record R : R;
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.Equals(object?)").WithLocation(2, 8),
+                // (2,8): error CS0115: 'R.GetHashCode()': no suitable method found to override
+                // record R : R;
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.GetHashCode()").WithLocation(2, 8)
+                );
+        }
+
         [Fact, WorkItem(49628, "https://github.com/dotnet/roslyn/issues/49628")]
         public void AmbigCtor()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -228,7 +228,6 @@ class E
             comp.VerifyDiagnostics();
         }
 
-        
         [Fact, WorkItem(49263, "https://github.com/dotnet/roslyn/issues/49263")]
         public void DeriveFromSelf()
         {
@@ -275,7 +274,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(src, references: new[] { useCompilationReference ? lib_comp.ToMetadataReference() : lib_comp.EmitToImageReference() });
+            var comp = CreateCompilation(src, references: new[] { AsReference(lib_comp, useCompilationReference) });
             comp.VerifyEmitDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -228,32 +228,6 @@ class E
             comp.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem(49263, "https://github.com/dotnet/roslyn/issues/49263")]
-        public void DeriveFromSelf()
-        {
-            var src = @"
-record R : R;
-";
-            var comp = CreateCompilation(src);
-            comp.VerifyEmitDiagnostics(
-                // (2,8): error CS0146: Circular base type dependency involving 'R' and 'R'
-                // record R : R;
-                Diagnostic(ErrorCode.ERR_CircularBase, "R").WithArguments("R", "R").WithLocation(2, 8),
-                // (2,8): error CS0115: 'R.ToString()': no suitable method found to override
-                // record R : R;
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.ToString()").WithLocation(2, 8),
-                // (2,8): error CS0115: 'R.EqualityContract': no suitable method found to override
-                // record R : R;
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.EqualityContract").WithLocation(2, 8),
-                // (2,8): error CS0115: 'R.Equals(object?)': no suitable method found to override
-                // record R : R;
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.Equals(object?)").WithLocation(2, 8),
-                // (2,8): error CS0115: 'R.GetHashCode()': no suitable method found to override
-                // record R : R;
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "R").WithArguments("R.GetHashCode()").WithLocation(2, 8)
-                );
-        }
-
         [CombinatorialData]
         [Theory, WorkItem(49302, "https://github.com/dotnet/roslyn/issues/49302")]
         public void GetSimpleNonTypeMembers(bool useCompilationReference)
@@ -5370,7 +5344,7 @@ record C2: Error;
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(49263, "https://github.com/dotnet/roslyn/issues/49263")]
         public void ToString_SelfReferentialBase()
         {
             var src = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -276,6 +276,20 @@ class C
                 model.GetSymbolInfo(node).Symbol.ToTestDisplayString());
         }
 
+        [Fact, WorkItem(49302, "https://github.com/dotnet/roslyn/issues/49302")]
+        public void GetSimpleNonTypeMembers_DirectApiCheck()
+        {
+            var src = @"
+public record RecordA(RecordB B);
+
+public record RecordB(int C);
+";
+            var comp = CreateCompilation(src);
+            var b = comp.GlobalNamespace.GetTypeMember("RecordB");
+            AssertEx.SetEqual(new[] { "System.Boolean RecordB.op_Equality(RecordB? r1, RecordB? r2)" },
+                b.GetSimpleNonTypeMembers("op_Equality").ToTestDisplayStrings());
+        }
+
         [Fact, WorkItem(49628, "https://github.com/dotnet/roslyn/issues/49628")]
         public void AmbigCtor()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49302 (incorrectly resolving to object equality operator)
Closes https://github.com/dotnet/roslyn/issues/49263

Filled https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1273244 for ask-mode approval.
