### PR TITLE
Use the partial semantics workspace for the navbars to avoid expensive computation

### DIFF
--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -382,7 +382,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             }
             else
             {
-                var document = _subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+                // When navigating, just use the partial semantics workspace.  Navigation doesn't need the fully bound
+                // compilations to be created, and it can save us a lot of costly time building skeleton assemblies.
+                var document = _subjectBuffer.CurrentSnapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
                 if (document != null)
                 {
                     var languageService = document.GetRequiredLanguageService<INavigationBarItemService>();


### PR DESCRIPTION
Precursor to potentially moving these parts of NavBar out of process.