### PR TITLE
Fix source generator multi-targeting handling

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/HierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/Def/Implementation/HierarchyItemToProjectIdMap.cs
@@ -16,11 +16,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     [ExportWorkspaceService(typeof(IHierarchyItemToProjectIdMap), ServiceLayer.Host), Shared]
     internal class HierarchyItemToProjectIdMap : IHierarchyItemToProjectIdMap
     {
-        private readonly VisualStudioWorkspace _workspace;
+        private readonly VisualStudioWorkspaceImpl _workspace;
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-        public HierarchyItemToProjectIdMap(VisualStudioWorkspace workspace)
+        public HierarchyItemToProjectIdMap(VisualStudioWorkspaceImpl workspace)
             => _workspace = workspace;
 
         public bool TryGetProjectId(IVsHierarchyItem hierarchyItem, string? targetFrameworkMoniker, [NotNullWhen(true)] out ProjectId? projectId)
@@ -31,14 +31,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             // project system to the language service, so that's the one the one to query here. To do that we need to get
             // the "nested" hierarchy from the IVsHierarchyItem.
             var nestedHierarchy = hierarchyItem.HierarchyIdentity.NestedHierarchy;
-            var nestedHierarchyId = hierarchyItem.HierarchyIdentity.NestedItemID;
-
-            if (!nestedHierarchy.TryGetCanonicalName(nestedHierarchyId, out var nestedCanonicalName)
-                || !nestedHierarchy.TryGetItemName(nestedHierarchyId, out var nestedName))
-            {
-                projectId = null;
-                return false;
-            }
 
             // First filter the projects by matching up properties on the input hierarchy against properties on each
             // project's hierarchy.
@@ -55,32 +47,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                         return false;
                     }
 
-                    // Here we try to match the hierarchy from Solution Explorer to a hierarchy from the Roslyn project.
-                    // The canonical name of a hierarchy item must be unique _within_ an hierarchy, but since we're
-                    // examining multiple hierarchies the canonical name could be the same. Indeed this happens when two
-                    // project files are in the same folder--they both use the full path to the _folder_ as the canonical
-                    // name. To distinguish them we also examine the "regular" name, which will necessarily be different
-                    // if the two projects are in the same folder.
-                    // Note that if a project has been loaded with Lightweight Solution Load it won't even have a
-                    // hierarchy, so we need to check for null first.
                     var hierarchy = _workspace.GetHierarchy(p.Id);
 
-                    if (hierarchy != null
-                        && hierarchy.TryGetCanonicalName((uint)VSConstants.VSITEMID.Root, out var projectCanonicalName)
-                        && hierarchy.TryGetItemName((uint)VSConstants.VSITEMID.Root, out var projectName)
-                        && projectCanonicalName.Equals(nestedCanonicalName, System.StringComparison.OrdinalIgnoreCase)
-                        && projectName.Equals(nestedName))
-                    {
-                        if (targetFrameworkMoniker == null)
-                        {
-                            return true;
-                        }
-
-                        return hierarchy.TryGetTargetFrameworkMoniker((uint)VSConstants.VSITEMID.Root, out var projectTargetFrameworkMoniker)
-                            && projectTargetFrameworkMoniker.Equals(targetFrameworkMoniker);
-                    }
-
-                    return false;
+                    return hierarchy == nestedHierarchy;
                 })
                 .ToArray();
 
@@ -89,6 +58,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 projectId = candidateProjects[0].Id;
                 return true;
+            }
+
+            // For CPS projects, we may have a string we extracted from a $TFM-prefixed capability; compare that to the string we're given
+            // from CPS to see if this matches.
+            if (targetFrameworkMoniker != null)
+            {
+                var matchingProject = candidateProjects.FirstOrDefault(p => _workspace.TryGetDependencyNodeTargetIdentifier(p.Id) == targetFrameworkMoniker);
+
+                if (matchingProject != null)
+                {
+                    projectId = matchingProject.Id;
+                    return true;
+                }
             }
 
             // If we have multiple candidates then we might be dealing with Web Application Projects. In this case

--- a/src/VisualStudio/Core/Def/Implementation/HierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/Def/Implementation/HierarchyItemToProjectIdMap.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -25,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         public HierarchyItemToProjectIdMap(VisualStudioWorkspace workspace)
             => _workspace = workspace;
 
-        public bool TryGetProjectId(IVsHierarchyItem hierarchyItem, string targetFrameworkMoniker, out ProjectId projectId)
+        public bool TryGetProjectId(IVsHierarchyItem hierarchyItem, string? targetFrameworkMoniker, [NotNullWhen(true)] out ProjectId? projectId)
         {
             // A project node is represented in two different hierarchies: the solution's IVsHierarchy (where it is a leaf node)
             // and the project's own IVsHierarchy (where it is the root node). The IVsHierarchyItem joins them together for the

--- a/src/VisualStudio/Core/Def/Implementation/IHierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/Def/Implementation/IHierarchyItemToProjectIdMap.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.Shell;
@@ -25,6 +24,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         /// (one per target framework) for a single project on disk.</param>
         /// <param name="projectId">The <see cref="ProjectId"/> of the found project, if any.</param>
         /// <returns>True if the desired project was found; false otherwise.</returns>
-        bool TryGetProjectId(IVsHierarchyItem hierarchyItem, string targetFrameworkMoniker, out ProjectId projectId);
+        bool TryGetProjectId(IVsHierarchyItem hierarchyItem, string? targetFrameworkMoniker, [NotNullWhen(true)] out ProjectId? projectId);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/AdditionalPropertyNames.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/AdditionalPropertyNames.cs
@@ -18,5 +18,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         public const string MaxSupportedLangVersion = nameof(MaxSupportedLangVersion);
         public const string RunAnalyzers = nameof(RunAnalyzers);
         public const string RunAnalyzersDuringLiveAnalysis = nameof(RunAnalyzersDuringLiveAnalysis);
+        public const string TemporaryDependencyNodeTargetIdentifier = nameof(TemporaryDependencyNodeTargetIdentifier);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -403,6 +403,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             set => _workspace.SetMaxLanguageVersion(Id, value);
         }
 
