### PR TITLE
Handle SyntaxKind.QualifiedName in LanguagerParser.GetPrecedence

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9849,6 +9849,7 @@ tryAgain:
                 case SyntaxKind.PostDecrementExpression:
                 case SyntaxKind.PostIncrementExpression:
                 case SyntaxKind.PredefinedType:
+                case SyntaxKind.QualifiedName:
                 case SyntaxKind.RefExpression:
                 case SyntaxKind.SimpleMemberAccessExpression:
                 case SyntaxKind.StackAllocArrayCreationExpression:

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7385,10 +7385,10 @@ done:;
                 return true;
             }
 
-            return IsPossibleFirstTypedIdentifierInLocaDeclarationStatement(isGlobalScriptLevel);
+            return IsPossibleFirstTypedIdentifierInLocalDeclarationStatement(isGlobalScriptLevel);
         }
 
-        private bool IsPossibleFirstTypedIdentifierInLocaDeclarationStatement(bool isGlobalScriptLevel)
+        private bool IsPossibleFirstTypedIdentifierInLocalDeclarationStatement(bool isGlobalScriptLevel)
         {
             bool? typedIdentifier = IsPossibleTypedIdentifierStart(this.CurrentToken, this.PeekToken(1), allowThisKeyword: false);
             if (typedIdentifier != null)
@@ -7526,7 +7526,7 @@ done:;
                     EatToken();
                 }
 
-                return IsPossibleFirstTypedIdentifierInLocaDeclarationStatement(isGlobalScriptLevel: false);
+                return IsPossibleFirstTypedIdentifierInLocalDeclarationStatement(isGlobalScriptLevel: false);
             }
             finally
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -225,6 +225,61 @@ class A
             Assert.Equal("(1,2011): error CS1056: Unexpected character '\\u003E\\u003E\\u003E\\u003E'", actualErrors.ElementAt(201).ToString(EnsureEnglishUICulture.PreferredOrNull));
         }
 
+        [Fact]
+        public void QualifiedName_01()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        A::B.C<D> x,
+        A::B.C<D> y;
+    }
+}";
+            ParseAndValidate(source,
+                // (6,10): error CS1002: ; expected
+                //         A::B.C<D> y;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "::").WithLocation(6, 10),
+                // (6,10): error CS1001: Identifier expected
+                //         A::B.C<D> y;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "::").WithLocation(6, 10));
+        }
+
+        [Fact]
+        public void QualifiedName_02()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        ::A.B<C> x;
+    }
+}";
+            ParseAndValidate(source,
+                // (4,6): error CS1001: Identifier expected
+                //     {
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(4, 6));
+        }
+
+        [Fact]
+        public void QualifiedName_03()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        ::A.B<C>();
+    }
+}";
+            ParseAndValidate(source,
+                // (4,6): error CS1001: Identifier expected
+                //     {
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(4, 6));
+        }
+
         #region "Helpers"
 
         private static void ParseAndValidate(string text, params DiagnosticDescription[] expectedErrors)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -233,6 +233,20 @@ class A
 {
     static void Main()
     {
+        A::B.C<D> x;
+    }
+}";
+            ParseAndValidate(source);
+        }
+
+        [Fact]
+        public void QualifiedName_02()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
         A::B.C<D> x,
         A::B.C<D> y;
     }
@@ -247,7 +261,7 @@ class A
         }
 
         [Fact]
-        public void QualifiedName_02()
+        public void QualifiedName_03()
         {
             var source =
 @"class Program
@@ -264,7 +278,7 @@ class A
         }
 
         [Fact]
-        public void QualifiedName_03()
+        public void QualifiedName_04()
         {
             var source =
 @"class Program


### PR DESCRIPTION
The C# compiler was throwing `System.InvalidOperationException` parsing the following:
```C#
::A.B<C> x;
```