### PR TITLE
Avoid double declaration of switch expression variables in PDB symbols

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -1426,7 +1426,8 @@ oneMoreTime:
             // If named, add it to the local debug scope.
             if (localDef.Name != null &&
                 !(local.SynthesizedKind == SynthesizedLocalKind.UserDefined &&
-                    local.ScopeDesignatorOpt?.Kind() == SyntaxKind.SwitchSection)) // Visibility scope of such locals is represented by BoundScope node.
+                // Visibility scope of such locals is represented by BoundScope node.
+                (local.ScopeDesignatorOpt?.Kind() == SyntaxKind.SwitchSection || local.ScopeDesignatorOpt?.Kind() == SyntaxKind.SwitchExpressionArm)))
             {
                 _builder.AddLocalToScope(localDef);
             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -1427,7 +1427,7 @@ oneMoreTime:
             if (localDef.Name != null &&
                 !(local.SynthesizedKind == SynthesizedLocalKind.UserDefined &&
                 // Visibility scope of such locals is represented by BoundScope node.
-                (local.ScopeDesignatorOpt?.Kind() == SyntaxKind.SwitchSection || local.ScopeDesignatorOpt?.Kind() == SyntaxKind.SwitchExpressionArm)))
+                (local.ScopeDesignatorOpt?.Kind() is SyntaxKind.SwitchSection or SyntaxKind.SwitchExpressionArm)))
             {
                 _builder.AddLocalToScope(localDef);
             }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -9044,31 +9044,22 @@ class Program
           </sequencePoints>
           <scope startOffset=""0x0"" endOffset=""0x1b5"">
             <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x1b5"" attributes=""0"" />
-            <scope startOffset=""0x1"" endOffset=""0x1b4"">
-              <local name=""x"" il_index=""1"" il_start=""0x1"" il_end=""0x1b4"" attributes=""0"" />
-              <local name=""y"" il_index=""2"" il_start=""0x1"" il_end=""0x1b4"" attributes=""0"" />
-              <local name=""z"" il_index=""3"" il_start=""0x1"" il_end=""0x1b4"" attributes=""0"" />
-              <local name=""p"" il_index=""4"" il_start=""0x1"" il_end=""0x1b4"" attributes=""0"" />
-              <local name=""q"" il_index=""5"" il_start=""0x1"" il_end=""0x1b4"" attributes=""0"" />
-              <local name=""p"" il_index=""6"" il_start=""0x1"" il_end=""0x1b4"" attributes=""0"" />
-              <local name=""z"" il_index=""7"" il_start=""0x1"" il_end=""0x1b4"" attributes=""0"" />
-              <scope startOffset=""0x14d"" endOffset=""0x15e"">
-                <local name=""x"" il_index=""1"" il_start=""0x14d"" il_end=""0x15e"" attributes=""0"" />
-              </scope>
-              <scope startOffset=""0x163"" endOffset=""0x16a"">
-                <local name=""y"" il_index=""2"" il_start=""0x163"" il_end=""0x16a"" attributes=""0"" />
-                <local name=""z"" il_index=""3"" il_start=""0x163"" il_end=""0x16a"" attributes=""0"" />
-              </scope>
-              <scope startOffset=""0x191"" endOffset=""0x198"">
-                <local name=""p"" il_index=""4"" il_start=""0x191"" il_end=""0x198"" attributes=""0"" />
-                <local name=""q"" il_index=""5"" il_start=""0x191"" il_end=""0x198"" attributes=""0"" />
-              </scope>
-              <scope startOffset=""0x198"" endOffset=""0x19f"">
-                <local name=""p"" il_index=""6"" il_start=""0x198"" il_end=""0x19f"" attributes=""0"" />
-              </scope>
-              <scope startOffset=""0x19f"" endOffset=""0x1a7"">
-                <local name=""z"" il_index=""7"" il_start=""0x19f"" il_end=""0x1a7"" attributes=""0"" />
-              </scope>
+            <scope startOffset=""0x14d"" endOffset=""0x15e"">
+              <local name=""x"" il_index=""1"" il_start=""0x14d"" il_end=""0x15e"" attributes=""0"" />
+            </scope>
+            <scope startOffset=""0x163"" endOffset=""0x16a"">
+              <local name=""y"" il_index=""2"" il_start=""0x163"" il_end=""0x16a"" attributes=""0"" />
+              <local name=""z"" il_index=""3"" il_start=""0x163"" il_end=""0x16a"" attributes=""0"" />
+            </scope>
+            <scope startOffset=""0x191"" endOffset=""0x198"">
+              <local name=""p"" il_index=""4"" il_start=""0x191"" il_end=""0x198"" attributes=""0"" />
+              <local name=""q"" il_index=""5"" il_start=""0x191"" il_end=""0x198"" attributes=""0"" />
+            </scope>
+            <scope startOffset=""0x198"" endOffset=""0x19f"">
+              <local name=""p"" il_index=""6"" il_start=""0x198"" il_end=""0x19f"" attributes=""0"" />
+            </scope>
+            <scope startOffset=""0x19f"" endOffset=""0x1a7"">
+              <local name=""z"" il_index=""7"" il_start=""0x19f"" il_end=""0x1a7"" attributes=""0"" />
             </scope>
           </scope>
         </method>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/50301