### PR TITLE
Add repro for 50198

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -28138,5 +28138,24 @@ namespace System.Runtime.CompilerServices
 </member>
 ", constructor.GetDocumentationCommentXml());
         }
+
+        [Fact, WorkItem(50198, "https://github.com/dotnet/roslyn/issues/50198")]
+        public void Repro50198()
+        {
+            var src = @"
+using System.ComponentModel;
+
+public record BaseViewModel : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+}
+";
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics(
+                // (6,46): warning CS0067: The event 'BaseViewModel.PropertyChanged' is never used
+                //     public event PropertyChangedEventHandler PropertyChanged;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "PropertyChanged").WithArguments("BaseViewModel.PropertyChanged").WithLocation(6, 46)
+                );
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/50198

With this unittest, I was able to repro the stack overflow on commit SHA `2267a84d` (used in SDK `5.0.200-preview.20614.14`).
But it looks like this was fixed before my recent change in the area (to delay binding when constructing record symbols), so I'm not sure exactly which PR fixed it.