### PR TITLE
Use Helix for release build and skip nullable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,8 @@ jobs:
     jobName: Build_Windows_Release
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
-    vmImageName: windows-2019
+    queueName: BuildPool.Windows.10.Amd64.Open
+    buildArguments: "/p:Features=run-nullable-analysis=never"
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -15,6 +15,9 @@ parameters:
 - name: vmImageName
   type: string
   default: ''
+- name: buildArguments
+  type: string
+  default: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -40,7 +43,7 @@ jobs:
       displayName: Build
       inputs:
         filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -publish -binaryLog -skipDocumentation
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -publish -binaryLog -skipDocumentation ${{ parameters.buildArguments }}
 
     - task: PowerShell@2 
       displayName: Prepare Unit Tests


### PR DESCRIPTION
Helix recently deployed some improvements to I/O perf that makes them more consistently faster than the AzDO build agents.

I'd like to drop the use of AzDO agents for the Windows build, and instead take advantage of the Debug/Release split to see if we can observe a difference in the Build task duration based on whether nullable analysis is suppressed in the build.