### PR TITLE
Nullable warning on argument changes state to not-null

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1867,21 +1867,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     GetParameterAsDiagnosticArgument(parameterOpt),
                     GetContainingSymbolAsDiagnosticArgument(parameterOpt));
 
-                if (targetType.Type.IsPossiblyNullableReferenceTypeTypeParameter())
-                {
-                    var slotBuilder = ArrayBuilder<int>.GetInstance();
-                    GetSlotsToMarkAsNotNullable(value, slotBuilder);
-                    foreach (var slot in slotBuilder)
-                    {
-                        Debug.Assert(State[slot] == NullableFlowState.MaybeDefault);
-                        State[slot] = NullableFlowState.MaybeNull;
-                    }
-                    slotBuilder.Free();
-                }
-                else
-                {
-                    LearnFromNonNullTest(value, ref State);
-                }
+                LearnFromNonNullTest(value, ref State);
             }
             else if (useLegacyWarnings)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/50602

@RikkiGibson The current behavior is definitely intentional, looking at PR https://github.com/dotnet/roslyn/pull/49576, but I can't remember the rationale for choosing that behavior at the time :-/
Do you remember?