### PR TITLE
Use segmented collections to avoid LOH allocations in the formatter

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -501,6 +501,7 @@ Global
 		src\Analyzers\VisualBasic\Analyzers\VisualBasicAnalyzers.projitems*{2531a8c4-97dd-47bc-a79c-b7846051e137}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\VisualBasic\VisualBasicCompilerExtensions.projitems*{2531a8c4-97dd-47bc-a79c-b7846051e137}*SharedItemsImports = 5
 		src\Analyzers\Core\Analyzers\Analyzers.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
+		src\Dependencies\Collections\Microsoft.CodeAnalysis.Collections.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
 		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems*{275812ee-dedb-4232-9439-91c9757d2ae4}*SharedItemsImports = 5
 		src\ExpressionEvaluator\VisualBasic\Source\ResultProvider\BasicResultProvider.projitems*{3140fe61-0856-4367-9aa3-8081b9a80e35}*SharedItemsImports = 13

--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -43,4 +43,5 @@
   <Import Project="..\..\..\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems" Label="Shared" />
   <Import Project="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CompilerExtensions.projitems" Label="Shared" />
   <Import Project="..\..\..\Analyzers\Core\Analyzers\Analyzers.projitems" Label="Shared" />
+  <Import Project="..\..\..\Dependencies\Collections\Microsoft.CodeAnalysis.Collections.projitems" Label="Shared" />
 </Project>

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder+KeyCollection.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder+KeyCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 internal KeyCollection(ImmutableSegmentedDictionary<TKey, TValue>.Builder dictionary)
                 {
                     Debug.Assert(dictionary is not null);
-                    _dictionary = dictionary;
+                    _dictionary = dictionary!;
                 }
 
                 public int Count => _dictionary.Count;

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder+ValueCollection.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder+ValueCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 internal ValueCollection(ImmutableSegmentedDictionary<TKey, TValue>.Builder dictionary)
                 {
                     Debug.Assert(dictionary is not null);
-                    _dictionary = dictionary;
+                    _dictionary = dictionary!;
                 }
 
                 public int Count => _dictionary.Count;

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+Builder.cs
@@ -207,7 +207,9 @@ namespace Microsoft.CodeAnalysis.Collections
                 return false;
             }
 
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
             public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
                 => ReadOnlyDictionary.TryGetValue(key, out value);
 
             public ImmutableSegmentedDictionary<TKey, TValue> ToImmutable()

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2.cs
@@ -269,7 +269,9 @@ namespace Microsoft.CodeAnalysis.Collections
             return false;
         }
 
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
             => _dictionary.TryGetValue(key, out value);
 
         public ImmutableSegmentedDictionary<TKey, TValue> WithComparer(IEqualityComparer<TKey>? keyComparer)

--- a/src/Dependencies/Collections/Internal/ArraySortHelper.cs
+++ b/src/Dependencies/Collections/Internal/ArraySortHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             // Add a try block here to detect bogus comparisons
             try
             {
-                IntrospectiveSort(keys, comparer);
+                IntrospectiveSort(keys, comparer!);
             }
             catch (IndexOutOfRangeException)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
             if (keys.Length > 1)
             {
-                IntroSort(keys, 2 * (SegmentedArraySortUtils.Log2((uint)keys.Length) + 1), comparer);
+                IntroSort(keys, 2 * (SegmentedArraySortUtils.Log2((uint)keys.Length) + 1), comparer!);
             }
         }
 
@@ -153,33 +153,33 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
                     if (partitionSize == 2)
                     {
-                        SwapIfGreater(keys, comparer, 0, 1);
+                        SwapIfGreater(keys, comparer!, 0, 1);
                         return;
                     }
 
                     if (partitionSize == 3)
                     {
-                        SwapIfGreater(keys, comparer, 0, 1);
-                        SwapIfGreater(keys, comparer, 0, 2);
-                        SwapIfGreater(keys, comparer, 1, 2);
+                        SwapIfGreater(keys, comparer!, 0, 1);
+                        SwapIfGreater(keys, comparer!, 0, 2);
+                        SwapIfGreater(keys, comparer!, 1, 2);
                         return;
                     }
 
-                    InsertionSort(keys.Slice(0, partitionSize), comparer);
+                    InsertionSort(keys.Slice(0, partitionSize), comparer!);
                     return;
                 }
 
                 if (depthLimit == 0)
                 {
-                    HeapSort(keys.Slice(0, partitionSize), comparer);
+                    HeapSort(keys.Slice(0, partitionSize), comparer!);
                     return;
                 }
                 depthLimit--;
 
