### PR TITLE
[EE] Prettify compiler-generated field names with IDkmClrFullNameProvider.GetClrMemberName

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.Parser.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.Parser.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal static partial class GeneratedNames
+    {
+        internal const char DotReplacementInTypeNames = '-';
+        internal const string AnonymousNamePrefix = "<>f__AnonymousType";
+
+        internal static bool TryParseAnonymousTypeTemplateName(string name, out int index)
+        {
+            // No callers require anonymous types from net modules,
+            // so names with module id are ignored.
+            if (name.StartsWith(AnonymousNamePrefix, StringComparison.Ordinal))
+            {
+                if (int.TryParse(name.Substring(AnonymousNamePrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out index))
+                {
+                    return true;
+                }
+            }
+
+            index = -1;
+            return false;
+        }
+
+        // The type of generated name. See TryParseGeneratedName.
+        internal static GeneratedNameKind GetKind(string name)
+        {
+            GeneratedNameKind kind;
+            int openBracketOffset;
+            int closeBracketOffset;
+            return TryParseGeneratedName(name, out kind, out openBracketOffset, out closeBracketOffset) ? kind : GeneratedNameKind.None;
+        }
+
+        // Parse the generated name. Returns true for names of the form
+        // [CS$]<[middle]>c[__[suffix]] where [CS$] is included for certain
+        // generated names, where [middle] and [__[suffix]] are optional,
+        // and where c is a single character in [1-9a-z]
+        // (csharp\LanguageAnalysis\LIB\SpecialName.cpp).
+        internal static bool TryParseGeneratedName(
+            string name,
+            out GeneratedNameKind kind,
+            out int openBracketOffset,
+            out int closeBracketOffset)
+        {
+            openBracketOffset = -1;
+            if (name.StartsWith("CS$<", StringComparison.Ordinal))
+            {
+                openBracketOffset = 3;
+            }
+            else if (name.StartsWith("<", StringComparison.Ordinal))
+            {
+                openBracketOffset = 0;
+            }
+
+            if (openBracketOffset >= 0)
+            {
+                closeBracketOffset = name.IndexOfBalancedParenthesis(openBracketOffset, '>');
+                if (closeBracketOffset >= 0 && closeBracketOffset + 1 < name.Length)
+                {
+                    int c = name[closeBracketOffset + 1];
+                    if ((c >= '1' && c <= '9') || (c >= 'a' && c <= 'z')) // Note '0' is not special.
+                    {
+                        kind = (GeneratedNameKind)c;
+                        return true;
+                    }
+                }
+            }
+
+            kind = GeneratedNameKind.None;
+            openBracketOffset = -1;
+            closeBracketOffset = -1;
+            return false;
+        }
+
+        internal static int IndexOfBalancedParenthesis(this string str, int openingOffset, char closing)
+        {
+            char opening = str[openingOffset];
+
+            int depth = 1;
+            for (int i = openingOffset + 1; i < str.Length; i++)
+            {
+                var c = str[i];
+                if (c == opening)
+                {
+                    depth++;
+                }
+                else if (c == closing)
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        internal static bool TryParseSourceMethodNameFromGeneratedName(string generatedName, GeneratedNameKind requiredKind, out string methodName)
+        {
+            int openBracketOffset;
+            int closeBracketOffset;
+            GeneratedNameKind kind;
+            if (!TryParseGeneratedName(generatedName, out kind, out openBracketOffset, out closeBracketOffset))
+            {
+                methodName = null;
+                return false;
+            }
+
+            if (requiredKind != 0 && kind != requiredKind)
+            {
+                methodName = null;
+                return false;
+            }
+
+            methodName = generatedName.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+
+            if (kind.IsTypeName())
+            {
+                methodName = methodName.Replace(DotReplacementInTypeNames, '.');
+            }
+
+            return true;
+        }
+
+        // Extracts the slot index from a name of a field that stores hoisted variables or awaiters.
+        // Such a name ends with "__{slot index + 1}". 
+        // Returned slot index is >= 0.
+        internal static bool TryParseSlotIndex(string fieldName, out int slotIndex)
+        {
+            int lastUnder = fieldName.LastIndexOf('_');
+            if (lastUnder - 1 < 0 || lastUnder == fieldName.Length || fieldName[lastUnder - 1] != '_')
+            {
+                slotIndex = -1;
+                return false;
+            }
+
+            if (int.TryParse(fieldName.Substring(lastUnder + 1), NumberStyles.None, CultureInfo.InvariantCulture, out slotIndex) && slotIndex >= 1)
+            {
+                slotIndex--;
+                return true;
+            }
+
+            slotIndex = -1;
+            return false;
+        }        
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal static partial class GeneratedNames
     {
         internal const string SynthesizedLocalNamePrefix = "CS$";
-        internal const char DotReplacementInTypeNames = '-';
         private const string SuffixSeparator = "__";
         private const char IdSeparator = '_';
         private const char GenerationSeparator = '#';
@@ -70,24 +69,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return name;
-        }
-
-        internal const string AnonymousNamePrefix = "<>f__AnonymousType";
-
-        internal static bool TryParseAnonymousTypeTemplateName(string name, out int index)
-        {
-            // No callers require anonymous types from net modules,
-            // so names with module id are ignored.
-            if (name.StartsWith(AnonymousNamePrefix, StringComparison.Ordinal))
-            {
-                if (int.TryParse(name.Substring(AnonymousNamePrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out index))
-                {
-                    return true;
-                }
-            }
-
-            index = -1;
-            return false;
         }
 
         internal static string MakeAnonymousTypeBackingFieldName(string propertyName)
@@ -280,109 +261,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result.ToStringAndFree();
         }
 
-        // The type of generated name. See TryParseGeneratedName.
-        internal static GeneratedNameKind GetKind(string name)
-        {
-            GeneratedNameKind kind;
-            int openBracketOffset;
-            int closeBracketOffset;
-            return TryParseGeneratedName(name, out kind, out openBracketOffset, out closeBracketOffset) ? kind : GeneratedNameKind.None;
-        }
-
-        // Parse the generated name. Returns true for names of the form
-        // [CS$]<[middle]>c[__[suffix]] where [CS$] is included for certain
-        // generated names, where [middle] and [__[suffix]] are optional,
-        // and where c is a single character in [1-9a-z]
-        // (csharp\LanguageAnalysis\LIB\SpecialName.cpp).
-        internal static bool TryParseGeneratedName(
-            string name,
-            out GeneratedNameKind kind,
-            out int openBracketOffset,
-            out int closeBracketOffset)
-        {
-            openBracketOffset = -1;
-            if (name.StartsWith("CS$<", StringComparison.Ordinal))
-            {
-                openBracketOffset = 3;
-            }
-            else if (name.StartsWith("<", StringComparison.Ordinal))
-            {
-                openBracketOffset = 0;
-            }
-
-            if (openBracketOffset >= 0)
-            {
-                closeBracketOffset = name.IndexOfBalancedParenthesis(openBracketOffset, '>');
-                if (closeBracketOffset >= 0 && closeBracketOffset + 1 < name.Length)
-                {
-                    int c = name[closeBracketOffset + 1];
-                    if ((c >= '1' && c <= '9') || (c >= 'a' && c <= 'z')) // Note '0' is not special.
-                    {
-                        kind = (GeneratedNameKind)c;
-                        return true;
-                    }
-                }
-            }
-
-            kind = GeneratedNameKind.None;
-            openBracketOffset = -1;
-            closeBracketOffset = -1;
-            return false;
-        }
-
-        internal static bool TryParseSourceMethodNameFromGeneratedName(string generatedName, GeneratedNameKind requiredKind, out string methodName)
-        {
-            int openBracketOffset;
-            int closeBracketOffset;
-            GeneratedNameKind kind;
-            if (!TryParseGeneratedName(generatedName, out kind, out openBracketOffset, out closeBracketOffset))
-            {
-                methodName = null;
-                return false;
-            }
-
-            if (requiredKind != 0 && kind != requiredKind)
-            {
-                methodName = null;
-                return false;
-            }
-
-            methodName = generatedName.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
-
-            if (kind.IsTypeName())
-            {
-                methodName = methodName.Replace(DotReplacementInTypeNames, '.');
-            }
-
-            return true;
-        }
-
         internal static string AsyncAwaiterFieldName(int slotIndex)
         {
             Debug.Assert((char)GeneratedNameKind.AwaiterField == 'u');
             return "<>u__" + StringExtensions.GetNumeral(slotIndex + 1);
-        }
-
-        // Extracts the slot index from a name of a field that stores hoisted variables or awaiters.
-        // Such a name ends with "__{slot index + 1}". 
-        // Returned slot index is >= 0.
-        internal static bool TryParseSlotIndex(string fieldName, out int slotIndex)
-        {
-            int lastUnder = fieldName.LastIndexOf('_');
-            if (lastUnder - 1 < 0 || lastUnder == fieldName.Length || fieldName[lastUnder - 1] != '_')
-            {
-                slotIndex = -1;
-                return false;
-            }
-
-            if (int.TryParse(fieldName.Substring(lastUnder + 1), NumberStyles.None, CultureInfo.InvariantCulture, out slotIndex) && slotIndex >= 1)
-            {
-                slotIndex--;
-                return true;
-            }
-
-            slotIndex = -1;
-            return false;
         }
 
         internal static string MakeCachedFrameInstanceFieldName()

--- a/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
@@ -226,31 +226,6 @@ namespace Roslyn.Utilities
             }
         }
 
-        internal static int IndexOfBalancedParenthesis(this string str, int openingOffset, char closing)
-        {
-            char opening = str[openingOffset];
-
-            int depth = 1;
-            for (int i = openingOffset + 1; i < str.Length; i++)
-            {
-                var c = str[i];
-                if (c == opening)
-                {
-                    depth++;
-                }
-                else if (c == closing)
-                {
-                    depth--;
-                    if (depth == 0)
-                    {
-                        return i;
-                    }
-                }
-            }
-
-            return -1;
-        }
-
         // String isn't IEnumerable<char> in the current Portable profile. 
         internal static char First(this string arg)
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.ObjectModel;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
@@ -45,6 +46,21 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             expression = RemoveComments(expression);
             expression = RemoveFormatSpecifiers(expression, out formatSpecifiers);
             return RemoveLeadingAndTrailingContent(expression, 0, expression.Length, IsWhitespace, ch => ch == ';' || IsWhitespace(ch));
+        }
+
+        /// <summary>
+        /// Parses a compiler-generated name and returns the simpler user-visible name.
+        /// </summary>
+        internal override string PrettifyCompilerGeneratedName(string name)
+        {
+            if (!GeneratedNames.TryParseGeneratedName(name, out GeneratedNameKind kind, out int openBracketOffset, out int closeBracketOffset) ||
+                kind == GeneratedNameKind.None)
+            {
+                return name;
+            }
+
+            string result = name.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+            return result;
         }
 
         private static string RemoveComments(string expression)

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/NetFX20/CSharpResultProvider.NetFX20.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/NetFX20/CSharpResultProvider.NetFX20.csproj
@@ -28,6 +28,12 @@
     <Compile Include="..\..\..\..\..\Compilers\CSharp\Portable\SymbolDisplay\ObjectDisplay.cs">
       <Link>Compiler\SymbolDisplay\ObjectDisplay.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNameKind.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNameKind.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNames.Parser.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNames.Parser.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Source\ResultProvider\NetFX20\ResultProvider.NetFX20.csproj" />

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.CSharp.ResultProvider.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.CSharp.ResultProvider.csproj
@@ -28,9 +28,18 @@
     <Compile Include="..\..\..\..\..\Compilers\CSharp\Portable\SymbolDisplay\ObjectDisplay.cs">
       <Link>Compiler\SymbolDisplay\ObjectDisplay.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNameKind.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNameKind.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNames.Parser.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNames.Parser.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Core\Source\ResultProvider\Portable\Microsoft.CodeAnalysis.ResultProvider.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.ResultProvider.UnitTests" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine-implementation" Version="$(MicrosoftVisualStudioDebuggerEngineimplementationVersion)" />

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.CSharp.ResultProvider.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.CSharp.ResultProvider.csproj
@@ -39,9 +39,6 @@
     <ProjectReference Include="..\..\..\..\Core\Source\ResultProvider\Portable\Microsoft.CodeAnalysis.ResultProvider.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.ResultProvider.UnitTests" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine-implementation" Version="$(MicrosoftVisualStudioDebuggerEngineimplementationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Metadata-implementation" Version="$(MicrosoftVisualStudioDebuggerMetadataimplementationVersion)" />
   </ItemGroup>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Microsoft.CodeAnalysis.CSharp.ResultProvider.UnitTests.csproj
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Microsoft.CodeAnalysis.CSharp.ResultProvider.UnitTests.csproj
@@ -27,6 +27,12 @@
     <Compile Include="..\..\..\..\Compilers\CSharp\Portable\SymbolDisplay\ObjectDisplay.cs">
       <Link>Compiler\SymbolDisplay\ObjectDisplay.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNameKind.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNameKind.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNames.Parser.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNames.Parser.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -137,6 +137,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             bool memberIsStatic)
         {
             string qualifier;
+
             if (memberIsStatic)
             {
                 bool sawInvalidIdentifier;
@@ -160,6 +161,22 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 qualifier = parentFullName;
             }
+
+            if (qualifier.IsCompilerGenerated())
+            {
+                qualifier = PrettifyCompilerGeneratedName(qualifier);
+            }
+
+            if (memberName.IsCompilerGenerated())
+            {
+                memberName = PrettifyCompilerGeneratedName(memberName);
+            }
+
+            if (string.IsNullOrEmpty(qualifier))
+            {
+                return memberName;
+            }
+
             return $"{qualifier}.{memberName}";
         }
 
@@ -187,6 +204,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal abstract bool IsPredefinedType(Type type);
 
         internal abstract bool IsWhitespace(char c);
+
+        internal abstract string PrettifyCompilerGeneratedName(string name);
 
         // Note: We could be less conservative (e.g. "new C()").
         private bool NeedsParentheses(string expr)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -49,6 +49,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return RemoveLeadingAndTrailingWhitespace(expression)
         End Function
 
+        Friend Overrides Function PrettifyCompilerGeneratedName(expression As String) As String
+            Return expression
+        End Function
+
         Private Shared Function RemoveComments(expression As String) As String
             ' Workaround for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/847849
             ' Do not remove any comments that might be in a string. 


### PR DESCRIPTION
Issue:
- The debugger's NullReferenceException analysis feature figures out what was null through metadata and calls into the EE to display the offender as an expression.
- If a field reference was null, we end up calling into GetClrMemberName.
- However, for hoisted locals, etc we end up with an ugly mangled name like `<myVar>5__1` was null.

Changes:
1. Formatter:
- Tweak implementation to handle compiler generated names.

2. CSharpFormatter:
- Add implementation for C#. VB is still TODO.
- Split up GeneratedNames so that it can be included in the CSharpResultProvider.