### PR TITLE
Walk unit directories in parallel in PrepareTests

### DIFF
--- a/src/Tools/PrepareTests/MinimizeUtil.cs
+++ b/src/Tools/PrepareTests/MinimizeUtil.cs
@@ -70,9 +70,8 @@ internal static class MinimizeUtil
             return idToFilePathMap;
         }
 
-        List<(Guid mvid, FilePathInfo pathInfo)> walkDirectory(string unitDirPath)
+        IEnumerable<(Guid mvid, FilePathInfo pathInfo)> walkDirectory(string unitDirPath)
         {
-            var mvidList = new List<(Guid, FilePathInfo)>();
             string? lastOutputDirectory = null;
             foreach (var sourceFilePath in Directory.EnumerateFiles(unitDirPath, "*", SearchOption.AllDirectories))
             {
@@ -93,7 +92,7 @@ internal static class MinimizeUtil
                         Directory: currentDirName,
                         RelativePath: Path.Combine(currentRelativeDirectory, fileName),
                         FullPath: sourceFilePath);
-                    mvidList.Add((mvid, filePathInfo));
+                    yield return (mvid, filePathInfo);
                 }
                 else
                 {
@@ -101,8 +100,6 @@ internal static class MinimizeUtil
                     CreateHardLink(destFilePath, sourceFilePath);
                 }
             }
-
-            return mvidList;
         }
 
         // Now that we have a complete list of PE files, determine which are duplicates

--- a/src/Tools/PrepareTests/MinimizeUtil.cs
+++ b/src/Tools/PrepareTests/MinimizeUtil.cs
@@ -61,7 +61,7 @@ internal static class MinimizeUtil
             directories = directories.Concat(Directory.EnumerateDirectories(artifactsDir, "RunTests"));
 
             var idToFilePathMap = directories.AsParallel()
-                .SelectMany(walkDirectory)
+                .SelectMany(unitDirPath => walkDirectory(unitDirPath, sourceDirectory, destinationDirectory))
                 .GroupBy(pair => pair.mvid)
                 .ToDictionary(
                     group => group.Key,
@@ -70,7 +70,7 @@ internal static class MinimizeUtil
             return idToFilePathMap;
         }
 