-                int p = PickPivotAndPartition(keys.Slice(0, partitionSize), comparer);
+                int p = PickPivotAndPartition(keys.Slice(0, partitionSize), comparer!);
 
                 // Note we've already partitioned around the pivot and do not have to move the pivot again.
-                IntroSort(keys.Slice(p + 1, partitionSize - (p + 1)), depthLimit, comparer);
+                IntroSort(keys.Slice(p + 1, partitionSize - (p + 1)), depthLimit, comparer!);
                 partitionSize = p;
             }
         }
@@ -195,9 +195,9 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             int middle = hi >> 1;
 
             // Sort lo, mid and hi appropriately, then pick mid as the pivot.
-            SwapIfGreater(keys, comparer, 0, middle);  // swap the low with the mid point
-            SwapIfGreater(keys, comparer, 0, hi);   // swap the low with the high
-            SwapIfGreater(keys, comparer, middle, hi); // swap the middle with the high
+            SwapIfGreater(keys, comparer!, 0, middle);  // swap the low with the mid point
+            SwapIfGreater(keys, comparer!, 0, hi);   // swap the low with the high
+            SwapIfGreater(keys, comparer!, middle, hi); // swap the middle with the high
 
             T pivot = keys[middle];
             Swap(keys, middle, hi - 1);
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
             while (left < right)
             {
-                while (comparer(keys[++left], pivot) < 0)
+                while (comparer!(keys[++left], pivot) < 0)
                 {
                     // Intentionally empty
                 }
@@ -237,13 +237,13 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             int n = keys.Length;
             for (int i = n >> 1; i >= 1; i--)
             {
-                DownHeap(keys, i, n, 0, comparer);
+                DownHeap(keys, i, n, 0, comparer!);
             }
 
             for (int i = n; i > 1; i--)
             {
                 Swap(keys, 0, i - 1);
-                DownHeap(keys, 1, i - 1, 0, comparer);
+                DownHeap(keys, 1, i - 1, 0, comparer!);
             }
         }
 
@@ -257,12 +257,12 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             while (i <= n >> 1)
             {
                 int child = 2 * i;
-                if (child < n && comparer(keys[lo + child - 1], keys[lo + child]) < 0)
+                if (child < n && comparer!(keys[lo + child - 1], keys[lo + child]) < 0)
                 {
                     child++;
                 }
 
-                if (!(comparer(d, keys[lo + child - 1]) < 0))
+                if (!(comparer!(d, keys[lo + child - 1]) < 0))
                     break;
 
                 keys[lo + i - 1] = keys[lo + child - 1];
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 }
                 else
                 {
-                    order = array[i].CompareTo(value);
+                    order = array[i].CompareTo(value!);
                 }
 
                 if (order == 0)
@@ -688,7 +688,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             Debug.Assert(0 <= j && j < keys.Length && j < values.Length);
             Debug.Assert(i != j);
 
-            if (comparer.Compare(keys[i], keys[j]) > 0)
+            if (comparer!.Compare(keys[i], keys[j]) > 0)
             {
                 TKey key = keys[i];
                 keys[i] = keys[j];
@@ -721,7 +721,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
             if (keys.Length > 1)
             {
-                IntroSort(keys, values, 2 * (SegmentedArraySortUtils.Log2((uint)keys.Length) + 1), comparer);
+                IntroSort(keys, values, 2 * (SegmentedArraySortUtils.Log2((uint)keys.Length) + 1), comparer!);
             }
         }
 
@@ -740,33 +740,33 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
                     if (partitionSize == 2)
                     {
-                        SwapIfGreaterWithValues(keys, values, comparer, 0, 1);
+                        SwapIfGreaterWithValues(keys, values, comparer!, 0, 1);
                         return;
                     }
 
                     if (partitionSize == 3)
                     {
-                        SwapIfGreaterWithValues(keys, values, comparer, 0, 1);
-                        SwapIfGreaterWithValues(keys, values, comparer, 0, 2);
-                        SwapIfGreaterWithValues(keys, values, comparer, 1, 2);
+                        SwapIfGreaterWithValues(keys, values, comparer!, 0, 1);
+                        SwapIfGreaterWithValues(keys, values, comparer!, 0, 2);
+                        SwapIfGreaterWithValues(keys, values, comparer!, 1, 2);
                         return;
                     }
 
-                    InsertionSort(keys.Slice(0, partitionSize), values.Slice(0, partitionSize), comparer);
+                    InsertionSort(keys.Slice(0, partitionSize), values.Slice(0, partitionSize), comparer!);
                     return;
                 }
 
                 if (depthLimit == 0)
                 {
-                    HeapSort(keys.Slice(0, partitionSize), values.Slice(0, partitionSize), comparer);
+                    HeapSort(keys.Slice(0, partitionSize), values.Slice(0, partitionSize), comparer!);
                     return;
                 }
                 depthLimit--;
 
