### PR TITLE
Analyze properties with conditional attributes in patterns

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             // dispatch to the switch sections
-            var (initialState, afterSwitchState) = VisitSwitchStatementDispatch(node);
+            var afterSwitchState = VisitSwitchStatementDispatch(node);
 
             // visit switch sections
             var switchSections = node.SwitchSections;
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        protected virtual (TLocalState initialState, TLocalState afterSwitchState) VisitSwitchStatementDispatch(BoundSwitchStatement node)
+        protected virtual TLocalState VisitSwitchStatementDispatch(BoundSwitchStatement node)
         {
             // visit switch header
             VisitRvalue(node.Expression);
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Join(ref afterSwitchState, ref initialState);
             }
 
-            return (initialState, afterSwitchState);
+            return afterSwitchState;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5131,6 +5131,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            ApplyMemberPostConditions(receiverSlot, method);
+        }
+
+        private void ApplyMemberPostConditions(int receiverSlot, MethodSymbol method)
+        {
+            Debug.Assert(receiverSlot >= 0);
             do
             {
                 var type = method.ContainingType;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -271,14 +271,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public static PossiblyConditionalState Create(NullableWalker nullableWalker)
             {
-                if (nullableWalker.IsConditionalState)
-                {
-                    return new PossiblyConditionalState(nullableWalker.StateWhenTrue, nullableWalker.StateWhenFalse);
-                }
-                else
-                {
-                    return new PossiblyConditionalState(nullableWalker.State);
-                }
+                return nullableWalker.IsConditionalState
+                    ? new PossiblyConditionalState(nullableWalker.StateWhenTrue, nullableWalker.StateWhenFalse)
+                    : new PossiblyConditionalState(nullableWalker.State);
             }
 
             public PossiblyConditionalState Clone()


### PR DESCRIPTION
`LearnFromDecisionDag` is the method that analyzes the pattern DAG and figures out the nullable state for each label in the DAG.

Three main parts of the change:
1. Previously, that method assumed that we're starting with an unconditional state. Now, it can handle the split state resulting (such as that from a property marked with `MemberNotNullWhen`).
2. The DAG for `{ IsOk : true }` is composed of an evaluation step (that evaluates the property) and a test step. Now, it is possible for the evaluation step to result in a split state. So the data structure that keeps track of the worst case state as input for each DAG node now has to store states that may be conditional.
3. We'd like the analysis of `(IsOk, ...) is (true, ...)` to behave like that of `IsOk is true` despite temps and tuples being involved. So we re-use the slots of the element expressions when possible. Note this only works for top-level tuple, not for nested tuple.

Filed issue https://github.com/dotnet/roslyn/issues/50980 for equality on tuples. We'd like the analysis of `(IsOk, ...) == (true, ...)` to behave like that of `IsOk == true`.

Fixes https://github.com/dotnet/roslyn/issues/49750
Fixes https://github.com/dotnet/roslyn/issues/51020 (patterns on tuple inputs). 