### PR TITLE
Update pattern matcher to find lowercase substring matches within words

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -890,6 +890,8 @@ testHost, @"public class Goo
             {
                 var expecteditems = new List<NavigateToItem>
                 {
+                    new NavigateToItem("getkeyword", NavigateToItemKind.Field, "csharp", null, null, s_emptyFuzzyPatternMatch, null),
+                    new NavigateToItem("get_keyword", NavigateToItemKind.Field, "csharp", null, null, s_emptyFuzzyPatternMatch, null),
                     new NavigateToItem("get_key_word", NavigateToItemKind.Field, "csharp", null, null,s_emptySubstringPatternMatch, null),
                     new NavigateToItem("GetKeyWord", NavigateToItemKind.Field, "csharp", null, null, s_emptySubstringPatternMatch_NotCaseSensitive, null)
                 };

--- a/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
+++ b/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         [InlineData("FogBar", "GoooB")]
         [InlineData("GooActBarCatAlp", "GooAlpBarCat")]
         // We don't want a lowercase pattern to match *across* a word boundary.
-        [InlineData("AbcdefGhijefghij", "efghij")]
+        [InlineData("AbcdefGhijklmnop", "efghij")]
         [InlineData("Fog_Bar", "F__B")]
         [InlineData("FogBarBaz", "FZ")]
         [InlineData("_mybutton", "myB")]

--- a/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
+++ b/src/EditorFeatures/Test/Utilities/PatternMatcherTests.cs
@@ -143,24 +143,24 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 
         [InlineData("[|system.ref|]lection", "system.ref", PatternMatchKind.Prefix, CaseSensitive)]
 
-        [InlineData("Fog[|B|]ar", "b", PatternMatchKind.Substring, CaseInsensitive)]
+        [InlineData("Fog[|B|]ar", "b", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
 
-        [InlineData("_[|my|]Button", "my", PatternMatchKind.Substring, CaseSensitive)]
-        [InlineData("my[|_b|]utton", "_b", PatternMatchKind.Substring, CaseSensitive)]
-        [InlineData("_[|my|]button", "my", PatternMatchKind.Substring, CaseSensitive)]
-        [InlineData("_my[|_b|]utton", "_b", PatternMatchKind.Substring, CaseSensitive)]
-        [InlineData("_[|myb|]utton", "myb", PatternMatchKind.Substring, CaseSensitive)]
-        [InlineData("_[|myB|]utton", "myB", PatternMatchKind.Substring, CaseSensitive)]
+        [InlineData("_[|my|]Button", "my", PatternMatchKind.StartOfWordSubstring, CaseSensitive)]
+        [InlineData("my[|_b|]utton", "_b", PatternMatchKind.StartOfWordSubstring, CaseSensitive)]
+        [InlineData("_[|my|]button", "my", PatternMatchKind.StartOfWordSubstring, CaseSensitive)]
+        [InlineData("_my[|_b|]utton", "_b", PatternMatchKind.StartOfWordSubstring, CaseSensitive)]
+        [InlineData("_[|myb|]utton", "myb", PatternMatchKind.StartOfWordSubstring, CaseSensitive)]
+        [InlineData("_[|myB|]utton", "myB", PatternMatchKind.NonLowercaseSubstring, CaseSensitive)]
 
-        [InlineData("my[|_B|]utton", "_b", PatternMatchKind.Substring, CaseInsensitive)]
-        [InlineData("_my[|_B|]utton", "_b", PatternMatchKind.Substring, CaseInsensitive)]
-        [InlineData("_[|myB|]utton", "myb", PatternMatchKind.Substring, CaseInsensitive)]
+        [InlineData("my[|_B|]utton", "_b", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
+        [InlineData("_my[|_B|]utton", "_b", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
+        [InlineData("_[|myB|]utton", "myb", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
 
         [InlineData("[|AbCd|]xxx[|Ef|]Cd[|Gh|]", "AbCdEfGh", PatternMatchKind.CamelCaseNonContiguousPrefix, CaseSensitive)]
 
-        [InlineData("A[|BCD|]EFGH", "bcd", PatternMatchKind.Substring, CaseInsensitive)]
-        [InlineData("FogBar[|ChangedEventArgs|]", "changedeventargs", PatternMatchKind.Substring, CaseInsensitive)]
-        [InlineData("Abcdefghij[|EfgHij|]", "efghij", PatternMatchKind.Substring, CaseInsensitive)]
+        [InlineData("A[|BCD|]EFGH", "bcd", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
+        [InlineData("FogBar[|ChangedEventArgs|]", "changedeventargs", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
+        [InlineData("Abcdefghij[|EfgHij|]", "efghij", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
 
         [InlineData("[|F|]og[|B|]ar", "FB", PatternMatchKind.CamelCaseExact, CaseSensitive)]
         [InlineData("[|Fo|]g[|B|]ar", "FoB", PatternMatchKind.CamelCaseExact, CaseSensitive)]
@@ -195,7 +195,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 
         [InlineData("my[|_b|]utton", "_B", PatternMatchKind.CamelCaseSubstring, CaseInsensitive)]
         [InlineData("[|_|]my_[|b|]utton", "_B", PatternMatchKind.CamelCaseNonContiguousPrefix, CaseInsensitive)]
-        // Test is internal as PatternMatchKind is internal, but this is still ran.
+        [InlineData("Com[|bin|]e", "bin", PatternMatchKind.LowercaseSubstring, CaseSensitive)]
+        [InlineData("Combine[|Bin|]ary", "bin", PatternMatchKind.StartOfWordSubstring, CaseInsensitive)]
+        [WorkItem(51029, "https://github.com/dotnet/roslyn/issues/51029")]
         internal void TestNonFuzzyMatch(
             string candidate, string pattern, PatternMatchKind matchKind, bool isCaseSensitive)
         {
@@ -212,7 +214,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         [InlineData("FogBarBaz", "ZZ")]
         [InlineData("FogBar", "GoooB")]
         [InlineData("GooActBarCatAlp", "GooAlpBarCat")]
-        [InlineData("Abcdefghijefghij", "efghij")]
+        // We don't want a lowercase pattern to match *across* a word boundary.
+        [InlineData("AbcdefGhijefghij", "efghij")]
         [InlineData("Fog_Bar", "F__B")]
         [InlineData("FogBarBaz", "FZ")]
         [InlineData("_mybutton", "myB")]
@@ -248,7 +251,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         {
             var match = TryMatchMultiWordPattern("Add[|Metadata|]Reference", "metadata");
 
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -264,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         {
             var match = TryMatchMultiWordPattern("Add[|Metadata|]Reference", "Metadata");
 
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -280,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         {
             var match = TryMatchMultiWordPattern("Add[|M|]etadataReference", "M");
 
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -289,7 +292,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             var match = TryMatchMultiWordPattern("[|Add|][|Metadata|]Reference", "add metadata");
 
             AssertContainsType(PatternMatchKind.Prefix, match);
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -298,7 +301,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             var match = TryMatchMultiWordPattern("[|A|]dd[|M|]etadataReference", "A M");
 
             AssertContainsType(PatternMatchKind.Prefix, match);
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -314,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         {
             var match = TryMatchMultiWordPattern("Add[|Metadata|][|Ref|]erence", "ref Metadata");
 
-            Assert.True(match.Select(m => m.Kind).SequenceEqual(new[] { PatternMatchKind.Substring, PatternMatchKind.Substring }));
+            Assert.True(match.Select(m => m.Kind).SequenceEqual(new[] { PatternMatchKind.StartOfWordSubstring, PatternMatchKind.StartOfWordSubstring }));
         }
 
         [Fact]
@@ -322,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         {
             var match = TryMatchMultiWordPattern("Add[|M|]etadata[|Ref|]erence", "ref M");
 
-            Assert.True(match.Select(m => m.Kind).SequenceEqual(new[] { PatternMatchKind.Substring, PatternMatchKind.Substring }));
+            Assert.True(match.Select(m => m.Kind).SequenceEqual(new[] { PatternMatchKind.StartOfWordSubstring, PatternMatchKind.StartOfWordSubstring }));
         }
 
         [Fact]
@@ -347,7 +350,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             var match = TryMatchMultiWordPattern("[|Add|][|Meta|]dataReference", "add Meta");
 
             AssertContainsType(PatternMatchKind.Prefix, match);
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -356,7 +359,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             var match = TryMatchMultiWordPattern("[|Add|][|Meta|]dataReference", "Add meta");
 
             AssertContainsType(PatternMatchKind.Prefix, match);
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -365,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             var match = TryMatchMultiWordPattern("[|Add|][|Meta|]dataReference", "Add Meta");
 
             AssertContainsType(PatternMatchKind.Prefix, match);
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
         }
 
         [Fact]
@@ -381,7 +384,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         {
             var match = TryMatchMultiWordPattern("Get[|K|]ey[|W|]ord", "K*W");
 
-            Assert.True(match.Select(m => m.Kind).SequenceEqual(new[] { PatternMatchKind.Substring, PatternMatchKind.Substring }));
+            Assert.True(match.Select(m => m.Kind).SequenceEqual(new[] { PatternMatchKind.StartOfWordSubstring, PatternMatchKind.StartOfWordSubstring }));
         }
 
         [WorkItem(544628, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544628")]
@@ -394,7 +397,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         public void MatchMultiWordPattern_LowercaseSubstring2()
         {
             var match = TryMatchMultiWordPattern("Goo[|A|]ttribute", "a");
-            AssertContainsType(PatternMatchKind.Substring, match);
+            AssertContainsType(PatternMatchKind.StartOfWordSubstring, match);
             Assert.False(match.First().IsCaseSensitive);
         }
 

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -27,13 +27,16 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             ImmutableArray.Create(
                 (PatternMatchKind.Exact, NavigateToMatchKind.Exact),
                 (PatternMatchKind.Prefix, NavigateToMatchKind.Prefix),
-                (PatternMatchKind.Substring, NavigateToMatchKind.Substring),
+                (PatternMatchKind.NonLowercaseSubstring, NavigateToMatchKind.Substring),
+                (PatternMatchKind.StartOfWordSubstring, NavigateToMatchKind.Substring),
                 (PatternMatchKind.CamelCaseExact, NavigateToMatchKind.CamelCaseExact),
                 (PatternMatchKind.CamelCasePrefix, NavigateToMatchKind.CamelCasePrefix),
                 (PatternMatchKind.CamelCaseNonContiguousPrefix, NavigateToMatchKind.CamelCaseNonContiguousPrefix),
                 (PatternMatchKind.CamelCaseSubstring, NavigateToMatchKind.CamelCaseSubstring),
                 (PatternMatchKind.CamelCaseNonContiguousSubstring, NavigateToMatchKind.CamelCaseNonContiguousSubstring),
-                (PatternMatchKind.Fuzzy, NavigateToMatchKind.Fuzzy));
+                (PatternMatchKind.Fuzzy, NavigateToMatchKind.Fuzzy),
+                // Map our value to 'Fuzzy' as that's the lower value the platform supports.
+                (PatternMatchKind.LowercaseSubstring, NavigateToMatchKind.Fuzzy));
 
         public static Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInCurrentProcessAsync(
             Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatchKind.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatchKind.cs
@@ -24,9 +24,16 @@ namespace Microsoft.CodeAnalysis.PatternMatching
         Prefix,
 
         /// <summary>
-        /// The pattern was a substring of the candidate string, but in a way that wasn't a CamelCase match.
+        /// The pattern was a substring of the candidate string, but in a way that wasn't a CamelCase match.  The
+        /// pattern had to have at least one non lowercase letter in it, and the match needs to be case sensitive.
         /// </summary>
-        Substring,
+        NonLowercaseSubstring,
+
+        /// <summary>
+        /// The pattern was a substring of the candidate string, starting at a word within that candidate.  The pattern
+        /// can be all lowercase here.
+        /// </summary>
+        StartOfWordSubstring,
 
         // Note: CamelCased matches are ordered from best to worst.
 
@@ -89,6 +96,13 @@ namespace Microsoft.CodeAnalysis.PatternMatching
         /// a certain amount of misspellings, missing words, etc. See <see cref="SpellChecker"/> for 
         /// more details.
         /// </summary>
-        Fuzzy
+        Fuzzy,
+
+        /// <summary>
+        /// The pattern was a substring of the candidate and wasn't either <see cref="NonLowercaseSubstring"/> or <see
+        /// cref="StartOfWordSubstring"/>.  This can happen when the pattern is allow lowercases and matches some non
+        /// word portion of the candidate.
+        /// </summary>
+        LowercaseSubstring,
     }
 }

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatchKind.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatchKind.cs
@@ -26,12 +26,13 @@ namespace Microsoft.CodeAnalysis.PatternMatching
         /// <summary>
         /// The pattern was a substring of the candidate string, but in a way that wasn't a CamelCase match.  The
         /// pattern had to have at least one non lowercase letter in it, and the match needs to be case sensitive.
+        /// This will match 'savedWork' against 'FindUnsavedWork'.
         /// </summary>
         NonLowercaseSubstring,
 
         /// <summary>
         /// The pattern was a substring of the candidate string, starting at a word within that candidate.  The pattern
-        /// can be all lowercase here.
+        /// can be all lowercase here.  This will match 'save' or 'Save' in 'FindSavedWork'
         /// </summary>
         StartOfWordSubstring,
 
@@ -101,7 +102,8 @@ namespace Microsoft.CodeAnalysis.PatternMatching
         /// <summary>
         /// The pattern was a substring of the candidate and wasn't either <see cref="NonLowercaseSubstring"/> or <see
         /// cref="StartOfWordSubstring"/>.  This can happen when the pattern is allow lowercases and matches some non
-        /// word portion of the candidate.
+        /// word portion of the candidate.  For example, finding 'save' in 'GetUnsavedWork'.  This will not match across
+        /// word boundaries.  i.e. it will not match 'save' to 'VisaVerify' even though 'saVe' is in that candidate.
         /// </summary>
         LowercaseSubstring,
     }

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -196,8 +196,8 @@ namespace Microsoft.CodeAnalysis.PatternMatching
                         {
                             if (char.IsUpper(candidate[caseInsensitiveIndex]))
                             {
-                                return new PatternMatch(PatternMatchKind.StartOfWordSubstring, punctuationStripped,
-                                    isCaseSensitive: false,
+                                return new PatternMatch(
+                                    PatternMatchKind.StartOfWordSubstring, punctuationStripped, isCaseSensitive: true,
                                     matchedSpan: GetMatchedSpan(caseInsensitiveIndex, patternChunk.Text.Length));
                             }
                             else

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -194,34 +194,45 @@ namespace Microsoft.CodeAnalysis.PatternMatching
                         var caseSensitiveIndex = _compareInfo.IndexOf(candidate, patternChunk.Text, CompareOptions.None);
                         if (caseSensitiveIndex > 0)
                         {
-                            return new PatternMatch(
-                                PatternMatchKind.Substring, punctuationStripped, isCaseSensitive: true,
-                                matchedSpan: GetMatchedSpan(caseSensitiveIndex, patternChunk.Text.Length));
+                            if (char.IsUpper(candidate[caseInsensitiveIndex]))
+                            {
+                                return new PatternMatch(PatternMatchKind.StartOfWordSubstring, punctuationStripped,
+                                    isCaseSensitive: false,
+                                    matchedSpan: GetMatchedSpan(caseInsensitiveIndex, patternChunk.Text.Length));
+                            }
+                            else
+                            {
+                                return new PatternMatch(
+                                    PatternMatchKind.NonLowercaseSubstring, punctuationStripped, isCaseSensitive: true,
+                                    matchedSpan: GetMatchedSpan(caseSensitiveIndex, patternChunk.Text.Length));
+                            }
                         }
                     }
                     else
                     {
-                        // Pattern was all lowercase.  This can lead to lots of false positives.  For
-                        // example, we don't want "bin" to match "CombineUnits".  Instead, we want it
-                        // to match "BinaryOperator".  As such, make sure our match looks like it's 
-                        // starting an actual word in the candidate.  
+                        // Pattern was all lowercase.  This can lead to lots of hits.  For example, "bin" in
+                        // "CombineUnits".  Instead, we want it to match "Operator[|Bin|]ary" first rather than
+                        // Com[|bin|]eUnits
 
-                        // Do a quick check to avoid the expensive work of having to go get the candidate
-                        // humps.  
+                        // If the lowercase search string matched what looks to be the start of a word then that's a
+                        // reasonable hit. This is equivalent to 'bin' matching 'Operator[|Bin|]ary'
                         if (char.IsUpper(candidate[caseInsensitiveIndex]))
                         {
-                            return new PatternMatch(PatternMatchKind.Substring, punctuationStripped,
+                            return new PatternMatch(PatternMatchKind.StartOfWordSubstring, punctuationStripped,
                                 isCaseSensitive: false,
                                 matchedSpan: GetMatchedSpan(caseInsensitiveIndex, patternChunk.Text.Length));
                         }
 
+                        // Now do the more expensive check to see if we're at the start of a word.  This is to catch
+                        // word matches like CombineBinary.  We want to find the hit against '[|Bin|]ary' not
+                        // 'Com[|bin|]e'
                         candidateHumpsOpt = StringBreaker.GetWordParts(candidate);
                         for (int i = 0, n = candidateHumpsOpt.Count; i < n; i++)
                         {
                             var hump = TextSpan.FromBounds(candidateHumpsOpt[i].Start, candidateLength);
                             if (PartStartsWith(candidate, hump, patternChunk.Text, CompareOptions.IgnoreCase))
                             {
-                                return new PatternMatch(PatternMatchKind.Substring, punctuationStripped,
+                                return new PatternMatch(PatternMatchKind.StartOfWordSubstring, punctuationStripped,
                                     isCaseSensitive: PartStartsWith(candidate, hump, patternChunk.Text, CompareOptions.None),
                                     matchedSpan: GetMatchedSpan(hump.Start, patternChunk.Text.Length));
                             }
@@ -232,14 +243,33 @@ namespace Microsoft.CodeAnalysis.PatternMatching
                 // Didn't have an exact/prefix match, or a high enough quality substring match.
                 // See if we can find a camel case match.
                 if (candidateHumpsOpt == null)
-                {
                     candidateHumpsOpt = StringBreaker.GetWordParts(candidate);
-                }
 
                 // Didn't have an exact/prefix match, or a high enough quality substring match.
                 // See if we can find a camel case match.  
-                return TryCamelCaseMatch(
-                    candidate, patternChunk, punctuationStripped, patternIsLowercase, candidateHumpsOpt);
+                var match = TryCamelCaseMatch(candidate, patternChunk, punctuationStripped, patternIsLowercase, candidateHumpsOpt);
+                if (match != null)
+                    return match;
+
+                // If pattern was all lowercase, we allow it to match an all lowercase section of the candidate.  But
+                // only after we've tried all other forms first.  This is the weakest of all matches.  For example, if
+                // user types 'bin' we want to match 'OperatorBinary' (start of word) or 'BinaryInformationNode' (camel
+                // humps) before matching 'Combine'.
+                // 
+                // We only do this for strings longer than three characters to avoid too many false positives when the
+                // user has only barely started writing a word.
+                if (patternIsLowercase && caseInsensitiveIndex > 0 && patternChunk.Text.Length >= 3)
+                {
+                    var caseSensitiveIndex = _compareInfo.IndexOf(candidate, patternChunk.Text, CompareOptions.None);
+                    if (caseSensitiveIndex > 0)
+                    {
+                        return new PatternMatch(
+                            PatternMatchKind.LowercaseSubstring, punctuationStripped, isCaseSensitive: true,
+                            matchedSpan: GetMatchedSpan(caseSensitiveIndex, patternChunk.Text.Length));
+                    }
+                }
+
+                return null;
             }
             finally
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51029

This allows searching for a word like `save` to match `FindUnsavedItems`.  Importantly, the lowercase search term can match a substring portion of the candidate as long as that portion is all lowercase as well.  So it will not match `VisaVerify`.

Looks like:

![image](https://user-images.githubusercontent.com/4564579/107092188-f7dc0600-67b7-11eb-8201-4ecbf8b98408.png)