-                int p = PickPivotAndPartition(keys.Slice(0, partitionSize), values.Slice(0, partitionSize), comparer);
+                int p = PickPivotAndPartition(keys.Slice(0, partitionSize), values.Slice(0, partitionSize), comparer!);
 
                 // Note we've already partitioned around the pivot and do not have to move the pivot again.
-                IntroSort(keys.Slice(p + 1, partitionSize - (p + 1)), values.Slice(p + 1, partitionSize - (p + 1)), depthLimit, comparer);
+                IntroSort(keys.Slice(p + 1, partitionSize - (p + 1)), values.Slice(p + 1, partitionSize - (p + 1)), depthLimit, comparer!);
                 partitionSize = p;
             }
         }
@@ -782,9 +782,9 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             int middle = hi >> 1;
 
             // Sort lo, mid and hi appropriately, then pick mid as the pivot.
-            SwapIfGreaterWithValues(keys, values, comparer, 0, middle);  // swap the low with the mid point
-            SwapIfGreaterWithValues(keys, values, comparer, 0, hi);   // swap the low with the high
-            SwapIfGreaterWithValues(keys, values, comparer, middle, hi); // swap the middle with the high
+            SwapIfGreaterWithValues(keys, values, comparer!, 0, middle);  // swap the low with the mid point
+            SwapIfGreaterWithValues(keys, values, comparer!, 0, hi);   // swap the low with the high
+            SwapIfGreaterWithValues(keys, values, comparer!, middle, hi); // swap the middle with the high
 
             TKey pivot = keys[middle];
             Swap(keys, values, middle, hi - 1);
@@ -792,7 +792,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
             while (left < right)
             {
-                while (comparer.Compare(keys[++left], pivot) < 0)
+                while (comparer!.Compare(keys[++left], pivot) < 0)
                 {
                     // Intentionally empty
                 }
@@ -824,13 +824,13 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             int n = keys.Length;
             for (int i = n >> 1; i >= 1; i--)
             {
-                DownHeap(keys, values, i, n, 0, comparer);
+                DownHeap(keys, values, i, n, 0, comparer!);
             }
 
             for (int i = n; i > 1; i--)
             {
                 Swap(keys, values, 0, i - 1);
-                DownHeap(keys, values, 1, i - 1, 0, comparer);
+                DownHeap(keys, values, 1, i - 1, 0, comparer!);
             }
         }
 