+        internal string DependencyNodeTargetIdentifier
+        {
+            set => _workspace.SetDependencyNodeTargetIdentifier(Id, value);
+        }
+
         #region Batching
 
         public BatchScope CreateBatchScope()

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -74,6 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private ImmutableDictionary<ProjectId, IVsHierarchy?> _projectToHierarchyMap = ImmutableDictionary<ProjectId, IVsHierarchy?>.Empty;
         private ImmutableDictionary<ProjectId, Guid> _projectToGuidMap = ImmutableDictionary<ProjectId, Guid>.Empty;
         private readonly Dictionary<ProjectId, string?> _projectToMaxSupportedLangVersionMap = new();
+        private readonly Dictionary<ProjectId, string> _projectToDependencyNodeTargetIdentifier = new();
 
         /// <summary>
         /// A map to fetch the path to a rule set file for a project. This right now is only used to implement
@@ -1314,6 +1315,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return _projectToGuidMap.GetValueOrDefault(projectId, defaultValue: Guid.Empty);
         }
 
+        internal string? TryGetDependencyNodeTargetIdentifier(ProjectId projectId)
+        {
+            lock (_gate)
+            {
+                return _projectToDependencyNodeTargetIdentifier.GetValueOrDefault(projectId, defaultValue: null);
+            }
+        }
+
         internal override void SetDocumentContext(DocumentId documentId)
         {
             _foregroundObject.AssertIsForeground();
@@ -1588,6 +1597,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _projectToHierarchyMap = _projectToHierarchyMap.Remove(projectId);
                 _projectToGuidMap = _projectToGuidMap.Remove(projectId);
                 _projectToMaxSupportedLangVersionMap.Remove(projectId);
+                _projectToDependencyNodeTargetIdentifier.Remove(projectId);
                 _projectToRuleSetFilePath.Remove(projectId);
 
                 foreach (var (projectName, projects) in _projectSystemNameToProjectsMap)
@@ -1976,6 +1986,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             lock (_gate)
             {
                 _projectToMaxSupportedLangVersionMap[projectId] = maxLanguageVersion;
+            }
+        }
+
+        internal void SetDependencyNodeTargetIdentifier(ProjectId projectId, string targetIdentifier)
+        {
+            lock (_gate)
+            {
+                _projectToDependencyNodeTargetIdentifier[projectId] = targetIdentifier;
             }
         }
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -177,6 +177,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 var boolValue = bool.TryParse(value, out var parsedBoolValue) ? parsedBoolValue : (bool?)null;
                 _visualStudioProject.RunAnalyzersDuringLiveAnalysis = boolValue;
             }
+            else if (name == AdditionalPropertyNames.TemporaryDependencyNodeTargetIdentifier && !RoslynString.IsNullOrEmpty(value))
+            {
+                _visualStudioProject.DependencyNodeTargetIdentifier = value;
+            }
         }
 
         public void AddMetadataReference(string referencePath, MetadataReferenceProperties properties)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -824,7 +824,9 @@ namespace Microsoft.CodeAnalysis
 
                 // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
                 // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
-                using var _ = ArrayBuilder<byte>.GetInstance(capacity: (generatorName.Length + hintName.Length + 1) * 2, out var hashInput);
+                var projectIdBytes = projectId.Id.ToByteArray();
+                using var _ = ArrayBuilder<byte>.GetInstance(capacity: (generatorName.Length + hintName.Length + 1) * 2 + projectIdBytes.Length, out var hashInput);
+                hashInput.AddRange(projectIdBytes);
                 hashInput.AddRange(Encoding.Unicode.GetBytes(generatorName));
 
                 // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.UnitTests.Persistence;
 using Xunit;
@@ -33,13 +34,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         public static Project AddEmptyProject(Solution solution, string languageName = LanguageNames.CSharp)
         {
+            var id = ProjectId.CreateNewId();
             return solution.AddProject(
                 ProjectInfo.Create(
-                    ProjectId.CreateNewId(),
+                    id,
                     VersionStamp.Default,
                     name: "TestProject",
                     assemblyName: "TestProject",
-                    language: languageName)).Projects.Single();
+                    language: languageName)).GetRequiredProject(id);
         }
 
 #nullable disable

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/IDictionaryExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
@@ -35,7 +36,8 @@ namespace Roslyn.Utilities
             return default!;
         }
 
-        public static TValue GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+        [return: NotNullIfNotNull("defaultValue")]
+        public static TValue? GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue? defaultValue)
             where TKey : notnull
         {
             if (dictionary.TryGetValue(key, out var value))


### PR DESCRIPTION
We have a somewhat complicated dance between the project system and Roslyn for putting analyzer nodes in the Solution Explorer. The project system is addressing [their portion of the problem](https://github.com/dotnet/project-system/issues/6820) (a full writeup is there) and this is our portion.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1275676. This also fixes https://github.com/dotnet/roslyn/issues/50714 which is a small fix, and without it makes testing this difficult since otherwise the files can be hard to distinguish. That is fixed in a separate commit.

