### PR TITLE
Switch to simpler byte processing code now that Mono issue has been fixed

### DIFF
--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/SqlConnection.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2.Interop
                     Span<byte> bytes = stackalloc byte[Checksum.HashSize];
                     self.ThrowIfNotOk(NativeMethods.sqlite3_blob_read(blobHandle, bytes, offset: 0));
 
-                    Contract.ThrowIfFalse(Checksum.HashData.FromSpan(bytes, out var result));
+                    Contract.ThrowIfFalse(MemoryMarshal.TryRead(bytes, out Checksum.HashData result));
                     return new Optional<Checksum.HashData>(result);
                 });
         }

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                     {
                         checksum ??= Checksum.Null;
                         Span<byte> checksumBytes = stackalloc byte[Checksum.HashSize];
-                        checksum.WriteTo(checksumBytes);
+                        Contract.ThrowIfFalse(checksum.TryWriteTo(checksumBytes));
 
                         var (dataBytes, dataLength, dataPooled) = GetBytes(stream);
 

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                     {
                         checksum ??= Checksum.Null;
                         Span<byte> checksumBytes = stackalloc byte[Checksum.HashSize];
-                        Contract.ThrowIfFalse(checksum.TryWriteTo(checksumBytes));
+                        checksum.WriteTo(checksumBytes);
 
                         var (dataBytes, dataLength, dataPooled) = GetBytes(stream);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -37,82 +37,34 @@ namespace Microsoft.CodeAnalysis
             => _checksum = hash;
 
         /// <summary>
-        /// Create Checksum from given byte array. if byte array is bigger than
-        /// <see cref="HashSize"/>, it will be truncated to the size
+        /// Create Checksum from given byte array. if byte array is bigger than <see cref="HashSize"/>, it will be
+        /// truncated to the size.
         /// </summary>
         public static Checksum From(byte[] checksum)
-        {
-            if (checksum.Length == 0)
-            {
-                return Null;
-            }
-
-            if (checksum.Length < HashSize)
-            {
-                throw new ArgumentException($"checksum must be equal or bigger than the hash size: {HashSize}", nameof(checksum));
-            }
-
-            return FromWorker(checksum);
-        }
+            => From(checksum.AsSpan());
 
         /// <summary>
-        /// Create Checksum from given byte array. if byte array is bigger than
-        /// <see cref="HashSize"/>, it will be truncated to the size
+        /// Create Checksum from given byte array. if byte array is bigger than <see cref="HashSize"/>, it will be
+        /// truncated to the size.
         /// </summary>
         public static Checksum From(ImmutableArray<byte> checksum)
+            => From(checksum.AsSpan());
+
+        public static Checksum From(ReadOnlySpan<byte> checksum)
         {
             if (checksum.Length == 0)
-            {
                 return Null;
-            }
 
             if (checksum.Length < HashSize)
-            {
-                throw new ArgumentException($"{nameof(checksum)} must be equal or bigger than the hash size: {HashSize}", nameof(checksum));
-            }
+                throw new ArgumentException($"checksum must be equal or bigger than the hash size: {HashSize}", nameof(checksum));
 
-            using var pooled = SharedPools.ByteArray.GetPooledObject();
-            var bytes = pooled.Object;
-            checksum.CopyTo(sourceIndex: 0, bytes, destinationIndex: 0, length: HashSize);
-
-            return FromWorker(bytes);
-        }
-
-        public static Checksum FromSerialized(byte[] checksum)
-        {
-            if (checksum.Length == 0)
-            {
-                return Null;
-            }
-
-            if (checksum.Length != HashSize)
-            {
-                throw new ArgumentException($"{nameof(checksum)} must be equal to the hash size: {HashSize}", nameof(checksum));
-            }
-
-            return FromWorker(checksum);
-        }
-
-        private static unsafe Checksum FromWorker(byte[] checksum)
-        {
-            fixed (byte* data = checksum)
-            {
-                // Avoid a direct dereferencing assignment since sizeof(HashData) may be greater than HashSize.
-                //
-                // ex) "https://bugzilla.xamarin.com/show_bug.cgi?id=60298" - LayoutKind.Explicit, Size = 12 ignored with 64bit alignment
-                // or  "https://github.com/dotnet/roslyn/issues/23722" - Checksum throws on Mono 64-bit
-                return new Checksum(HashData.FromPointer((HashData*)data));
-            }
+            Contract.ThrowIfFalse(MemoryMarshal.TryRead(checksum, out HashData hash));
+            return new Checksum(hash);
         }
 
         public bool Equals(Checksum other)
         {
-            if (other == null)
-            {
-                return false;
-            }
-
-            return _checksum == other._checksum;
+            return other != null && _checksum == other._checksum;
         }
 
         public override bool Equals(object obj)
@@ -121,8 +73,13 @@ namespace Microsoft.CodeAnalysis
         public override int GetHashCode()
             => _checksum.GetHashCode();
 
-        public override unsafe string ToString()
+        public unsafe string ToBase64String()
         {
+#if NETCOREAPP
+            Span<byte> bytes = stackalloc byte[sizeof(HashData)];
+            Contract.ThrowIfFalse(this.TryWriteTo(bytes));
+            return Convert.ToBase64String(bytes);
+#else
             var data = new byte[sizeof(HashData)];
             fixed (byte* dataPtr = data)
             {
@@ -130,7 +87,14 @@ namespace Microsoft.CodeAnalysis
             }
 
             return Convert.ToBase64String(data, 0, HashSize);
+#endif
         }
+
+        public static Checksum FromBase64String(string value)
+            => value == null ? null : From(Convert.FromBase64String(value));
+
+        public override unsafe string ToString()
+            => ToBase64String();
 
         public static bool operator ==(Checksum left, Checksum right)
             => EqualityComparer<Checksum>.Default.Equals(left, right);
@@ -149,8 +113,8 @@ namespace Microsoft.CodeAnalysis
         public void WriteTo(ObjectWriter writer)
             => _checksum.WriteTo(writer);
 
-        public void WriteTo(Span<byte> span)
-            => _checksum.WriteTo(span);
+        public bool TryWriteTo(Span<byte> span)
+            => MemoryMarshal.TryWrite(span, ref Unsafe.AsRef(in _checksum));
 
         public static Checksum ReadFrom(ObjectReader reader)
             => new(HashData.ReadFrom(reader));
@@ -189,50 +153,13 @@ namespace Microsoft.CodeAnalysis
                 => x.Equals(y);
 
             public static bool operator !=(HashData x, HashData y)
-                => !x.Equals(y);
+                => !(x == y);
 
             public void WriteTo(ObjectWriter writer)
             {
                 writer.WriteInt64(Data1);
                 writer.WriteInt64(Data2);
                 writer.WriteInt32(Data3);
-            }
-
-            public void WriteTo(Span<byte> span)
-            {
-                Contract.ThrowIfFalse(span.Length >= HashSize);
-                unsafe
-                {
-                    fixed (byte* bytes = span)
-                    {
-                        // Avoid a direct dereferencing assignment since sizeof(HashData) may be greater than HashSize.
-                        //
-                        // ex) "https://bugzilla.xamarin.com/show_bug.cgi?id=60298" - LayoutKind.Explicit, Size = 12 ignored with 64bit alignment
-                        // or  "https://github.com/dotnet/roslyn/issues/23722" - Checksum throws on Mono 64-bit
-
-                        *(long*)bytes = this.Data1;
-                        *(long*)(bytes + sizeof(long)) = this.Data2;
-                        *(int*)(bytes + sizeof(long) + sizeof(long)) = this.Data3;
-                    }
-                }
-            }
-
-            public static unsafe bool FromSpan(Span<byte> bytes, out HashData result)
-            {
-                if (bytes.Length < HashSize)
-                {
-                    result = default;
-                    return false;
-                }
-
-                unsafe
-                {
-                    fixed (byte* ptr = bytes)
-                    {
-                        result = FromPointer((HashData*)ptr);
-                        return true;
-                    }
-                }
             }
 
             public static unsafe HashData FromPointer(HashData* hash)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -73,27 +73,30 @@ namespace Microsoft.CodeAnalysis
         public override int GetHashCode()
             => _checksum.GetHashCode();
 
-        public unsafe string ToBase64String()
+        public string ToBase64String()
         {
 #if NETCOREAPP
             Span<byte> bytes = stackalloc byte[sizeof(HashData)];
             Contract.ThrowIfFalse(this.TryWriteTo(bytes));
             return Convert.ToBase64String(bytes);
 #else
-            var data = new byte[sizeof(HashData)];
-            fixed (byte* dataPtr = data)
+            unsafe
             {
-                *(HashData*)dataPtr = _checksum;
-            }
+                var data = new byte[sizeof(HashData)];
+                fixed (byte* dataPtr = data)
+                {
+                    *(HashData*)dataPtr = _checksum;
+                }
 
-            return Convert.ToBase64String(data, 0, HashSize);
+                return Convert.ToBase64String(data, 0, HashSize);
+            }
 #endif
         }
 
         public static Checksum FromBase64String(string value)
             => value == null ? null : From(Convert.FromBase64String(value));
 
-        public override unsafe string ToString()
+        public override string ToString()
             => ToBase64String();
 
         public static bool operator ==(Checksum left, Checksum right)

--- a/src/Workspaces/Remote/Core/Serialization/RoslynJsonConverter.cs
+++ b/src/Workspaces/Remote/Core/Serialization/RoslynJsonConverter.cs
@@ -174,13 +174,10 @@ namespace Microsoft.CodeAnalysis.Remote
         private class ChecksumJsonConverter : BaseJsonConverter<Checksum>
         {
             protected override Checksum ReadValue(JsonReader reader, JsonSerializer serializer)
-            {
-                var value = (string)reader.Value;
-                return value == null ? null : Checksum.FromSerialized(Convert.FromBase64String(value));
-            }
+                => Checksum.FromBase64String((string)reader.Value);
 
             protected override void WriteValue(JsonWriter writer, Checksum value, JsonSerializer serializer)
-                => writer.WriteValue(value?.ToString());
+                => writer.WriteValue(value?.ToBase64String());
         }
 
         private class PinnedSolutionInfoJsonConverter : BaseJsonConverter<PinnedSolutionInfo>


### PR DESCRIPTION
We avoided some more idiomatic ways of converting between bytes and value types due to an old mono bug: https://bugzilla.xamarin.com/show_bug.cgi?id=60298

That bug was fixed in https://github.com/mono/mono/releases/tag/mono-5.12.0.226 which VS4Mac is already using.  So this PR removes the hacky approaches and moves to the better idiomatic forms we have.