@@ -846,12 +846,12 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             while (i <= n >> 1)
             {
                 int child = 2 * i;
-                if (child < n && comparer.Compare(keys[lo + child - 1], keys[lo + child]) < 0)
+                if (child < n && comparer!.Compare(keys[lo + child - 1], keys[lo + child]) < 0)
                 {
                     child++;
                 }
 
-                if (!(comparer.Compare(d, keys[lo + child - 1]) < 0))
+                if (!(comparer!.Compare(d, keys[lo + child - 1]) < 0))
                     break;
 
                 keys[lo + i - 1] = keys[lo + child - 1];
@@ -873,7 +873,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 TValue tValue = values[i + 1];
 
                 int j = i;
-                while (j >= 0 && comparer.Compare(t, keys[j]) < 0)
+                while (j >= 0 && comparer!.Compare(t, keys[j]) < 0)
                 {
                     keys[j + 1] = keys[j];
                     values[j + 1] = values[j];

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -129,11 +130,11 @@ namespace Microsoft.CodeAnalysis.Formatting
             cancellationToken.ThrowIfCancellationRequested();
 
             // iterating tree is very expensive. do it once and cache it to list
-            List<SyntaxNode> nodeIterator;
+            SegmentedList<SyntaxNode> nodeIterator;
             using (Logger.LogBlock(FunctionId.Formatting_IterateNodes, cancellationToken))
             {
                 const int magicLengthToNodesRatio = 5;
-                var result = new List<SyntaxNode>(Math.Max(this.SpanToFormat.Length / magicLengthToNodesRatio, 4));
+                var result = new SegmentedList<SyntaxNode>(Math.Max(this.SpanToFormat.Length / magicLengthToNodesRatio, 4));
 
                 foreach (var node in _commonRoot.DescendantNodesAndSelf(this.SpanToFormat))
                 {
@@ -181,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             return new NodeOperations(indentBlockOperation, suppressOperation, anchorIndentationOperations, alignmentOperation);
         }
 
-        private static List<T> AddOperations<T>(List<SyntaxNode> nodes, Action<List<T>, SyntaxNode> addOperations, CancellationToken cancellationToken)
+        private static List<T> AddOperations<T>(SegmentedList<SyntaxNode> nodes, Action<List<T>, SyntaxNode> addOperations, CancellationToken cancellationToken)
         {
             var operations = new List<T>();
             var list = new List<T>();
@@ -199,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             return operations;
         }
 
-        private TokenPairWithOperations[] CreateTokenOperation(
+        private SegmentedArray<TokenPairWithOperations> CreateTokenOperation(
             TokenStream tokenStream,
             CancellationToken cancellationToken)
         {
@@ -208,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             using (Logger.LogBlock(FunctionId.Formatting_CollectTokenOperation, cancellationToken))
             {
                 // pre-allocate list once. this is cheaper than re-adjusting list as items are added.
-                var list = new TokenPairWithOperations[tokenStream.TokenCount - 1];
+                var list = new SegmentedArray<TokenPairWithOperations>(tokenStream.TokenCount - 1);
 
                 foreach (var (index, currentToken, nextToken) in tokenStream.TokenIterator)
                 {
@@ -227,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         private void ApplyTokenOperations(
             FormattingContext context,
             NodeOperations nodeOperations,
-            TokenPairWithOperations[] tokenOperations,
+            SegmentedArray<TokenPairWithOperations> tokenOperations,
             CancellationToken cancellationToken)
         {
             var applier = new OperationApplier(context, _formattingRules);
@@ -355,7 +356,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         private static void ApplyAnchorOperations(
             FormattingContext context,
-            TokenPairWithOperations[] tokenOperations,
+            SegmentedArray<TokenPairWithOperations> tokenOperations,
             OperationApplier applier,
             CancellationToken cancellationToken)
         {
@@ -412,7 +413,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         private static void ApplySpaceAndWrappingOperations(
             FormattingContext context,
-            TokenPairWithOperations[] tokenOperations,
+            SegmentedArray<TokenPairWithOperations> tokenOperations,
             OperationApplier applier,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.Iterator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.Iterator.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
@@ -13,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Formatting
         // not sure whether it is worth it. but I already wrote it to test, so going to just keep it.
         private class Iterator : IEnumerable<(int index, SyntaxToken currentToken, SyntaxToken nextToken)>
         {
-            private readonly List<SyntaxToken> _tokensIncludingZeroWidth;
+            private readonly SegmentedList<SyntaxToken> _tokensIncludingZeroWidth;
 
-            public Iterator(List<SyntaxToken> tokensIncludingZeroWidth)
+            public Iterator(SegmentedList<SyntaxToken> tokensIncludingZeroWidth)
                 => _tokensIncludingZeroWidth = tokensIncludingZeroWidth;
 
             public IEnumerator<(int index, SyntaxToken currentToken, SyntaxToken nextToken)> GetEnumerator()
@@ -26,13 +27,13 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             private struct Enumerator : IEnumerator<(int index, SyntaxToken currentToken, SyntaxToken nextToken)>
             {
-                private readonly List<SyntaxToken> _tokensIncludingZeroWidth;
+                private readonly SegmentedList<SyntaxToken> _tokensIncludingZeroWidth;
                 private readonly int _maxCount;
 
                 private (int index, SyntaxToken currentToken, SyntaxToken nextToken) _current;
                 private int _index;
 
-                public Enumerator(List<SyntaxToken> tokensIncludingZeroWidth)
+                public Enumerator(SegmentedList<SyntaxToken> tokensIncludingZeroWidth)
                 {
                     _tokensIncludingZeroWidth = tokensIncludingZeroWidth;
                     _maxCount = _tokensIncludingZeroWidth.Count - 1;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         private const int MagicTextLengthToTokensRatio = 10;
 
         // caches token information within given formatting span to improve perf
-        private readonly List<SyntaxToken> _tokens;
+        private readonly SegmentedList<SyntaxToken> _tokens;
 
         // caches original trivia info to improve perf
         private readonly TriviaData[] _cachedOriginalTriviaInfo;
@@ -58,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                 // use some heuristics to get initial size of list rather than blindly start from default size == 4
                 var sizeOfList = spanToFormat.Length / MagicTextLengthToTokensRatio;
-                _tokens = new List<SyntaxToken>(sizeOfList);
+                _tokens = new SegmentedList<SyntaxToken>(sizeOfList);
                 _tokens.AddRange(_treeData.GetApplicableTokens(spanToFormat));
 
                 Debug.Assert(this.TokenCount > 0);


### PR DESCRIPTION
Supersedes #43464 using the **Microsoft.CodeAnalysis.Collections** package.