### PR TITLE
Handle BoundTypeArguments in the VB operation factory

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -277,6 +277,8 @@ Namespace Microsoft.CodeAnalysis.Operations
                     Return CreateBoundReDimOperation(DirectCast(boundNode, BoundRedimStatement))
                 Case BoundKind.RedimClause
                     Return CreateBoundReDimClauseOperation(DirectCast(boundNode, BoundRedimClause))
+                Case BoundKind.TypeArguments
+                    Return CreateBoundTypeArgumentsOperation(DirectCast(boundNode, BoundTypeArguments))
 
                 Case BoundKind.AddressOfOperator,
                      BoundKind.ArrayLiteral,
@@ -643,6 +645,23 @@ Namespace Microsoft.CodeAnalysis.Operations
             ' if child has syntax node point to same syntax node as bad expression, then this invalid expression Is implicit
             Dim isImplicit = boundBadExpression.WasCompilerGenerated OrElse boundBadExpression.ChildBoundNodes.Any(Function(e) e?.Syntax Is boundBadExpression.Syntax)
             Dim children = CreateFromArray(Of BoundExpression, IOperation)(boundBadExpression.ChildBoundNodes)
+            Return New InvalidOperation(children, _semanticModel, syntax, type, constantValue, isImplicit)
+        End Function
+
+        Private Function CreateBoundTypeArgumentsOperation(boundTypeArguments As BoundTypeArguments) As IInvalidOperation
+            ' This can occur in scenarios involving unresolved extension methods in Strict mode, such as
+            ' element.UnresolvedExtension(Of String)()
+            ' Binding treats the `Of String` as the argument to the method, resulting in one of the children of the BoundBadExpression
+            ' being these type arguments. Just create an invalid operation to represent the node, as it won't ever be surfaced in good
+            ' code.
+
+            Dim syntax As SyntaxNode = boundTypeArguments.Syntax
+            ' Match GetTypeInfo behavior for the syntax
+            Dim type As ITypeSymbol = Nothing
+            Dim constantValue As ConstantValue = boundTypeArguments.ConstantValueOpt
+            Dim isImplicit As Boolean = boundTypeArguments.WasCompilerGenerated
+            Dim children As ImmutableArray(Of IOperation) = ImmutableArray(Of IOperation).Empty
+
             Return New InvalidOperation(children, _semanticModel, syntax, type, constantValue, isImplicit)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -649,11 +649,10 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundTypeArgumentsOperation(boundTypeArguments As BoundTypeArguments) As IInvalidOperation
-            ' This can occur in scenarios involving unresolved extension methods in Strict mode, such as
-            ' element.UnresolvedExtension(Of String)()
-            ' Binding treats the `Of String` as the argument to the method, resulting in one of the children of the BoundBadExpression
-            ' being these type arguments. Just create an invalid operation to represent the node, as it won't ever be surfaced in good
-            ' code.
+            ' This can occur in scenarios involving latebound member accesses in Strict mode, such as
+            ' element.UnresolvedMember(Of String)
+            ' The BadExpression has 2 children in this case: the receiver, and the type arguments. 
+            ' Just create an invalid operation to represent the node, as it won't ever be surfaced in good code.
 
             Dim syntax As SyntaxNode = boundTypeArguments.Syntax
             ' Match GetTypeInfo behavior for the syntax

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_InvalidExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_InvalidExpression.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System
 Imports Microsoft.CodeAnalysis.Operations
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -916,7 +917,6 @@ Block[B8] - Exit
         <Fact, WorkItem(35813, "https://github.com/dotnet/roslyn/issues/35813"), WorkItem(45382, "https://github.com/dotnet/roslyn/issues/45382")>
         Public Sub InvalidTypeArguments()
             Dim source = <![CDATA[
-Option Strict On
 Class C
     Public Sub M(node As Object)
         node.ExtensionMethod(Of Object)() 'BIND:"node.ExtensionMethod(Of Object)()"
@@ -924,7 +924,7 @@ Class C
 End Class
 ]]>.Value
 
-            Dim expectedOperationTree = <![CDATA[
+            Dim expectedStrictOperationTree = <![CDATA[
 IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'node.Extens ... f Object)()')
   Children(1):
       IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'node.Extens ... (Of Object)')
@@ -940,7 +940,22 @@ BC30574: Option Strict On disallows late binding.
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ]]>.Value
 
-            VerifyOperationTreeAndDiagnosticsForTest(Of InvocationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+            VerifyOperationTreeAndDiagnosticsForTest(Of InvocationExpressionSyntax)("Option Strict On" + Environment.NewLine + source, expectedStrictOperationTree, expectedDiagnostics)
+
+            Dim expectedNonStrictOperationTree = <![CDATA[
+IDynamicInvocationOperation (OperationKind.DynamicInvocation, Type: System.Object) (Syntax: 'node.Extens ... f Object)()')
+  Expression: 
+    IDynamicMemberReferenceOperation (Member Name: "ExtensionMethod", Containing Type: null) (OperationKind.DynamicMemberReference, Type: System.Object) (Syntax: 'node.Extens ... (Of Object)')
+      Type Arguments(1):
+        Symbol: System.Object
+      Instance Receiver: 
+        IParameterReferenceOperation: node (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'node')
+  Arguments(0)
+  ArgumentNames(0)
+  ArgumentRefKinds: null
+]]>.Value
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of InvocationExpressionSyntax)("Option Strict Off" + Environment.NewLine + source, expectedNonStrictOperationTree, expectedDiagnostics:=String.Empty)
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/45382. Fixes https://github.com/dotnet/roslyn/issues/35813.