-        IEnumerable<(Guid mvid, FilePathInfo pathInfo)> walkDirectory(string unitDirPath)
+        static IEnumerable<(Guid mvid, FilePathInfo pathInfo)> walkDirectory(string unitDirPath, string sourceDirectory, string destinationDirectory)
         {
             string? lastOutputDirectory = null;
             foreach (var sourceFilePath in Directory.EnumerateFiles(unitDirPath, "*", SearchOption.AllDirectories))

--- a/src/Tools/PrepareTests/MinimizeUtil.cs
+++ b/src/Tools/PrepareTests/MinimizeUtil.cs
@@ -17,21 +17,41 @@ internal static class MinimizeUtil
 
     internal static void Run(string sourceDirectory, string destinationDirectory, bool isUnix)
     {
-        // Map of all PE files MVID to the path information
-        var idToFilePathMap = new Dictionary<Guid, List<FilePathInfo>>();
-
         const string duplicateDirectoryName = ".duplicate";
         var duplicateDirectory = Path.Combine(destinationDirectory, duplicateDirectoryName);
         Directory.CreateDirectory(duplicateDirectory);
 
-        initialWalk();
+        // https://github.com/dotnet/roslyn/issues/49486
+        // we should avoid copying the files under Resources.
+        Directory.CreateDirectory(Path.Combine(destinationDirectory, "src/Workspaces/MSBuildTest/Resources"));
+        var individualFiles = new[]
+        {
+            "global.json",
+            "NuGet.config",
+            "src/Workspaces/MSBuildTest/Resources/.editorconfig",
+            "src/Workspaces/MSBuildTest/Resources/global.json",
+            "src/Workspaces/MSBuildTest/Resources/Directory.Build.props",
+            "src/Workspaces/MSBuildTest/Resources/Directory.Build.targets",
+            "src/Workspaces/MSBuildTest/Resources/Directory.Build.rsp",
+            "src/Workspaces/MSBuildTest/Resources/NuGet.Config",
+        };
+
+        foreach (var individualFile in individualFiles)
+        {
+            var outputPath = Path.Combine(destinationDirectory, individualFile);
+            var outputDirectory = Path.GetDirectoryName(outputPath)!;
+            CreateHardLink(outputPath, Path.Combine(sourceDirectory, individualFile));
+        }
+
+        // Map of all PE files MVID to the path information
+        var idToFilePathMap = initialWalk();
         resolveDuplicates();
         writeHydrateFile();
 
         // The goal of initial walk is to
         //  1. Record any PE files as they are eligable for de-dup
         //  2. Hard link all other files into destination directory
-        void initialWalk()
+        Dictionary<Guid, List<FilePathInfo>> initialWalk()
         {
             IEnumerable<string> directories = new[] {
                 Path.Combine(sourceDirectory, "eng")
@@ -40,60 +60,49 @@ internal static class MinimizeUtil
             directories = directories.Concat(Directory.EnumerateDirectories(artifactsDir, "*.UnitTests"));
             directories = directories.Concat(Directory.EnumerateDirectories(artifactsDir, "RunTests"));
 
-            foreach (var unitDirPath in directories)
+            var idToFilePathMap = directories.AsParallel()
+                .SelectMany(walkDirectory)
+                .GroupBy(pair => pair.mvid)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Select(pair => pair.pathInfo).ToList());
+
+            return idToFilePathMap;
+        }
+
+        List<(Guid mvid, FilePathInfo pathInfo)> walkDirectory(string unitDirPath)
+        {
+            var mvidList = new List<(Guid, FilePathInfo)>();
+            string? lastOutputDirectory = null;
+            foreach (var sourceFilePath in Directory.EnumerateFiles(unitDirPath, "*", SearchOption.AllDirectories))
             {
-                foreach (var sourceFilePath in Directory.EnumerateFiles(unitDirPath, "*", SearchOption.AllDirectories))
+                var currentDirName = Path.GetDirectoryName(sourceFilePath)!;
+                var currentRelativeDirectory = Path.GetRelativePath(sourceDirectory, currentDirName);
+                var currentOutputDirectory = Path.Combine(destinationDirectory, currentRelativeDirectory);
+                if (currentOutputDirectory != lastOutputDirectory)
                 {
-                    var currentDirName = Path.GetDirectoryName(sourceFilePath)!;
-                    var currentRelativeDirectory = Path.GetRelativePath(sourceDirectory, currentDirName);
-                    var currentOutputDirectory = Path.Combine(destinationDirectory, currentRelativeDirectory);
                     Directory.CreateDirectory(currentOutputDirectory);
-                    var fileName = Path.GetFileName(sourceFilePath);
+                    lastOutputDirectory = currentOutputDirectory;
+                }
+                var fileName = Path.GetFileName(sourceFilePath);
 
-                    if (fileName.EndsWith(".dll") && TryGetMvid(sourceFilePath, out var mvid))
-                    {
-                        if (!idToFilePathMap.TryGetValue(mvid, out var list))
-                        {
-                            list = new List<FilePathInfo>();
-                            idToFilePathMap[mvid] = list;
-                        }
-
-                        var filePathInfo = new FilePathInfo(
-                            RelativeDirectory: currentRelativeDirectory,
-                            Directory: currentDirName,
-                            RelativePath: Path.Combine(currentRelativeDirectory, fileName),
-                            FullPath: sourceFilePath);
-                        list.Add(filePathInfo);
-                    }
-                    else
-                    {
-                        var destFilePath = Path.Combine(currentOutputDirectory, fileName);
-                        CreateHardLink(destFilePath, sourceFilePath);
-                    }
+                if (fileName.EndsWith(".dll") && TryGetMvid(sourceFilePath, out var mvid))
+                {
+                    var filePathInfo = new FilePathInfo(
+                        RelativeDirectory: currentRelativeDirectory,
+                        Directory: currentDirName,
+                        RelativePath: Path.Combine(currentRelativeDirectory, fileName),
+                        FullPath: sourceFilePath);
+                    mvidList.Add((mvid, filePathInfo));
+                }
+                else
+                {
+                    var destFilePath = Path.Combine(currentOutputDirectory, fileName);
+                    CreateHardLink(destFilePath, sourceFilePath);
                 }
             }
 
-            // https://github.com/dotnet/roslyn/issues/49486
-            // we should avoid copying the files under Resources.
-            var individualFiles = new[]
-            {
-                "global.json",
-                "NuGet.config",
-                "src/Workspaces/MSBuildTest/Resources/.editorconfig",
-                "src/Workspaces/MSBuildTest/Resources/global.json",
-                "src/Workspaces/MSBuildTest/Resources/Directory.Build.props",
-                "src/Workspaces/MSBuildTest/Resources/Directory.Build.targets",
-                "src/Workspaces/MSBuildTest/Resources/Directory.Build.rsp",
-                "src/Workspaces/MSBuildTest/Resources/NuGet.Config",
-            };
-
-            foreach (var individualFile in individualFiles)
-            {
-                var outputPath = Path.Combine(destinationDirectory, individualFile);
-                var outputDirectory = Path.GetDirectoryName(outputPath)!;
-                Directory.CreateDirectory(outputDirectory);
-                CreateHardLink(outputPath, Path.Combine(sourceDirectory, individualFile));
-            }
+            return mvidList;
         }
 
         // Now that we have a complete list of PE files, determine which are duplicates
@@ -265,7 +274,7 @@ scriptroot=""$( cd -P ""$( dirname ""$source"" )"" && pwd )""
             if (!success)
             {
                 // for debugging: https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
-                throw new IOException($"Failed to create hard link from {fileName} to {existingFileName} with exception 0x{Marshal.GetLastWin32Error():X}");
+                throw new IOException($"Failed to create hard link from {existingFileName} to {fileName} with exception 0x{Marshal.GetLastWin32Error():X}");
             }
         }
         else

--- a/src/Tools/PrepareTests/MinimizeUtil.cs
+++ b/src/Tools/PrepareTests/MinimizeUtil.cs
@@ -85,7 +85,7 @@ internal static class MinimizeUtil
                 }
                 var fileName = Path.GetFileName(sourceFilePath);
 
-                if (fileName.EndsWith(".dll") && TryGetMvid(sourceFilePath, out var mvid))
+                if (fileName.EndsWith(".dll", StringComparison.Ordinal) && TryGetMvid(sourceFilePath, out var mvid))
                 {
                     var filePathInfo = new FilePathInfo(
                         RelativeDirectory: currentRelativeDirectory,


### PR DESCRIPTION
Related to #49968

Suggest reviewing with "hide whitespace changes" enabled.

Local measurements from **before** this change:
```ps1
> rm -r .\artifacts\testPayload\
> Measure-Command { .\eng\prepare-tests.ps1 }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 8
Milliseconds      : 88
Ticks             : 80884654
TotalDays         : 9.36164976851852E-05
TotalHours        : 0.00224679594444444
TotalMinutes      : 0.134807756666667
TotalSeconds      : 8.0884654
TotalMilliseconds : 8088.4654


> rm -r .\artifacts\testPayload\
> Measure-Command { .\eng\prepare-tests.ps1 }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 8
Milliseconds      : 78
Ticks             : 80781851
TotalDays         : 9.34975127314815E-05
TotalHours        : 0.00224394030555556
TotalMinutes      : 0.134636418333333
TotalSeconds      : 8.0781851
TotalMilliseconds : 8078.1851
```

Local measurements from **after** this change:
```ps1
> rm -r .\artifacts\testPayload\
> Measure-Command { .\eng\prepare-tests.ps1 }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 2
Milliseconds      : 183
Ticks             : 21832304
TotalDays         : 2.52688703703704E-05
TotalHours        : 0.000606452888888889
TotalMinutes      : 0.0363871733333333
TotalSeconds      : 2.1832304
TotalMilliseconds : 2183.2304


> rm -r .\artifacts\testPayload\
> Measure-Command { .\eng\prepare-tests.ps1 }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 2
Milliseconds      : 163
Ticks             : 21630180
TotalDays         : 2.50349305555556E-05
TotalHours        : 0.000600838333333333
TotalMinutes      : 0.0360503
TotalSeconds      : 2.163018
TotalMilliseconds : 2163.018
```

I have a 12-core AMD CPU and a Samsung M.2 SSD, which could explain the magnitude of the difference locally.

In CI this only reduces the time from maybe 7-8 seconds to 6 if the packages are hot, or 17 seconds down to maybe 14 seconds if the packages are cold. I don't know exactly what distinguishes these cases, but it tends to correlate with whether restore takes < 1 minute or 3-4 minutes, which I think is related to whether the NuGet cache is already populated on the machine at the start of the job.