### PR TITLE
Add UI for editorconfig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # User-specific files
 *.suo
+*.svclog
 *.user
 *.userprefs
 *.sln.docstates

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # User-specific files
 *.suo
-*.svclog
 *.user
 *.userprefs
 *.sln.docstates

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentLruCache.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentLruCache.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.InternalUtilities
 
         private void MoveNodeToTop(LinkedListNode<K> node)
         {
-            if (!object.ReferenceEquals(_nodeList.First, node))
+            if (!ReferenceEquals(_nodeList.First, node))
             {
                 _nodeList.Remove(node);
                 _nodeList.AddFirst(node);

--- a/src/Compilers/Test/Core/Traits/Traits.cs
+++ b/src/Compilers/Test/Core/Traits/Traits.cs
@@ -227,6 +227,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string DocCommentFormatting = nameof(DocCommentFormatting);
             public const string DocumentationComments = nameof(DocumentationComments);
             public const string EditorConfig = nameof(EditorConfig);
+            public const string EditorConfigUI = nameof(EditorConfigUI);
             public const string EncapsulateField = nameof(EncapsulateField);
             public const string EndConstructGeneration = nameof(EndConstructGeneration);
             public const string ErrorList = nameof(ErrorList);

--- a/src/EditorFeatures/CSharp/CSharpEditorResources.resx
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.resx
@@ -434,4 +434,7 @@
   <data name="When_variable_type_is_apparent" xml:space="preserve">
     <value>When variable type is apparent</value>
   </data>
+  <data name="Outside_namespace" xml:space="preserve">
+    <value>Outside namespace</value>
+  </data>
 </root>

--- a/src/EditorFeatures/CSharp/CSharpEditorResources.resx
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.resx
@@ -182,4 +182,256 @@
     <value>Add Missing Usings on Paste</value>
     <comment>"usings" is a language specific term and should not be localized</comment>
   </data>
+  <data name="Avoid_expression_statements_that_implicitly_ignore_value" xml:space="preserve">
+    <value>Avoid expression statements that implicitly ignore value</value>
+  </data>
+  <data name="Avoid_unused_value_assignments" xml:space="preserve">
+    <value>Avoid unused value assignments</value>
+  </data>
+  <data name="Discard" xml:space="preserve">
+    <value>Discard</value>
+  </data>
+  <data name="Elsewhere" xml:space="preserve">
+    <value>Elsewhere</value>
+  </data>
+  <data name="For_built_in_types" xml:space="preserve">
+    <value>For built-in types</value>
+  </data>
+  <data name="Ignore_spaces_in_declaration_statements" xml:space="preserve">
+    <value>Ignore spaces in declaration statements</value>
+  </data>
+  <data name="Indent_block_contents" xml:space="preserve">
+    <value>Indent block contents</value>
+  </data>
+  <data name="Indent_case_contents" xml:space="preserve">
+    <value>Indent case contents</value>
+  </data>
+  <data name="Indent_case_contents_when_block" xml:space="preserve">
+    <value>Indent case contents (when block)</value>
+  </data>
+  <data name="Indent_case_labels" xml:space="preserve">
+    <value>Indent case labels</value>
+  </data>
+  <data name="Indent_open_and_close_braces" xml:space="preserve">
+    <value>Indent open and close braces</value>
+  </data>
+  <data name="Insert_spaces_within_parentheses_of_control_flow_statements" xml:space="preserve">
+    <value>Insert spaces within parentheses of control flow statements</value>
+  </data>
+  <data name="Insert_spaces_within_square_brackets" xml:space="preserve">
+    <value>Insert spaces within square brackets</value>
+  </data>
+  <data name="Insert_space_after_cast" xml:space="preserve">
+    <value>Insert space after cast</value>
+  </data>
+  <data name="Insert_space_after_colon_for_base_or_interface_in_type_declaration" xml:space="preserve">
+    <value>Insert space after colon for base or interface in type declaration</value>
+  </data>
+  <data name="Insert_space_after_comma" xml:space="preserve">
+    <value>Insert space after comma</value>
+  </data>
+  <data name="Insert_space_after_dot" xml:space="preserve">
+    <value>Insert space after dot</value>
+  </data>
+  <data name="Insert_space_after_keywords_in_control_flow_statements" xml:space="preserve">
+    <value>Insert space after keywords in control flow statements</value>
+  </data>
+  <data name="Insert_space_after_semicolon_in_for_statement" xml:space="preserve">
+    <value>Insert space after semicolon in "for" statement</value>
+  </data>
+  <data name="Insert_space_before_colon_for_base_or_interface_in_type_declaration" xml:space="preserve">
+    <value>Insert space before colon for base or interface in type declaration</value>
+  </data>
+  <data name="Insert_space_before_comma" xml:space="preserve">
+    <value>Insert space before comma</value>
+  </data>
+  <data name="Insert_space_before_dot" xml:space="preserve">
+    <value>Insert space before dot</value>
+  </data>
+  <data name="Insert_space_before_open_square_bracket" xml:space="preserve">
+    <value>Insert space before open square bracket</value>
+  </data>
+  <data name="Insert_space_before_semicolon_in_for_statement" xml:space="preserve">
+    <value>Insert space before semicolon in "for" statement</value>
+  </data>
+  <data name="Insert_space_between_method_name_and_its_opening_parenthesis1" xml:space="preserve">
+    <value>Insert space between method name and its opening parenthesis</value>
+  </data>
+  <data name="Insert_space_between_method_name_and_its_opening_parenthesis2" xml:space="preserve">
+    <value>Insert space between method name and its opening parenthesis</value>
+  </data>
+  <data name="Insert_space_within_argument_list_parentheses" xml:space="preserve">
+    <value>Insert space within argument list parentheses</value>
+  </data>
+  <data name="Insert_space_within_empty_argument_list_parentheses" xml:space="preserve">
+    <value>Insert space within empty argument list parentheses</value>
+  </data>
+  <data name="Insert_space_within_empty_parameter_list_parentheses" xml:space="preserve">
+    <value>Insert space within empty parameter list parentheses</value>
+  </data>
+  <data name="Insert_space_within_empty_square_brackets" xml:space="preserve">
+    <value>Insert space within empty square brackets</value>
+  </data>
+  <data name="Insert_space_within_parameter_list_parentheses" xml:space="preserve">
+    <value>Insert space within parameter list parentheses</value>
+  </data>
+  <data name="Insert_space_within_parentheses_of_expressions" xml:space="preserve">
+    <value>Insert space within parentheses of expressions</value>
+  </data>
+  <data name="Insert_space_within_parentheses_of_type_casts" xml:space="preserve">
+    <value>Insert space within parentheses of type casts</value>
+  </data>
+  <data name="Inside_namespace" xml:space="preserve">
+    <value>Inside namespace</value>
+  </data>
+  <data name="Label_Indentation" xml:space="preserve">
+    <value>Label Indentation</value>
+  </data>
+  <data name="Leave_block_on_single_line" xml:space="preserve">
+    <value>Leave block on single line</value>
+  </data>
+  <data name="Leave_statements_and_member_declarations_on_the_same_line" xml:space="preserve">
+    <value>Leave statements and member declarations on the same line</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Never</value>
+  </data>
+  <data name="Place_catch_on_new_line" xml:space="preserve">
+    <value>Place "catch" on new line</value>
+  </data>
+  <data name="Place_else_on_new_line" xml:space="preserve">
+    <value>Place "else" on new line</value>
+  </data>
+  <data name="Place_finally_on_new_line" xml:space="preserve">
+    <value>Place "finally" on new line</value>
+  </data>
+  <data name="Place_members_in_anonymous_types_on_new_line" xml:space="preserve">
+    <value>Place members in anonymous types on new line</value>
+  </data>
+  <data name="Place_members_in_object_initializers_on_new_line" xml:space="preserve">
+    <value>Place members in object initializers on new line</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_anonymous_methods" xml:space="preserve">
+    <value>Place open brace on new line for anonymous methods</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_anonymous_types" xml:space="preserve">
+    <value>Place open brace on new line for anonymous types</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_control_blocks" xml:space="preserve">
+    <value>Place open brace on new line for control blocks</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_lambda_expression" xml:space="preserve">
+    <value>Place open brace on new line for lambda expression</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_methods_local_functions" xml:space="preserve">
+    <value>Place open brace on new line for methods and local functions</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers" xml:space="preserve">
+    <value>Place open brace on new line for object, collection, array, and with initializers</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_properties_indexers_and_events" xml:space="preserve">
+    <value>Place open brace on new line for properties, indexers, and events</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors" xml:space="preserve">
+    <value>Place open brace on new line for property, indexer, and event accessors</value>
+  </data>
+  <data name="Place_open_brace_on_new_line_for_types" xml:space="preserve">
+    <value>Place open brace on new line for types</value>
+  </data>
+  <data name="Place_query_expression_clauses_on_new_line" xml:space="preserve">
+    <value>Place query expression clauses on new line</value>
+  </data>
+  <data name="Preferred_using_directive_placement" xml:space="preserve">
+    <value>Preferred 'using' directive placement</value>
+  </data>
+  <data name="Prefer_conditional_delegate_call" xml:space="preserve">
+    <value>Prefer conditional delegate call</value>
+  </data>
+  <data name="Prefer_deconstructed_variable_declaration" xml:space="preserve">
+    <value>Prefer deconstructed variable declaration</value>
+  </data>
+  <data name="Prefer_explicit_type" xml:space="preserve">
+    <value>Prefer explicit type</value>
+  </data>
+  <data name="Prefer_index_operator" xml:space="preserve">
+    <value>Prefer index operator</value>
+  </data>
+  <data name="Prefer_inlined_variable_declaration" xml:space="preserve">
+    <value>Prefer inlined variable declaration</value>
+  </data>
+  <data name="Prefer_local_function_over_anonymous_function" xml:space="preserve">
+    <value>Prefer local function over anonymous function</value>
+  </data>
+  <data name="Prefer_pattern_matching" xml:space="preserve">
+    <value>Prefer pattern matching</value>
+  </data>
+  <data name="Prefer_pattern_matching_over_as_with_null_check" xml:space="preserve">
+    <value>Prefer pattern matching over 'as' with 'null' check</value>
+  </data>
+  <data name="Prefer_pattern_matching_over_is_with_cast_check" xml:space="preserve">
+    <value>Prefer pattern matching over 'is' with 'cast' check</value>
+  </data>
+  <data name="Prefer_pattern_matching_over_mixed_type_check" xml:space="preserve">
+    <value>Prefer pattern matching over mixed type check</value>
+  </data>
+  <data name="Prefer_range_operator" xml:space="preserve">
+    <value>Prefer range operator</value>
+  </data>
+  <data name="Prefer_simple_default_expression" xml:space="preserve">
+    <value>Prefer simple 'default' expression</value>
+  </data>
+  <data name="Prefer_simple_using_statement" xml:space="preserve">
+    <value>Prefer simple 'using' statement</value>
+  </data>
+  <data name="Prefer_static_local_functions" xml:space="preserve">
+    <value>Prefer static local functions</value>
+  </data>
+  <data name="Prefer_switch_expression" xml:space="preserve">
+    <value>Prefer switch expression</value>
+  </data>
+  <data name="Prefer_throw_expression" xml:space="preserve">
+    <value>Prefer throw-expression</value>
+  </data>
+  <data name="Prefer_var" xml:space="preserve">
+    <value>Prefer 'var'</value>
+  </data>
+  <data name="Set_spacing_for_operators" xml:space="preserve">
+    <value>Set spacing for operators</value>
+  </data>
+  <data name="Unused_local" xml:space="preserve">
+    <value>Unused local</value>
+  </data>
+  <data name="Use_expression_body_for_accessors" xml:space="preserve">
+    <value>Use expression body for accessors</value>
+  </data>
+  <data name="Use_expression_body_for_constructors" xml:space="preserve">
+    <value>Use expression body for constructors</value>
+  </data>
+  <data name="Use_expression_body_for_indexers" xml:space="preserve">
+    <value>Use expression body for indexers</value>
+  </data>
+  <data name="Use_expression_body_for_lambdas" xml:space="preserve">
+    <value>Use expression body for lambdas</value>
+  </data>
+  <data name="Use_expression_body_for_local_functions" xml:space="preserve">
+    <value>Use expression body for local functions</value>
+  </data>
+  <data name="Use_expression_body_for_methods" xml:space="preserve">
+    <value>Use expression body for methods</value>
+  </data>
+  <data name="Use_expression_body_for_operators" xml:space="preserve">
+    <value>Use expression body for operators</value>
+  </data>
+  <data name="Use_expression_body_for_properties" xml:space="preserve">
+    <value>Use expression body for properties</value>
+  </data>
+  <data name="When_on_single_line" xml:space="preserve">
+    <value>When on single line</value>
+  </data>
+  <data name="When_possible" xml:space="preserve">
+    <value>When possible</value>
+  </data>
+  <data name="When_variable_type_is_apparent" xml:space="preserve">
+    <value>When variable type is apparent</value>
+  </data>
 </root>

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsLanguageServiceFactory.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsLanguageServiceFactory.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.DataProvider.CodeStyle
+{
+    [ExportLanguageServiceFactory(typeof(ILanguageSettingsProviderFactory<CodeStyleSetting>), LanguageNames.CSharp), Shared]
+    internal class CSharpCodeStyleSettingsLanguageServiceFactory : ILanguageServiceFactory
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpCodeStyleSettingsLanguageServiceFactory()
+        {
+        }
+
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            var workspace = languageServices.WorkspaceServices.Workspace;
+            return new CSharpCodeStyleSettingsProviderFactory(workspace);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProvider.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProvider.cs
@@ -22,42 +22,40 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.Da
         public CSharpCodeStyleSettingsProvider(string fileName, OptionUpdater settingsUpdater, Workspace workspace)
             : base(fileName, settingsUpdater, workspace)
         {
+            Update();
         }
 
-        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        protected override void UpdateOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
         {
-            return Task.Run(() =>
-            {
-                var varSettings = GetVarCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(varSettings);
+            var varSettings = GetVarCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(varSettings);
 
-                var usingSettings = GetUsingsCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(usingSettings);
+            var usingSettings = GetUsingsCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(usingSettings);
 
-                var modifierSettings = GetModifierCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(modifierSettings);
+            var modifierSettings = GetModifierCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(modifierSettings);
 
-                var codeBlockSettings = GetCodeBlockCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(codeBlockSettings);
+            var codeBlockSettings = GetCodeBlockCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(codeBlockSettings);
 
-                var nullCheckingSettings = GetNullCheckingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(nullCheckingSettings);
+            var nullCheckingSettings = GetNullCheckingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(nullCheckingSettings);
 
-                var expressionSettings = GetExpressionCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(expressionSettings);
+            var expressionSettings = GetExpressionCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(expressionSettings);
 
-                var patternMatchingSettings = GetPatternMatchingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(patternMatchingSettings);
+            var patternMatchingSettings = GetPatternMatchingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(patternMatchingSettings);
 
-                var variableSettings = GetVariableCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(variableSettings);
+            var variableSettings = GetVariableCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(variableSettings);
 
-                var expressionBodySettings = GetExpressionBodyCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(expressionBodySettings);
+            var expressionBodySettings = GetExpressionBodyCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(expressionBodySettings);
 
-                var unusedValueSettings = GetUnusedValueCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(unusedValueSettings);
-            });
+            var unusedValueSettings = GetUnusedValueCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(unusedValueSettings);
         }
 
         private static IEnumerable<CodeStyleSetting> GetVarCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProvider.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.Da
                 option: CSharpCodeStyleOptions.PreferredUsingDirectivePlacement,
                 description: CSharpEditorResources.Preferred_using_directive_placement,
                 enumValues: new[] { AddImportPlacement.InsideNamespace, AddImportPlacement.OutsideNamespace },
-                valueDescriptions: new[] { CSharpEditorResources.Inside_namespace },
+                valueDescriptions: new[] { CSharpEditorResources.Inside_namespace, CSharpEditorResources.Outside_namespace },
                 editorConfigOptions: editorConfigOptions,
                 visualStudioOptions: visualStudioOptions, updater: updaterService);
         }

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProvider.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProvider.cs
@@ -1,0 +1,226 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.AddImports;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.CSharp;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.DataProvider.CodeStyle
+{
+    internal class CSharpCodeStyleSettingsProvider : SettingsProviderBase<CodeStyleSetting, OptionUpdater, IOption2, object>
+    {
+        public CSharpCodeStyleSettingsProvider(string fileName, OptionUpdater settingsUpdater, Workspace workspace)
+            : base(fileName, settingsUpdater, workspace)
+        {
+        }
+
+        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        {
+            return Task.Run(() =>
+            {
+                var varSettings = GetVarCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(varSettings);
+
+                var usingSettings = GetUsingsCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(usingSettings);
+
+                var modifierSettings = GetModifierCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(modifierSettings);
+
+                var codeBlockSettings = GetCodeBlockCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(codeBlockSettings);
+
+                var nullCheckingSettings = GetNullCheckingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(nullCheckingSettings);
+
+                var expressionSettings = GetExpressionCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(expressionSettings);
+
+                var patternMatchingSettings = GetPatternMatchingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(patternMatchingSettings);
+
+                var variableSettings = GetVariableCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(variableSettings);
+
+                var expressionBodySettings = GetExpressionBodyCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(expressionBodySettings);
+
+                var unusedValueSettings = GetUnusedValueCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(unusedValueSettings);
+            });
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetVarCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.VarForBuiltInTypes,
+                description: CSharpEditorResources.For_built_in_types,
+                trueValueDescription: CSharpEditorResources.Prefer_var,
+                falseValueDescription: CSharpEditorResources.Prefer_explicit_type,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.VarWhenTypeIsApparent,
+                description: CSharpEditorResources.When_variable_type_is_apparent,
+                trueValueDescription: CSharpEditorResources.Prefer_var,
+                falseValueDescription: CSharpEditorResources.Prefer_explicit_type,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.VarElsewhere,
+                description: CSharpEditorResources.Elsewhere,
+                trueValueDescription: CSharpEditorResources.Prefer_var,
+                falseValueDescription: CSharpEditorResources.Prefer_explicit_type,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetUsingsCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(
+                option: CSharpCodeStyleOptions.PreferredUsingDirectivePlacement,
+                description: CSharpEditorResources.Preferred_using_directive_placement,
+                enumValues: new[] { AddImportPlacement.InsideNamespace, AddImportPlacement.OutsideNamespace },
+                valueDescriptions: new[] { CSharpEditorResources.Inside_namespace },
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetNullCheckingCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferThrowExpression,
+                description: CSharpEditorResources.Prefer_throw_expression,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferConditionalDelegateCall,
+                description: CSharpEditorResources.Prefer_conditional_delegate_call,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetModifierCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferStaticLocalFunction,
+                description: CSharpEditorResources.Prefer_static_local_functions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetCodeBlockCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferSimpleUsingStatement,
+                description: CSharpEditorResources.Prefer_simple_using_statement,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetExpressionCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferSwitchExpression, description: CSharpEditorResources.Prefer_switch_expression, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferSimpleDefaultExpression, description: CSharpEditorResources.Prefer_simple_default_expression, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction, description: CSharpEditorResources.Prefer_local_function_over_anonymous_function, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferIndexOperator, description: CSharpEditorResources.Prefer_index_operator, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferRangeOperator, description: CSharpEditorResources.Prefer_range_operator, editorConfigOptions, visualStudioOptions, updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetPatternMatchingCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferPatternMatching, description: CSharpEditorResources.Prefer_pattern_matching, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck, description: CSharpEditorResources.Prefer_pattern_matching_over_is_with_cast_check, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck, description: CSharpEditorResources.Prefer_pattern_matching_over_as_with_null_check, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferNotPattern, description: CSharpEditorResources.Prefer_pattern_matching_over_mixed_type_check, editorConfigOptions, visualStudioOptions, updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetVariableCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferInlinedVariableDeclaration, description: CSharpEditorResources.Prefer_inlined_variable_declaration, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.PreferDeconstructedVariableDeclaration, description: CSharpEditorResources.Prefer_deconstructed_variable_declaration, editorConfigOptions, visualStudioOptions, updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetExpressionBodyCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            var enumValues = new[] { ExpressionBodyPreference.Never, ExpressionBodyPreference.WhenPossible, ExpressionBodyPreference.WhenOnSingleLine };
+            var valueDescriptions = new[] { CSharpEditorResources.Never, CSharpEditorResources.When_possible, CSharpEditorResources.When_on_single_line };
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedMethods,
+                description: CSharpEditorResources.Use_expression_body_for_methods,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedConstructors,
+                description: CSharpEditorResources.Use_expression_body_for_constructors,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedOperators,
+                description: CSharpEditorResources.Use_expression_body_for_operators,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedProperties,
+                description: CSharpEditorResources.Use_expression_body_for_properties,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedIndexers,
+                description: CSharpEditorResources.Use_expression_body_for_indexers,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedAccessors,
+                description: CSharpEditorResources.Use_expression_body_for_accessors,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedLambdas,
+                description: CSharpEditorResources.Use_expression_body_for_lambdas,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+            yield return CodeStyleSetting.Create(option: CSharpCodeStyleOptions.PreferExpressionBodiedLocalFunctions,
+                description: CSharpEditorResources.Use_expression_body_for_local_functions,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: editorConfigOptions,
+                visualStudioOptions: visualStudioOptions, updater: updaterService);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetUnusedValueCodeStyleOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            var enumValues = new[]
+            {
+                UnusedValuePreference.UnusedLocalVariable,
+                UnusedValuePreference.DiscardVariable
+            };
+
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.UnusedValueAssignment,
+                description: CSharpEditorResources.Avoid_unused_value_assignments,
+                enumValues,
+                new[] { CSharpEditorResources.Unused_local, CSharpEditorResources.Discard },
+                editorConfigOptions,
+                visualStudioOptions,
+                updaterService);
+
+            yield return CodeStyleSetting.Create(CSharpCodeStyleOptions.UnusedValueExpressionStatement,
+                description: CSharpEditorResources.Avoid_expression_statements_that_implicitly_ignore_value,
+                enumValues,
+                new[] { CSharpEditorResources.Unused_local, CSharpEditorResources.Discard },
+                editorConfigOptions,
+                visualStudioOptions,
+                updaterService);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProviderFactory.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/CodeStyle/CSharpCodeStyleSettingsProviderFactory.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.DataProvider.CodeStyle
+{
+    internal class CSharpCodeStyleSettingsProviderFactory : ILanguageSettingsProviderFactory<CodeStyleSetting>
+    {
+        private readonly Workspace _workspace;
+
+        public CSharpCodeStyleSettingsProviderFactory(Workspace workspace) => _workspace = workspace;
+
+        public ISettingsProvider<CodeStyleSetting> GetForFile(string filePath)
+            => new CSharpCodeStyleSettingsProvider(filePath, new OptionUpdater(_workspace, filePath), _workspace);
+    }
+}

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsLanguageServiceFactory.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsLanguageServiceFactory.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.DataProvider.Formatting
+{
+    [ExportLanguageServiceFactory(typeof(ILanguageSettingsProviderFactory<FormattingSetting>), LanguageNames.CSharp), Shared]
+    internal class CSharpFormattingSettingsLanguageServiceFactory : ILanguageServiceFactory
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpFormattingSettingsLanguageServiceFactory()
+        {
+        }
+
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            var workspace = languageServices.WorkspaceServices.Workspace;
+            return new CSharpFormattingSettingsProviderFactory(workspace);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsProvider.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsProvider.cs
@@ -21,21 +21,19 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.Da
         public CSharpFormattingSettingsProvider(string filePath, OptionUpdater updaterService, Workspace workspace)
             : base(filePath, updaterService, workspace)
         {
+            Update();
         }
 
-        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        protected override void UpdateOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
         {
-            return Task.Run(() =>
-            {
-                var spacingOptions = GetSpacingOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(spacingOptions.ToImmutableArray());
-                var newLineOptions = GetNewLineOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(newLineOptions.ToImmutableArray());
-                var indentationOptions = GetIndentationOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(indentationOptions.ToImmutableArray());
-                var wrappingOptions = GetWrappingOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(wrappingOptions.ToImmutableArray());
-            });
+            var spacingOptions = GetSpacingOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(spacingOptions.ToImmutableArray());
+            var newLineOptions = GetNewLineOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(newLineOptions.ToImmutableArray());
+            var indentationOptions = GetIndentationOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(indentationOptions.ToImmutableArray());
+            var wrappingOptions = GetWrappingOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(wrappingOptions.ToImmutableArray());
         }
 
         private static IEnumerable<FormattingSetting> GetSpacingOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsProvider.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsProvider.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.CSharp;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.DataProvider.Formatting
+{
+    internal class CSharpFormattingSettingsProvider : SettingsProviderBase<FormattingSetting, OptionUpdater, IOption2, object>
+    {
+        public CSharpFormattingSettingsProvider(string filePath, OptionUpdater updaterService, Workspace workspace)
+            : base(filePath, updaterService, workspace)
+        {
+        }
+
+        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        {
+            return Task.Run(() =>
+            {
+                var spacingOptions = GetSpacingOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(spacingOptions.ToImmutableArray());
+                var newLineOptions = GetNewLineOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(newLineOptions.ToImmutableArray());
+                var indentationOptions = GetIndentationOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(indentationOptions.ToImmutableArray());
+                var wrappingOptions = GetWrappingOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(wrappingOptions.ToImmutableArray());
+            });
+        }
+
+        private static IEnumerable<FormattingSetting> GetSpacingOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpacingAfterMethodDeclarationName, CSharpEditorResources.Insert_space_between_method_name_and_its_opening_parenthesis2, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceWithinMethodDeclarationParenthesis, CSharpEditorResources.Insert_space_within_parameter_list_parentheses, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBetweenEmptyMethodDeclarationParentheses, CSharpEditorResources.Insert_space_within_empty_parameter_list_parentheses, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceAfterMethodCallName, CSharpEditorResources.Insert_space_between_method_name_and_its_opening_parenthesis1, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceWithinMethodCallParentheses, CSharpEditorResources.Insert_space_within_argument_list_parentheses, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBetweenEmptyMethodCallParentheses, CSharpEditorResources.Insert_space_within_empty_argument_list_parentheses, editorConfigOptions, visualStudioOptions, updaterService);
+
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceAfterControlFlowStatementKeyword, CSharpEditorResources.Insert_space_after_keywords_in_control_flow_statements, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceWithinExpressionParentheses, CSharpEditorResources.Insert_space_within_parentheses_of_expressions, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceWithinCastParentheses, CSharpEditorResources.Insert_space_within_parentheses_of_type_casts, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceWithinOtherParentheses, CSharpEditorResources.Insert_spaces_within_parentheses_of_control_flow_statements, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceAfterCast, CSharpEditorResources.Insert_space_after_cast, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpacesIgnoreAroundVariableDeclaration, CSharpEditorResources.Ignore_spaces_in_declaration_statements, editorConfigOptions, visualStudioOptions, updaterService);
+
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBeforeOpenSquareBracket, CSharpEditorResources.Insert_space_before_open_square_bracket, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBetweenEmptySquareBrackets, CSharpEditorResources.Insert_space_within_empty_square_brackets, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceWithinSquareBrackets, CSharpEditorResources.Insert_spaces_within_square_brackets, editorConfigOptions, visualStudioOptions, updaterService);
+
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceAfterColonInBaseTypeDeclaration, CSharpEditorResources.Insert_space_after_colon_for_base_or_interface_in_type_declaration, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceAfterComma, CSharpEditorResources.Insert_space_after_comma, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceAfterDot, CSharpEditorResources.Insert_space_after_dot, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceAfterSemicolonsInForStatement, CSharpEditorResources.Insert_space_after_semicolon_in_for_statement, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBeforeColonInBaseTypeDeclaration, CSharpEditorResources.Insert_space_before_colon_for_base_or_interface_in_type_declaration, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBeforeComma, CSharpEditorResources.Insert_space_before_comma, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBeforeDot, CSharpEditorResources.Insert_space_before_dot, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpaceBeforeSemicolonsInForStatement, CSharpEditorResources.Insert_space_before_semicolon_in_for_statement, editorConfigOptions, visualStudioOptions, updaterService);
+
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.SpacingAroundBinaryOperator, CSharpEditorResources.Set_spacing_for_operators, editorConfigOptions, visualStudioOptions, updaterService);
+        }
+
+        private static IEnumerable<FormattingSetting> GetNewLineOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInTypes, CSharpEditorResources.Place_open_brace_on_new_line_for_types, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInMethods, CSharpEditorResources.Place_open_brace_on_new_line_for_methods_local_functions, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInProperties, CSharpEditorResources.Place_open_brace_on_new_line_for_properties_indexers_and_events, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInAccessors, CSharpEditorResources.Place_open_brace_on_new_line_for_property_indexer_and_event_accessors, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInAnonymousMethods, CSharpEditorResources.Place_open_brace_on_new_line_for_anonymous_methods, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInControlBlocks, CSharpEditorResources.Place_open_brace_on_new_line_for_control_blocks, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInAnonymousTypes, CSharpEditorResources.Place_open_brace_on_new_line_for_anonymous_types, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInObjectCollectionArrayInitializers, CSharpEditorResources.Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLinesForBracesInLambdaExpressionBody, CSharpEditorResources.Place_open_brace_on_new_line_for_lambda_expression, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLineForElse, CSharpEditorResources.Place_else_on_new_line, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLineForCatch, CSharpEditorResources.Place_catch_on_new_line, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLineForFinally, CSharpEditorResources.Place_finally_on_new_line, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLineForMembersInObjectInit, CSharpEditorResources.Place_members_in_object_initializers_on_new_line, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLineForMembersInAnonymousTypes, CSharpEditorResources.Place_members_in_anonymous_types_on_new_line, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.NewLineForClausesInQuery, CSharpEditorResources.Place_query_expression_clauses_on_new_line, editorConfigOptions, visualStudioOptions, updaterService);
+        }
+
+        private static IEnumerable<FormattingSetting> GetIndentationOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.IndentBlock, CSharpEditorResources.Indent_block_contents, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.IndentBraces, CSharpEditorResources.Indent_open_and_close_braces, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.IndentSwitchCaseSection, CSharpEditorResources.Indent_case_contents, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.IndentSwitchCaseSectionWhenBlock, CSharpEditorResources.Indent_case_contents_when_block, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.IndentSwitchSection, CSharpEditorResources.Indent_case_labels, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.LabelPositioning, CSharpEditorResources.Label_Indentation, editorConfigOptions, visualStudioOptions, updaterService);
+        }
+
+        private static IEnumerable<FormattingSetting> GetWrappingOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updaterService)
+        {
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.WrappingPreserveSingleLine, CSharpEditorResources.Leave_block_on_single_line, editorConfigOptions, visualStudioOptions, updaterService);
+            yield return FormattingSetting.Create(CSharpFormattingOptions2.WrappingKeepStatementsOnSingleLine, CSharpEditorResources.Leave_statements_and_member_declarations_on_the_same_line, editorConfigOptions, visualStudioOptions, updaterService);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsProviderFactory.cs
+++ b/src/EditorFeatures/CSharp/EditorConfigSettings/DataProvider/Formatting/CSharpFormattingSettingsProviderFactory.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings.DataProvider.Formatting
+{
+    internal class CSharpFormattingSettingsProviderFactory : ILanguageSettingsProviderFactory<FormattingSetting>
+    {
+        private readonly Workspace _workspace;
+
+        public CSharpFormattingSettingsProviderFactory(Workspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public ISettingsProvider<FormattingSetting> GetForFile(string filePath)
+        {
+            var updaterService = new OptionUpdater(_workspace, filePath);
+            return new CSharpFormattingSettingsProvider(filePath, updaterService, _workspace);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Přidávají se chybějící direktivy using...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Zvolená verze: {0}</target>
@@ -32,9 +42,24 @@
         <target state="translated">Protokol o dekompilaci</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Opravit interpolovaný doslovný řetězec</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Generovat odběr událostí</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Načíst z {0}</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Modul se nenašel!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Přeložit modul: {0} z {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Chytré odsazování</target>
@@ -97,9 +457,69 @@
         <target state="translated">Rozdělit řetězec</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">UPOZORNĚNÍ: Neshoda verzí. Očekáváno: {0}, získáno: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Fehlende using-Anweisungen werden hinzugefügt...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Ausgewählte Version: {0}</target>
@@ -32,9 +42,24 @@
         <target state="translated">Dekompilierungsprotokoll</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Interpolierte ausführliche Zeichenfolge korrigieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Ereignisabonnement generieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Laden von: {0}</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Das Modul wurde nicht gefunden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Modul auflösen: {0} von {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Intelligenter Einzug</target>
@@ -97,9 +457,69 @@
         <target state="translated">Zeichenfolge teilen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">WARNUNG: Versionskonflikt. Erwartet: "{0}", erhalten: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Agregando los valores using que faltan...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Versión elegida: "{0}"</target>
@@ -32,9 +42,24 @@
         <target state="translated">Registro de descompilación</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Corregir cadena textual interpolada</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Generar suscripción de eventos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Cargar desde: "{0}"</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">No se encontró el módulo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Resolver el módulo: "{0}" de "{1}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Sangría inteligente</target>
@@ -97,9 +457,69 @@
         <target state="translated">Dividir cadena</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">AVISO: No coinciden las versiones. Se esperaba "{0}", se obtuvo "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Ajout des usings manquants...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Version choisie : '{0}'</target>
@@ -32,9 +42,24 @@
         <target state="translated">Journal de décompilation</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Corriger la chaîne verbatim interpolée</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Générer un abonnement à des événements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Charger à partir de : '{0}'</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Module introuvable !</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Résoudre le module '{0}' sur '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Retrait intelligent</target>
@@ -97,9 +457,69 @@
         <target state="translated">Fractionner la chaîne</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">AVERTISSEMENT : Incompatibilité de version. Attendu : '{0}'. Reçu : '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Aggiunta di using mancanti...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Versione selezionata: '{0}'</target>
@@ -32,9 +42,24 @@
         <target state="translated">Log di decompilazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Correggi stringa verbatim interpolata</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Genera sottoscrizione di eventi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Carica da: '{0}'</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Modulo non trovato.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Risolvi il modulo: '{0}' di '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Rientro automatico</target>
@@ -97,9 +457,69 @@
         <target state="translated">Dividi stringa</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">AVVISO: versione non corrispondente. Prevista: '{0}'. Ottenuta: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
@@ -12,6 +12,16 @@
         <target state="translated">欠落している usings を追加しています...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">選択されたバージョン: '{0}'</target>
@@ -32,9 +42,24 @@
         <target state="translated">逆コンパイルのログ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">挿入された逐語的文字列を修正します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">イベント サブスクリプションの生成</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">読み込み元: '{0}'</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">モジュールが見つかりません</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">モジュールの解決: '{1}' の '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">スマート インデント</target>
@@ -97,9 +457,69 @@
         <target state="translated">文字列を分割します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">警告: バージョンが一致しません。必要なバージョン: '{0}'、現在のバージョン: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
@@ -12,6 +12,16 @@
         <target state="translated">누락된 using 추가 중...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">선택한 버전: '{0}'</target>
@@ -32,9 +42,24 @@
         <target state="translated">디컴파일 로그</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">보간된 축자 문자열 수정</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">이벤트 구독 생성</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">로드 위치: '{0}'</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">모듈을 찾을 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">모듈 확인: '{0}'/'{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">스마트 들여쓰기</target>
@@ -97,9 +457,69 @@
         <target state="translated">문자열 분할</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">WARN: 버전이 일치하지 않습니다. 예상: '{0}', 실제: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Trwa dodawanie brakujących dyrektyw using...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Wybrana wersja: „{0}”</target>
@@ -32,9 +42,24 @@
         <target state="translated">Dziennik dekompilacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Napraw interpolowany ciąg dosłowny wyrażenia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Generuj subskrypcję zdarzenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Załaduj z: „{0}”</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Nie znaleziono modułu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Rozpoznaj moduł: „{0}” z „{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Inteligentne tworzenie wcięć</target>
@@ -97,9 +457,69 @@
         <target state="translated">Rozdziel ciąg</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">OSTRZEŻENIE: niezgodność wersji. Oczekiwano: „{0}”, uzyskano: „{1}”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Adicionando as usings ausentes...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Versão escolhida: '{0}'</target>
@@ -32,9 +42,24 @@
         <target state="translated">Log de descompilação</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Corrigir cadeia de caracteres verbatim interpolada</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Gerar Assinatura de Evento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Carregar de: '{0}'</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Módulo não encontrado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Resolver o módulo: '{0}' de '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Recuo Inteligente</target>
@@ -97,9 +457,69 @@
         <target state="translated">Dividir cadeia de caracteres</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">AVISO: incompatibilidade de versão. Esperado: '{0}', Obtido: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Добавление недостающих директив using…</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Выбранная версия: "{0}"</target>
@@ -32,9 +42,24 @@
         <target state="translated">Журнал декомпиляции</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Исправить интерполированную буквальную строку</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Создать подписку на события</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Загрузить из: "{0}"</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Модуль не найден.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">Разрешить модуль: "{0}" из "{1}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Интеллектуальные отступы</target>
@@ -97,9 +457,69 @@
         <target state="translated">Разделить строку</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">Внимание! Несовпадение версий. Ожидалось: "{0}", получено: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Eksik using yönergeleri ekleniyor...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">Seçilen sürüm: '{0}'</target>
@@ -32,9 +42,24 @@
         <target state="translated">Kaynak koda dönüştürme günlüğü</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">Ara değer olarak eklenmiş tam dizeyi düzelt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">Olay Aboneliği Oluştur</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">Şuradan yükle: '{0}'</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">Modül bulunamadı!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">'{1}' modül içinden '{0}' modülü çözümle</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">Akıllı Girintileme</target>
@@ -97,9 +457,69 @@
         <target state="translated">Dizeyi böl</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">UYARI: Sürüm uyumsuzluğu. Beklenen: '{0}', Alınan: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="translated">正在添加缺少的 usings…</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">所选版本: "{0}"</target>
@@ -32,9 +42,24 @@
         <target state="translated">反编译日志</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">修复插值的逐字字符串</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">生成事件订阅</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">从以下位置加载: "{0}"</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">找不到模块!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">解析模块: "{0}" 个(共 "{1}" 个)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">智能缩进</target>
@@ -97,9 +457,69 @@
         <target state="translated">拆分字符串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">警告: 版本不匹配。应为: "{0}"，实际为: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="translated">正在新增缺少的 using...</target>
         <note>Shown in a thread await dialog. "usings" is a language specific term and should not be localized</note>
       </trans-unit>
+      <trans-unit id="Avoid_expression_statements_that_implicitly_ignore_value">
+        <source>Avoid expression statements that implicitly ignore value</source>
+        <target state="new">Avoid expression statements that implicitly ignore value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_value_assignments">
+        <source>Avoid unused value assignments</source>
+        <target state="new">Avoid unused value assignments</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Chosen_version_0">
         <source>Chosen version: '{0}'</source>
         <target state="translated">選擇的版本: '{0}'</target>
@@ -32,9 +42,24 @@
         <target state="translated">反向組譯記錄檔</target>
         <note />
       </trans-unit>
+      <trans-unit id="Discard">
+        <source>Discard</source>
+        <target state="new">Discard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Elsewhere">
+        <source>Elsewhere</source>
+        <target state="new">Elsewhere</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
         <source>Fix interpolated verbatim string</source>
         <target state="translated">修正插入的逐字字串</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_built_in_types">
+        <source>For built-in types</source>
+        <target state="new">For built-in types</target>
         <note />
       </trans-unit>
       <trans-unit id="Found_0_assemblies_for_1">
@@ -62,6 +87,166 @@
         <target state="translated">產生事件訂閱</target>
         <note />
       </trans-unit>
+      <trans-unit id="Ignore_spaces_in_declaration_statements">
+        <source>Ignore spaces in declaration statements</source>
+        <target state="new">Ignore spaces in declaration statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_block_contents">
+        <source>Indent block contents</source>
+        <target state="new">Indent block contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents">
+        <source>Indent case contents</source>
+        <target state="new">Indent case contents</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_contents_when_block">
+        <source>Indent case contents (when block)</source>
+        <target state="new">Indent case contents (when block)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_case_labels">
+        <source>Indent case labels</source>
+        <target state="new">Indent case labels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_open_and_close_braces">
+        <source>Indent open and close braces</source>
+        <target state="new">Indent open and close braces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_cast">
+        <source>Insert space after cast</source>
+        <target state="new">Insert space after cast</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space after colon for base or interface in type declaration</source>
+        <target state="new">Insert space after colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_comma">
+        <source>Insert space after comma</source>
+        <target state="new">Insert space after comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_dot">
+        <source>Insert space after dot</source>
+        <target state="new">Insert space after dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_keywords_in_control_flow_statements">
+        <source>Insert space after keywords in control flow statements</source>
+        <target state="new">Insert space after keywords in control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_after_semicolon_in_for_statement">
+        <source>Insert space after semicolon in "for" statement</source>
+        <target state="new">Insert space after semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_colon_for_base_or_interface_in_type_declaration">
+        <source>Insert space before colon for base or interface in type declaration</source>
+        <target state="new">Insert space before colon for base or interface in type declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_comma">
+        <source>Insert space before comma</source>
+        <target state="new">Insert space before comma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_dot">
+        <source>Insert space before dot</source>
+        <target state="new">Insert space before dot</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_open_square_bracket">
+        <source>Insert space before open square bracket</source>
+        <target state="new">Insert space before open square bracket</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_before_semicolon_in_for_statement">
+        <source>Insert space before semicolon in "for" statement</source>
+        <target state="new">Insert space before semicolon in "for" statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis1">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_between_method_name_and_its_opening_parenthesis2">
+        <source>Insert space between method name and its opening parenthesis</source>
+        <target state="new">Insert space between method name and its opening parenthesis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_argument_list_parentheses">
+        <source>Insert space within argument list parentheses</source>
+        <target state="new">Insert space within argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_argument_list_parentheses">
+        <source>Insert space within empty argument list parentheses</source>
+        <target state="new">Insert space within empty argument list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_parameter_list_parentheses">
+        <source>Insert space within empty parameter list parentheses</source>
+        <target state="new">Insert space within empty parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_empty_square_brackets">
+        <source>Insert space within empty square brackets</source>
+        <target state="new">Insert space within empty square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parameter_list_parentheses">
+        <source>Insert space within parameter list parentheses</source>
+        <target state="new">Insert space within parameter list parentheses</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_expressions">
+        <source>Insert space within parentheses of expressions</source>
+        <target state="new">Insert space within parentheses of expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_space_within_parentheses_of_type_casts">
+        <source>Insert space within parentheses of type casts</source>
+        <target state="new">Insert space within parentheses of type casts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_parentheses_of_control_flow_statements">
+        <source>Insert spaces within parentheses of control flow statements</source>
+        <target state="new">Insert spaces within parentheses of control flow statements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_spaces_within_square_brackets">
+        <source>Insert spaces within square brackets</source>
+        <target state="new">Insert spaces within square brackets</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Inside_namespace">
+        <source>Inside namespace</source>
+        <target state="new">Inside namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Label_Indentation">
+        <source>Label Indentation</source>
+        <target state="new">Label Indentation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_block_on_single_line">
+        <source>Leave block on single line</source>
+        <target state="new">Leave block on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Leave_statements_and_member_declarations_on_the_same_line">
+        <source>Leave statements and member declarations on the same line</source>
+        <target state="new">Leave statements and member declarations on the same line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Load_from_0">
         <source>Load from: '{0}'</source>
         <target state="translated">載入來源: '{0}'</target>
@@ -70,6 +255,176 @@
       <trans-unit id="Module_not_found">
         <source>Module not found!</source>
         <target state="translated">找不到模組!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Never">
+        <source>Never</source>
+        <target state="new">Never</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_catch_on_new_line">
+        <source>Place "catch" on new line</source>
+        <target state="new">Place "catch" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_else_on_new_line">
+        <source>Place "else" on new line</source>
+        <target state="new">Place "else" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_finally_on_new_line">
+        <source>Place "finally" on new line</source>
+        <target state="new">Place "finally" on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_anonymous_types_on_new_line">
+        <source>Place members in anonymous types on new line</source>
+        <target state="new">Place members in anonymous types on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_members_in_object_initializers_on_new_line">
+        <source>Place members in object initializers on new line</source>
+        <target state="new">Place members in object initializers on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_methods">
+        <source>Place open brace on new line for anonymous methods</source>
+        <target state="new">Place open brace on new line for anonymous methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_anonymous_types">
+        <source>Place open brace on new line for anonymous types</source>
+        <target state="new">Place open brace on new line for anonymous types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_control_blocks">
+        <source>Place open brace on new line for control blocks</source>
+        <target state="new">Place open brace on new line for control blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_lambda_expression">
+        <source>Place open brace on new line for lambda expression</source>
+        <target state="new">Place open brace on new line for lambda expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_methods_local_functions">
+        <source>Place open brace on new line for methods and local functions</source>
+        <target state="new">Place open brace on new line for methods and local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_object_collection_array_and_with_initializers">
+        <source>Place open brace on new line for object, collection, array, and with initializers</source>
+        <target state="new">Place open brace on new line for object, collection, array, and with initializers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_properties_indexers_and_events">
+        <source>Place open brace on new line for properties, indexers, and events</source>
+        <target state="new">Place open brace on new line for properties, indexers, and events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_property_indexer_and_event_accessors">
+        <source>Place open brace on new line for property, indexer, and event accessors</source>
+        <target state="new">Place open brace on new line for property, indexer, and event accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_open_brace_on_new_line_for_types">
+        <source>Place open brace on new line for types</source>
+        <target state="new">Place open brace on new line for types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Place_query_expression_clauses_on_new_line">
+        <source>Place query expression clauses on new line</source>
+        <target state="new">Place query expression clauses on new line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_delegate_call">
+        <source>Prefer conditional delegate call</source>
+        <target state="new">Prefer conditional delegate call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_deconstructed_variable_declaration">
+        <source>Prefer deconstructed variable declaration</source>
+        <target state="new">Prefer deconstructed variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_type">
+        <source>Prefer explicit type</source>
+        <target state="new">Prefer explicit type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_index_operator">
+        <source>Prefer index operator</source>
+        <target state="new">Prefer index operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inlined_variable_declaration">
+        <source>Prefer inlined variable declaration</source>
+        <target state="new">Prefer inlined variable declaration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_local_function_over_anonymous_function">
+        <source>Prefer local function over anonymous function</source>
+        <target state="new">Prefer local function over anonymous function</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching">
+        <source>Prefer pattern matching</source>
+        <target state="new">Prefer pattern matching</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_as_with_null_check">
+        <source>Prefer pattern matching over 'as' with 'null' check</source>
+        <target state="new">Prefer pattern matching over 'as' with 'null' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_is_with_cast_check">
+        <source>Prefer pattern matching over 'is' with 'cast' check</source>
+        <target state="new">Prefer pattern matching over 'is' with 'cast' check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_pattern_matching_over_mixed_type_check">
+        <source>Prefer pattern matching over mixed type check</source>
+        <target state="new">Prefer pattern matching over mixed type check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_range_operator">
+        <source>Prefer range operator</source>
+        <target state="new">Prefer range operator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_default_expression">
+        <source>Prefer simple 'default' expression</source>
+        <target state="new">Prefer simple 'default' expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simple_using_statement">
+        <source>Prefer simple 'using' statement</source>
+        <target state="new">Prefer simple 'using' statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_static_local_functions">
+        <source>Prefer static local functions</source>
+        <target state="new">Prefer static local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_switch_expression">
+        <source>Prefer switch expression</source>
+        <target state="new">Prefer switch expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_throw_expression">
+        <source>Prefer throw-expression</source>
+        <target state="new">Prefer throw-expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_var">
+        <source>Prefer 'var'</source>
+        <target state="new">Prefer 'var'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Preferred_using_directive_placement">
+        <source>Preferred 'using' directive placement</source>
+        <target state="new">Preferred 'using' directive placement</target>
         <note />
       </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
@@ -87,6 +442,11 @@
         <target state="translated">解析模組: '{0}' 之 '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Set_spacing_for_operators">
+        <source>Set spacing for operators</source>
+        <target state="new">Set spacing for operators</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Smart_Indenting">
         <source>Smart Indenting</source>
         <target state="translated">智慧縮排</target>
@@ -97,9 +457,69 @@
         <target state="translated">分割字串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_local">
+        <source>Unused local</source>
+        <target state="new">Unused local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_accessors">
+        <source>Use expression body for accessors</source>
+        <target state="new">Use expression body for accessors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_constructors">
+        <source>Use expression body for constructors</source>
+        <target state="new">Use expression body for constructors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_indexers">
+        <source>Use expression body for indexers</source>
+        <target state="new">Use expression body for indexers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_lambdas">
+        <source>Use expression body for lambdas</source>
+        <target state="new">Use expression body for lambdas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_local_functions">
+        <source>Use expression body for local functions</source>
+        <target state="new">Use expression body for local functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_methods">
+        <source>Use expression body for methods</source>
+        <target state="new">Use expression body for methods</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_operators">
+        <source>Use expression body for operators</source>
+        <target state="new">Use expression body for operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_expression_body_for_properties">
+        <source>Use expression body for properties</source>
+        <target state="new">Use expression body for properties</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
         <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
         <target state="translated">警告: 版本不符。應為: '{0}'，但取得: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_on_single_line">
+        <source>When on single line</source>
+        <target state="new">When on single line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_possible">
+        <source>When possible</source>
+        <target state="new">When possible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="When_variable_type_is_apparent">
+        <source>When variable type is apparent</source>
+        <target state="new">When variable type is apparent</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_items_in_cache">

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
@@ -262,6 +262,11 @@
         <target state="new">Never</target>
         <note />
       </trans-unit>
+      <trans-unit id="Outside_namespace">
+        <source>Outside namespace</source>
+        <target state="new">Outside namespace</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Place_catch_on_new_line">
         <source>Place "catch" on new line</source>
         <target state="new">Place "catch" on new line</target>

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/Aggregator/SettingsAggregatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/Aggregator/SettingsAggregatorTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Aggregator
+{
+    [UseExportProvider]
+    public class SettingsAggregatorTests
+    {
+        public static Workspace CreateWorkspace(params Type[]? additionalParts)
+            => new AdhocWorkspace(EditorTestCompositions.EditorFeatures.AddParts(additionalParts).GetHostServices(), WorkspaceKind.Host);
+
+        private static Workspace CreateWorkspaceWithProjectAndDocuments()
+        {
+            var projectId = ProjectId.CreateNewId();
+
+            var workspace = CreateWorkspace();
+
+            Assert.True(workspace.TryApplyChanges(workspace.CurrentSolution
+                .AddProject(projectId, "proj1", "proj1.dll", LanguageNames.CSharp)
+                .AddDocument(DocumentId.CreateNewId(projectId), "goo.cs", "public class Goo { }")
+                .AddAdditionalDocument(DocumentId.CreateNewId(projectId), "add.txt", "text")
+                .AddAnalyzerConfigDocument(DocumentId.CreateNewId(projectId), "editorcfg", SourceText.From("config"), filePath: "/a/b")));
+
+            return workspace;
+        }
+
+        private static void TestGettingProvider<T>()
+        {
+            var workspace = CreateWorkspaceWithProjectAndDocuments();
+            var settingsAggregator = workspace.Services.GetRequiredService<ISettingsAggregator>();
+            var settingsProvider = settingsAggregator.GetSettingsProvider<T>("/a/b/config");
+            Assert.NotNull(settingsProvider);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public void TestGettingCodeStyleProvider() => TestGettingProvider<CodeStyleSetting>();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public void TestGettingAnalyzerProvider() => TestGettingProvider<AnalyzerSetting>();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public void TestGettingFormattingProvider() => TestGettingProvider<FormattingSetting>();
+    }
+}

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.MockAnalyzerReference.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.MockAnalyzerReference.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.DataProvider
+{
+    public partial class DataProviderTests
+    {
+        private class MockAnalyzerReference : AnalyzerReference
+        {
+            public readonly CodeFixProvider? Fixer;
+            public readonly ImmutableArray<DiagnosticAnalyzer> Analyzers;
+
+            private static readonly CodeFixProvider s_defaultFixer = new MockFixer();
+            private static readonly ImmutableArray<DiagnosticAnalyzer> s_defaultAnalyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new MockDiagnosticAnalyzer());
+
+            public MockAnalyzerReference(CodeFixProvider? fixer, ImmutableArray<DiagnosticAnalyzer> analyzers)
+            {
+                Fixer = fixer;
+                Analyzers = analyzers;
+            }
+
+            public MockAnalyzerReference()
+                : this(s_defaultFixer, s_defaultAnalyzers)
+            {
+            }
+
+            public MockAnalyzerReference(CodeFixProvider? fixer)
+                : this(fixer, s_defaultAnalyzers)
+            {
+            }
+
+            public override string Display => "MockAnalyzerReference";
+
+            public override string FullPath => string.Empty;
+
+            public override object Id => "MockAnalyzerReference";
+
+            public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language)
+                => Analyzers;
+
+            public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages()
+                => Analyzers;
+
+            public ImmutableArray<CodeFixProvider> GetFixers()
+                => Fixer != null ? ImmutableArray.Create(Fixer) : ImmutableArray<CodeFixProvider>.Empty;
+
+            public class MockFixer : CodeFixProvider
+            {
+                public const string Id = "MyDiagnostic";
+                public bool Called;
+                public int ContextDiagnosticsCount;
+
+                public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Id);
+
+                public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+                {
+                    Called = true;
+                    ContextDiagnosticsCount = context.Diagnostics.Length;
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class MockDiagnosticAnalyzer : DiagnosticAnalyzer
+            {
+                public MockDiagnosticAnalyzer(ImmutableArray<(string id, string category)> reportedDiagnosticIdsWithCategories)
+                    => SupportedDiagnostics = CreateSupportedDiagnostics(reportedDiagnosticIdsWithCategories);
+
+                public MockDiagnosticAnalyzer(string diagnosticId, string category)
+                    : this(ImmutableArray.Create((diagnosticId, category)))
+                {
+                }
+
+                public MockDiagnosticAnalyzer(ImmutableArray<string> reportedDiagnosticIds)
+                    : this(reportedDiagnosticIds.SelectAsArray(id => (id, "InternalCategory")))
+                {
+                }
+
+                public MockDiagnosticAnalyzer()
+                    : this(ImmutableArray.Create(MockFixer.Id))
+                {
+                }
+
+                private static ImmutableArray<DiagnosticDescriptor> CreateSupportedDiagnostics(ImmutableArray<(string id, string category)> reportedDiagnosticIdsWithCategories)
+                {
+                    var builder = ArrayBuilder<DiagnosticDescriptor>.GetInstance();
+                    foreach (var (diagnosticId, category) in reportedDiagnosticIdsWithCategories)
+                    {
+                        var descriptor = new DiagnosticDescriptor(diagnosticId, "MockDiagnostic", "MockDiagnostic", category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+                        builder.Add(descriptor);
+                    }
+
+                    return builder.ToImmutableAndFree();
+                }
+
+                public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+                public override void Initialize(AnalysisContext context)
+                {
+                    context.RegisterSyntaxTreeAction(c =>
+                    {
+                        foreach (var descriptor in SupportedDiagnostics)
+                        {
+                            c.ReportDiagnostic(Diagnostic.Create(descriptor, c.Tree.GetLocation(TextSpan.FromBounds(0, 0))));
+                        }
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.TestViewModel.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.TestViewModel.cs
@@ -14,31 +14,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
     {
         private class TestViewModel : ISettingsEditorViewModel
         {
-            private readonly int _expectedNumberOfTimesCalled;
-            private int _releaseCount;
-            private readonly SemaphoreSlim _sync;
+            public void NotifyOfUpdate() { }
 
-            public TestViewModel(int expectedNumberOfTimesCalled)
+            Task<SourceText> ISettingsEditorViewModel.UpdateEditorConfigAsync(SourceText sourceText)
             {
-                _sync = new SemaphoreSlim(expectedNumberOfTimesCalled);
-                _expectedNumberOfTimesCalled = expectedNumberOfTimesCalled;
-                _releaseCount = 0;
-            }
-
-            public async Task WaitForComplete()
-            {
-                do
-                {
-                    await _sync.WaitAsync().ConfigureAwait(false);
-                } while (_releaseCount != _expectedNumberOfTimesCalled);
-            }
-
-            public Task<IReadOnlyList<TextChange>?> GetChangesAsync() => throw new NotImplementedException();
-
-            public void NotifyOfUpdate()
-            {
-                Interlocked.Increment(ref _releaseCount);
-                _sync.Release();
+                throw new NotImplementedException();
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.TestViewModel.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.TestViewModel.cs
@@ -35,11 +35,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
 
             public Task<IReadOnlyList<TextChange>?> GetChangesAsync() => throw new NotImplementedException();
 
-            public Task NotifyOfUpdateAsync()
+            public void NotifyOfUpdate()
             {
                 Interlocked.Increment(ref _releaseCount);
                 _sync.Release();
-                return Task.CompletedTask;
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.TestViewModel.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.TestViewModel.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.DataProvider
+{
+    public partial class DataProviderTests
+    {
+        private class TestViewModel : ISettingsEditorViewModel
+        {
+            private readonly int _expectedNumberOfTimesCalled;
+            private int _releaseCount;
+            private readonly SemaphoreSlim _sync;
+
+            public TestViewModel(int expectedNumberOfTimesCalled)
+            {
+                _sync = new SemaphoreSlim(expectedNumberOfTimesCalled);
+                _expectedNumberOfTimesCalled = expectedNumberOfTimesCalled;
+                _releaseCount = 0;
+            }
+
+            public async Task WaitForComplete()
+            {
+                do
+                {
+                    await _sync.WaitAsync().ConfigureAwait(false);
+                } while (_releaseCount != _expectedNumberOfTimesCalled);
+            }
+
+            public Task<IReadOnlyList<TextChange>?> GetChangesAsync() => throw new NotImplementedException();
+
+            public Task NotifyOfUpdateAsync()
+            {
+                Interlocked.Increment(ref _releaseCount);
+                _sync.Release();
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.cs
@@ -74,13 +74,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
-        public async Task TestGettingAnalyzerSettingsProviderWorkspaceServiceAsync()
+        public void TestGettingAnalyzerSettingsProviderWorkspaceServiceAsync()
         {
             var settingsProviderFactory = GettingSettingsProviderFactoryFromWorkspace<AnalyzerSetting>();
             var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
-            var model = new TestViewModel(expectedNumberOfTimesCalled: 1);
+            var model = new TestViewModel();
             settingsProvider.RegisterViewModel(model);
-            await model.WaitForComplete();
             var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
             var result = Assert.Single(dataSnapShot);
             Assert.Equal("MyDiagnostic", result.Id);
@@ -91,49 +90,45 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
-        public async Task TestGettingCodeStyleSettingProviderWorkspaceServiceAsync()
+        public void TestGettingCodeStyleSettingProviderWorkspaceServiceAsync()
         {
             var settingsProviderFactory = GettingSettingsProviderFactoryFromWorkspace<CodeStyleSetting>();
             var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
-            var model = new TestViewModel(expectedNumberOfTimesCalled: 8);
+            var model = new TestViewModel();
             settingsProvider.RegisterViewModel(model);
-            await model.WaitForComplete();
             var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
             Assert.Equal(26, dataSnapShot.Length);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
-        public async Task TestGettingCodeStyleSettingsProviderLanguageServiceAsync()
+        public void TestGettingCodeStyleSettingsProviderLanguageServiceAsync()
         {
             var settingsProviderFactory = GettingSettingsProviderFactoryFromLanguageService<CodeStyleSetting>(LanguageNames.CSharp);
             var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
-            var model = new TestViewModel(expectedNumberOfTimesCalled: 10);
+            var model = new TestViewModel();
             settingsProvider.RegisterViewModel(model);
-            await model.WaitForComplete();
             var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
             Assert.Equal(29, dataSnapShot.Length);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
-        public async Task TestGettingFormattingSettingProviderWorkspaceServiceAsync()
+        public void TestGettingFormattingSettingProviderWorkspaceServiceAsync()
         {
             var settingsProviderFactory = GettingSettingsProviderFactoryFromWorkspace<FormattingSetting>();
             var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
-            var model = new TestViewModel(expectedNumberOfTimesCalled: 1);
+            var model = new TestViewModel();
             settingsProvider.RegisterViewModel(model);
-            await model.WaitForComplete();
             var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
             Assert.Equal(5, dataSnapShot.Length);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
-        public async Task TestGettingFormattingSettingProviderLanguageServiceAsync()
+        public void TestGettingFormattingSettingProviderLanguageServiceAsync()
         {
             var settingsProviderFactory = GettingSettingsProviderFactoryFromLanguageService<FormattingSetting>(LanguageNames.CSharp);
             var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
-            var model = new TestViewModel(expectedNumberOfTimesCalled: 4);
+            var model = new TestViewModel();
             settingsProvider.RegisterViewModel(model);
-            await model.WaitForComplete();
             var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
             Assert.Equal(47, dataSnapShot.Length);
         }

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/DataProvider/DataProviderTests.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.DataProvider
+{
+    [UseExportProvider]
+    public partial class DataProviderTests
+    {
+        private static Workspace GetWorkspace()
+        {
+            var projectId = ProjectId.CreateNewId();
+            var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices(), WorkspaceKind.Host);
+            Assert.True(workspace.TryApplyChanges(workspace.CurrentSolution
+                .AddProject(projectId, "proj1", "proj1.dll", LanguageNames.CSharp)
+                .AddDocument(DocumentId.CreateNewId(projectId), "goo.cs", "public class Goo { }")
+                .AddAdditionalDocument(DocumentId.CreateNewId(projectId), "add.txt", "text")
+                .AddAnalyzerReference(projectId, new MockAnalyzerReference())
+                .AddAnalyzerConfigDocument(DocumentId.CreateNewId(projectId), "editorcfg", SourceText.From("config"), filePath: "/a/b")));
+            return workspace;
+        }
+
+        private static IWorkspaceSettingsProviderFactory<T> GettingSettingsProviderFactoryFromWorkspace<T>()
+            => GetWorkspace().Services.GetRequiredService<IWorkspaceSettingsProviderFactory<T>>();
+
+        private static ILanguageSettingsProviderFactory<T> GettingSettingsProviderFactoryFromLanguageService<T>(string languageName)
+            => GetWorkspace().Services.GetLanguageServices(languageName).GetRequiredService<ILanguageSettingsProviderFactory<T>>();
+
+        private static ISettingsProvider<T> TestGettingSettingsProviderFromWorkspace<T>()
+        {
+            var settingsProviderFactory = GettingSettingsProviderFactoryFromWorkspace<T>();
+            var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
+            Assert.NotNull(settingsProvider);
+            return settingsProvider;
+        }
+
+        private static ISettingsProvider<T> TestGettingSettingsProviderFromLanguageService<T>()
+        {
+            var settingsProviderFactory = GettingSettingsProviderFactoryFromLanguageService<T>(LanguageNames.CSharp);
+            var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
+            Assert.NotNull(settingsProvider);
+            return settingsProvider;
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public void TestGettingAnalyzerSettingsProvider()
+        {
+            TestGettingSettingsProviderFromWorkspace<AnalyzerSetting>();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public void TestGettingCodeStyleSettingsProvider()
+        {
+            TestGettingSettingsProviderFromWorkspace<CodeStyleSetting>();
+            TestGettingSettingsProviderFromLanguageService<CodeStyleSetting>();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public void TestGettingFormattingSettingsProvider()
+        {
+            TestGettingSettingsProviderFromWorkspace<FormattingSetting>();
+            TestGettingSettingsProviderFromLanguageService<FormattingSetting>();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestGettingAnalyzerSettingsProviderWorkspaceServiceAsync()
+        {
+            var settingsProviderFactory = GettingSettingsProviderFactoryFromWorkspace<AnalyzerSetting>();
+            var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
+            var model = new TestViewModel(expectedNumberOfTimesCalled: 1);
+            settingsProvider.RegisterViewModel(model);
+            await model.WaitForComplete();
+            var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
+            var result = Assert.Single(dataSnapShot);
+            Assert.Equal("MyDiagnostic", result.Id);
+            Assert.Equal("MockDiagnostic", result.Title);
+            Assert.Equal(string.Empty, result.Description);
+            Assert.Equal("InternalCategory", result.Category);
+            Assert.True(result.IsEnabled);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestGettingCodeStyleSettingProviderWorkspaceServiceAsync()
+        {
+            var settingsProviderFactory = GettingSettingsProviderFactoryFromWorkspace<CodeStyleSetting>();
+            var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
+            var model = new TestViewModel(expectedNumberOfTimesCalled: 8);
+            settingsProvider.RegisterViewModel(model);
+            await model.WaitForComplete();
+            var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
+            Assert.Equal(26, dataSnapShot.Length);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestGettingCodeStyleSettingsProviderLanguageServiceAsync()
+        {
+            var settingsProviderFactory = GettingSettingsProviderFactoryFromLanguageService<CodeStyleSetting>(LanguageNames.CSharp);
+            var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
+            var model = new TestViewModel(expectedNumberOfTimesCalled: 10);
+            settingsProvider.RegisterViewModel(model);
+            await model.WaitForComplete();
+            var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
+            Assert.Equal(29, dataSnapShot.Length);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestGettingFormattingSettingProviderWorkspaceServiceAsync()
+        {
+            var settingsProviderFactory = GettingSettingsProviderFactoryFromWorkspace<FormattingSetting>();
+            var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
+            var model = new TestViewModel(expectedNumberOfTimesCalled: 1);
+            settingsProvider.RegisterViewModel(model);
+            await model.WaitForComplete();
+            var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
+            Assert.Equal(5, dataSnapShot.Length);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestGettingFormattingSettingProviderLanguageServiceAsync()
+        {
+            var settingsProviderFactory = GettingSettingsProviderFactoryFromLanguageService<FormattingSetting>(LanguageNames.CSharp);
+            var settingsProvider = settingsProviderFactory.GetForFile("/a/b/config");
+            var model = new TestViewModel(expectedNumberOfTimesCalled: 4);
+            settingsProvider.RegisterViewModel(model);
+            await model.WaitForComplete();
+            var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
+            Assert.Equal(47, dataSnapShot.Length);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.TestAnalyzerConfigOptions.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.TestAnalyzerConfigOptions.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests
+{
+    public partial class SettingsUpdaterTests
+    {
+        private class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+        {
+            public static TestAnalyzerConfigOptions Instance = new TestAnalyzerConfigOptions();
+
+            public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+            {
+                value = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImports;
@@ -17,8 +16,6 @@ using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Text;
-using Moq;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -58,7 +55,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var analyzerConfigDocument = CreateAnalyzerConfigDocument(workspace, initialEditorConfig);
-            var result = await SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, options, default);
+            var sourcetext = await analyzerConfigDocument.GetTextAsync(default);
+            var result = SettingsUpdateHelper.TryUpdateAnalyzerConfigDocument(sourcetext, analyzerConfigDocument.FilePath!, workspace.Options, options);
             Assert.Equal(updatedEditorConfig, result?.ToString());
         }
 
@@ -66,7 +64,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var analyzerConfigDocument = CreateAnalyzerConfigDocument(workspace, initialEditorConfig);
-            var result = await SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, options, default);
+            var sourcetext = await analyzerConfigDocument.GetTextAsync(default);
+            var result = SettingsUpdateHelper.TryUpdateAnalyzerConfigDocument(sourcetext, analyzerConfigDocument.FilePath!, options);
             Assert.Equal(updatedEditorConfig, result?.ToString());
         }
 

--- a/src/EditorFeatures/CSharpTest/SettingsUpdater/SettingsUpdaterTests.cs
+++ b/src/EditorFeatures/CSharpTest/SettingsUpdater/SettingsUpdaterTests.cs
@@ -1,0 +1,323 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImports;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests
+{
+    [UseExportProvider]
+    public class SettingsUpdaterTests : TestBase
+    {
+        public static Workspace CreateWorkspace(Type[]? additionalParts = null)
+            => new AdhocWorkspace(FeaturesTestCompositions.Features.AddParts(additionalParts).GetHostServices());
+
+        private static Workspace CreateWorkspaceWithProjectAndDocuments()
+        {
+            var projectId = ProjectId.CreateNewId();
+
+            var workspace = CreateWorkspace();
+
+            Assert.True(workspace.TryApplyChanges(workspace.CurrentSolution
+                .AddProject(projectId, "proj1", "proj1.dll", LanguageNames.CSharp)
+                .AddDocument(DocumentId.CreateNewId(projectId), "goo.cs", "public class Goo { }")
+                .AddAdditionalDocument(DocumentId.CreateNewId(projectId), "add.txt", "text")
+                .AddAnalyzerConfigDocument(DocumentId.CreateNewId(projectId), "editorcfg", SourceText.From("config"), filePath: "/a/b")));
+
+            return workspace;
+        }
+
+        private static AnalyzerConfigDocument CreateAnalyzerConfigDocument(Workspace workspace, string contents)
+        {
+            var solution = workspace.CurrentSolution;
+            var documentId = solution.Projects.Single().State.AnalyzerConfigDocumentStates.Ids.First();
+            var text = SourceText.From(contents);
+            var newSolution1 = solution.WithAnalyzerConfigDocumentText(documentId, text, PreservationMode.PreserveIdentity);
+            var analyzerConfigDocument = newSolution1.GetAnalyzerConfigDocument(documentId);
+            Assert.True(analyzerConfigDocument!.TryGetText(out var actualText));
+            Assert.Same(text, actualText);
+            return analyzerConfigDocument;
+        }
+
+        private static async Task TestAsync(string initialEditorConfig, string updatedEditorConfig, params (IOption2, object)[] options)
+        {
+            using var workspace = CreateWorkspaceWithProjectAndDocuments();
+            var analyzerConfigDocument = CreateAnalyzerConfigDocument(workspace, initialEditorConfig);
+            var result = await SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, options, default);
+            Assert.Equal(updatedEditorConfig, result?.ToString());
+        }
+
+        private static async Task TestAsync(string initialEditorConfig, string updatedEditorConfig, params (AnalyzerSetting, DiagnosticSeverity)[] options)
+        {
+            using var workspace = CreateWorkspaceWithProjectAndDocuments();
+            var analyzerConfigDocument = CreateAnalyzerConfigDocument(workspace, initialEditorConfig);
+            var result = await SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, options, default);
+            Assert.Equal(updatedEditorConfig, result?.ToString());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddNewWhitespaceOptionAsync()
+        {
+            await TestAsync(
+                string.Empty,
+                "[*.cs]\r\ncsharp_new_line_before_else=true",
+                (CSharpFormattingOptions2.NewLineForElse, true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddNewBoolCodeStyleOptionWithSeverityAsync()
+        {
+            var option = CSharpCodeStyleOptions.PreferThrowExpression.DefaultValue;
+            option.Value = true;
+            option.Notification = CodeStyle.NotificationOption2.Suggestion;
+            await TestAsync(
+                string.Empty,
+                "[*.cs]\r\ncsharp_style_throw_expression=true:suggestion",
+                (CSharpCodeStyleOptions.PreferThrowExpression, option));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddNewEnumCodeStyleOptionWithSeverityAsync()
+        {
+            var option = CSharpCodeStyleOptions.PreferredUsingDirectivePlacement.DefaultValue;
+            option.Value = AddImportPlacement.InsideNamespace;
+            option.Notification = CodeStyle.NotificationOption2.Warning;
+            await TestAsync(
+                string.Empty,
+                "[*.cs]\r\ncsharp_using_directive_placement=inside_namespace:warning",
+                (CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, option));
+        }
+
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        internal async Task TestAddNewAnalyzerOptionOptionAsync(
+            [CombinatorialValues(Language.CSharp, Language.VisualBasic, (Language.CSharp | Language.VisualBasic))]
+            Language language,
+            [CombinatorialValues(DiagnosticSeverity.Warning, DiagnosticSeverity.Error, DiagnosticSeverity.Info, DiagnosticSeverity.Hidden)]
+            DiagnosticSeverity severity)
+        {
+            var expectedHeader = "";
+            if (language.HasFlag(Language.CSharp) && language.HasFlag(Language.VisualBasic))
+            {
+                expectedHeader = "[*.{cs,vb}]";
+            }
+            else if (language.HasFlag(Language.CSharp))
+            {
+                expectedHeader = "[*.cs]";
+            }
+            else if (language.HasFlag(Language.VisualBasic))
+            {
+                expectedHeader = "[*.vb]";
+            }
+
+            var expectedSeverity = severity.ToEditorConfigString();
+
+            var id = "Test001";
+            var descriptor = new DiagnosticDescriptor(id: id, title: "", messageFormat: "", category: "Naming", defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: false);
+            var analyzerSetting = new AnalyzerSetting(descriptor, ReportDiagnostic.Suppress, null!, language);
+
+            await TestAsync(
+                string.Empty,
+                $"{expectedHeader}\r\ndotnet_diagnostic.{id}.severity={expectedSeverity}",
+                (analyzerSetting, severity));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestUpdateExistingWhitespaceOptionAsync()
+        {
+            await TestAsync(
+                "[*.cs]\r\ncsharp_new_line_before_else=true",
+                "[*.cs]\r\ncsharp_new_line_before_else=false",
+                (CSharpFormattingOptions2.NewLineForElse, false));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddNewWhitespaceOptionToExistingFileAsync()
+        {
+            var initialEditorConfig = @"
+[*.{cs,vb}]
+
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity=false
+
+";
+
+            var updatedEditorConfig = @"
+[*.{cs,vb}]
+
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity=false
+
+
+[*.cs]
+csharp_new_line_before_else=true";
+            await TestAsync(
+                initialEditorConfig,
+                updatedEditorConfig,
+                (CSharpFormattingOptions2.NewLineForElse, true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddNewWhitespaceOptionToWithNonMathcingGroupsAsync()
+        {
+            var initialEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2";
+
+            var updatedEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+[*.cs]
+csharp_new_line_before_else=true";
+            await TestAsync(
+                initialEditorConfig,
+                updatedEditorConfig,
+                (CSharpFormattingOptions2.NewLineForElse, true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddNewWhitespaceOptionWithStarGroup()
+        {
+            var initialEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+
+# CSharp code style settings:
+[*.cs]";
+
+            var updatedEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+
+# CSharp code style settings:
+[*.cs]
+csharp_new_line_before_else=true";
+
+            await TestAsync(
+                initialEditorConfig,
+                updatedEditorConfig,
+                (CSharpFormattingOptions2.NewLineForElse, true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddMultimpleNewWhitespaceOptions()
+        {
+            await TestAsync(
+                string.Empty,
+                "[*.cs]\r\ncsharp_new_line_before_else=true\r\ncsharp_new_line_before_catch=true\r\ncsharp_new_line_before_finally=true",
+                (CSharpFormattingOptions2.NewLineForElse, true),
+                (CSharpFormattingOptions2.NewLineForCatch, true),
+                (CSharpFormattingOptions2.NewLineForFinally, true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddOptionThatAppliesToBothLanguages()
+        {
+            var initialEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+
+# CSharp code style settings:
+[*.cs]";
+
+            var updatedEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+dotnet_sort_system_directives_first=true
+
+# CSharp code style settings:
+[*.cs]";
+
+            await TestAsync(
+                initialEditorConfig,
+                updatedEditorConfig,
+                (GenerationOptions.PlaceSystemNamespaceFirst, true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddOptionWithRelativePathGroupingPresent()
+        {
+            var initialEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+
+# Test CSharp code style settings:
+[*Test.cs]
+
+# CSharp code style settings:
+[*.cs]";
+
+            var updatedEditorConfig = @"
+root = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+
+# Test CSharp code style settings:
+[*Test.cs]
+
+# CSharp code style settings:
+[*.cs]
+csharp_new_line_before_else=true";
+
+            await TestAsync(
+                initialEditorConfig,
+                updatedEditorConfig,
+                (CSharpFormattingOptions2.NewLineForElse, true));
+        }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj
+++ b/src/EditorFeatures/Core.Wpf/Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj
@@ -69,8 +69,6 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Update="EditorFeaturesWpfResources.resx" GenerateSource="true" />
   </ItemGroup>
 </Project>

--- a/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/ISettingsAggregator.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/ISettingsAggregator.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings
+{
+    internal interface ISettingsAggregator : IWorkspaceService
+    {
+        ISettingsProvider<TData>? GetSettingsProvider<TData>(string fileName);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregator.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings
+{
+    internal partial class SettingsAggregator : ISettingsAggregator
+    {
+        private readonly Workspace _workspace;
+        private readonly ISettingsProviderFactory<AnalyzerSetting> _analyzerProvider;
+        private ISettingsProviderFactory<FormattingSetting> _formattingProvider;
+        private ISettingsProviderFactory<CodeStyleSetting> _codeStyleProvider;
+
+        public SettingsAggregator(Workspace workspace)
+        {
+            _workspace = workspace;
+            _workspace.WorkspaceChanged += UpdateProviders;
+            _formattingProvider = GetOptionsProviderFactory<FormattingSetting>(_workspace);
+            _codeStyleProvider = GetOptionsProviderFactory<CodeStyleSetting>(_workspace);
+            _analyzerProvider = GetOptionsProviderFactory<AnalyzerSetting>(_workspace);
+        }
+
+        private void UpdateProviders(object? sender, WorkspaceChangeEventArgs e)
+        {
+            switch (e.Kind)
+            {
+                case WorkspaceChangeKind.SolutionChanged:
+                case WorkspaceChangeKind.SolutionAdded:
+                case WorkspaceChangeKind.SolutionRemoved:
+                case WorkspaceChangeKind.SolutionCleared:
+                case WorkspaceChangeKind.SolutionReloaded:
+                case WorkspaceChangeKind.ProjectAdded:
+                case WorkspaceChangeKind.ProjectRemoved:
+                case WorkspaceChangeKind.ProjectChanged:
+                    _formattingProvider = GetOptionsProviderFactory<FormattingSetting>(_workspace);
+                    _codeStyleProvider = GetOptionsProviderFactory<CodeStyleSetting>(_workspace);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        public ISettingsProvider<TData>? GetSettingsProvider<TData>(string fileName)
+        {
+            if (typeof(TData) == typeof(AnalyzerSetting))
+            {
+                return (ISettingsProvider<TData>)_analyzerProvider.GetForFile(fileName);
+            }
+
+            if (typeof(TData) == typeof(FormattingSetting))
+            {
+                return (ISettingsProvider<TData>)_formattingProvider.GetForFile(fileName);
+            }
+
+            if (typeof(TData) == typeof(CodeStyleSetting))
+            {
+                return (ISettingsProvider<TData>)_codeStyleProvider.GetForFile(fileName);
+            }
+
+            return null;
+        }
+
+        private static ISettingsProviderFactory<T> GetOptionsProviderFactory<T>(Workspace workspace)
+        {
+            var providers = new List<ISettingsProviderFactory<T>>();
+            var commonProvider = workspace.Services.GetRequiredService<IWorkspaceSettingsProviderFactory<T>>();
+            providers.Add(commonProvider);
+            var solution = workspace.CurrentSolution;
+            var supportsCSharp = solution.Projects.Any(p => p.Language.Equals(LanguageNames.CSharp, StringComparison.OrdinalIgnoreCase));
+            var supportsVisualBasic = solution.Projects.Any(p => p.Language.Equals(LanguageNames.VisualBasic, StringComparison.OrdinalIgnoreCase));
+            if (supportsCSharp)
+            {
+                TryAddProviderForLanguage(LanguageNames.CSharp, workspace, providers);
+            }
+            if (supportsVisualBasic)
+            {
+                TryAddProviderForLanguage(LanguageNames.VisualBasic, workspace, providers);
+            }
+
+            return new CombinedOptionsProviderFactory<T>(providers.ToImmutableArray());
+
+            static void TryAddProviderForLanguage(string language, Workspace workspace, List<ISettingsProviderFactory<T>> providers)
+            {
+                var provider = workspace.Services.GetLanguageServices(language).GetService<ILanguageSettingsProviderFactory<T>>();
+                if (provider is not null)
+                {
+                    providers.Add(provider);
+                }
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregatorFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Aggregator/SettingsAggregatorFactory.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings
+{
+
+    [ExportWorkspaceServiceFactory(typeof(ISettingsAggregator), ServiceLayer.Default), Shared]
+    internal class SettingsAggregatorFactory : IWorkspaceServiceFactory
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public SettingsAggregatorFactory()
+        {
+        }
+
+        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+            => new SettingsAggregator(workspaceServices.Workspace);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/AnalyzerSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/AnalyzerSetting.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal class AnalyzerSetting
+    {
+        private readonly DiagnosticDescriptor _descriptor;
+        private readonly AnalyzerSettingsUpdater _settingsUpdater;
+
+        public AnalyzerSetting(DiagnosticDescriptor descriptor,
+                               ReportDiagnostic effectiveSeverity,
+                               AnalyzerSettingsUpdater settingsUpdater,
+                               Language language)
+        {
+            _descriptor = descriptor;
+            _settingsUpdater = settingsUpdater;
+            DiagnosticSeverity severity = default;
+            if (effectiveSeverity == ReportDiagnostic.Default)
+            {
+                severity = descriptor.DefaultSeverity;
+            }
+            else if (effectiveSeverity.ToDiagnosticSeverity() is DiagnosticSeverity severity1)
+            {
+                severity = severity1;
+            }
+
+            var enabled = effectiveSeverity != ReportDiagnostic.Suppress;
+            IsEnabled = enabled;
+            Severity = severity;
+            Language = language;
+        }
+
+        public string Id => _descriptor.Id;
+        public string Title => _descriptor.Title.ToString(CultureInfo.CurrentCulture);
+        public string Description => _descriptor.Description.ToString(CultureInfo.CurrentCulture);
+        public string Category => _descriptor.Category;
+        public DiagnosticSeverity Severity { get; private set; }
+        public bool IsEnabled { get; private set; }
+        public Language Language { get; }
+
+        internal void ChangeSeverity(DiagnosticSeverity severity)
+        {
+            if (severity == Severity)
+                return;
+
+            _ = _settingsUpdater.QueueUpdateAsync(this, severity);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/AnalyzerSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/AnalyzerSetting.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
             if (severity == Severity)
                 return;
 
+            Severity = severity;
             _ = _settingsUpdater.QueueUpdateAsync(this, severity);
         }
     }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.BooleanCodeStyleSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.BooleanCodeStyleSetting.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract partial class CodeStyleSetting
+    {
+        private class BooleanCodeStyleSetting : BooleanCodeStyleSettingBase
+        {
+            private readonly Option2<CodeStyleOption2<bool>> _option;
+            private readonly AnalyzerConfigOptions _editorConfigOptions;
+            private readonly OptionSet _visualStudioOptions;
+
+            public BooleanCodeStyleSetting(Option2<CodeStyleOption2<bool>> option,
+                                           string description,
+                                           string? trueValueDescription,
+                                           string? falseValueDescription,
+                                           AnalyzerConfigOptions editorConfigOptions,
+                                           OptionSet visualStudioOptions,
+                                           OptionUpdater updater)
+                : base(description, option.Group.Description, trueValueDescription, falseValueDescription, updater)
+            {
+                _option = option;
+                _editorConfigOptions = editorConfigOptions;
+                _visualStudioOptions = visualStudioOptions;
+            }
+
+            public override bool IsDefinedInEditorConfig => _editorConfigOptions.TryGetEditorConfigOption<CodeStyleOption2<bool>>(_option, out _);
+
+            protected override void ChangeSeverity(NotificationOption2 severity)
+            {
+                var option = GetOption();
+                option.Notification = severity;
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            public override void ChangeValue(int valueIndex)
+            {
+                var value = valueIndex == 0;
+                var option = GetOption();
+                option.Value = value;
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            protected override CodeStyleOption2<bool> GetOption()
+                => _editorConfigOptions.TryGetEditorConfigOption(_option, out CodeStyleOption2<bool>? value) && value is not null
+                    ? value
+                    : _visualStudioOptions.GetOption(_option);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.BooleanCodeStyleSettingBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.BooleanCodeStyleSettingBase.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
 
             public override string Category { get; }
             public override Type Type => typeof(bool);
-            public override ReportDiagnostic Severity => GetOption().Notification.Severity;
+            public override DiagnosticSeverity Severity => GetOption().Notification.Severity.ToDiagnosticSeverity() ?? DiagnosticSeverity.Hidden;
             public override string GetCurrentValue() => GetOption().Value ? _trueValueDescription : _falseValueDescription;
             public override object? Value => GetOption().Value;
             public override string[] GetValues() => new[] { _trueValueDescription, _falseValueDescription };

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.BooleanCodeStyleSettingBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.BooleanCodeStyleSettingBase.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract partial class CodeStyleSetting
+    {
+        private abstract class BooleanCodeStyleSettingBase : CodeStyleSetting
+        {
+            private readonly string _trueValueDescription;
+            private readonly string _falseValueDescription;
+
+            public BooleanCodeStyleSettingBase(string description,
+                                               string category,
+                                               string? trueValueDescription,
+                                               string? falseValueDescription,
+                                               OptionUpdater updater)
+                : base(description, updater)
+            {
+                Category = category;
+                _trueValueDescription = trueValueDescription ?? EditorFeaturesResources.Yes;
+                _falseValueDescription = falseValueDescription ?? EditorFeaturesResources.No;
+            }
+
+            public override string Category { get; }
+            public override Type Type => typeof(bool);
+            public override ReportDiagnostic Severity => GetOption().Notification.Severity;
+            public override string GetCurrentValue() => GetOption().Value ? _trueValueDescription : _falseValueDescription;
+            public override object? Value => GetOption().Value;
+            public override string[] GetValues() => new[] { _trueValueDescription, _falseValueDescription };
+            protected abstract CodeStyleOption2<bool> GetOption();
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.EnumCodeStyleSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.EnumCodeStyleSetting.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract partial class CodeStyleSetting
+    {
+        private class EnumCodeStyleSetting<T> : EnumCodeStyleSettingBase<T>
+            where T : Enum
+        {
+            private readonly Option2<CodeStyleOption2<T>> _option;
+            private readonly AnalyzerConfigOptions _editorConfigOptions;
+            private readonly OptionSet _visualStudioOptions;
+
+            public EnumCodeStyleSetting(Option2<CodeStyleOption2<T>> option,
+                                        string description,
+                                        T[] enumValues,
+                                        string[] valueDescriptions,
+                                        AnalyzerConfigOptions editorConfigOptions,
+                                        OptionSet visualStudioOptions,
+                                        OptionUpdater updater)
+                : base(description, enumValues, valueDescriptions, option.Group.Description, updater)
+            {
+                _option = option;
+                _editorConfigOptions = editorConfigOptions;
+                _visualStudioOptions = visualStudioOptions;
+            }
+
+            public override bool IsDefinedInEditorConfig => _editorConfigOptions.TryGetEditorConfigOption<CodeStyleOption2<T>>(_option, out _);
+
+            protected override void ChangeSeverity(NotificationOption2 severity)
+            {
+                var option = GetOption();
+                option.Notification = severity;
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            public override void ChangeValue(int valueIndex)
+            {
+                var option = GetOption();
+                option.Value = _enumValues[valueIndex];
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            protected override CodeStyleOption2<T> GetOption()
+                => _editorConfigOptions.TryGetEditorConfigOption(_option, out CodeStyleOption2<T>? value) && value is not null
+                    ? value
+                    : _visualStudioOptions.GetOption(_option);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.EnumCodeStyleSettingBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.EnumCodeStyleSettingBase.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
 using Microsoft.CodeAnalysis.Utilities;
 
@@ -24,6 +25,10 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
                                             OptionUpdater updater)
                 : base(description, updater)
             {
+                if (enumValues.Length != valueDescriptions.Length)
+                {
+                    throw new InvalidOperationException("Values and descriptions must have matching number of elements");
+                }
                 _enumValues = enumValues;
                 _valueDescriptions = valueDescriptions;
                 Category = category;
@@ -33,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
             public override Type Type => typeof(T);
             public override string GetCurrentValue() => _valueDescriptions[_enumValues.IndexOf(GetOption().Value)];
             public override object? Value => GetOption().Value;
-            public override ReportDiagnostic Severity => GetOption().Notification.Severity;
+            public override DiagnosticSeverity Severity => GetOption().Notification.Severity.ToDiagnosticSeverity() ?? DiagnosticSeverity.Hidden;
             public override string[] GetValues() => _valueDescriptions;
             protected abstract CodeStyleOption2<T> GetOption();
         }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.EnumCodeStyleSettingBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.EnumCodeStyleSettingBase.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract partial class CodeStyleSetting
+    {
+        private abstract class EnumCodeStyleSettingBase<T> : CodeStyleSetting
+            where T : Enum
+        {
+            protected readonly T[] _enumValues;
+            private readonly string[] _valueDescriptions;
+
+            public EnumCodeStyleSettingBase(string description,
+                                            T[] enumValues,
+                                            string[] valueDescriptions,
+                                            string category,
+                                            OptionUpdater updater)
+                : base(description, updater)
+            {
+                _enumValues = enumValues;
+                _valueDescriptions = valueDescriptions;
+                Category = category;
+            }
+
+            public override string Category { get; }
+            public override Type Type => typeof(T);
+            public override string GetCurrentValue() => _valueDescriptions[_enumValues.IndexOf(GetOption().Value)];
+            public override object? Value => GetOption().Value;
+            public override ReportDiagnostic Severity => GetOption().Notification.Severity;
+            public override string[] GetValues() => _valueDescriptions;
+            protected abstract CodeStyleOption2<T> GetOption();
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.PerLanguageBooleanCodeStyleSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.PerLanguageBooleanCodeStyleSetting.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract partial class CodeStyleSetting
+    {
+        private class PerLanguageBooleanCodeStyleSetting : BooleanCodeStyleSettingBase
+        {
+            private readonly PerLanguageOption2<CodeStyleOption2<bool>> _option;
+            private readonly AnalyzerConfigOptions _editorConfigOptions;
+            private readonly OptionSet _visualStudioOptions;
+
+            public PerLanguageBooleanCodeStyleSetting(PerLanguageOption2<CodeStyleOption2<bool>> option,
+                                                      string description,
+                                                      string? trueValueDescription,
+                                                      string? falseValueDescription,
+                                                      AnalyzerConfigOptions editorConfigOptions,
+                                                      OptionSet visualStudioOptions,
+                                                      OptionUpdater updater)
+                : base(description, option.Group.Description, trueValueDescription, falseValueDescription, updater)
+            {
+                _option = option;
+                _editorConfigOptions = editorConfigOptions;
+                _visualStudioOptions = visualStudioOptions;
+            }
+
+            public override bool IsDefinedInEditorConfig => _editorConfigOptions.TryGetEditorConfigOption<CodeStyleOption2<bool>>(_option, out _);
+
+            protected override void ChangeSeverity(NotificationOption2 severity)
+            {
+                var option = GetOption();
+                option.Notification = severity;
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            public override void ChangeValue(int valueIndex)
+            {
+                var value = valueIndex == 0;
+                var option = GetOption();
+                option.Value = value;
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            protected override CodeStyleOption2<bool> GetOption()
+                => _editorConfigOptions.TryGetEditorConfigOption(_option, out CodeStyleOption2<bool>? value) && value is not null
+                    ? value
+                    : _visualStudioOptions.GetOption<CodeStyleOption2<bool>>(new OptionKey2(_option, LanguageNames.CSharp));
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.PerLanguageEnumCodeStyleSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.PerLanguageEnumCodeStyleSetting.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract partial class CodeStyleSetting
+    {
+        private class PerLanguageEnumCodeStyleSetting<T> : EnumCodeStyleSettingBase<T>
+            where T : Enum
+        {
+            private readonly PerLanguageOption2<CodeStyleOption2<T>> _option;
+            private readonly AnalyzerConfigOptions _editorConfigOptions;
+            private readonly OptionSet _visualStudioOptions;
+
+            public PerLanguageEnumCodeStyleSetting(PerLanguageOption2<CodeStyleOption2<T>> option,
+                                                   string description,
+                                                   T[] enumValues,
+                                                   string[] valueDescriptions,
+                                                   AnalyzerConfigOptions editorConfigOptions,
+                                                   OptionSet visualStudioOptions,
+                                                   OptionUpdater updater)
+                : base(description, enumValues, valueDescriptions, option.Group.Description, updater)
+            {
+                _option = option;
+                _editorConfigOptions = editorConfigOptions;
+                _visualStudioOptions = visualStudioOptions;
+            }
+
+            public override bool IsDefinedInEditorConfig => _editorConfigOptions.TryGetEditorConfigOption<CodeStyleOption2<T>>(_option, out _);
+
+            protected override void ChangeSeverity(NotificationOption2 severity)
+            {
+                var option = GetOption();
+                option.Notification = severity;
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            public override void ChangeValue(int valueIndex)
+            {
+                var option = GetOption();
+                option.Value = _enumValues[valueIndex];
+                _ = Updater.QueueUpdateAsync(_option, option);
+            }
+
+            protected override CodeStyleOption2<T> GetOption()
+                => _editorConfigOptions.TryGetEditorConfigOption(_option, out CodeStyleOption2<T>? value) && value is not null
+                    ? value
+                    // TODO(jmarolf): Should we expose duplicate options if the user has a different setting in VB vs. C#?
+                    //                Today this code will choose whatever option is set for C# as the default.
+                    : _visualStudioOptions.GetOption<CodeStyleOption2<T>>(new OptionKey2(_option, LanguageNames.CSharp));
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
         public abstract Type Type { get; }
         public abstract string[] GetValues();
         public abstract string GetCurrentValue();
-        public abstract ReportDiagnostic Severity { get; }
+        public abstract DiagnosticSeverity Severity { get; }
         public abstract bool IsDefinedInEditorConfig { get; }
 
         public CodeStyleSetting(string description, OptionUpdater updater)

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyle/CodeStyleSetting.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract partial class CodeStyleSetting
+    {
+        public string Description { get; }
+
+        protected readonly OptionUpdater Updater;
+
+        public abstract string Category { get; }
+        public abstract object? Value { get; }
+        public abstract Type Type { get; }
+        public abstract string[] GetValues();
+        public abstract string GetCurrentValue();
+        public abstract ReportDiagnostic Severity { get; }
+        public abstract bool IsDefinedInEditorConfig { get; }
+
+        public CodeStyleSetting(string description, OptionUpdater updater)
+        {
+            Description = description;
+            Updater = updater;
+        }
+
+        public void ChangeSeverity(DiagnosticSeverity severity)
+        {
+            var notification = severity switch
+            {
+                DiagnosticSeverity.Hidden => NotificationOption2.Silent,
+                DiagnosticSeverity.Info => NotificationOption2.Suggestion,
+                DiagnosticSeverity.Warning => NotificationOption2.Warning,
+                DiagnosticSeverity.Error => NotificationOption2.Error,
+                _ => NotificationOption2.None,
+            };
+
+            ChangeSeverity(notification);
+        }
+
+        protected abstract void ChangeSeverity(NotificationOption2 severity);
+        public abstract void ChangeValue(int valueIndex);
+
+        internal static CodeStyleSetting Create(Option2<CodeStyleOption2<bool>> option,
+                                                string description,
+                                                AnalyzerConfigOptions editorConfigOptions,
+                                                OptionSet visualStudioOptions,
+                                                OptionUpdater updater,
+                                                string? trueValueDescription = null,
+                                                string? falseValueDescription = null)
+        {
+            return new BooleanCodeStyleSetting(option, description, trueValueDescription, falseValueDescription, editorConfigOptions, visualStudioOptions, updater);
+        }
+
+        internal static CodeStyleSetting Create(PerLanguageOption2<CodeStyleOption2<bool>> option,
+                                                string description,
+                                                AnalyzerConfigOptions editorConfigOptions,
+                                                OptionSet visualStudioOptions,
+                                                OptionUpdater updater,
+                                                string? trueValueDescription = null,
+                                                string? falseValueDescription = null)
+        {
+            return new PerLanguageBooleanCodeStyleSetting(option, description, trueValueDescription, falseValueDescription, editorConfigOptions, visualStudioOptions, updater);
+        }
+
+        internal static CodeStyleSetting Create<T>(Option2<CodeStyleOption2<T>> option,
+                                                   string description,
+                                                   T[] enumValues,
+                                                   string[] valueDescriptions,
+                                                   AnalyzerConfigOptions editorConfigOptions,
+                                                   OptionSet visualStudioOptions,
+                                                   OptionUpdater updater)
+            where T : Enum
+        {
+            return new EnumCodeStyleSetting<T>(option, description, enumValues, valueDescriptions, editorConfigOptions, visualStudioOptions, updater);
+        }
+
+        internal static CodeStyleSetting Create<T>(PerLanguageOption2<CodeStyleOption2<T>> option,
+                                                   string description,
+                                                   T[] enumValues,
+                                                   string[] valueDescriptions,
+                                                   AnalyzerConfigOptions editorConfigOptions,
+                                                   OptionSet visualStudioOptions,
+                                                   OptionUpdater updater)
+            where T : Enum
+        {
+            return new PerLanguageEnumCodeStyleSetting<T>(option, description, enumValues, valueDescriptions, editorConfigOptions, visualStudioOptions, updater);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/FormattingSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/FormattingSetting.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal abstract class FormattingSetting
+    {
+        protected OptionUpdater Updater { get; }
+        protected string? Language { get; }
+
+        protected FormattingSetting(string description, OptionUpdater updater, string? language = null)
+        {
+            Description = description ?? throw new ArgumentNullException(nameof(description));
+            Updater = updater;
+            Language = language;
+        }
+
+        public string Description { get; }
+        public abstract string Category { get; }
+        public abstract Type Type { get; }
+        public abstract OptionKey2 Key { get; }
+        public abstract void SetValue(object value);
+        public abstract object? GetValue();
+        public abstract bool IsDefinedInEditorConfig { get; }
+
+        public static PerLanguageFormattingSetting<TOption> Create<TOption>(PerLanguageOption2<TOption> option,
+                                                                            string description,
+                                                                            AnalyzerConfigOptions editorConfigOptions,
+                                                                            OptionSet visualStudioOptions,
+                                                                            OptionUpdater updater)
+            where TOption : notnull
+        {
+            return new PerLanguageFormattingSetting<TOption>(option, description, editorConfigOptions, visualStudioOptions, updater);
+        }
+
+        public static FormattingSetting<TOption> Create<TOption>(Option2<TOption> option,
+                                                                 string description,
+                                                                 AnalyzerConfigOptions editorConfigOptions,
+                                                                 OptionSet visualStudioOptions,
+                                                                 OptionUpdater updater)
+            where TOption : struct
+        {
+            return new FormattingSetting<TOption>(option, description, editorConfigOptions, visualStudioOptions, updater);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/FormattingSetting`1.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/FormattingSetting`1.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal sealed class FormattingSetting<T> : FormattingSetting
+        where T : notnull
+    {
+        public override bool IsDefinedInEditorConfig => _options.TryGetEditorConfigOption<T>(_option, out _);
+
+        public T Value
+        {
+            get
+            {
+                if (_options.TryGetEditorConfigOption(_option, out T? value) &&
+                    value is not null)
+                {
+                    return value;
+                }
+
+                return _visualStudioOptions.GetOption(_option);
+            }
+        }
+
+        public override Type Type => typeof(T);
+        public override string Category => _option.Group.Description;
+
+        public override OptionKey2 Key => new(_option, _option.OptionDefinition.IsPerLanguage ? Language ?? LanguageNames.CSharp : null);
+
+        private readonly Option2<T> _option;
+        private readonly AnalyzerConfigOptions _options;
+        private readonly OptionSet _visualStudioOptions;
+
+        public FormattingSetting(Option2<T> option,
+                                 string description,
+                                 AnalyzerConfigOptions options,
+                                 OptionSet visualStudioOptions,
+                                 OptionUpdater updater)
+            : base(description, updater)
+        {
+            _option = option;
+            _options = options;
+            _visualStudioOptions = visualStudioOptions;
+        }
+
+        public override void SetValue(object value)
+        {
+            _ = Updater.QueueUpdateAsync(_option, value);
+        }
+
+        public override object? GetValue() => Value;
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/FormattingSetting`1.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/FormattingSetting`1.cs
@@ -14,10 +14,26 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
     {
         public override bool IsDefinedInEditorConfig => _options.TryGetEditorConfigOption<T>(_option, out _);
 
+        private bool _isValueSet;
+        private T? _value;
         public T Value
         {
+            private set
+            {
+                if (!_isValueSet)
+                {
+                    _isValueSet = true;
+                }
+
+                _value = value;
+            }
             get
             {
+                if (_value is not null && _isValueSet)
+                {
+                    return _value;
+                }
+
                 if (_options.TryGetEditorConfigOption(_option, out T? value) &&
                     value is not null)
                 {
@@ -51,6 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
 
         public override void SetValue(object value)
         {
+            Value = (T)value;
             _ = Updater.QueueUpdateAsync(_option, value);
         }
 

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/PerLanguageFormattingSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/PerLanguageFormattingSetting.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
+{
+    internal sealed class PerLanguageFormattingSetting<T> : FormattingSetting
+        where T : notnull
+    {
+        public T? Value
+        {
+            get
+            {
+                if (_editorConfigOptions.TryGetEditorConfigOption(_option, out T? value) &&
+                    value is not null)
+                {
+                    return value;
+                }
+
+                return (T?)_visualStudioOptions.GetOption(Key);
+            }
+        }
+
+        private readonly PerLanguageOption2<T> _option;
+        private readonly AnalyzerConfigOptions _editorConfigOptions;
+        private readonly OptionSet _visualStudioOptions;
+
+        public PerLanguageFormattingSetting(PerLanguageOption2<T> option,
+                                            string description,
+                                            AnalyzerConfigOptions editorConfigOptions,
+                                            OptionSet visualStudioOptions,
+                                            OptionUpdater updater)
+            : base(description, updater)
+        {
+            _option = option;
+            _editorConfigOptions = editorConfigOptions;
+            _visualStudioOptions = visualStudioOptions;
+        }
+
+        public override string Category => _option.Group.Description;
+        public override Type Type => typeof(T);
+
+        public override OptionKey2 Key => new(_option, _option.OptionDefinition.IsPerLanguage ? Language ?? LanguageNames.CSharp : null);
+
+        public override bool IsDefinedInEditorConfig => _editorConfigOptions.TryGetEditorConfigOption<T>(_option, out _);
+
+        public override void SetValue(object value)
+        {
+            _ = Updater.QueueUpdateAsync(_option, value);
+        }
+
+        public override object? GetValue() => Value;
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/PerLanguageFormattingSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/Formatting/PerLanguageFormattingSetting.cs
@@ -12,17 +12,33 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
     internal sealed class PerLanguageFormattingSetting<T> : FormattingSetting
         where T : notnull
     {
-        public T? Value
+        private bool _isValueSet;
+        private T? _value;
+        public T Value
         {
+            private set
+            {
+                if (!_isValueSet)
+                {
+                    _isValueSet = true;
+                }
+
+                _value = value;
+            }
             get
             {
+                if (_value is not null && _isValueSet)
+                {
+                    return _value;
+                }
+
                 if (_editorConfigOptions.TryGetEditorConfigOption(_option, out T? value) &&
                     value is not null)
                 {
                     return value;
                 }
 
-                return (T?)_visualStudioOptions.GetOption(Key);
+                return (T)_visualStudioOptions.GetOption(Key)!;
             }
         }
 
@@ -51,6 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
 
         public override void SetValue(object value)
         {
+            Value = (T)value;
             _ = Updater.QueueUpdateAsync(_option, value);
         }
 

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
@@ -24,21 +24,19 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Analyz
             : base(fileName, settingsUpdater, workspace)
         {
             _analyzerService = analyzerService;
+            Update();
         }
 
-        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet _)
+        protected override void UpdateOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet _)
         {
-            return Task.Run(() =>
+            var solution = Workspace.CurrentSolution;
+            var projects = solution.GetProjectsForPath(FileName);
+            var analyzerReferences = projects.SelectMany(p => p.AnalyzerReferences).DistinctBy(a => a.Id).ToImmutableArray();
+            foreach (var analyzerReference in analyzerReferences)
             {
-                var solution = Workspace.CurrentSolution;
-                var projects = solution.GetProjectsForPath(FileName);
-                var analyzerReferences = projects.SelectMany(p => p.AnalyzerReferences).DistinctBy(a => a.Id).ToImmutableArray();
-                foreach (var analyzerReference in analyzerReferences)
-                {
-                    var configSettings = GetSettings(analyzerReference, editorConfigOptions);
-                    AddRange(configSettings);
-                }
-            });
+                var configSettings = GetSettings(analyzerReference, editorConfigOptions);
+                AddRange(configSettings);
+            }
         }
 
         private IEnumerable<AnalyzerSetting> GetSettings(AnalyzerReference analyzerReference, AnalyzerConfigOptions editorConfigOptions)

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Extensions;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Analyzer
+{
+    internal class AnalyzerSettingsProvider : SettingsProviderBase<AnalyzerSetting, AnalyzerSettingsUpdater, AnalyzerSetting, DiagnosticSeverity>
+    {
+        private readonly IDiagnosticAnalyzerService _analyzerService;
+
+        public AnalyzerSettingsProvider(string fileName, AnalyzerSettingsUpdater settingsUpdater, Workspace workspace, IDiagnosticAnalyzerService analyzerService)
+            : base(fileName, settingsUpdater, workspace)
+        {
+            _analyzerService = analyzerService;
+        }
+
+        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet _)
+        {
+            return Task.Run(() =>
+            {
+                var solution = Workspace.CurrentSolution;
+                var projects = solution.GetProjectsForPath(FileName);
+                var analyzerReferences = projects.SelectMany(p => p.AnalyzerReferences).DistinctBy(a => a.Id).ToImmutableArray();
+                foreach (var analyzerReference in analyzerReferences)
+                {
+                    var configSettings = GetSettings(analyzerReference, editorConfigOptions);
+                    AddRange(configSettings);
+                }
+            });
+        }
+
+        private IEnumerable<AnalyzerSetting> GetSettings(AnalyzerReference analyzerReference, AnalyzerConfigOptions editorConfigOptions)
+        {
+            IEnumerable<DiagnosticAnalyzer> csharpAnalyzers = analyzerReference.GetAnalyzers(LanguageNames.CSharp);
+            IEnumerable<DiagnosticAnalyzer> visualBasicAnalyzers = analyzerReference.GetAnalyzers(LanguageNames.VisualBasic);
+            var dotnetAnalyzers = csharpAnalyzers.Intersect(visualBasicAnalyzers, DiagnosticAnalyzerComparer.Instance);
+            csharpAnalyzers = csharpAnalyzers.Except(dotnetAnalyzers, DiagnosticAnalyzerComparer.Instance);
+            visualBasicAnalyzers = visualBasicAnalyzers.Except(dotnetAnalyzers, DiagnosticAnalyzerComparer.Instance);
+
+            var csharpSettings = ToAnalyzerSetting(csharpAnalyzers, Language.CSharp);
+            var csharpAndVisualBasicSettings = csharpSettings.Concat(ToAnalyzerSetting(visualBasicAnalyzers, Language.VisualBasic));
+            return csharpAndVisualBasicSettings.Concat(ToAnalyzerSetting(dotnetAnalyzers, Language.CSharp | Language.VisualBasic));
+
+            IEnumerable<AnalyzerSetting> ToAnalyzerSetting(IEnumerable<DiagnosticAnalyzer> analyzers,
+                                                                   Language language)
+            {
+                return analyzers
+                    .SelectMany(a => _analyzerService.AnalyzerInfoCache.GetDiagnosticDescriptors(a))
+                    .GroupBy(d => d.Id)
+                    .OrderBy(g => g.Key, StringComparer.CurrentCulture)
+                    .Select(g =>
+                    {
+                        var selectedDiagnostic = g.First();
+                        var severity = selectedDiagnostic.GetEffectiveSeverity(editorConfigOptions);
+                        return new AnalyzerSetting(selectedDiagnostic, severity, SettingsUpdater, language);
+                    });
+            }
+        }
+
+        private class DiagnosticAnalyzerComparer : IEqualityComparer<DiagnosticAnalyzer>
+        {
+            public static readonly DiagnosticAnalyzerComparer Instance = new();
+
+            public bool Equals(DiagnosticAnalyzer? x, DiagnosticAnalyzer? y)
+            {
+                if (x is null && y is null)
+                    return true;
+
+                if (x is null || y is null)
+                    return false;
+
+                return x.GetAnalyzerIdAndVersion().GetHashCode() == y.GetAnalyzerIdAndVersion().GetHashCode();
+            }
+
+            public int GetHashCode(DiagnosticAnalyzer obj) => obj.GetAnalyzerIdAndVersion().GetHashCode();
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProviderFactory.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Analyzer
+{
+    internal class AnalyzerSettingsProviderFactory : IWorkspaceSettingsProviderFactory<AnalyzerSetting>
+    {
+        private readonly Workspace _workspace;
+        private readonly IDiagnosticAnalyzerService _analyzerService;
+
+        public AnalyzerSettingsProviderFactory(Workspace workspace, IDiagnosticAnalyzerService analyzerService)
+        {
+            _workspace = workspace;
+            _analyzerService = analyzerService;
+        }
+
+        public ISettingsProvider<AnalyzerSetting> GetForFile(string filePath)
+        {
+            var updater = new AnalyzerSettingsUpdater(_workspace, filePath);
+            return new AnalyzerSettingsProvider(filePath, updater, _workspace, _analyzerService);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsWorkspaceServiceFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsWorkspaceServiceFactory.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Analyzer
+{
+    [ExportWorkspaceServiceFactory(typeof(IWorkspaceSettingsProviderFactory<AnalyzerSetting>)), Shared]
+    internal class AnalyzerSettingsWorkspaceServiceFactory : IWorkspaceServiceFactory
+    {
+        private readonly IDiagnosticAnalyzerService _analyzerService;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerSettingsWorkspaceServiceFactory(IDiagnosticAnalyzerService analyzerService)
+        {
+            _analyzerService = analyzerService;
+        }
+
+        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+            => new AnalyzerSettingsProviderFactory(workspaceServices.Workspace, _analyzerService);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
@@ -17,36 +17,36 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.CodeSt
         public CommonCodeStyleSettingsProvider(string filePath, OptionUpdater settingsUpdater, Workspace workspace)
             : base(filePath, settingsUpdater, workspace)
         {
+            Update();
         }
 
-        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        protected override void UpdateOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
         {
-            return Task.Run(() =>
-            {
-                var qualifySettings = GetQualifyCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(qualifySettings);
+            var qualifySettings = GetQualifyCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(qualifySettings);
 
-                var predefinedTypesSettings = GetPredefinedTypesCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(predefinedTypesSettings);
+            var predefinedTypesSettings = GetPredefinedTypesCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(predefinedTypesSettings);
 
-                var nullCheckingSettings = GetNullCheckingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(nullCheckingSettings);
+            var nullCheckingSettings = GetNullCheckingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(nullCheckingSettings);
 
-                var modifierSettings = GetModifierCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(modifierSettings);
+            var modifierSettings = GetModifierCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(modifierSettings);
 
-                var codeBlockSettings = GetCodeBlockCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(codeBlockSettings);
+            var codeBlockSettings = GetCodeBlockCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(codeBlockSettings);
 
-                var expressionSettings = GetExpressionCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(expressionSettings);
+            var expressionSettings = GetExpressionCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(expressionSettings);
 
-                var parameterSettings = GetParameterCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(parameterSettings);
+            var parameterSettings = GetParameterCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(parameterSettings);
 
-                var parenthesesSettings = GetParenthesesCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(parenthesesSettings);
-            });
+            var parenthesesSettings = GetParenthesesCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(parenthesesSettings);
+
+            // TODO(jmarolf): set as stable
         }
 
         private static IEnumerable<CodeStyleSetting> GetQualifyCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
@@ -1,0 +1,190 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.CodeStyle
+{
+    internal class CommonCodeStyleSettingsProvider : SettingsProviderBase<CodeStyleSetting, OptionUpdater, IOption2, object>
+    {
+        public CommonCodeStyleSettingsProvider(string filePath, OptionUpdater settingsUpdater, Workspace workspace)
+            : base(filePath, settingsUpdater, workspace)
+        {
+        }
+
+        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        {
+            return Task.Run(() =>
+            {
+                var qualifySettings = GetQualifyCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(qualifySettings);
+
+                var predefinedTypesSettings = GetPredefinedTypesCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(predefinedTypesSettings);
+
+                var nullCheckingSettings = GetNullCheckingCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(nullCheckingSettings);
+
+                var modifierSettings = GetModifierCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(modifierSettings);
+
+                var codeBlockSettings = GetCodeBlockCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(codeBlockSettings);
+
+                var expressionSettings = GetExpressionCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(expressionSettings);
+
+                var parameterSettings = GetParameterCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(parameterSettings);
+
+                var parenthesesSettings = GetParenthesesCodeStyleOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(parenthesesSettings);
+            });
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetQualifyCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.QualifyFieldAccess,
+                description: EditorFeaturesResources.Qualify_field_access_with_this_or_Me,
+                trueValueDescription: EditorFeaturesResources.Prefer_this_or_Me,
+                falseValueDescription: EditorFeaturesResources.Do_not_prefer_this_or_Me,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.QualifyPropertyAccess,
+                description: EditorFeaturesResources.Qualify_property_access_with_this_or_Me,
+                trueValueDescription: EditorFeaturesResources.Prefer_this_or_Me,
+                falseValueDescription: EditorFeaturesResources.Do_not_prefer_this_or_Me,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.QualifyMethodAccess,
+                description: EditorFeaturesResources.Qualify_method_access_with_this_or_Me,
+                trueValueDescription: EditorFeaturesResources.Prefer_this_or_Me,
+                falseValueDescription: EditorFeaturesResources.Do_not_prefer_this_or_Me,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.QualifyEventAccess,
+                description: EditorFeaturesResources.Qualify_event_access_with_this_or_Me,
+                trueValueDescription: EditorFeaturesResources.Prefer_this_or_Me,
+                falseValueDescription: EditorFeaturesResources.Do_not_prefer_this_or_Me,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetPredefinedTypesCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration,
+                description: EditorFeaturesResources.For_locals_parameters_and_members,
+                trueValueDescription: EditorFeaturesResources.Prefer_predefined_type,
+                falseValueDescription: EditorFeaturesResources.Prefer_framework_type,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration,
+                description: EditorFeaturesResources.For_member_access_expressions,
+                trueValueDescription: EditorFeaturesResources.Prefer_predefined_type,
+                falseValueDescription: EditorFeaturesResources.Prefer_framework_type,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetNullCheckingCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferCoalesceExpression,
+                description: EditorFeaturesResources.Prefer_coalesce_expression,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferNullPropagation,
+                description: EditorFeaturesResources.Prefer_null_propagation,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferIsNullCheckOverReferenceEqualityMethod,
+                description: EditorFeaturesResources.Prefer_is_null_for_reference_equality_checks,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetModifierCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferReadonly,
+                description: EditorFeaturesResources.Prefer_readonly_fields,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetCodeBlockCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferAutoProperties,
+                description: EditorFeaturesResources.analyzer_Prefer_auto_properties,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferSystemHashCode,
+                description: EditorFeaturesResources.Prefer_System_HashCode_in_GetHashCode,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetExpressionCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferObjectInitializer, description: EditorFeaturesResources.Prefer_object_initializer, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferCollectionInitializer, description: EditorFeaturesResources.Prefer_collection_initializer, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferSimplifiedBooleanExpressions, description: EditorFeaturesResources.Prefer_simplified_boolean_expressions, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferConditionalExpressionOverAssignment, description: EditorFeaturesResources.Prefer_conditional_expression_over_if_with_assignments, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferConditionalExpressionOverReturn, description: EditorFeaturesResources.Prefer_conditional_expression_over_if_with_returns, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferExplicitTupleNames, description: EditorFeaturesResources.Prefer_explicit_tuple_name, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferInferredTupleNames, description: EditorFeaturesResources.Prefer_inferred_tuple_names, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferInferredAnonymousTypeMemberNames, description: EditorFeaturesResources.Prefer_inferred_anonymous_type_member_names, options, visualStudioOptions, updater);
+            yield return CodeStyleSetting.Create(CodeStyleOptions2.PreferCompoundAssignment, description: EditorFeaturesResources.Prefer_compound_assignments, options, visualStudioOptions, updater);
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetParenthesesCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            var enumValues = new[] { ParenthesesPreference.AlwaysForClarity, ParenthesesPreference.NeverIfUnnecessary };
+            var valueDescriptions = new[] { EditorFeaturesResources.Always_for_clarity, EditorFeaturesResources.Never_if_unnecessary };
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.ArithmeticBinaryParentheses,
+                description: EditorFeaturesResources.In_arithmetic_binary_operators,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.OtherBinaryParentheses,
+                description: EditorFeaturesResources.In_other_binary_operators,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.RelationalBinaryParentheses,
+                description: EditorFeaturesResources.In_relational_binary_operators,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+
+            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.OtherParentheses,
+                description: EditorFeaturesResources.In_other_operators,
+                enumValues: enumValues,
+                valueDescriptions: valueDescriptions,
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+
+        }
+
+        private static IEnumerable<CodeStyleSetting> GetParameterCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return CodeStyleSetting.Create(
+                option: CodeStyleOptions2.UnusedParameters,
+                description: EditorFeaturesResources.Avoid_unused_parameters,
+                enumValues: new[] { UnusedParametersPreference.NonPublicMethods, UnusedParametersPreference.AllMethods },
+                new[] { EditorFeaturesResources.Non_public_methods },
+                editorConfigOptions: options,
+                visualStudioOptions: visualStudioOptions, updater: updater);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.CodeSt
                 option: CodeStyleOptions2.UnusedParameters,
                 description: EditorFeaturesResources.Avoid_unused_parameters,
                 enumValues: new[] { UnusedParametersPreference.NonPublicMethods, UnusedParametersPreference.AllMethods },
-                new[] { EditorFeaturesResources.Non_public_methods },
+                new[] { EditorFeaturesResources.Non_public_methods, EditorFeaturesResources.All_methods },
                 editorConfigOptions: options,
                 visualStudioOptions: visualStudioOptions, updater: updater);
         }

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProviderFactory.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.CodeStyle
+{
+    internal class CommonCodeStyleSettingsProviderFactory : IWorkspaceSettingsProviderFactory<CodeStyleSetting>
+    {
+        private readonly Workspace _workspace;
+
+        public CommonCodeStyleSettingsProviderFactory(Workspace workspace) => _workspace = workspace;
+
+        public ISettingsProvider<CodeStyleSetting> GetForFile(string filePath)
+            => new CommonCodeStyleSettingsProvider(filePath, new OptionUpdater(_workspace, filePath), _workspace);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsWorkspaceServiceFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsWorkspaceServiceFactory.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.CodeStyle
+{
+    [ExportWorkspaceServiceFactory(typeof(IWorkspaceSettingsProviderFactory<CodeStyleSetting>)), Shared]
+    internal class CommonCodeStyleSettingsWorkspaceServiceFactory : IWorkspaceServiceFactory
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CommonCodeStyleSettingsWorkspaceServiceFactory() { }
+
+        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+            => new CommonCodeStyleSettingsProviderFactory(workspaceServices.Workspace);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedOptionsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedOptionsProviderFactory.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Shared.Collections;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
+{
+    internal class CombinedOptionsProviderFactory<T> : ISettingsProviderFactory<T>
+    {
+        private ImmutableArray<ISettingsProviderFactory<T>> _factories;
+
+        public CombinedOptionsProviderFactory(ImmutableArray<ISettingsProviderFactory<T>> factories)
+        {
+            _factories = factories;
+        }
+
+        public ISettingsProvider<T> GetForFile(string filePath)
+        {
+            var providers = TemporaryArray<ISettingsProvider<T>>.Empty;
+            foreach (var factory in _factories)
+            {
+                providers.Add(factory.GetForFile(filePath));
+            }
+
+            return new CombinedProvider<T>(providers.ToImmutableAndClear());
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
 
         public async Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync()
         {
-            var changes = await Task.WhenAll(_providers.Select(x => x.GetChangedEditorConfigAsync())).ConfigureAwait(false);
+            var changesArray = await Task.WhenAll(_providers.Select(x => x.GetChangedEditorConfigAsync())).ConfigureAwait(false);
 
-            changes = changes.WhereNotNull().ToArray();
+            var changes = changesArray.WhereNotNull();
             if (!changes.Any())
                 return null;
 

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
@@ -2,13 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
 {
@@ -21,21 +17,14 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
             _providers = providers;
         }
 
-        public async Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync()
+        public async Task<SourceText> GetChangedEditorConfigAsync(SourceText sourceText)
         {
-            var changesArray = await Task.WhenAll(_providers.Select(x => x.GetChangedEditorConfigAsync())).ConfigureAwait(false);
-
-            var changes = changesArray.WhereNotNull();
-            if (!changes.Any())
-                return null;
-
-            var result = new List<TextChange>();
-            foreach (var change in changes)
+            foreach (var provider in _providers)
             {
-                result.AddRange(change);
+                sourceText = await provider.GetChangedEditorConfigAsync(sourceText).ConfigureAwait(false);
             }
 
-            return result;
+            return sourceText;
         }
 
         public ImmutableArray<T> GetCurrentDataSnapshot()

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
+{
+    internal class CombinedProvider<T> : ISettingsProvider<T>
+    {
+        private readonly ImmutableArray<ISettingsProvider<T>> _providers;
+
+        public CombinedProvider(ImmutableArray<ISettingsProvider<T>> providers)
+        {
+            _providers = providers;
+        }
+
+        public async Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync()
+        {
+            var changes = await Task.WhenAll(_providers.Select(x => x.GetChangedEditorConfigAsync())).ConfigureAwait(false);
+
+            changes = changes.Where(x => x is not null).ToArray();
+            if (!changes.Any())
+                return null;
+
+            var result = new List<TextChange>();
+            foreach (var change in changes)
+            {
+                result.AddRange(change!); // compiler does not see through linq in nullable yet
+            }
+
+            return result;
+        }
+
+        public ImmutableArray<T> GetCurrentDataSnapshot()
+        {
+            var snapShot = ImmutableArray<T>.Empty;
+            foreach (var provider in _providers)
+            {
+                snapShot = snapShot.Concat(provider.GetCurrentDataSnapshot());
+            }
+
+            return snapShot;
+        }
+
+        public void RegisterViewModel(ISettingsEditorViewModel model)
+        {
+            foreach (var provider in _providers)
+            {
+                provider.RegisterViewModel(model);
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/CombinedProvider.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
 {
@@ -24,14 +25,14 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
         {
             var changes = await Task.WhenAll(_providers.Select(x => x.GetChangedEditorConfigAsync())).ConfigureAwait(false);
 
-            changes = changes.Where(x => x is not null).ToArray();
+            changes = changes.WhereNotNull().ToArray();
             if (!changes.Any())
                 return null;
 
             var result = new List<TextChange>();
             foreach (var change in changes)
             {
-                result.AddRange(change!); // compiler does not see through linq in nullable yet
+                result.AddRange(change);
             }
 
             return result;

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsProvider.cs
@@ -17,15 +17,13 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Format
         public CommonFormattingSettingsProvider(string fileName, OptionUpdater settingsUpdater, Workspace workspace)
             : base(fileName, settingsUpdater, workspace)
         {
+            Update();
         }
 
-        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        protected override void UpdateOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
         {
-            return Task.Run(() =>
-            {
-                var defaultOptions = GetDefaultOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
-                AddRange(defaultOptions);
-            });
+            var defaultOptions = GetDefaultOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+            AddRange(defaultOptions);
         }
 
         private static IEnumerable<FormattingSetting> GetDefaultOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updater)

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsProvider.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Formatting
+{
+    internal class CommonFormattingSettingsProvider : SettingsProviderBase<FormattingSetting, OptionUpdater, IOption2, object>
+    {
+        public CommonFormattingSettingsProvider(string fileName, OptionUpdater settingsUpdater, Workspace workspace)
+            : base(fileName, settingsUpdater, workspace)
+        {
+        }
+
+        protected override Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions)
+        {
+            return Task.Run(() =>
+            {
+                var defaultOptions = GetDefaultOptions(editorConfigOptions, visualStudioOptions, SettingsUpdater);
+                AddRange(defaultOptions);
+            });
+        }
+
+        private static IEnumerable<FormattingSetting> GetDefaultOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions, OptionUpdater updater)
+        {
+            yield return FormattingSetting.Create(FormattingOptions2.UseTabs, EditorFeaturesResources.Use_Tabs, editorConfigOptions, visualStudioOptions, updater);
+            yield return FormattingSetting.Create(FormattingOptions2.TabSize, EditorFeaturesResources.Tab_Size, editorConfigOptions, visualStudioOptions, updater);
+            yield return FormattingSetting.Create(FormattingOptions2.IndentationSize, EditorFeaturesResources.Indentation_Size, editorConfigOptions, visualStudioOptions, updater);
+            yield return FormattingSetting.Create(FormattingOptions2.NewLine, EditorFeaturesResources.New_Line, editorConfigOptions, visualStudioOptions, updater);
+            yield return FormattingSetting.Create(FormattingOptions2.InsertFinalNewLine, EditorFeaturesResources.Insert_Final_Newline, editorConfigOptions, visualStudioOptions, updater);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsProviderFactory.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Formatting
+{
+    internal class CommonFormattingSettingsProviderFactory : IWorkspaceSettingsProviderFactory<FormattingSetting>
+    {
+        private readonly Workspace _workspace;
+
+        public CommonFormattingSettingsProviderFactory(Workspace workspace) => _workspace = workspace;
+
+        public ISettingsProvider<FormattingSetting> GetForFile(string filePath)
+            => new CommonFormattingSettingsProvider(filePath, new OptionUpdater(_workspace, filePath), _workspace);
+
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsWorkspaceServiceFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Formatting/CommonFormattingSettingsWorkspaceServiceFactory.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Formatting
+{
+    [ExportWorkspaceServiceFactory(typeof(IWorkspaceSettingsProviderFactory<FormattingSetting>)), Shared]
+    internal class CommonFormattingSettingsWorkspaceServiceFactory : IWorkspaceServiceFactory
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CommonFormattingSettingsWorkspaceServiceFactory() { }
+
+        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+            => new CommonFormattingSettingsProviderFactory(workspaceServices.Workspace);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ILanguageSettingsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ILanguageSettingsProviderFactory.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
+{
+    internal interface ILanguageSettingsProviderFactory<TData> : ISettingsProviderFactory<TData>, ILanguageService
+    {
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ISettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ISettingsProvider.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
+{
+    internal interface ISettingsProvider<TData>
+    {
+        void RegisterViewModel(ISettingsEditorViewModel model);
+        ImmutableArray<TData> GetCurrentDataSnapshot();
+        Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync();
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ISettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ISettingsProvider.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
     {
         void RegisterViewModel(ISettingsEditorViewModel model);
         ImmutableArray<TData> GetCurrentDataSnapshot();
-        Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync();
+        Task<SourceText> GetChangedEditorConfigAsync(SourceText sourceText);
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ISettingsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/ISettingsProviderFactory.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
+{
+    internal interface ISettingsProviderFactory<TData>
+    {
+        ISettingsProvider<TData> GetForFile(string filePath);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/IWorkspaceSettingsProviderFactory.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/IWorkspaceSettingsProviderFactory.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
+{
+    internal interface IWorkspaceSettingsProviderFactory<TData> : ISettingsProviderFactory<TData>, IWorkspaceService
+    {
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
@@ -17,7 +17,7 @@ using static Microsoft.CodeAnalysis.ProjectState;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
 {
-    internal abstract class SettingsProviderBase<TData, TOptionsUpdater, TOption, TValue> : ISettingsProvider<TData>, IDisposable
+    internal abstract class SettingsProviderBase<TData, TOptionsUpdater, TOption, TValue> : ISettingsProvider<TData>
         where TOptionsUpdater : ISettingUpdater<TOption, TValue>
     {
         private readonly List<TData> _snapshot = new();
@@ -34,32 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
             FileName = fileName;
             SettingsUpdater = settingsUpdater;
             Workspace = workspace;
-            Workspace.WorkspaceChanged += OnWorkspaceChanged;
             Update();
-        }
-
-        private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
-        {
-            switch (e.Kind)
-            {
-                case WorkspaceChangeKind.SolutionChanged:
-                case WorkspaceChangeKind.SolutionAdded:
-                case WorkspaceChangeKind.SolutionRemoved:
-                case WorkspaceChangeKind.SolutionCleared:
-                case WorkspaceChangeKind.SolutionReloaded:
-                case WorkspaceChangeKind.ProjectAdded:
-                case WorkspaceChangeKind.ProjectRemoved:
-                case WorkspaceChangeKind.ProjectChanged:
-                case WorkspaceChangeKind.ProjectReloaded:
-                case WorkspaceChangeKind.AnalyzerConfigDocumentAdded:
-                case WorkspaceChangeKind.AnalyzerConfigDocumentRemoved:
-                case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
-                case WorkspaceChangeKind.AnalyzerConfigDocumentChanged:
-                    Update();
-                    break;
-                default:
-                    break;
-            }
         }
 
         private void Update()
@@ -96,8 +71,5 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
 
         public void RegisterViewModel(ISettingsEditorViewModel viewModel)
             => _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
-
-        public void Dispose()
-            => Workspace.WorkspaceChanged -= OnWorkspaceChanged;
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Extensions;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.ProjectState;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
+{
+    internal abstract class SettingsProviderBase<TData, TOptionsUpdater, TOption, TValue> : ISettingsProvider<TData>, IDisposable
+        where TOptionsUpdater : ISettingUpdater<TOption, TValue>
+    {
+        private readonly List<TData> _snapshot = new();
+        private static readonly object s_gate = new();
+        private ISettingsEditorViewModel? _viewModel;
+        protected readonly string FileName;
+        protected readonly TOptionsUpdater SettingsUpdater;
+        protected readonly Workspace Workspace;
+
+        protected abstract Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions);
+
+        protected SettingsProviderBase(string fileName, TOptionsUpdater settingsUpdater, Workspace workspace)
+        {
+            FileName = fileName;
+            SettingsUpdater = settingsUpdater;
+            Workspace = workspace;
+            Workspace.WorkspaceChanged += OnWorkspaceChanged;
+            Update();
+        }
+
+        private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
+        {
+            switch (e.Kind)
+            {
+                case WorkspaceChangeKind.SolutionChanged:
+                case WorkspaceChangeKind.SolutionAdded:
+                case WorkspaceChangeKind.SolutionRemoved:
+                case WorkspaceChangeKind.SolutionCleared:
+                case WorkspaceChangeKind.SolutionReloaded:
+                case WorkspaceChangeKind.ProjectAdded:
+                case WorkspaceChangeKind.ProjectRemoved:
+                case WorkspaceChangeKind.ProjectChanged:
+                case WorkspaceChangeKind.ProjectReloaded:
+                case WorkspaceChangeKind.AnalyzerConfigDocumentAdded:
+                case WorkspaceChangeKind.AnalyzerConfigDocumentRemoved:
+                case WorkspaceChangeKind.AnalyzerConfigDocumentReloaded:
+                case WorkspaceChangeKind.AnalyzerConfigDocumentChanged:
+                    Update();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void Update()
+        {
+            var givenFolder = new DirectoryInfo(FileName).Parent;
+            var solution = Workspace.CurrentSolution;
+            var projects = solution.GetProjectsForPath(FileName);
+            var project = projects.First();
+            var configOptionsProvider = new WorkspaceAnalyzerConfigOptionsProvider(project.State);
+            var options = configOptionsProvider.GetOptionsForSourcePath(givenFolder.FullName);
+            _ = UpdateOptionsAsync(options, Workspace.Options);
+        }
+
+        public Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync()
+            => SettingsUpdater.GetChangedEditorConfigAsync(default);
+
+        public ImmutableArray<TData> GetCurrentDataSnapshot()
+        {
+            lock (s_gate)
+            {
+                return _snapshot.ToImmutableArray();
+            }
+        }
+
+        protected void AddRange(IEnumerable<TData> items)
+        {
+            lock (s_gate)
+            {
+                _snapshot.AddRange(items);
+            }
+
+            _ = _viewModel?.NotifyOfUpdateAsync();
+        }
+
+        public void RegisterViewModel(ISettingsEditorViewModel viewModel)
+            => _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+
+        public void Dispose()
+            => Workspace.WorkspaceChanged -= OnWorkspaceChanged;
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
@@ -27,17 +27,16 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
         protected readonly TOptionsUpdater SettingsUpdater;
         protected readonly Workspace Workspace;
 
-        protected abstract Task UpdateOptionsAsync(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions);
+        protected abstract void UpdateOptions(AnalyzerConfigOptions editorConfigOptions, OptionSet visualStudioOptions);
 
         protected SettingsProviderBase(string fileName, TOptionsUpdater settingsUpdater, Workspace workspace)
         {
             FileName = fileName;
             SettingsUpdater = settingsUpdater;
             Workspace = workspace;
-            Update();
         }
 
-        private void Update()
+        protected void Update()
         {
             var givenFolder = new DirectoryInfo(FileName).Parent;
             var solution = Workspace.CurrentSolution;
@@ -45,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
             var project = projects.First();
             var configOptionsProvider = new WorkspaceAnalyzerConfigOptionsProvider(project.State);
             var options = configOptionsProvider.GetOptionsForSourcePath(givenFolder.FullName);
-            _ = UpdateOptionsAsync(options, Workspace.Options);
+            UpdateOptions(options, Workspace.Options);
         }
 
         public Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync()
@@ -66,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
                 _snapshot.AddRange(items);
             }
 
-            _ = _viewModel?.NotifyOfUpdateAsync();
+            _viewModel?.NotifyOfUpdate();
         }
 
         public void RegisterViewModel(ISettingsEditorViewModel viewModel)

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/SettingsProviderBase.cs
@@ -52,8 +52,16 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider
             UpdateOptions(options, Workspace.Options);
         }
 
-        public Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync()
-            => SettingsUpdater.GetChangedEditorConfigAsync(default);
+        public async Task<SourceText> GetChangedEditorConfigAsync(SourceText sourceText)
+        {
+            if (!await SettingsUpdater.HasAnyChangesAsync().ConfigureAwait(false))
+            {
+                return sourceText;
+            }
+
+            var text = await SettingsUpdater.GetChangedEditorConfigAsync(sourceText, default).ConfigureAwait(false);
+            return text is not null ? text : sourceText;
+        }
 
         public ImmutableArray<TData> GetCurrentDataSnapshot()
         {

--- a/src/EditorFeatures/Core/EditorConfigSettings/Extensions/EnumerableExtensions.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Extensions
+{
+    internal static class EnumerableExtensions
+    {
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            var seenKeys = new HashSet<TKey>();
+            foreach (var element in source)
+            {
+                if (seenKeys.Add(keySelector(element)))
+                {
+                    yield return element;
+                }
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Extensions/SolutionExtensions.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Extensions/SolutionExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Extensions
+{
+    internal static class SolutionExtensions
+    {
+        public static ImmutableArray<Project> GetProjectsForPath(this Solution solution, string givenPath)
+        {
+            var givenFolder = new DirectoryInfo(givenPath).Parent;
+            var solutionFolder = new DirectoryInfo(solution.FilePath).Parent;
+            if (givenFolder.FullName == solutionFolder.FullName)
+            {
+                return solution.Projects.ToImmutableArray();
+            }
+
+            var builder = ArrayBuilder<Project>.GetInstance();
+            foreach (var (projectDirectoryPath, project) in solution.Projects.Select(p => (new DirectoryInfo(p.FilePath).Parent, p)))
+            {
+                if (ContainsPath(givenFolder, projectDirectoryPath))
+                {
+                    builder.Add(project);
+                }
+            }
+
+            return builder.ToImmutableAndFree();
+
+            static bool ContainsPath(DirectoryInfo givenPath, DirectoryInfo projectPath)
+            {
+                if (projectPath.FullName == givenPath.FullName)
+                {
+                    return true;
+                }
+
+                while (projectPath.Parent is not null)
+                {
+                    if (projectPath.Parent.FullName == givenPath.FullName)
+                    {
+                        return true;
+                    }
+                    projectPath = projectPath.Parent;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Extensions/SolutionExtensions.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Extensions/SolutionExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Extensions
     {
         public static ImmutableArray<Project> GetProjectsForPath(this Solution solution, string givenPath)
         {
-            var givenFolder = new DirectoryInfo(givenPath).Parent;
+            var givenFolder = new DirectoryInfo(Path.GetDirectoryName(givenPath));
             var solutionFolder = new DirectoryInfo(solution.FilePath).Parent;
             if (givenFolder.FullName == solutionFolder.FullName)
             {

--- a/src/EditorFeatures/Core/EditorConfigSettings/Extensions/SolutionExtensions.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Extensions/SolutionExtensions.cs
@@ -13,9 +13,14 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Extensions
     {
         public static ImmutableArray<Project> GetProjectsForPath(this Solution solution, string givenPath)
         {
-            var givenFolder = new DirectoryInfo(Path.GetDirectoryName(givenPath));
-            var solutionFolder = new DirectoryInfo(solution.FilePath).Parent;
-            if (givenFolder.FullName == solutionFolder.FullName)
+            if (Path.GetDirectoryName(givenPath) is not string givenFolderPath ||
+                solution.FilePath is null)
+            {
+                return solution.Projects.ToImmutableArray();
+            }
+
+            var givenFolder = new DirectoryInfo(givenFolderPath);
+            if (givenFolder.FullName == (new DirectoryInfo(solution.FilePath).Parent).FullName)
             {
                 return solution.Projects.ToImmutableArray();
             }

--- a/src/EditorFeatures/Core/EditorConfigSettings/ISettingsEditorViewModel.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/ISettingsEditorViewModel.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal interface ISettingsEditorViewModel
     {
-        Task NotifyOfUpdateAsync();
+        void NotifyOfUpdate();
         Task<IReadOnlyList<TextChange>?> GetChangesAsync();
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/ISettingsEditorViewModel.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/ISettingsEditorViewModel.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    internal interface ISettingsEditorViewModel
+    {
+        Task NotifyOfUpdateAsync();
+        Task<IReadOnlyList<TextChange>?> GetChangesAsync();
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/ISettingsEditorViewModel.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/ISettingsEditorViewModel.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.Editor
     internal interface ISettingsEditorViewModel
     {
         void NotifyOfUpdate();
-        Task<IReadOnlyList<TextChange>?> GetChangesAsync();
+        Task<SourceText> UpdateEditorConfigAsync(SourceText sourceText);
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Language.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Language.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings
+{
+    [Flags]
+    internal enum Language
+    {
+        CSharp = 1,
+        VisualBasic = 2,
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/AnalyzerSettingsUpdater.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/AnalyzerSettingsUpdater.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
+{
+    internal class AnalyzerSettingsUpdater : SettingsUpdaterBase<AnalyzerSetting, DiagnosticSeverity>
+    {
+        public AnalyzerSettingsUpdater(Workspace workspace, string editorconfigPath) : base(workspace, editorconfigPath)
+        {
+        }
+
+        protected override Task<SourceText?> GetNewTextAsync(AnalyzerConfigDocument analyzerConfigDocument,
+                                                             IReadOnlyList<(AnalyzerSetting option, DiagnosticSeverity value)> settingsToUpdate,
+                                                             CancellationToken token)
+            => SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, settingsToUpdate, token);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/AnalyzerSettingsUpdater.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/AnalyzerSettingsUpdater.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
         {
         }
 
-        protected override Task<SourceText?> GetNewTextAsync(AnalyzerConfigDocument analyzerConfigDocument,
-                                                             IReadOnlyList<(AnalyzerSetting option, DiagnosticSeverity value)> settingsToUpdate,
-                                                             CancellationToken token)
-            => SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, settingsToUpdate, token);
+        protected override SourceText? GetNewText(SourceText sourceText,
+                                                  IReadOnlyList<(AnalyzerSetting option, DiagnosticSeverity value)> settingsToUpdate,
+                                                  CancellationToken token)
+            => SettingsUpdateHelper.TryUpdateAnalyzerConfigDocument(sourceText, EditorconfigPath, settingsToUpdate);
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/ISettingUpdater.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/ISettingUpdater.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
     internal interface ISettingUpdater<TSetting, TValue>
     {
         Task<bool> QueueUpdateAsync(TSetting setting, TValue value);
-        Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync(CancellationToken token);
+        Task<SourceText?> GetChangedEditorConfigAsync(SourceText sourceText, CancellationToken token);
+        Task<bool> HasAnyChangesAsync();
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/ISettingUpdater.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/ISettingUpdater.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
+{
+    internal interface ISettingUpdater<TSetting, TValue>
+    {
+        Task<bool> QueueUpdateAsync(TSetting setting, TValue value);
+        Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync(CancellationToken token);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/OptionUpdater.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/OptionUpdater.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
+{
+
+    internal class OptionUpdater : SettingsUpdaterBase<IOption2, object>
+    {
+        public OptionUpdater(Workspace workspace, string editorconfigPath)
+            : base(workspace, editorconfigPath)
+        {
+        }
+
+        protected override Task<SourceText?> GetNewTextAsync(AnalyzerConfigDocument analyzerConfigDocument,
+                                                             IReadOnlyList<(IOption2 option, object value)> settingsToUpdate,
+                                                             CancellationToken token)
+            => SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, settingsToUpdate, token);
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/OptionUpdater.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/OptionUpdater.cs
@@ -18,9 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
         {
         }
 
-        protected override Task<SourceText?> GetNewTextAsync(AnalyzerConfigDocument analyzerConfigDocument,
-                                                             IReadOnlyList<(IOption2 option, object value)> settingsToUpdate,
-                                                             CancellationToken token)
-            => SettingsUpdateHelper.TryUpdateAnalyzerConfigDocumentAsync(analyzerConfigDocument, settingsToUpdate, token);
+        protected override SourceText? GetNewText(SourceText SourceText,
+                                                  IReadOnlyList<(IOption2 option, object value)> settingsToUpdate,
+                                                  CancellationToken token)
+            => SettingsUpdateHelper.TryUpdateAnalyzerConfigDocument(SourceText, EditorconfigPath, Workspace.Options, settingsToUpdate);
     }
 }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdateHelper.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdateHelper.cs
@@ -1,0 +1,374 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
+{
+    internal static partial class SettingsUpdateHelper
+    {
+        private const string DiagnosticOptionPrefix = "dotnet_diagnostic.";
+        private const string SeveritySuffix = ".severity";
+
+        public static async Task<SourceText?> TryUpdateAnalyzerConfigDocumentAsync(AnalyzerConfigDocument analyzerConfigDocument,
+                                                                                   IReadOnlyList<(AnalyzerSetting option, DiagnosticSeverity value)> settingsToUpdate,
+                                                                                   CancellationToken token)
+        {
+            if (analyzerConfigDocument is null)
+                throw new ArgumentNullException(nameof(analyzerConfigDocument));
+            if (settingsToUpdate is null)
+                throw new ArgumentNullException(nameof(settingsToUpdate));
+
+            var originalText = await analyzerConfigDocument.GetTextAsync(token).ConfigureAwait(false);
+            var filePath = analyzerConfigDocument.FilePath;
+            if (filePath is null)
+                return null;
+
+            var settings = settingsToUpdate.Select(x => TryGetOptionValueAndLanguage(x.option, x.value)).ToList();
+
+            return TryUpdateAnalyzerConfigDocument(originalText, filePath, settings);
+
+            static (string option, string value, Language language) TryGetOptionValueAndLanguage(AnalyzerSetting diagnostic, DiagnosticSeverity severity)
+            {
+                var optionName = $"{DiagnosticOptionPrefix}{diagnostic.Id}{SeveritySuffix}";
+                var optionValue = severity.ToEditorConfigString();
+                var language = diagnostic.Language;
+                return (optionName, optionValue, language);
+            }
+        }
+
+        public static async Task<SourceText?> TryUpdateAnalyzerConfigDocumentAsync(AnalyzerConfigDocument analyzerConfigDocument,
+                                                                                   IReadOnlyList<(IOption2 option, object value)> settingsToUpdate,
+                                                                                   CancellationToken token)
+        {
+            if (analyzerConfigDocument is null)
+                throw new ArgumentNullException(nameof(analyzerConfigDocument));
+            if (settingsToUpdate is null)
+                throw new ArgumentNullException(nameof(settingsToUpdate));
+
+            var originalText = await analyzerConfigDocument.GetTextAsync(token).ConfigureAwait(false);
+            var filePath = analyzerConfigDocument.FilePath;
+            if (filePath is null)
+                return null;
+
+            var optionSet = analyzerConfigDocument.Project.Solution.Workspace.Options;
+            var updatedText = originalText;
+            var settings = settingsToUpdate.Select(x => TryGetOptionValueAndLanguage(x.option, x.value, analyzerConfigDocument))
+                                           .Where(x => x.success)
+                                           .Select(x => (x.option, x.value, x.language))
+                                           .ToList();
+
+            return TryUpdateAnalyzerConfigDocument(originalText, filePath, settings);
+
+            static (bool success, string option, string value, Language language) TryGetOptionValueAndLanguage(IOption2 option, object value, AnalyzerConfigDocument document)
+            {
+                var optionSet = document.Project.Solution.Workspace.Options;
+                if (option.StorageLocations.FirstOrDefault(x => x is IEditorConfigStorageLocation2) is not IEditorConfigStorageLocation2 storageLocation)
+                {
+                    return (false, null!, null!, default);
+                }
+
+                var optionName = storageLocation.KeyName;
+                var optionValue = storageLocation.GetEditorConfigStringValue(value, optionSet);
+                if (value is ICodeStyleOption codeStyleOption)
+                {
+                    var severity = codeStyleOption.Notification switch
+                    {
+                        { Severity: ReportDiagnostic.Hidden } => "refactoring",
+                        { Severity: ReportDiagnostic.Info } => "suggestion",
+                        { Severity: ReportDiagnostic.Warn } => "warning",
+                        { Severity: ReportDiagnostic.Error } => "error",
+                        _ => string.Empty
+                    };
+                    optionValue = $"{optionValue}:{severity}";
+                }
+
+                Language language = default;
+                if (option.IsPerLanguage)
+                {
+                    language = Language.CSharp | Language.VisualBasic;
+                }
+                else if (document.Project.Language.Equals(LanguageNames.CSharp, StringComparison.Ordinal))
+                {
+                    language = Language.CSharp;
+                }
+                else if (document.Project.Language.Equals(LanguageNames.VisualBasic, StringComparison.Ordinal))
+                {
+                    language = Language.VisualBasic;
+                }
+
+                return (true, optionName, optionValue, language);
+            }
+        }
+
+        public static SourceText? TryUpdateAnalyzerConfigDocument(SourceText originalText,
+                                                                  string filePath,
+                                                                  IReadOnlyList<(string option, string value, Language language)> settingsToUpdate)
+        {
+            if (originalText is null)
+                throw new ArgumentNullException(nameof(originalText));
+            if (filePath is null)
+                throw new ArgumentNullException(nameof(filePath));
+            if (settingsToUpdate is null)
+                throw new ArgumentNullException(nameof(settingsToUpdate));
+
+            var updatedText = originalText;
+            TextLine? lastValidHeaderSpanEnd;
+            TextLine? lastValidSpecificHeaderSpanEnd;
+            foreach (var (option, value, language) in settingsToUpdate)
+            {
+                SourceText? newText;
+                (newText, lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd) = UpdateIfExistsInFile(updatedText, filePath, option, value, language);
+                if (newText != null)
+                {
+                    updatedText = newText;
+                    continue;
+                }
+
+                (newText, lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd) = AddMissingRule(updatedText, lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd, option, value, language);
+                if (newText != null)
+                {
+                    updatedText = newText;
+                }
+            }
+
+            return updatedText.Equals(originalText) ? null : updatedText;
+        }
+
+        /// <summary>
+        /// <para>Regular expression for .editorconfig header.</para>
+        /// <para>For example: "[*.cs]    # Optional comment"</para>
+        /// <para>             "[*.{vb,cs}]"</para>
+        /// <para>             "[*]    ; Optional comment"</para>
+        /// <para>             "[ConsoleApp/Program.cs]"</para>
+        /// </summary>
+        private static readonly Regex s_headerPattern = new(@"\[(\*|[^ #;\[\]]+\.({[^ #;{}\.\[\]]+}|[^ #;{}\.\[\]]+))\]\s*([#;].*)?");
+
+        /// <summary>
+        /// <para>Regular expression for .editorconfig code style option entry.</para>
+        /// <para>For example:</para>
+        /// <para> 1. "dotnet_style_object_initializer = true   # Optional comment"</para>
+        /// <para> 2. "dotnet_style_object_initializer = true:suggestion   ; Optional comment"</para>
+        /// <para> 3. "dotnet_diagnostic.CA2000.severity = suggestion   # Optional comment"</para>
+        /// <para> 4. "dotnet_analyzer_diagnostic.category-Security.severity = suggestion   # Optional comment"</para>
+        /// <para> 5. "dotnet_analyzer_diagnostic.severity = suggestion   # Optional comment"</para>
+        /// <para>Regex groups:</para>
+        /// <para> 1. Option key</para>
+        /// <para> 2. Option value</para>
+        /// <para> 3. Optional severity suffix in option value, i.e. ':severity' suffix</para>
+        /// <para>4. Optional comment suffix</para>
+        /// </summary>
+        private static readonly Regex s_optionEntryPattern = new($@"(.*)=([\w, ]*)(:[\w]+)?([ ]*[;#].*)?");
+
+        private static (SourceText? newText, TextLine? lastValidHeaderSpanEnd, TextLine? lastValidSpecificHeaderSpanEnd) UpdateIfExistsInFile(SourceText editorConfigText,
+                                                                                                                                              string filePath,
+                                                                                                                                              string optionName,
+                                                                                                                                              string optionValue,
+                                                                                                                                              Language language)
+        {
+            var editorConfigDirectory = PathUtilities.GetDirectoryName(filePath);
+            Assumes.NotNull(editorConfigDirectory);
+            var relativePath = PathUtilities.GetRelativePath(editorConfigDirectory.ToLowerInvariant(), filePath);
+
+            TextLine? mostRecentHeader = null;
+            TextLine? lastValidHeader = null;
+            TextLine? lastValidHeaderSpanEnd = null;
+
+            TextLine? lastValidSpecificHeader = null;
+            TextLine? lastValidSpecificHeaderSpanEnd = null;
+
+            var textChange = new TextChange();
+            foreach (var curLine in editorConfigText.Lines)
+            {
+                var curLineText = curLine.ToString();
+                if (s_optionEntryPattern.IsMatch(curLineText))
+                {
+                    var groups = s_optionEntryPattern.Match(curLineText).Groups;
+                    var (untrimmedKey, key, value, severity, comment) = GetGroups(groups);
+
+                    // Verify the most recent header is a valid header
+                    if (IsValidHeader(mostRecentHeader, lastValidHeader) &&
+                        string.Equals(key, optionName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // We found the rule in the file -- replace it with updated option value.
+                        textChange = new TextChange(curLine.Span, $"{untrimmedKey}={optionValue}{comment}");
+                    }
+                }
+                else if (s_headerPattern.IsMatch(curLineText.Trim()))
+                {
+                    mostRecentHeader = curLine;
+                    if (ShouldSetAsLastValidHeader(curLineText, out var mostRecentHeaderText))
+                    {
+                        lastValidHeader = mostRecentHeader;
+                    }
+                    else
+                    {
+                        var (fileName, splicedFileExtensions) = ParseHeaderParts(mostRecentHeaderText);
+                        if ((relativePath.IsEmpty() || new Regex(fileName).IsMatch(relativePath)) &&
+                            HeaderMatchesLanguageRequirements(language, splicedFileExtensions))
+                        {
+                            lastValidHeader = mostRecentHeader;
+                        }
+                    }
+                }
+
+                // We want to keep track of how far this (valid) section spans.
+                if (IsValidHeader(mostRecentHeader, lastValidHeader) && IsNotEmptyOrComment(curLineText))
+                {
+                    lastValidHeaderSpanEnd = curLine;
+                    if (lastValidSpecificHeader != null && mostRecentHeader.Equals(lastValidSpecificHeader))
+                    {
+                        lastValidSpecificHeaderSpanEnd = curLine;
+                    }
+                }
+            }
+
+            // We return only the last text change in case of duplicate entries for the same rule.
+            if (textChange != default)
+            {
+                return (editorConfigText.WithChanges(textChange), lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd);
+            }
+
+            // Rule not found.
+            return (null, lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd);
+
+            static (string untrimmedKey, string key, string value, string severitySuffixInValue, string commentValue) GetGroups(GroupCollection groups)
+            {
+                var untrimmedKey = groups[1].Value.ToString();
+                var key = untrimmedKey.Trim();
+                var value = groups[2].Value.ToString();
+                var severitySuffixInValue = groups[3].Value.ToString();
+                var commentValue = groups[4].Value.ToString();
+                return (untrimmedKey, key, value, severitySuffixInValue, commentValue);
+            }
+
+            static bool IsValidHeader(TextLine? mostRecentHeader, TextLine? lastValidHeader)
+            {
+                return mostRecentHeader is not null &&
+                       lastValidHeader is not null &&
+                       mostRecentHeader.Equals(lastValidHeader);
+            }
+
+            static bool ShouldSetAsLastValidHeader(string curLineText, out string mostRecentHeaderText)
+            {
+                var groups = s_headerPattern.Match(curLineText.Trim()).Groups;
+                mostRecentHeaderText = groups[1].Value.ToString().ToLowerInvariant();
+                return mostRecentHeaderText.Equals("*", StringComparison.Ordinal);
+            }
+
+            static (string fileName, string[] splicedFileExtensions) ParseHeaderParts(string mostRecentHeaderText)
+            {
+                // We splice on the last occurrence of '.' to account for filenames containing periods.
+                var nameExtensionSplitIndex = mostRecentHeaderText.LastIndexOf('.');
+                var fileName = mostRecentHeaderText.Substring(0, nameExtensionSplitIndex);
+                var splicedFileExtensions = mostRecentHeaderText[(nameExtensionSplitIndex + 1)..].Split(',', ' ', '{', '}');
+
+                // Replacing characters in the header with the regex equivalent.
+                fileName = fileName.Replace(".", @"\.");
+                fileName = fileName.Replace("*", ".*");
+                fileName = fileName.Replace("/", @"\/");
+
+                return (fileName, splicedFileExtensions);
+            }
+
+            static bool IsNotEmptyOrComment(string currentLineText)
+            {
+                return !string.IsNullOrWhiteSpace(currentLineText) && !currentLineText.Trim().StartsWith("#", StringComparison.OrdinalIgnoreCase);
+            }
+
+            static bool HeaderMatchesLanguageRequirements(Language language, string[] splicedFileExtensions)
+            {
+                return IsCSharpOnly(language, splicedFileExtensions) || IsVisualBasicOnly(language, splicedFileExtensions) || IsBothVisualBasicAndCSharp(language, splicedFileExtensions);
+            }
+
+            static bool IsCSharpOnly(Language language, string[] splicedFileExtensions)
+            {
+                return language.HasFlag(Language.CSharp) && !language.HasFlag(Language.VisualBasic) && splicedFileExtensions.Contains("cs") && splicedFileExtensions.Length == 1;
+            }
+
+            static bool IsVisualBasicOnly(Language language, string[] splicedFileExtensions)
+            {
+                return language.HasFlag(Language.VisualBasic) && !language.HasFlag(Language.CSharp) && splicedFileExtensions.Contains("vb") && splicedFileExtensions.Length == 1;
+            }
+
+            static bool IsBothVisualBasicAndCSharp(Language language, string[] splicedFileExtensions)
+            {
+                return language.HasFlag(Language.VisualBasic) && language.HasFlag(Language.CSharp) && splicedFileExtensions.Contains("vb") && splicedFileExtensions.Contains("cs");
+            }
+        }
+
+        private static (SourceText? newText, TextLine? lastValidHeaderSpanEnd, TextLine? lastValidSpecificHeaderSpanEnd) AddMissingRule(SourceText editorConfigText,
+                                                                                                                                        TextLine? lastValidHeaderSpanEnd,
+                                                                                                                                        TextLine? lastValidSpecificHeaderSpanEnd,
+                                                                                                                                        string optionName,
+                                                                                                                                        string optionValue,
+                                                                                                                                        Language language)
+        {
+            var newEntry = $"{optionName}={optionValue}";
+            if (lastValidSpecificHeaderSpanEnd.HasValue)
+            {
+                if (lastValidSpecificHeaderSpanEnd.Value.ToString().Trim().Length != 0)
+                {
+                    newEntry = "\r\n" + newEntry; // TODO(jmarolf): do we need to read in the users newline settings?
+                }
+
+                return (editorConfigText.WithChanges((TextChange)new TextChange(new TextSpan(lastValidSpecificHeaderSpanEnd.Value.Span.End, 0), newEntry)), lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd);
+            }
+            else if (lastValidHeaderSpanEnd.HasValue)
+            {
+                if (lastValidHeaderSpanEnd.Value.ToString().Trim().Length != 0)
+                {
+                    newEntry = "\r\n" + newEntry; // TODO(jmarolf): do we need to read in the users newline settings?
+                }
+
+                return (editorConfigText.WithChanges((TextChange)new TextChange(new TextSpan(lastValidHeaderSpanEnd.Value.Span.End, 0), newEntry)), lastValidHeaderSpanEnd, lastValidSpecificHeaderSpanEnd);
+            }
+
+            // We need to generate a new header such as '[*.cs]' or '[*.vb]':
+            //      - For compiler diagnostic entries and code style entries which have per-language option = false, generate only [*.cs] or [*.vb].
+            //      - For the remainder, generate [*.{cs,vb}]
+            // Insert a newline if not already present
+            var lines = editorConfigText.Lines;
+            var lastLine = lines.Count > 0 ? lines[^1] : default;
+            var prefix = string.Empty;
+            if (lastLine.ToString().Trim().Length != 0)
+            {
+                prefix = "\r\n";
+            }
+
+            // Insert newline if file is not empty
+            if (lines.Count > 1 && lastLine.ToString().Trim().Length == 0)
+            {
+                prefix += "\r\n";
+            }
+
+            if (language.HasFlag(Language.CSharp) && language.HasFlag(Language.VisualBasic))
+            {
+                prefix += "[*.{cs,vb}]\r\n";
+            }
+            else if (language.HasFlag(Language.CSharp))
+            {
+                prefix += "[*.cs]\r\n";
+            }
+            else if (language.HasFlag(Language.VisualBasic))
+            {
+                prefix += "[*.vb]\r\n";
+            }
+
+            var result = editorConfigText.WithChanges((TextChange)new TextChange(new TextSpan(editorConfigText.Length, 0), prefix + newEntry));
+            return (result, lastValidHeaderSpanEnd, result.Lines[^2]);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdateHelper.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdateHelper.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
                 {
                     var severity = codeStyleOption.Notification switch
                     {
-                        { Severity: ReportDiagnostic.Hidden } => "refactoring",
+                        { Severity: ReportDiagnostic.Hidden } => "silent",
                         { Severity: ReportDiagnostic.Info } => "suggestion",
                         { Severity: ReportDiagnostic.Warn } => "warning",
                         { Severity: ReportDiagnostic.Error } => "error",

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdaterBase.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdaterBase.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
+{
+    internal abstract class SettingsUpdaterBase<TOption, TValue> : ISettingUpdater<TOption, TValue>
+    {
+        private readonly List<(TOption option, TValue value)> _queue = new();
+        private readonly SemaphoreSlim _guard = new(1);
+        private readonly Workspace _workspace;
+        private readonly string _editorconfigPath;
+
+        protected abstract Task<SourceText?> GetNewTextAsync(AnalyzerConfigDocument analyzerConfigDocument, IReadOnlyList<(TOption option, TValue value)> settingsToUpdate, CancellationToken token);
+
+        protected SettingsUpdaterBase(Workspace workspace, string editorconfigPath)
+        {
+            _workspace = workspace;
+            _editorconfigPath = editorconfigPath;
+        }
+
+        public async Task<bool> QueueUpdateAsync(TOption setting, TValue value)
+        {
+            using (await _guard.DisposableWaitAsync().ConfigureAwait(false))
+            {
+                _queue.Add((setting, value));
+            }
+
+            return true;
+        }
+
+        public async Task<IReadOnlyList<TextChange>?> GetChangedEditorConfigAsync(CancellationToken token)
+        {
+            var solution = _workspace.CurrentSolution;
+            var analyzerConfigDocument = solution.Projects
+                .SelectMany(p => p.AnalyzerConfigDocuments)
+                .FirstOrDefault(d => d.FilePath == _editorconfigPath);
+
+            if (analyzerConfigDocument is null)
+                return null;
+
+            var originalText = await analyzerConfigDocument.GetTextAsync(token).ConfigureAwait(false);
+            using (await _guard.DisposableWaitAsync(token).ConfigureAwait(false))
+            {
+                var newText = await GetNewTextAsync(analyzerConfigDocument, _queue, token).ConfigureAwait(false);
+                if (newText is null || newText.Equals(originalText))
+                {
+                    _queue.Clear();
+                    return null;
+                }
+                else
+                {
+                    _queue.Clear();
+                    return newText.GetTextChanges(originalText);
+                }
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -1071,4 +1071,7 @@ Do you want to proceed?</value>
   <data name="Use_Tabs" xml:space="preserve">
     <value>Use Tabs</value>
   </data>
+  <data name="All_methods" xml:space="preserve">
+    <value>All methods</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -951,4 +951,124 @@ Do you want to proceed?</value>
   <data name="Gathering_Suggestions_Waiting_for_the_solution_to_fully_load" xml:space="preserve">
     <value>Gathering Suggestions - Waiting for the solution to fully load</value>
   </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="Always_for_clarity" xml:space="preserve">
+    <value>Always for clarity</value>
+  </data>
+  <data name="analyzer_Prefer_auto_properties" xml:space="preserve">
+    <value>Prefer auto properties</value>
+  </data>
+  <data name="Avoid_unused_parameters" xml:space="preserve">
+    <value>Avoid unused parameters</value>
+  </data>
+  <data name="Do_not_prefer_this_or_Me" xml:space="preserve">
+    <value>Do not prefer 'this.' or 'Me.'</value>
+  </data>
+  <data name="For_locals_parameters_and_members" xml:space="preserve">
+    <value>For locals, parameters and members</value>
+  </data>
+  <data name="For_member_access_expressions" xml:space="preserve">
+    <value>For member access expressions</value>
+  </data>
+  <data name="In_arithmetic_binary_operators" xml:space="preserve">
+    <value>In arithmetic operators</value>
+  </data>
+  <data name="In_other_binary_operators" xml:space="preserve">
+    <value>In other binary operators</value>
+  </data>
+  <data name="In_other_operators" xml:space="preserve">
+    <value>In other operators</value>
+  </data>
+  <data name="In_relational_binary_operators" xml:space="preserve">
+    <value>In relational operators</value>
+  </data>
+  <data name="Never_if_unnecessary" xml:space="preserve">
+    <value>Never if unnecessary</value>
+  </data>
+  <data name="Non_public_methods" xml:space="preserve">
+    <value>Non-public methods</value>
+  </data>
+  <data name="Prefer_coalesce_expression" xml:space="preserve">
+    <value>Prefer coalesce expression</value>
+  </data>
+  <data name="Prefer_collection_initializer" xml:space="preserve">
+    <value>Prefer collection initializer</value>
+  </data>
+  <data name="Prefer_compound_assignments" xml:space="preserve">
+    <value>Prefer compound assignments</value>
+  </data>
+  <data name="Prefer_conditional_expression_over_if_with_assignments" xml:space="preserve">
+    <value>Prefer conditional expression over 'if' with assignments</value>
+  </data>
+  <data name="Prefer_conditional_expression_over_if_with_returns" xml:space="preserve">
+    <value>Prefer conditional expression over 'if' with returns</value>
+  </data>
+  <data name="Prefer_explicit_tuple_name" xml:space="preserve">
+    <value>Prefer explicit tuple name</value>
+  </data>
+  <data name="Prefer_framework_type" xml:space="preserve">
+    <value>Prefer framework type</value>
+  </data>
+  <data name="Prefer_inferred_anonymous_type_member_names" xml:space="preserve">
+    <value>Prefer inferred anonymous type member names</value>
+  </data>
+  <data name="Prefer_inferred_tuple_names" xml:space="preserve">
+    <value>Prefer inferred tuple element names</value>
+  </data>
+  <data name="Prefer_is_null_for_reference_equality_checks" xml:space="preserve">
+    <value>Prefer 'is null' for reference equality checks</value>
+  </data>
+  <data name="Prefer_null_propagation" xml:space="preserve">
+    <value>Prefer null propagation</value>
+  </data>
+  <data name="Prefer_object_initializer" xml:space="preserve">
+    <value>Prefer object initializer</value>
+  </data>
+  <data name="Prefer_predefined_type" xml:space="preserve">
+    <value>Prefer predefined type</value>
+  </data>
+  <data name="Prefer_readonly_fields" xml:space="preserve">
+    <value>Prefer readonly fields</value>
+  </data>
+  <data name="Prefer_simplified_boolean_expressions" xml:space="preserve">
+    <value>Prefer simplified boolean expressions</value>
+  </data>
+  <data name="Prefer_System_HashCode_in_GetHashCode" xml:space="preserve">
+    <value>Prefer 'System.HashCode' in 'GetHashCode'</value>
+  </data>
+  <data name="Prefer_this_or_Me" xml:space="preserve">
+    <value>Prefer 'this.' or 'Me.'</value>
+  </data>
+  <data name="Qualify_event_access_with_this_or_Me" xml:space="preserve">
+    <value>Qualify event access with 'this' or 'Me'</value>
+  </data>
+  <data name="Qualify_field_access_with_this_or_Me" xml:space="preserve">
+    <value>Qualify field access with 'this' or 'Me'</value>
+  </data>
+  <data name="Qualify_method_access_with_this_or_Me" xml:space="preserve">
+    <value>Qualify method access with 'this' or 'Me'</value>
+  </data>
+  <data name="Qualify_property_access_with_this_or_Me" xml:space="preserve">
+    <value>Qualify property access with 'this' or 'Me'</value>
+  </data>
+  <data name="Indentation_Size" xml:space="preserve">
+    <value>Indentation Size</value>
+  </data>
+  <data name="Insert_Final_Newline" xml:space="preserve">
+    <value>Insert Final Newline</value>
+  </data>
+  <data name="New_Line" xml:space="preserve">
+    <value>New Line</value>
+  </data>
+  <data name="Tab_Size" xml:space="preserve">
+    <value>Tab Size</value>
+  </data>
+  <data name="Use_Tabs" xml:space="preserve">
+    <value>Use Tabs</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Relace přejmenování na řádku je pro identifikátor {0} aktivní. Pokud chcete získat přístup k dalším možnostem, znovu volejte přejmenování na řádku. Můžete kdykoli pokračovat v úpravách identifikátoru, který se přejmenovává.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Aplikují se změny.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Nakonfigurovat teď</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filtr</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">Příkaz Formátovat dokument provedl další čištění.</target>
@@ -87,9 +112,39 @@
         <target state="translated">Přejít na základní typ</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Vložené nápovědy</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Hledají se báze...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Operátor – přetížení</target>
@@ -122,6 +197,91 @@
         <target state="translated">Sledování vkládání</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Text preprocesoru</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Interpunkce</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Symbol – statický</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">Tento symbol nemá žádný základ.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Přepíná se komentář k řádku...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Při přejmenování dojde k aktualizaci {0} odkazů v {1} souborech.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Tento element nejde přejmenovat, protože je obsažen v souboru jen pro čtení.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Už se sleduje dokument se shodným klíčem.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Für den Bezeichner "{0}" ist eine Inline-Umbenennungssitzung aktiv. Rufen Sie die Inline-Umbenennung erneut auf, um auf zusätzliche Optionen zuzugreifen. Sie können den Bezeichner, der gerade umbenannt wird, jederzeit weiterbearbeiten.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Änderungen werden übernommen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Jetzt konfigurieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filter</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">Bei der Dokumentformatierung wurde eine zusätzliche Bereinigung durchgeführt.</target>
@@ -87,9 +112,39 @@
         <target state="translated">Zu Basis wechseln</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Inlinehinweise</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Basen werden gesucht...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Operator - überladen</target>
@@ -122,6 +197,91 @@
         <target state="translated">Nachverfolgung von Einfügevorgängen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Präprozessortext</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Interpunktion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Symbol – statisch</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">Das Symbol verfügt über keine Basis.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Kommentarzeile wird ein-/ausgeschaltet...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Durch das Umbenennen werden {0} Verweise in {1} Dateien aktualisiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Dieses Element kann nicht umbenannt werden, weil es in einer schreibgeschützten Datei enthalten ist.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Dokument mit identischem Schlüssel wird bereits verfolgt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Hay una sesión de cambio de nombre insertado que está activa para el identificador "{0}". Vuelva a invocar el cambio de nombre insertado para acceder a más opciones. Puede continuar editando el identificador cuyo nombre se va a cambiar en cualquier momento.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Aplicando cambios</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Configúrela ahora</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filtrar</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">El formateo del documento realizó una limpieza adicional</target>
@@ -87,9 +112,39 @@
         <target state="translated">Ir a base</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Sugerencias insertadas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Buscando las bases...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Operador: sobrecargado</target>
@@ -122,6 +197,91 @@
         <target state="translated">Seguimiento de pegado</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Texto del preprocesador</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Puntuación</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Símbolo: estático</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">El símbolo no tiene base.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Alternando comentario de línea...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Al cambiar el nombre se actualizarán {0} referencias en {1} archivos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">No se puede cambiar el nombre de este elemento porque está incluido en un archivo de solo lectura.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Ya se está siguiendo un documento con una clave idéntica</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Une session de renommage inline est active pour l'identificateur '{0}'. Appelez à nouveau le renommage inline pour accéder à des options supplémentaires. Vous pouvez continuer à modifier l'identificateur renommé à tout moment.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Application des changements</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Configurer maintenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filtrer</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">L'opération Mettre en forme le document a effectué un nettoyage supplémentaire</target>
@@ -87,9 +112,39 @@
         <target state="translated">Accéder à la base</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Indicateurs inline</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Localisation des bases...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Opérateur - surchargé</target>
@@ -122,6 +197,91 @@
         <target state="translated">Suivi du collage</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Texte du préprocesseur</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Ponctuation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Symbole - statique</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">Le symbole n'a pas de base.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Activation/désactivation du commentaire de ligne...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Le renommage va entraîner la mise à jour de {0} références dans {1} fichiers.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Vous ne pouvez pas renommer cet élément, car il est contenu dans un fichier en lecture seule.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Suivi du document déjà initié avec une clé identique</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Per l'identificatore '{0}' è attiva una sessione di ridenominazione inline. Richiamare nuovamente la ridenominazione inline per accedere alle opzioni aggiuntive. È possibile continuare a modificare l'identificatore da rinominare in qualsiasi momento.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Applicazione delle modifiche in corso</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Configura ora</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filtro</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">Formatta documento ha eseguito una pulizia aggiuntiva</target>
@@ -87,9 +112,39 @@
         <target state="translated">Vai a base</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Suggerimenti inline</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Individuazione delle basi...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Operatore - Overload</target>
@@ -122,6 +197,91 @@
         <target state="translated">Verifica Incolla</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Testo preprocessore</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Punteggiatura</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Simbolo - Statico</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">Non è presente alcuna base per il simbolo.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Attivazione/disattivazione del commento per la riga...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Con la ridenominazione verranno aggiornati {0} riferimenti in {1} file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Non è possibile rinominare questo elemento perché è contenuto in un file di sola lettura.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">La verifica del documento con chiave identica è già in corso</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">識別子 '{0}' のインラインの名前変更セッションがアクティブです。追加オプションにアクセスするには、インラインの名前変更をもう一度呼び出します。名前を変更する識別子はいつでも引き続き編集できます。</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">変更の適用</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">今すぐ構成する</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">フィルター</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">ドキュメントのフォーマットで追加のクリーンアップが実行されました</target>
@@ -87,9 +112,39 @@
         <target state="translated">基本へ移動</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">インラインのヒント</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">ベースを検索しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">演算子 - オーバーロード</target>
@@ -122,6 +197,91 @@
         <target state="translated">追跡の貼り付け</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">プリプロセッサ テキスト</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">句読点</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">シンボル - 静的</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">シンボルにベースがありません。</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">行コメントを切り替えています...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">名前を変更すると、{1} 個のファイル内の {0} 個の参照が更新されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">この要素は、読み取り専用ファイルに含まれているため、名前を変更できません。</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">同じキーを持つドキュメントを既に追跡しています</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">식별자 '{0}'의 인라인 이름 바꾸기 세션이 활성 상태입니다. 추가 옵션에 액세스하려면 인라인 이름 바꾸기를 다시 호출하세요. 언제든지 이름을 바꾸려는 식별자를 계속 편집할 수 있습니다.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">변경 내용 적용</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">지금 구성</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">필터</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">추가 정리를 수행 하는 문서</target>
@@ -87,9 +112,39 @@
         <target state="translated">기본으로 이동</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">인라인 힌트</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">베이스를 찾는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">연산자 - 오버로드됨</target>
@@ -122,6 +197,91 @@
         <target state="translated">붙여넣기 추적</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">전처리기 텍스트</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">문장 부호</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">기호 - 정적</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">기호에 베이스가 없습니다.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">줄 주석을 토글하는 중...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">이름 바꾸기로 {1}개의 파일에서 {0}개의 참조가 업데이트됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">이 요소는 읽기 전용 파일에 포함되어 있으므로 이름을 바꿀 수 없습니다.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">동일한 키로 이미 문서를 추적하는 중</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Wbudowana sesja zmieniania nazwy jest aktywna dla identyfikatora „{0}”. Wywołaj ponownie wbudowane zmienianie nazwy, aby uzyskać dostęp do dodatkowych opcji. W dowolnym momencie możesz kontynuować edytowanie identyfikatora, którego nazwa jest zmieniana.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Stosowanie zmian</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Skonfiguruj je teraz</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filtr</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">Funkcja formatowania dokumentu wykonała dodatkowe czyszczenie</target>
@@ -87,9 +112,39 @@
         <target state="translated">Przejdź do podstawy</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Wskazówki w tekście</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Trwa lokalizowanie baz...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Operator — przeciążony</target>
@@ -122,6 +197,91 @@
         <target state="translated">Śledzenie wklejania</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Tekst preprocesora</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Interpunkcja</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Symbol — statyczny</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">Symbol nie ma wartości podstawowej.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Trwa przełączanie komentarza wiersza...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Zmiana nazwy spowoduje zaktualizowanie odwołań ({0}) w plikach ({1}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Nie możesz zmienić nazwy tego elementu, ponieważ jest on zawarty w pliku tylko do odczytu.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Dokument z identycznym kluczem jest już śledzony</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Uma sessão de renomeação embutida está ativa para o identificador '{0}'. Invoque a renomeação embutida novamente para acessar opções adicionais. Você pode continuar a editar o identificador que está sendo renomeado a qualquer momento.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Aplicando mudanças</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Configurar agora</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filtrar</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">A Formatação do Documento executou uma limpeza adicional</target>
@@ -87,9 +112,39 @@
         <target state="translated">Ir Para a Base</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Dicas Embutidas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Localizando as bases...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Operador – Sobrecarregado</target>
@@ -122,6 +197,91 @@
         <target state="translated">Colar Acompanhamento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Texto de Pré-Processador</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Pontuação</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Símbolo – Estático</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">O símbolo não tem nenhuma base.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Ativando/desativando o comentário de linha...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Renomear atualizará {0} referências em {1} arquivos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Você não pode renomear este elemento porque ele está contido em um arquivo somente leitura.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Já está a rastrear o documento com chave idêntica</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">Встроенный сеанс переименования активен для идентификатора "{0}". Снова вызовите встроенное переименование, чтобы получить доступ к дополнительным параметрам. Вы можете в любое время продолжить изменение переименованного идентификатора.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Применение изменений</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Настройте ее сейчас</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Фильтр</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">При форматировании документа была выполнена дополнительная очистка</target>
@@ -87,9 +112,39 @@
         <target state="translated">Перейти к базовому</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Встроенные подсказки</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Обнаружение баз…</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">Оператор — перегружен</target>
@@ -122,6 +197,91 @@
         <target state="translated">Вставить отслеживание</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Текст препроцессора</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Пунктуация</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Символ — статический</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">У этого символа нет основания.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Переключение комментария строки...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">При переименовании будут обновлены ссылки в количестве {0} шт. в следующем числе файлов: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Невозможно переименовать этот элемент, так как он содержится в файле, доступном только для чтения.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Документ с идентичным ключом уже отслеживается.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">'{0}' tanımlayıcısı için bir satır içi yeniden adlandırma oturumu etkin. Ek seçeneklere erişmek için satır içi yeniden adlandırmayı tekrar çağırın. İstediğiniz zaman yeniden adlandırılan tanımlayıcıyı düzenlemeye devam edebilirsiniz.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Değişiklikler uygulanıyor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">Hemen yapılandırın</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">Filtre</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">Biçimi belge ek temizleme işlemi</target>
@@ -87,9 +112,39 @@
         <target state="translated">Tabana Git</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">Satır İçi İpuçları</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">Tabanlar bulunuyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">İşleç - Aşırı Yüklenmiş</target>
@@ -122,6 +197,91 @@
         <target state="translated">İzleme Yapıştır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">Ön İşlemci Metni</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">Noktalama İşareti</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">Sembol - statik</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">Sembolde taban yok.</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">Satır açıklaması değiştiriliyor...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">Yeniden adlandırma işlemi {1} dosyadaki {0} başvuruyu güncelleştirecek.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">Salt okunur bir dosyada bulunduğundan bu öğeyi yeniden adlandıramazsınız.</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">Belge zaten özdeş anahtar ile izleniyor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">标识符“{0}”的内联重命名会话处于活动状态。再次调用内联重命名以访问其他选项。可随时继续编辑正在重命名的标识符。</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">应用更改</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">立即配置</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">筛选</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">格式文档执行了额外的清理</target>
@@ -87,9 +112,39 @@
         <target state="translated">转到基础映像</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">内联提示</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">正在查找基...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">运算符-重载</target>
@@ -122,6 +197,91 @@
         <target state="translated">粘贴跟踪信息</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">预处理器文本</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">标点</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">符号-静态</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">符号没有基数。</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">正在切换为行注释...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">重命名将更新 {1} 个文件中的 {0} 个引用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">无法重命名此元素，因为它包含在只读文件中。</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">已使用等价键跟踪文档</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="All_methods">
+        <source>All methods</source>
+        <target state="new">All methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Always_for_clarity">
         <source>Always for clarity</source>
         <target state="new">Always for clarity</target>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="Always_for_clarity">
+        <source>Always for clarity</source>
+        <target state="new">Always for clarity</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
         <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
         <target state="translated">識別碼 '{0}' 有正在使用的內嵌重新命名工作階段。再次叫用內嵌重新命名可存取其他選項。您隨時可以繼續編輯正在重新命名的識別碼。</target>
@@ -10,6 +15,11 @@
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">正在套用變更</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Avoid_unused_parameters">
+        <source>Avoid unused parameters</source>
+        <target state="new">Avoid unused parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="Change_configuration">
@@ -25,6 +35,11 @@
       <trans-unit id="Configure_it_now">
         <source>Configure it now</source>
         <target state="translated">立即設定</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_prefer_this_or_Me">
+        <source>Do not prefer 'this.' or 'Me.'</source>
+        <target state="new">Do not prefer 'this.' or 'Me.'</target>
         <note />
       </trans-unit>
       <trans-unit id="Do_not_show_this_message_again">
@@ -57,6 +72,16 @@
         <target state="translated">篩選</target>
         <note>Caption/tooltip for "Filter" image element displayed in completion popup.</note>
       </trans-unit>
+      <trans-unit id="For_locals_parameters_and_members">
+        <source>For locals, parameters and members</source>
+        <target state="new">For locals, parameters and members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="For_member_access_expressions">
+        <source>For member access expressions</source>
+        <target state="new">For member access expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Format_document_performed_additional_cleanup">
         <source>Format Document performed additional cleanup</source>
         <target state="translated">執行額外清除的格式化文件</target>
@@ -87,9 +112,39 @@
         <target state="translated">移至基底</target>
         <note />
       </trans-unit>
+      <trans-unit id="In_arithmetic_binary_operators">
+        <source>In arithmetic operators</source>
+        <target state="new">In arithmetic operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_binary_operators">
+        <source>In other binary operators</source>
+        <target state="new">In other binary operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_other_operators">
+        <source>In other operators</source>
+        <target state="new">In other operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="In_relational_binary_operators">
+        <source>In relational operators</source>
+        <target state="new">In relational operators</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indentation_Size">
+        <source>Indentation Size</source>
+        <target state="new">Indentation Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_Hints">
         <source>Inline Hints</source>
         <target state="translated">內嵌提示</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Insert_Final_Newline">
+        <source>Insert Final Newline</source>
+        <target state="new">Insert Final Newline</target>
         <note />
       </trans-unit>
       <trans-unit id="Invalid_assembly_name">
@@ -112,6 +167,26 @@
         <target state="translated">正在尋找基底...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Never_if_unnecessary">
+        <source>Never if unnecessary</source>
+        <target state="new">Never if unnecessary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_Line">
+        <source>New Line</source>
+        <target state="new">New Line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No">
+        <source>No</source>
+        <target state="new">No</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Non_public_methods">
+        <source>Non-public methods</source>
+        <target state="new">Non-public methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Operator_Overloaded">
         <source>Operator - Overloaded</source>
         <target state="translated">運算子 - 多載</target>
@@ -122,6 +197,91 @@
         <target state="translated">貼上追蹤</target>
         <note />
       </trans-unit>
+      <trans-unit id="Prefer_System_HashCode_in_GetHashCode">
+        <source>Prefer 'System.HashCode' in 'GetHashCode'</source>
+        <target state="new">Prefer 'System.HashCode' in 'GetHashCode'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_coalesce_expression">
+        <source>Prefer coalesce expression</source>
+        <target state="new">Prefer coalesce expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_collection_initializer">
+        <source>Prefer collection initializer</source>
+        <target state="new">Prefer collection initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_compound_assignments">
+        <source>Prefer compound assignments</source>
+        <target state="new">Prefer compound assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_assignments">
+        <source>Prefer conditional expression over 'if' with assignments</source>
+        <target state="new">Prefer conditional expression over 'if' with assignments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_conditional_expression_over_if_with_returns">
+        <source>Prefer conditional expression over 'if' with returns</source>
+        <target state="new">Prefer conditional expression over 'if' with returns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_explicit_tuple_name">
+        <source>Prefer explicit tuple name</source>
+        <target state="new">Prefer explicit tuple name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_framework_type">
+        <source>Prefer framework type</source>
+        <target state="new">Prefer framework type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_anonymous_type_member_names">
+        <source>Prefer inferred anonymous type member names</source>
+        <target state="new">Prefer inferred anonymous type member names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_inferred_tuple_names">
+        <source>Prefer inferred tuple element names</source>
+        <target state="new">Prefer inferred tuple element names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_is_null_for_reference_equality_checks">
+        <source>Prefer 'is null' for reference equality checks</source>
+        <target state="new">Prefer 'is null' for reference equality checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_null_propagation">
+        <source>Prefer null propagation</source>
+        <target state="new">Prefer null propagation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_object_initializer">
+        <source>Prefer object initializer</source>
+        <target state="new">Prefer object initializer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_predefined_type">
+        <source>Prefer predefined type</source>
+        <target state="new">Prefer predefined type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_readonly_fields">
+        <source>Prefer readonly fields</source>
+        <target state="new">Prefer readonly fields</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_simplified_boolean_expressions">
+        <source>Prefer simplified boolean expressions</source>
+        <target state="new">Prefer simplified boolean expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Prefer_this_or_Me">
+        <source>Prefer 'this.' or 'Me.'</source>
+        <target state="new">Prefer 'this.' or 'Me.'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Preprocessor_Text">
         <source>Preprocessor Text</source>
         <target state="translated">前置處理器文字</target>
@@ -130,6 +290,26 @@
       <trans-unit id="Punctuation">
         <source>Punctuation</source>
         <target state="translated">標點符號</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_event_access_with_this_or_Me">
+        <source>Qualify event access with 'this' or 'Me'</source>
+        <target state="new">Qualify event access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_field_access_with_this_or_Me">
+        <source>Qualify field access with 'this' or 'Me'</source>
+        <target state="new">Qualify field access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_method_access_with_this_or_Me">
+        <source>Qualify method access with 'this' or 'Me'</source>
+        <target state="new">Qualify method access with 'this' or 'Me'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Qualify_property_access_with_this_or_Me">
+        <source>Qualify property access with 'this' or 'Me'</source>
+        <target state="new">Qualify property access with 'this' or 'Me'</target>
         <note />
       </trans-unit>
       <trans-unit id="Rename_file_name_doesnt_match">
@@ -162,6 +342,11 @@
         <target state="translated">符號 - 靜態</target>
         <note />
       </trans-unit>
+      <trans-unit id="Tab_Size">
+        <source>Tab Size</source>
+        <target state="new">Tab Size</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_symbol_has_no_base">
         <source>The symbol has no base.</source>
         <target state="translated">該符號沒有任何基底。</target>
@@ -185,6 +370,11 @@
       <trans-unit id="Toggling_line_comment">
         <source>Toggling line comment...</source>
         <target state="translated">正在切換行註解...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_Tabs">
+        <source>Use Tabs</source>
+        <target state="new">Use Tabs</target>
         <note />
       </trans-unit>
       <trans-unit id="User_Members_Constants">
@@ -412,6 +602,11 @@
         <target state="translated">重新命名會更新 {1} 個檔案中的 {0} 個參考。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Yes">
+        <source>Yes</source>
+        <target state="new">Yes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file">
         <source>You cannot rename this element because it is contained in a read-only file.</source>
         <target state="translated">因為此項目包含在唯讀檔案中，所以無法重新命名。</target>
@@ -630,6 +825,11 @@
       <trans-unit id="Already_tracking_document_with_identical_key">
         <source>Already tracking document with identical key</source>
         <target state="translated">已追蹤具有相同索引鍵的文件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="analyzer_Prefer_auto_properties">
+        <source>Prefer auto properties</source>
+        <target state="new">Prefer auto properties</target>
         <note />
       </trans-unit>
       <trans-unit id="document_is_not_currently_being_tracked">

--- a/src/EditorFeatures/Test/EditorConfigSettings/Data/CodeStyleSettingsTest.cs
+++ b/src/EditorFeatures/Test/EditorConfigSettings/Data/CodeStyleSettingsTest.cs
@@ -1,13 +1,12 @@
-﻿extern alias WORKSPACES;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+extern alias WORKSPACES;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;

--- a/src/EditorFeatures/Test/EditorConfigSettings/Data/CodeStyleSettingsTest.cs
+++ b/src/EditorFeatures/Test/EditorConfigSettings/Data/CodeStyleSettingsTest.cs
@@ -1,0 +1,96 @@
+﻿extern alias WORKSPACES;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using WORKSPACES::Microsoft.CodeAnalysis.Options;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditorConfigSettings.Data
+{
+    public class CodeStyleSettingsTest
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void CodeStyleSettingBoolFactory(bool defaultValue)
+        {
+            var option = CreateBoolOption(defaultValue);
+            var editorConfigOptions = new TestAnalyzerConfigOptions();
+            var visualStudioOptions = new TestOptionSet<bool>(option.DefaultValue);
+            var setting = CodeStyleSetting.Create(option, description: "TestDesciption", editorConfigOptions, visualStudioOptions, updater: null!);
+            Assert.Equal(string.Empty, setting.Category);
+            Assert.Equal("TestDesciption", setting.Description);
+            Assert.False(setting.IsDefinedInEditorConfig);
+            Assert.Equal(typeof(bool), setting.Type);
+            Assert.Equal(defaultValue, setting.Value);
+        }
+
+        [Theory]
+        [InlineData(DayOfWeek.Monday)]
+        [InlineData(DayOfWeek.Friday)]
+        public static void CodeStyleSettingEnumFactory(DayOfWeek defaultValue)
+        {
+            var option = CreateEnumOption(defaultValue);
+            var editorConfigOptions = new TestAnalyzerConfigOptions();
+            var visualStudioOptions = new TestOptionSet<DayOfWeek>(option.DefaultValue);
+            var setting = CodeStyleSetting.Create(option,
+                                                  description: "TestDesciption",
+                                                  enumValues: (DayOfWeek[])Enum.GetValues(typeof(DayOfWeek)),
+                                                  valueDescriptions: Enum.GetNames(typeof(DayOfWeek)),
+                                                  editorConfigOptions,
+                                                  visualStudioOptions,
+                                                  updater: null!);
+            Assert.Equal(string.Empty, setting.Category);
+            Assert.Equal("TestDesciption", setting.Description);
+            Assert.False(setting.IsDefinedInEditorConfig);
+            Assert.Equal(typeof(DayOfWeek), setting.Type);
+            Assert.Equal(defaultValue, setting.Value);
+        }
+
+        private static Option2<CodeStyleOption2<bool>> CreateBoolOption(bool @default = false)
+        {
+            var option = CodeStyleOption2<bool>.Default;
+            option.Value = @default;
+            return new Option2<CodeStyleOption2<bool>>(feature: "TestFeature",
+                                                       name: "TestOption",
+                                                       defaultValue: option);
+        }
+
+        private static Option2<CodeStyleOption2<T>> CreateEnumOption<T>(T @default)
+            where T : notnull, Enum
+        {
+            var option = CodeStyleOption2<T>.Default;
+            option.Value = @default;
+            return new Option2<CodeStyleOption2<T>>(feature: "TestFeature",
+                                                    name: "TestOption",
+                                                    defaultValue: option);
+        }
+
+        private class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+        {
+            private readonly IDictionary<string, string> _dictionary;
+            public TestAnalyzerConfigOptions((string, string)[]? options = null)
+                => _dictionary = options?.ToDictionary(x => x.Item1, x => x.Item2) ?? new Dictionary<string, string>();
+            public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+                => _dictionary.TryGetValue(key, out value);
+        }
+
+        private class TestOptionSet<T> : OptionSet
+        {
+            private readonly object? _value;
+            public TestOptionSet(CodeStyleOption2<T> value) => _value = value;
+            public override OptionSet WithChangedOption(OptionKey optionAndLanguage, object? value) => this;
+            internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet) => Array.Empty<OptionKey>();
+            private protected override object? GetOptionCore(OptionKey optionKey) => _value;
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Impl/EditorConfigSettings/BinaryOperatorSpacingOptionsViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/EditorConfigSettings/BinaryOperatorSpacingOptionsViewModel.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings
+{
+    internal class BinaryOperatorSpacingOptionsViewModel : EnumSettingViewModel<BinaryOperatorSpacingOptions>
+    {
+        private readonly FormattingSetting _setting;
+
+        public BinaryOperatorSpacingOptionsViewModel(FormattingSetting setting)
+        {
+            _setting = setting;
+        }
+
+        protected override void ChangePropertyTo(BinaryOperatorSpacingOptions newValue)
+        {
+            _setting.SetValue(newValue);
+        }
+
+        protected override BinaryOperatorSpacingOptions GetCurrentValue()
+        {
+            return (BinaryOperatorSpacingOptions)_setting.GetValue()!;
+        }
+
+        protected override IReadOnlyDictionary<string, BinaryOperatorSpacingOptions> GetValuesAndDescriptions()
+        {
+            return EnumerateOptions().ToDictionary(x => x.description, x => x.value);
+
+            static IEnumerable<(string description, BinaryOperatorSpacingOptions value)> EnumerateOptions()
+            {
+                yield return (CSharpVSResources.Ignore_spaces_around_binary_operators, BinaryOperatorSpacingOptions.Ignore);
+                yield return (CSharpVSResources.Remove_spaces_before_and_after_binary_operators, BinaryOperatorSpacingOptions.Remove);
+                yield return (CSharpVSResources.Insert_space_before_and_after_binary_operators, BinaryOperatorSpacingOptions.Single);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Impl/EditorConfigSettings/BinaryOperatorSpacingOptionsViewModelFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/EditorConfigSettings/BinaryOperatorSpacingOptionsViewModelFactory.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings
+{
+    [Export(typeof(IEnumSettingViewModelFactory)), Shared]
+    internal class BinaryOperatorSpacingOptionsViewModelFactory : IEnumSettingViewModelFactory
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public BinaryOperatorSpacingOptionsViewModelFactory()
+        {
+        }
+
+        public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
+        {
+            return new BinaryOperatorSpacingOptionsViewModel(setting);
+        }
+
+        public bool IsSupported(OptionKey2 key)
+            => key.Option.Type == typeof(BinaryOperatorSpacingOptions);
+    }
+}

--- a/src/VisualStudio/CSharp/Impl/EditorConfigSettings/LabelPositionOptionsViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/EditorConfigSettings/LabelPositionOptionsViewModel.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.EditorConfigSettings
+{
+
+    [Export(typeof(IEnumSettingViewModelFactory)), Shared]
+    internal class LabelPositionOptionsViewModelFactory : IEnumSettingViewModelFactory
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public LabelPositionOptionsViewModelFactory()
+        {
+        }
+
+        public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
+        {
+            return new LabelPositionOptionsViewModel(setting);
+        }
+
+        public bool IsSupported(OptionKey2 key)
+            => key.Option.Type == typeof(LabelPositionOptions);
+    }
+
+    internal class LabelPositionOptionsViewModel : EnumSettingViewModel<LabelPositionOptions>
+    {
+        private readonly FormattingSetting _setting;
+
+        public LabelPositionOptionsViewModel(FormattingSetting setting)
+        {
+            _setting = setting;
+        }
+
+        protected override void ChangePropertyTo(LabelPositionOptions newValue)
+        {
+            _setting.SetValue(newValue);
+        }
+
+        protected override LabelPositionOptions GetCurrentValue()
+        {
+            return (LabelPositionOptions)_setting.GetValue()!;
+        }
+
+        protected override IReadOnlyDictionary<string, LabelPositionOptions> GetValuesAndDescriptions()
+        {
+            return EnumerateOptions().ToDictionary(x => x.description, x => x.value);
+
+            static IEnumerable<(string description, LabelPositionOptions value)> EnumerateOptions()
+            {
+                yield return ("place goto labels in leftmost column", LabelPositionOptions.LeftMost);
+                yield return ("indent labels normally", LabelPositionOptions.NoIndent);
+                yield return ("place goto labels one indent less than current", LabelPositionOptions.OneLess);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/CSharp/Impl/Microsoft.VisualStudio.LanguageServices.CSharp.csproj
+++ b/src/VisualStudio/CSharp/Impl/Microsoft.VisualStudio.LanguageServices.CSharp.csproj
@@ -15,18 +15,9 @@
     <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <ItemGroup Label="PkgDef">
-    <PkgDefInstalledProduct Include="{13c3bbb4-f18f-4111-9f54-a0fb010d9194}"
-                            Name="Microsoft Visual C#"
-                            DisplayName="#116"
-                            ProductDetails="#117"/>
-    <PkgDefPackageRegistration Include="{c5edd1ee-c43b-4360-9ce4-6b993ca12897}"
-                               Name="CSharpVsInteractiveWindowPackage"
-                               Class="Microsoft.VisualStudio.LanguageServices.CSharp.Interactive.CSharpVsInteractiveWindowPackage"
-                               AllowsBackgroundLoad="true"/>
-    <PkgDefPackageRegistration Include="{13c3bbb4-f18f-4111-9f54-a0fb010d9194}"
-                               Name="CSharpPackage"
-                               Class="Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpPackage"
-                               AllowsBackgroundLoad="true"/>
+    <PkgDefInstalledProduct Include="{13c3bbb4-f18f-4111-9f54-a0fb010d9194}" Name="Microsoft Visual C#" DisplayName="#116" ProductDetails="#117" />
+    <PkgDefPackageRegistration Include="{c5edd1ee-c43b-4360-9ce4-6b993ca12897}" Name="CSharpVsInteractiveWindowPackage" Class="Microsoft.VisualStudio.LanguageServices.CSharp.Interactive.CSharpVsInteractiveWindowPackage" AllowsBackgroundLoad="true" />
+    <PkgDefPackageRegistration Include="{13c3bbb4-f18f-4111-9f54-a0fb010d9194}" Name="CSharpPackage" Class="Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpPackage" AllowsBackgroundLoad="true" />
     <None Include="PackageRegistration.pkgdef" PkgDefEntry="FileContent" />
   </ItemGroup>
   <ItemGroup Label="Project References">

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.AnalyzerSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid>
+        <Border
+            x:Name="AnalyzerTable"
+            Grid.Row="0"
+            BorderThickness="1"
+            Margin="12 0"
+            VerticalAlignment="Stretch"
+            HorizontalAlignment="Stretch" />
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
 using Microsoft.VisualStudio.Shell.TableControl;
@@ -16,20 +18,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
     /// </summary>
     internal partial class AnalyzerSettingsView : UserControl, ISettingsEditorView
     {
-        private readonly IVsTextLines _vsTextLines;
-        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
-        private readonly IThreadingContext _threadingContext;
         private readonly IWpfSettingsEditorViewModel _viewModel;
 
-        public AnalyzerSettingsView(IVsTextLines vsTextLines,
-                                    IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
-                                    IThreadingContext threadingContext,
-                                    IWpfSettingsEditorViewModel viewModel)
+        public AnalyzerSettingsView(IWpfSettingsEditorViewModel viewModel)
         {
             InitializeComponent();
-            _vsTextLines = vsTextLines;
-            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
-            _threadingContext = threadingContext;
             _viewModel = viewModel;
             TableControl = _viewModel.GetTableControl();
             AnalyzerTable.Child = TableControl.Control;
@@ -37,18 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
 
         public UserControl SettingControl => this;
         public IWpfTableControl TableControl { get; }
-
-        public void OnClose()
-        {
-            _viewModel.ShutDown();
-        }
-
-        public void Synchronize()
-        {
-            if (IsKeyboardFocusWithin)
-            {
-                EditorTextUpdater.UpdateText(_threadingContext, _vsEditorAdaptersFactoryService, _vsTextLines, _viewModel);
-            }
-        }
+        public Task<SourceText> UpdateEditorConfigAsync(SourceText sourceText) => _viewModel.UpdateEditorConfigAsync(sourceText);
+        public void OnClose() => _viewModel.ShutDown();
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml.cs
@@ -38,6 +38,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public UserControl SettingControl => this;
         public IWpfTableControl TableControl { get; }
 
+        public void OnClose()
+        {
+            _viewModel.ShutDown();
+        }
+
         public void Synchronize()
         {
             if (IsKeyboardFocusWithin)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/AnalyzerSettingsView.xaml.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View
+{
+    /// <summary>
+    /// Interaction logic for AnalyzerSettingsView.xaml
+    /// </summary>
+    internal partial class AnalyzerSettingsView : UserControl, ISettingsEditorView
+    {
+        private readonly IVsTextLines _vsTextLines;
+        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
+        private readonly IThreadingContext _threadingContext;
+        private readonly IWpfSettingsEditorViewModel _viewModel;
+
+        public AnalyzerSettingsView(IVsTextLines vsTextLines,
+                                    IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
+                                    IThreadingContext threadingContext,
+                                    IWpfSettingsEditorViewModel viewModel)
+        {
+            InitializeComponent();
+            _vsTextLines = vsTextLines;
+            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
+            _threadingContext = threadingContext;
+            _viewModel = viewModel;
+            TableControl = _viewModel.GetTableControl();
+            AnalyzerTable.Child = TableControl.Control;
+        }
+
+        public UserControl SettingControl => this;
+        public IWpfTableControl TableControl { get; }
+
+        public void Synchronize()
+        {
+            if (IsKeyboardFocusWithin)
+            {
+                EditorTextUpdater.UpdateText(_threadingContext, _vsEditorAdaptersFactoryService, _vsTextLines, _viewModel);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerCategoryColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerCategoryColumnDefinition.cs
@@ -40,6 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public override double MinWidth => 80;
         public override bool DefaultVisible => false;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
         public override TextWrapping TextWrapping => TextWrapping.NoWrap;
 
         private static string? GetCategoryName(ITableEntryHandle entry)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerCategoryColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerCategoryColumnDefinition.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Analyzer;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.ColumnDefinitions
+{
+    [Export(typeof(IDefaultColumnGroup))]
+    [Name(nameof(AnalyzerCategoryGroupingSet))]    // Required, name of the default group
+    [GroupColumns(Category)] // Required, the names of the columns in the grouping
+    internal class AnalyzerCategoryGroupingSet : IDefaultColumnGroup
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerCategoryGroupingSet()
+        {
+        }
+    }
+
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Category)] // TODO(jmarolf): make sure all columns have ToString implementation
+    internal class AnalyzerCategoryColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerCategoryColumnDefinition()
+        {
+        }
+
+        public override string Name => Category;
+        public override string DisplayName => ServicesVSResources.Category;
+        public override double MinWidth => 80;
+        public override bool DefaultVisible => false;
+        public override bool IsFilterable => true;
+        public override TextWrapping TextWrapping => TextWrapping.NoWrap;
+
+        private static string? GetCategoryName(ITableEntryHandle entry)
+            => entry.TryGetValue(Category, out string? categoryName)
+                ? categoryName
+                : null;
+
+        public override IEntryBucket? CreateBucketForEntry(ITableEntryHandle entry)
+        {
+            var categoryName = GetCategoryName(entry);
+            return categoryName is not null ? new StringEntryBucket(categoryName) : null;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerDescriptionColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerDescriptionColumnDefinition.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public override string Name => Description;
         public override string DisplayName => ServicesVSResources.Description;
         public override bool IsFilterable => false;
+        public override bool IsSortable => false;
         public override double MinWidth => 350;
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerDescriptionColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerDescriptionColumnDefinition.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Analyzer;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.ColumnDefinitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Description)]
+    internal class AnalyzerDescriptionColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerDescriptionColumnDefinition()
+        {
+        }
+
+        public override string Name => Description;
+        public override string DisplayName => ServicesVSResources.Description;
+        public override bool IsFilterable => false;
+        public override double MinWidth => 350;
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerEnabledColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerEnabledColumnDefinition.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Analyzer;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.ColumnDefinitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Enabled)]
+    internal class AnalyzerEnabledColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerEnabledColumnDefinition()
+        {
+        }
+
+        public override string Name => Enabled;
+        public override string DisplayName => ServicesVSResources.Enabled;
+        public override bool IsFilterable => true;
+        public override double MinWidth => 50;
+
+        public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement content)
+        {
+            var checkBox = new CheckBox();
+            if (entry.TryGetValue(Name, out bool enabled))
+            {
+                checkBox.IsChecked = enabled;
+            }
+
+            content = checkBox;
+            return true;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerEnabledColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerEnabledColumnDefinition.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public override string Name => Enabled;
         public override string DisplayName => ServicesVSResources.Enabled;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
         public override double MinWidth => 50;
 
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement content)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerIdColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerIdColumnDefinition.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public override string Name => Id;
         public override string DisplayName => ServicesVSResources.Id;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
         public override double MinWidth => 50;
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerIdColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerIdColumnDefinition.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Analyzer;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.ColumnDefinitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Id)]
+    internal class AnalyzerIdColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerIdColumnDefinition()
+        {
+        }
+
+        public override string Name => Id;
+        public override string DisplayName => ServicesVSResources.Id;
+        public override bool IsFilterable => true;
+        public override double MinWidth => 50;
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
@@ -27,7 +27,27 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public override string Name => Severity;
         public override string DisplayName => ServicesVSResources.Severity;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
         public override double MinWidth => 120;
+
+        public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string? content)
+        {
+            if (!entry.TryGetValue(Severity, out AnalyzerSetting setting))
+            {
+                content = null;
+                return false;
+            }
+
+            content = setting.Severity switch
+            {
+                CodeAnalysis.DiagnosticSeverity.Hidden => ServicesVSResources.Disabled,
+                CodeAnalysis.DiagnosticSeverity.Info => ServicesVSResources.Suggestion,
+                CodeAnalysis.DiagnosticSeverity.Warning => ServicesVSResources.Warning,
+                CodeAnalysis.DiagnosticSeverity.Error => ServicesVSResources.Error,
+                _ => string.Empty,
+            };
+            return true;
+        }
 
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
         {

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Analyzer;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.ColumnDefinitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Severity)]
+    internal class AnalyzerSeverityColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerSeverityColumnDefinition()
+        {
+        }
+
+        public override string Name => Severity;
+        public override string DisplayName => ServicesVSResources.Severity;
+        public override bool IsFilterable => true;
+        public override double MinWidth => 120;
+
+        public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
+        {
+            if (!entry.TryGetValue(Severity, out AnalyzerSetting severity))
+            {
+                content = null;
+                return false;
+            }
+
+            var control = new SeverityControl(severity);
+            content = control;
+            return true;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
@@ -26,8 +26,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
 
         public override string Name => Severity;
         public override string DisplayName => ServicesVSResources.Severity;
-        public override bool IsFilterable => true;
-        public override bool IsSortable => true;
+        public override bool IsFilterable => false;
+        public override bool IsSortable => false;
         public override double MinWidth => 120;
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string? content)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerTitleColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerTitleColumnDefinition.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Analyzer;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.ColumnDefinitions
+{
+
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Title)]
+    internal class AnalyzerTitleColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public AnalyzerTitleColumnDefinition()
+        {
+        }
+
+        public override string Name => Title;
+        public override string DisplayName => ServicesVSResources.Title;
+        public override bool IsFilterable => false;
+        public override double MinWidth => 350;
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerTitleColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerTitleColumnDefinition.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public override string Name => Title;
         public override string DisplayName => ServicesVSResources.Title;
         public override bool IsFilterable => false;
+        public override bool IsSortable => false;
         public override double MinWidth => 350;
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View.SeverityControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid x:Name="RootGrid">
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View
+{
+    /// <summary>
+    /// Interaction logic for SeverityControl.xaml
+    /// </summary>
+    internal partial class SeverityControl : UserControl
+    {
+        private readonly ComboBox _comboBox;
+        private readonly AnalyzerSetting _setting;
+
+        public SeverityControl(AnalyzerSetting setting)
+        {
+            InitializeComponent();
+            var refactoring = CreateGridElement(KnownMonikers.None, ServicesVSResources.Disabled);
+            var suggestion = CreateGridElement(KnownMonikers.StatusInformation, ServicesVSResources.Suggestion);
+            var warning = CreateGridElement(KnownMonikers.StatusWarning, ServicesVSResources.Warning);
+            var error = CreateGridElement(KnownMonikers.StatusError, ServicesVSResources.Error);
+            _comboBox = new ComboBox()
+            {
+                ItemsSource = new[]
+                {
+                    refactoring,
+                    suggestion,
+                    warning,
+                    error
+                }
+            };
+
+            switch (setting.Severity)
+            {
+                case DiagnosticSeverity.Hidden:
+                    _comboBox.SelectedIndex = 0;
+                    break;
+                case DiagnosticSeverity.Info:
+                    _comboBox.SelectedIndex = 1;
+                    break;
+                case DiagnosticSeverity.Warning:
+                    _comboBox.SelectedIndex = 2;
+                    break;
+                case DiagnosticSeverity.Error:
+                    _comboBox.SelectedIndex = 3;
+                    break;
+                default:
+                    break;
+            }
+
+            _comboBox.SelectionChanged += ComboBox_SelectionChanged;
+
+            _ = RootGrid.Children.Add(_comboBox);
+            _setting = setting;
+        }
+
+        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            switch (_comboBox.SelectedIndex)
+            {
+                case 0:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Hidden);
+                    return;
+                case 1:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Info);
+                    return;
+                case 2:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Warning);
+                    return;
+                case 3:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Error);
+                    return;
+                default: return;
+            }
+        }
+
+        private static FrameworkElement CreateGridElement(ImageMoniker imageMoniker, string text)
+        {
+            var stackPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+
+            var block = new TextBlock
+            {
+                VerticalAlignment = VerticalAlignment.Center,
+                Text = text
+            };
+
+            if (!imageMoniker.IsNullImage())
+            {
+                // If we have an image and text, then create some space between them.
+                block.Margin = new Thickness(5.0, 0.0, 0.0, 0.0);
+
+                var image = new CrispImage
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Moniker = imageMoniker
+                };
+                image.Width = image.Height = 16.0;
+
+                _ = stackPanel.Children.Add(image);
+            }
+
+            // Always add the textblock last so it can follow the image.
+            _ = stackPanel.Children.Add(block);
+
+            return stackPanel;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
@@ -22,10 +22,10 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public SeverityControl(AnalyzerSetting setting)
         {
             InitializeComponent();
-            var refactoring = CreateGridElement(KnownMonikers.None, ServicesVSResources.Disabled);
-            var suggestion = CreateGridElement(KnownMonikers.StatusInformation, ServicesVSResources.Suggestion);
-            var warning = CreateGridElement(KnownMonikers.StatusWarning, ServicesVSResources.Warning);
-            var error = CreateGridElement(KnownMonikers.StatusError, ServicesVSResources.Error);
+            var refactoring = CreateItemElement(KnownMonikers.None, ServicesVSResources.Disabled);
+            var suggestion = CreateItemElement(KnownMonikers.StatusInformation, ServicesVSResources.Suggestion);
+            var warning = CreateItemElement(KnownMonikers.StatusWarning, ServicesVSResources.Warning);
+            var error = CreateItemElement(KnownMonikers.StatusError, ServicesVSResources.Error);
             _comboBox = new ComboBox()
             {
                 ItemsSource = new[]
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
             }
         }
 
-        private static FrameworkElement CreateGridElement(ImageMoniker imageMoniker, string text)
+        private static FrameworkElement CreateItemElement(ImageMoniker imageMoniker, string text)
         {
             var stackPanel = new StackPanel
             {

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
@@ -56,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
             }
 
             _comboBox.SelectionChanged += ComboBox_SelectionChanged;
-
+            _comboBox.SetValue(AutomationProperties.NameProperty, ServicesVSResources.Severity);
             _ = RootGrid.Children.Add(_comboBox);
             _setting = setting;
         }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/SeverityControl.xaml.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls;
@@ -23,18 +24,14 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         public SeverityControl(AnalyzerSetting setting)
         {
             InitializeComponent();
-            var refactoring = CreateItemElement(KnownMonikers.None, ServicesVSResources.Disabled);
-            var suggestion = CreateItemElement(KnownMonikers.StatusInformation, ServicesVSResources.Suggestion);
-            var warning = CreateItemElement(KnownMonikers.StatusWarning, ServicesVSResources.Warning);
-            var error = CreateItemElement(KnownMonikers.StatusError, ServicesVSResources.Error);
             _comboBox = new ComboBox()
             {
                 ItemsSource = new[]
                 {
-                    refactoring,
-                    suggestion,
-                    warning,
-                    error
+                    ServicesVSResources.Disabled,
+                    ServicesVSResources.Suggestion,
+                    ServicesVSResources.Warning,
+                    ServicesVSResources.Error
                 }
             };
 
@@ -64,57 +61,19 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
 
         private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            switch (_comboBox.SelectedIndex)
+            var severity = _comboBox.SelectedIndex switch
             {
-                case 0:
-                    _setting.ChangeSeverity(DiagnosticSeverity.Hidden);
-                    return;
-                case 1:
-                    _setting.ChangeSeverity(DiagnosticSeverity.Info);
-                    return;
-                case 2:
-                    _setting.ChangeSeverity(DiagnosticSeverity.Warning);
-                    return;
-                case 3:
-                    _setting.ChangeSeverity(DiagnosticSeverity.Error);
-                    return;
-                default: return;
-            }
-        }
-
-        private static FrameworkElement CreateItemElement(ImageMoniker imageMoniker, string text)
-        {
-            var stackPanel = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Stretch
+                0 => DiagnosticSeverity.Hidden,
+                1 => DiagnosticSeverity.Info,
+                2 => DiagnosticSeverity.Warning,
+                3 => DiagnosticSeverity.Error,
+                _ => throw new InvalidOperationException(),
             };
 
-            var block = new TextBlock
+            if (_setting.Severity != severity)
             {
-                VerticalAlignment = VerticalAlignment.Center,
-                Text = text
-            };
-
-            if (!imageMoniker.IsNullImage())
-            {
-                // If we have an image and text, then create some space between them.
-                block.Margin = new Thickness(5.0, 0.0, 0.0, 0.0);
-
-                var image = new CrispImage
-                {
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Moniker = imageMoniker
-                };
-                image.Width = image.Height = 16.0;
-
-                _ = stackPanel.Children.Add(image);
+                _setting.ChangeSeverity(severity);
             }
-
-            // Always add the textblock last so it can follow the image.
-            _ = stackPanel.Children.Add(block);
-
-            return stackPanel;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/AnalyzerSettingsViewModel.SettingsEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/AnalyzerSettingsViewModel.SettingsEntriesSnapshot.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.ViewModel
+{
+    internal partial class AnalyzerSettingsViewModel : SettingsViewModelBase<
+        AnalyzerSetting,
+        AnalyzerSettingsViewModel.SettingsSnapshotFactory,
+        AnalyzerSettingsViewModel.SettingsEntriesSnapshot>
+    {
+        internal sealed class SettingsEntriesSnapshot : SettingsEntriesSnapshotBase<AnalyzerSetting>
+        {
+            public SettingsEntriesSnapshot(ImmutableArray<AnalyzerSetting> data, int currentVersionNumber) : base(data, currentVersionNumber) { }
+
+            protected override bool TryGetValue(AnalyzerSetting result, string keyName, out object? content)
+            {
+                content = keyName switch
+                {
+                    ColumnDefinitions.Analyzer.Enabled => result.IsEnabled,
+                    ColumnDefinitions.Analyzer.Id => result.Id,
+                    ColumnDefinitions.Analyzer.Title => result.Title,
+                    ColumnDefinitions.Analyzer.Description => result.Description,
+                    ColumnDefinitions.Analyzer.Category => result.Category,
+                    ColumnDefinitions.Analyzer.Severity => result,
+                    _ => null,
+                };
+
+                return content is not null;
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/AnalyzerSettingsViewModel.SettingsSnapshotFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/AnalyzerSettingsViewModel.SettingsSnapshotFactory.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.ViewModel
+{
+    internal partial class AnalyzerSettingsViewModel : SettingsViewModelBase<
+        AnalyzerSetting,
+        AnalyzerSettingsViewModel.SettingsSnapshotFactory,
+        AnalyzerSettingsViewModel.SettingsEntriesSnapshot>
+    {
+        internal sealed class SettingsSnapshotFactory : SettingsSnapshotFactoryBase<AnalyzerSetting, SettingsEntriesSnapshot>
+        {
+            public SettingsSnapshotFactory(ISettingsProvider<AnalyzerSetting> data) : base(data) { }
+
+            protected override SettingsEntriesSnapshot CreateSnapshot(ImmutableArray<AnalyzerSetting> data, int currentVersionNumber)
+                => new(data, currentVersionNumber);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/AnalyzerSettingsViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/AnalyzerSettingsViewModel.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.ViewModel
+{
+
+    internal partial class AnalyzerSettingsViewModel : SettingsViewModelBase<
+        AnalyzerSetting,
+        AnalyzerSettingsViewModel.SettingsSnapshotFactory,
+        AnalyzerSettingsViewModel.SettingsEntriesSnapshot>
+    {
+
+        public AnalyzerSettingsViewModel(ISettingsProvider<AnalyzerSetting> data,
+                                         IWpfTableControlProvider controlProvider,
+                                         ITableManagerProvider tableMangerProvider)
+            : base(data, controlProvider, tableMangerProvider)
+        { }
+
+        public override string Identifier => "AnalyzerSettings";
+
+        protected override SettingsSnapshotFactory CreateSnapshotFactory(ISettingsProvider<AnalyzerSetting> data)
+            => new(data);
+
+        protected override IEnumerable<ColumnState2> GetInitialColumnStates()
+            => new[]
+            {
+                new ColumnState2(ColumnDefinitions.Analyzer.Id, isVisible: true, width: 0),
+                new ColumnState2(ColumnDefinitions.Analyzer.Title, isVisible: true, width: 0),
+                new ColumnState2(ColumnDefinitions.Analyzer.Description, isVisible: false, width: 0),
+                new ColumnState2(ColumnDefinitions.Analyzer.Category, isVisible: true, width: 0, groupingPriority: 1),
+                new ColumnState2(ColumnDefinitions.Analyzer.Severity, isVisible: true, width: 0)
+            };
+
+        protected override string[] GetFixedColumns()
+            => new[]
+            {
+                ColumnDefinitions.Analyzer.Category,
+                ColumnDefinitions.Analyzer.Id,
+                ColumnDefinitions.Analyzer.Title,
+                ColumnDefinitions.Analyzer.Description,
+                ColumnDefinitions.Analyzer.Severity
+            };
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View.CodeStyleSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid>
+        <Border Grid.Row="0"
+                x:Name="CodeStyleTable"
+                BorderThickness="1"
+                Margin="12 0"
+                VerticalAlignment="Stretch"
+                HorizontalAlignment="Stretch" />
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View
+{
+    /// <summary>
+    /// Interaction logic for CodeStyleView.xaml
+    /// </summary>
+    internal partial class CodeStyleSettingsView : UserControl, ISettingsEditorView
+    {
+        private readonly IVsTextLines _vsTextLines;
+        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
+        private readonly IThreadingContext _threadingContext;
+        private readonly IWpfSettingsEditorViewModel _viewModel;
+
+        public CodeStyleSettingsView(IVsTextLines vsTextLines,
+                                     IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
+                                     IThreadingContext threadingContext,
+                                     IWpfSettingsEditorViewModel viewModel)
+        {
+            InitializeComponent();
+            _vsTextLines = vsTextLines;
+            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
+            _threadingContext = threadingContext;
+            _viewModel = viewModel;
+            TableControl = _viewModel.GetTableControl();
+            CodeStyleTable.Child = TableControl.Control;
+            DataContext = viewModel;
+        }
+
+        public UserControl SettingControl => this;
+        public IWpfTableControl TableControl { get; }
+
+        public void Synchronize()
+        {
+            if (IsKeyboardFocusWithin)
+            {
+                EditorTextUpdater.UpdateText(_threadingContext, _vsEditorAdaptersFactoryService, _vsTextLines, _viewModel);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml.cs
@@ -39,6 +39,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         public UserControl SettingControl => this;
         public IWpfTableControl TableControl { get; }
 
+        public void OnClose()
+        {
+            _viewModel.ShutDown();
+        }
+
         public void Synchronize()
         {
             if (IsKeyboardFocusWithin)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSettingsView.xaml.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
 using Microsoft.VisualStudio.Shell.TableControl;
@@ -16,20 +18,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
     /// </summary>
     internal partial class CodeStyleSettingsView : UserControl, ISettingsEditorView
     {
-        private readonly IVsTextLines _vsTextLines;
-        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
-        private readonly IThreadingContext _threadingContext;
         private readonly IWpfSettingsEditorViewModel _viewModel;
 
-        public CodeStyleSettingsView(IVsTextLines vsTextLines,
-                                     IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
-                                     IThreadingContext threadingContext,
-                                     IWpfSettingsEditorViewModel viewModel)
+        public CodeStyleSettingsView(IWpfSettingsEditorViewModel viewModel)
         {
             InitializeComponent();
-            _vsTextLines = vsTextLines;
-            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
-            _threadingContext = threadingContext;
             _viewModel = viewModel;
             TableControl = _viewModel.GetTableControl();
             CodeStyleTable.Child = TableControl.Control;
@@ -38,18 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
 
         public UserControl SettingControl => this;
         public IWpfTableControl TableControl { get; }
-
-        public void OnClose()
-        {
-            _viewModel.ShutDown();
-        }
-
-        public void Synchronize()
-        {
-            if (IsKeyboardFocusWithin)
-            {
-                EditorTextUpdater.UpdateText(_threadingContext, _vsEditorAdaptersFactoryService, _vsTextLines, _viewModel);
-            }
-        }
+        public Task<SourceText> UpdateEditorConfigAsync(SourceText sourceText) => _viewModel.UpdateEditorConfigAsync(sourceText);
+        public void OnClose() => _viewModel.ShutDown();
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml
@@ -3,8 +3,27 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View"
              mc:Ignorable="d" 
              x:ClassModifier="internal">
-    <Grid x:Name="RootGrid">
-    </Grid>
+    <ComboBox x:Name="SeverityComboBox" SelectionChanged="ComboBox_SelectionChanged" AutomationProperties.Name="{x:Static local:CodeStyleSeverityControl.Severity}">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+            <imaging:CrispImage VerticalAlignment="Center"  Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.None}"/>
+            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Refactoring_Only}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+            <imaging:CrispImage VerticalAlignment="Center" Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.StatusInformation}"/>
+            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Suggestion}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+            <imaging:CrispImage VerticalAlignment="Center" Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.StatusWarning}"/>
+            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Warning}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+            <imaging:CrispImage VerticalAlignment="Center" Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.StatusError}"/>
+            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Error}"/>
+        </StackPanel>
+    </ComboBox>
 </UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml
@@ -8,22 +8,6 @@
              xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View"
              mc:Ignorable="d" 
              x:ClassModifier="internal">
-    <ComboBox x:Name="SeverityComboBox" SelectionChanged="ComboBox_SelectionChanged" AutomationProperties.Name="{x:Static local:CodeStyleSeverityControl.Severity}">
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-            <imaging:CrispImage VerticalAlignment="Center"  Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.None}"/>
-            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Refactoring_Only}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-            <imaging:CrispImage VerticalAlignment="Center" Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.StatusInformation}"/>
-            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Suggestion}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-            <imaging:CrispImage VerticalAlignment="Center" Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.StatusWarning}"/>
-            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Warning}"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-            <imaging:CrispImage VerticalAlignment="Center" Height="16" Width="16" Margin="5.0,0.0,0.0,0.0" Moniker="{x:Static catalog:KnownMonikers.StatusError}"/>
-            <TextBlock VerticalAlignment="Center" Text="{x:Static local:CodeStyleSeverityControl.Error}"/>
-        </StackPanel>
-    </ComboBox>
+    <Grid x:Name="RootGrid">
+    </Grid>
 </UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View.CodeStyleSeverityControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid x:Name="RootGrid">
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
@@ -14,20 +15,25 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
     /// </summary>
     internal partial class CodeStyleSeverityControl : UserControl
     {
+        private readonly ComboBox _comboBox;
         private readonly CodeStyleSetting _setting;
-
-        // internal resource string cannot be statically bound in WPF 
-        public static string Severity => ServicesVSResources.Severity;
-        public static string Refactoring_Only => ServicesVSResources.Refactoring_Only;
-        public static string Suggestion => ServicesVSResources.Suggestion;
-        public static string Warning => ServicesVSResources.Warning;
-        public static string Error => ServicesVSResources.Error;
 
         public CodeStyleSeverityControl(CodeStyleSetting setting)
         {
             InitializeComponent();
             _setting = setting;
-            SeverityComboBox.SelectedIndex = setting.Severity switch
+            _comboBox = new ComboBox()
+            {
+                ItemsSource = new[]
+                {
+                    ServicesVSResources.Refactoring_Only,
+                    ServicesVSResources.Suggestion,
+                    ServicesVSResources.Warning,
+                    ServicesVSResources.Error
+                }
+            };
+
+            _comboBox.SelectedIndex = setting.Severity switch
             {
                 DiagnosticSeverity.Hidden => 0,
                 DiagnosticSeverity.Info => 1,
@@ -35,11 +41,15 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
                 DiagnosticSeverity.Error => 3,
                 _ => throw new InvalidOperationException(),
             };
+
+            _comboBox.SelectionChanged += ComboBox_SelectionChanged;
+            _comboBox.SetValue(AutomationProperties.NameProperty, ServicesVSResources.Severity);
+            _ = RootGrid.Children.Add(_comboBox);
         }
 
         private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            var severity = SeverityComboBox.SelectedIndex switch
+            var severity = _comboBox.SelectedIndex switch
             {
                 0 => DiagnosticSeverity.Hidden,
                 1 => DiagnosticSeverity.Info,

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
@@ -56,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
             }
 
             _comboBox.SelectionChanged += ComboBox_SelectionChanged;
-
+            _comboBox.SetValue(AutomationProperties.NameProperty, ServicesVSResources.Severity);
             _ = RootGrid.Children.Add(_comboBox);
             _setting = setting;
         }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleSeverityControl.xaml.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View
+{
+    /// <summary>
+    /// Interaction logic for CodeStyleSeverityControl.xaml
+    /// </summary>
+    internal partial class CodeStyleSeverityControl : UserControl
+    {
+        private readonly ComboBox _comboBox;
+        private readonly CodeStyleSetting _setting;
+
+        public CodeStyleSeverityControl(CodeStyleSetting setting)
+        {
+            InitializeComponent();
+            var refactoring = CreateGridElement(KnownMonikers.None, ServicesVSResources.Refactoring_Only);
+            var suggestion = CreateGridElement(KnownMonikers.StatusInformation, ServicesVSResources.Suggestion);
+            var warning = CreateGridElement(KnownMonikers.StatusWarning, ServicesVSResources.Warning);
+            var error = CreateGridElement(KnownMonikers.StatusError, ServicesVSResources.Error);
+            _comboBox = new ComboBox()
+            {
+                ItemsSource = new[]
+    {
+                    refactoring,
+                    suggestion,
+                    warning,
+                    error
+                }
+            };
+
+            switch (setting.Severity)
+            {
+                case ReportDiagnostic.Hidden:
+                    _comboBox.SelectedIndex = 0;
+                    break;
+                case ReportDiagnostic.Info:
+                    _comboBox.SelectedIndex = 1;
+                    break;
+                case ReportDiagnostic.Warn:
+                    _comboBox.SelectedIndex = 2;
+                    break;
+                case ReportDiagnostic.Error:
+                    _comboBox.SelectedIndex = 3;
+                    break;
+                default:
+                    break;
+            }
+
+            _comboBox.SelectionChanged += ComboBox_SelectionChanged;
+
+            _ = RootGrid.Children.Add(_comboBox);
+            _setting = setting;
+        }
+
+        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            switch (_comboBox.SelectedIndex)
+            {
+                case 0:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Hidden);
+                    return;
+                case 1:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Info);
+                    return;
+                case 2:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Warning);
+                    return;
+                case 3:
+                    _setting.ChangeSeverity(DiagnosticSeverity.Error);
+                    return;
+                default: return;
+            }
+        }
+
+        private static FrameworkElement CreateGridElement(ImageMoniker imageMoniker, string text)
+        {
+            var stackPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+
+            var block = new TextBlock
+            {
+                VerticalAlignment = VerticalAlignment.Center,
+                Text = text
+            };
+
+            if (!imageMoniker.IsNullImage())
+            {
+                // If we have an image and text, then create some space between them.
+                block.Margin = new Thickness(5.0, 0.0, 0.0, 0.0);
+
+                var image = new CrispImage
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Moniker = imageMoniker
+                };
+                image.Width = image.Height = 16.0;
+
+                _ = stackPanel.Children.Add(image);
+            }
+
+            // Always add the textblock last so it can follow the image.
+            _ = stackPanel.Children.Add(block);
+
+            return stackPanel;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleValueControl.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleValueControl.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View.CodeStyleValueControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid x:Name="RootGrid">
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleValueControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleValueControl.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
 
@@ -26,6 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
                 ItemsSource = values
             };
             _comboBox.SelectedIndex = index;
+            _comboBox.SetValue(AutomationProperties.NameProperty, ServicesVSResources.Value);
             _comboBox.SelectionChanged += ComboBox_SelectionChanged;
             _ = RootGrid.Children.Add(_comboBox);
             _setting = setting;

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleValueControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/CodeStyleValueControl.xaml.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View
+{
+    /// <summary>
+    /// Interaction logic for CodeStyleValueControl.xaml
+    /// </summary>
+    internal partial class CodeStyleValueControl : UserControl
+    {
+        private readonly ComboBox _comboBox;
+        private readonly CodeStyleSetting _setting;
+
+        public CodeStyleValueControl(CodeStyleSetting setting)
+        {
+            InitializeComponent();
+            var values = setting.GetValues().ToList();
+            var index = values.IndexOf(setting.GetCurrentValue());
+            _comboBox = new ComboBox()
+            {
+                ItemsSource = values
+            };
+            _comboBox.SelectedIndex = index;
+            _comboBox.SelectionChanged += ComboBox_SelectionChanged;
+            _ = RootGrid.Children.Add(_comboBox);
+            _setting = setting;
+        }
+
+        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _setting.ChangeValue(_comboBox.SelectedIndex);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleCategoryColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleCategoryColumnDefinition.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.CodeStyle;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View.ColumnDefinitions
+{
+    [Export(typeof(IDefaultColumnGroup))]
+    [Name(nameof(CodeStyleCategoryGroupingSet))]    // Required, name of the default group
+    [GroupColumns(Category)] // Required, the names of the columns in the grouping
+    internal class CodeStyleCategoryGroupingSet : IDefaultColumnGroup
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CodeStyleCategoryGroupingSet()
+        {
+        }
+    }
+
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Category)]
+    internal class CodeStyleCategoryColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CodeStyleCategoryColumnDefinition()
+        {
+        }
+
+        public override string Name => Category;
+        public override string DisplayName => ServicesVSResources.Category;
+        public override double MinWidth => 80;
+        public override bool DefaultVisible => false;
+        public override bool IsFilterable => true;
+        public override TextWrapping TextWrapping => TextWrapping.NoWrap;
+
+        private static string? GetCategoryName(ITableEntryHandle entry)
+            => entry.TryGetValue(Category, out var categoryName)
+                ? categoryName as string
+                : null;
+
+        public override IEntryBucket? CreateBucketForEntry(ITableEntryHandle entry)
+        {
+            var categoryName = GetCategoryName(entry);
+            return categoryName is not null ? new StringEntryBucket(categoryName) : null;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleCategoryColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleCategoryColumnDefinition.cs
@@ -39,6 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         public override double MinWidth => 80;
         public override bool DefaultVisible => false;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
         public override TextWrapping TextWrapping => TextWrapping.NoWrap;
 
         private static string? GetCategoryName(ITableEntryHandle entry)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleDescriptionColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleDescriptionColumnDefinition.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         public override string Name => Description;
         public override string DisplayName => ServicesVSResources.Description;
         public override bool IsFilterable => false;
+        public override bool IsSortable => false;
         public override double MinWidth => 350;
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleDescriptionColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleDescriptionColumnDefinition.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.CodeStyle;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View.ColumnDefinitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Description)]
+    internal class CodeStyleDescriptionColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CodeStyleDescriptionColumnDefinition()
+        {
+        }
+
+        public override string Name => Description;
+        public override string DisplayName => ServicesVSResources.Description;
+        public override bool IsFilterable => false;
+        public override double MinWidth => 350;
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.CodeStyle;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View.ColumnDefinitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Severity)]
+    internal class CodeStyleSeverityColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CodeStyleSeverityColumnDefinition()
+        {
+        }
+
+        public override string Name => Severity;
+        public override string DisplayName => ServicesVSResources.Severity;
+        public override double MinWidth => 120;
+        public override bool DefaultVisible => false;
+        public override bool IsFilterable => true;
+
+        public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
+        {
+            if (!entry.TryGetValue(Severity, out CodeStyleSetting severity))
+            {
+                content = null;
+                return false;
+            }
+
+            var control = new CodeStyleSeverityControl(severity);
+            content = control;
+            return true;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
@@ -28,8 +28,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         public override string DisplayName => ServicesVSResources.Severity;
         public override double MinWidth => 120;
         public override bool DefaultVisible => false;
-        public override bool IsFilterable => true;
-        public override bool IsSortable => true;
+        public override bool IsFilterable => false;
+        public override bool IsSortable => false;
 
         public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string? content)
         {

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
@@ -31,27 +31,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         public override bool IsFilterable => false;
         public override bool IsSortable => false;
 
-        public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string? content)
-        {
-            if (!entry.TryGetValue(Severity, out CodeStyleSetting setting))
-            {
-                content = null;
-                return false;
-            }
-
-            content = setting.Severity switch
-            {
-                CodeAnalysis.ReportDiagnostic.Error => ServicesVSResources.Error,
-                CodeAnalysis.ReportDiagnostic.Warn => ServicesVSResources.Warning,
-                CodeAnalysis.ReportDiagnostic.Info => ServicesVSResources.Suggestion,
-                CodeAnalysis.ReportDiagnostic.Hidden => ServicesVSResources.Refactoring_Only,
-                CodeAnalysis.ReportDiagnostic.Default => string.Empty,
-                CodeAnalysis.ReportDiagnostic.Suppress => string.Empty,
-                _ => string.Empty,
-            };
-            return true;
-        }
-
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
         {
             if (!entry.TryGetValue(Severity, out CodeStyleSetting setting))

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleSeverityColumnDefinition.cs
@@ -29,16 +29,38 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         public override double MinWidth => 120;
         public override bool DefaultVisible => false;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
 
-        public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
+        public override bool TryCreateStringContent(ITableEntryHandle entry, bool truncatedText, bool singleColumnView, out string? content)
         {
-            if (!entry.TryGetValue(Severity, out CodeStyleSetting severity))
+            if (!entry.TryGetValue(Severity, out CodeStyleSetting setting))
             {
                 content = null;
                 return false;
             }
 
-            var control = new CodeStyleSeverityControl(severity);
+            content = setting.Severity switch
+            {
+                CodeAnalysis.ReportDiagnostic.Error => ServicesVSResources.Error,
+                CodeAnalysis.ReportDiagnostic.Warn => ServicesVSResources.Warning,
+                CodeAnalysis.ReportDiagnostic.Info => ServicesVSResources.Suggestion,
+                CodeAnalysis.ReportDiagnostic.Hidden => ServicesVSResources.Refactoring_Only,
+                CodeAnalysis.ReportDiagnostic.Default => string.Empty,
+                CodeAnalysis.ReportDiagnostic.Suppress => string.Empty,
+                _ => string.Empty,
+            };
+            return true;
+        }
+
+        public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
+        {
+            if (!entry.TryGetValue(Severity, out CodeStyleSetting setting))
+            {
+                content = null;
+                return false;
+            }
+
+            var control = new CodeStyleSeverityControl(setting);
             content = control;
             return true;
         }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleValueColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleValueColumnDefinition.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.CodeStyle;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View.ColumnDefinitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Value)]
+    internal class CodeStyleValueColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CodeStyleValueColumnDefinition()
+        {
+        }
+
+        public override string Name => Value;
+        public override string DisplayName => ServicesVSResources.Value;
+        public override double MinWidth => 120;
+        public override bool DefaultVisible => false;
+        public override bool IsFilterable => false;
+
+        public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
+        {
+            if (!entry.TryGetValue(Value, out CodeStyleSetting severity))
+            {
+                content = null;
+                return false;
+            }
+
+            var control = new CodeStyleValueControl(severity);
+            content = control;
+            return true;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleValueColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/View/ColumnDefinitions/CodeStyleValueColumnDefinition.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         public override double MinWidth => 120;
         public override bool DefaultVisible => false;
         public override bool IsFilterable => false;
+        public override bool IsSortable => false;
 
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
         {

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSettingsViewModel.SettingsEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSettingsViewModel.SettingsEntriesSnapshot.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.ViewModel
+{
+    internal partial class CodeStyleSettingsViewModel
+    {
+        internal class SettingsEntriesSnapshot : SettingsEntriesSnapshotBase<CodeStyleSetting>
+        {
+            public SettingsEntriesSnapshot(ImmutableArray<CodeStyleSetting> data, int currentVersionNumber) : base(data, currentVersionNumber) { }
+
+            protected override bool TryGetValue(CodeStyleSetting result, string keyName, out object? content)
+            {
+                content = keyName switch
+                {
+                    ColumnDefinitions.CodeStyle.Description => result.Description,
+                    ColumnDefinitions.CodeStyle.Category => result.Category,
+                    ColumnDefinitions.CodeStyle.Severity => result,
+                    ColumnDefinitions.CodeStyle.Value => result,
+                    _ => null,
+                };
+
+                return content is not null;
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSettingsViewModel.SettingsSnapshotFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSettingsViewModel.SettingsSnapshotFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.ViewModel
+{
+    internal partial class CodeStyleSettingsViewModel
+    {
+        internal sealed class SettingsSnapshotFactory : SettingsSnapshotFactoryBase<CodeStyleSetting, SettingsEntriesSnapshot>
+        {
+            public SettingsSnapshotFactory(ISettingsProvider<CodeStyleSetting> data) : base(data) { }
+
+            protected override SettingsEntriesSnapshot CreateSnapshot(ImmutableArray<CodeStyleSetting> data, int currentVersionNumber)
+                => new(data, currentVersionNumber);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSettingsViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSettingsViewModel.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.ViewModel
+{
+    internal partial class CodeStyleSettingsViewModel : SettingsViewModelBase<
+        CodeStyleSetting,
+        CodeStyleSettingsViewModel.SettingsSnapshotFactory,
+        CodeStyleSettingsViewModel.SettingsEntriesSnapshot>
+    {
+        public CodeStyleSettingsViewModel(ISettingsProvider<CodeStyleSetting> data,
+                                          IWpfTableControlProvider controlProvider,
+                                          ITableManagerProvider tableMangerProvider)
+            : base(data, controlProvider, tableMangerProvider)
+        { }
+
+        public override string Identifier => "CodeStyleSettings";
+
+        protected override SettingsSnapshotFactory CreateSnapshotFactory(ISettingsProvider<CodeStyleSetting> data)
+            => new(data);
+
+        protected override IEnumerable<ColumnState2> GetInitialColumnStates()
+            => new[]
+            {
+                new ColumnState2(ColumnDefinitions.CodeStyle.Category, isVisible: false, width: 0, groupingPriority: 1),
+                new ColumnState2(ColumnDefinitions.CodeStyle.Description, isVisible: true, width: 0),
+                new ColumnState2(ColumnDefinitions.CodeStyle.Value, isVisible: true, width: 0),
+                new ColumnState2(ColumnDefinitions.CodeStyle.Severity, isVisible: true, width: 0)
+            };
+
+        protected override string[] GetFixedColumns()
+            => new[]
+            {
+                ColumnDefinitions.CodeStyle.Category,
+                ColumnDefinitions.CodeStyle.Description,
+                ColumnDefinitions.CodeStyle.Value,
+                ColumnDefinitions.CodeStyle.Severity
+            };
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/ColumnDefinitions.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/ColumnDefinitions.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal static class ColumnDefinitions
+    {
+        private const string Prefix = "editorconfig.";
+
+        internal static class Analyzer
+        {
+            private const string AnalyzerPrefix = "analyzer.";
+            public const string Category = Prefix + AnalyzerPrefix + "categoryname";
+            public const string Enabled = Prefix + AnalyzerPrefix + "enabledname";
+            public const string Description = Prefix + AnalyzerPrefix + "descriptionname";
+            public const string Id = Prefix + AnalyzerPrefix + "idname";
+            public const string Severity = Prefix + AnalyzerPrefix + "severityname";
+            public const string Title = Prefix + AnalyzerPrefix + "titlename";
+        }
+
+        internal static class CodeStyle
+        {
+            private const string CodeStylePrefix = "codestyle.";
+            public const string Category = Prefix + CodeStylePrefix + "categoryname";
+            public const string Description = Prefix + CodeStylePrefix + "descriptionname";
+            public const string Value = Prefix + CodeStylePrefix + "valuename";
+            public const string Severity = Prefix + CodeStylePrefix + "severityname";
+        }
+
+        internal static class Formatting
+        {
+            private const string FormattingPrefix = "Formatting.";
+            public const string Category = Prefix + FormattingPrefix + "categoryname";
+            public const string Description = Prefix + FormattingPrefix + "descriptionname";
+            public const string Value = Prefix + FormattingPrefix + "valuename";
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EditorTextUpdater.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EditorTextUpdater.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal static class EditorTextUpdater
+    {
+        public static void UpdateText(IThreadingContext threadingContext,
+                                      IVsEditorAdaptersFactoryService editorAdaptersFactoryService,
+                                      IVsTextLines textLines,
+                                      IWpfSettingsEditorViewModel viewModel)
+            => threadingContext.JoinableTaskFactory.Run(async () =>
+            {
+                var buffer = editorAdaptersFactoryService.GetDocumentBuffer(textLines);
+                if (buffer is null)
+                {
+                    return;
+                }
+
+                var changes = await viewModel.GetChangesAsync().ConfigureAwait(true);
+                if (changes is null)
+                {
+                    return;
+                }
+
+                TextEditApplication.UpdateText(changes.ToImmutableArray(), buffer, EditOptions.DefaultMinimalChange);
+            });
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.EnumSettingView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid x:Name="RootGrid">
+            
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
         private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var index = _comboBox.SelectedIndex;
-            if (_descriptions.Length < index && index >= 0)
+            if (index < _descriptions.Length && index >= 0)
             {
                 _model.ChangeProperty(_descriptions[index]);
             }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Controls;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+
+    /// <summary>
+    /// Interaction logic for EnumPropertyView.xaml
+    /// </summary>
+    internal partial class EnumSettingView : UserControl
+    {
+        private readonly IEnumSettingViewModel _model;
+        private readonly string[] _descriptions;
+        private readonly ComboBox _comboBox;
+
+        public EnumSettingView(IEnumSettingViewModel model)
+        {
+            InitializeComponent();
+            _model = model;
+
+            _descriptions = _model.GetValueDescriptions();
+            _comboBox = new ComboBox()
+            {
+                ItemsSource = _descriptions
+            };
+
+            _comboBox.SelectedIndex = model.GetValueIndex();
+            _comboBox.SelectionChanged += ComboBox_SelectionChanged;
+
+            _ = RootGrid.Children.Add(_comboBox);
+        }
+
+        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var index = _comboBox.SelectedIndex;
+            if (_descriptions.Length < index && index >= 0)
+            {
+                _model.ChangeProperty(_descriptions[index]);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumPropertyView.xaml.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Windows.Automation;
 using System.Windows.Controls;
 
 namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
@@ -28,6 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
             };
 
             _comboBox.SelectedIndex = model.GetValueIndex();
+            _comboBox.SetValue(AutomationProperties.NameProperty, ServicesVSResources.Value);
             _comboBox.SelectionChanged += ComboBox_SelectionChanged;
 
             _ = RootGrid.Children.Add(_comboBox);

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumSettingViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/EnumSettingViewModel.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal abstract class EnumSettingViewModel<T> : IEnumSettingViewModel
+        where T : Enum
+    {
+        private readonly IReadOnlyDictionary<string, T> _mapping;
+
+        protected EnumSettingViewModel()
+        {
+            _mapping = GetValuesAndDescriptions();
+        }
+
+        public void ChangeProperty(string propertyDescription)
+        {
+            if (_mapping.TryGetValue(propertyDescription, out var value))
+            {
+                ChangePropertyTo(value);
+            }
+        }
+
+        public string[] GetValueDescriptions()
+            => _mapping.Keys.ToArray();
+
+        public int GetValueIndex()
+        {
+            var value = GetCurrentValue();
+            return _mapping.Values.ToList().IndexOf(value);
+        }
+
+        protected abstract IReadOnlyDictionary<string, T> GetValuesAndDescriptions();
+        protected abstract void ChangePropertyTo(T newValue);
+        protected abstract T GetCurrentValue();
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/IEnumSettingViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/IEnumSettingViewModel.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+
+    internal interface IEnumSettingViewModel
+    {
+        string[] GetValueDescriptions();
+        int GetValueIndex();
+        void ChangeProperty(string v);
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/IEnumSettingViewModelFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/IEnumSettingViewModelFactory.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal interface IEnumSettingViewModelFactory
+    {
+        bool IsSupported(OptionKey2 key);
+        IEnumSettingViewModel CreateViewModel(FormattingSetting setting);
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/RemoveSinkWhenDisposed.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/RemoveSinkWhenDisposed.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell.TableManager;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal class RemoveSinkWhenDisposed : IDisposable
+    {
+        private readonly List<ITableDataSink> _tableSinks;
+        private readonly ITableDataSink _sink;
+
+        public RemoveSinkWhenDisposed(List<ITableDataSink> tableSinks, ITableDataSink sink)
+        {
+            _tableSinks = tableSinks;
+            _sink = sink;
+        }
+
+        public void Dispose()
+        {
+            // whoever subscribed is no longer interested in my data.
+            // Remove them from the list of sinks
+            _ = _tableSinks.Remove(_sink);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsEntriesSnapshotBase.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsEntriesSnapshotBase.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.Shell.TableControl;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal abstract class SettingsEntriesSnapshotBase<T> : WpfTableEntriesSnapshotBase
+    {
+        private readonly ImmutableArray<T> _data;
+        private readonly int _currentVersionNumber;
+
+        public SettingsEntriesSnapshotBase(ImmutableArray<T> data, int currentVersionNumber)
+        {
+            _data = data;
+            _currentVersionNumber = currentVersionNumber;
+        }
+
+        public override int VersionNumber => _currentVersionNumber;
+        public override int Count => _data.Length;
+
+        public override bool TryGetValue(int index, string keyName, out object? content)
+        {
+            T? result;
+            try
+            {
+                if (index < 0 || index > _data.Length)
+                {
+                    content = null;
+                    return false;
+                }
+
+                result = _data[index];
+
+                if (result == null)
+                {
+                    content = null;
+                    return false;
+                }
+            }
+            catch (Exception)
+            {
+                content = null;
+                return false;
+            }
+
+            return TryGetValue(result, keyName, out content);
+        }
+
+        protected abstract bool TryGetValue(T result, string keyName, out object? content);
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsSnapshotFactoryBase.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsSnapshotFactoryBase.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.VisualStudio.Shell.TableManager;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal abstract class SettingsSnapshotFactoryBase<T, TEntriesSnapshot> : TableEntriesSnapshotFactoryBase
+        where TEntriesSnapshot : SettingsEntriesSnapshotBase<T>
+    {
+        private readonly ISettingsProvider<T> _data;
+
+        // State
+        private int _currentVersionNumber;
+        private int _lastSnapshotVersionNumber = -1;
+        private TEntriesSnapshot? _lastSnapshot;
+
+        // Disallow concurrent modification of state
+        private readonly object _gate = new();
+
+        public SettingsSnapshotFactoryBase(ISettingsProvider<T> data)
+        {
+            _data = data;
+        }
+
+        public override int CurrentVersionNumber => _currentVersionNumber;
+
+        public override ITableEntriesSnapshot? GetCurrentSnapshot() => GetSnapshot(CurrentVersionNumber);
+
+        internal void NotifyOfUpdate() => Interlocked.Increment(ref _currentVersionNumber);
+
+        public override ITableEntriesSnapshot? GetSnapshot(int versionNumber)
+        {
+            lock (_gate)
+            {
+                if (versionNumber == _currentVersionNumber)
+                {
+                    if (_lastSnapshotVersionNumber == _currentVersionNumber)
+                    {
+                        return _lastSnapshot;
+                    }
+                    else
+                    {
+                        var data = _data.GetCurrentDataSnapshot();
+                        var snapshot = CreateSnapshot(data, _currentVersionNumber);
+
+                        _lastSnapshot = snapshot;
+                        _lastSnapshotVersionNumber = _currentVersionNumber;
+
+                        return snapshot;
+                    }
+                }
+                else if (versionNumber < _currentVersionNumber)
+                {
+                    // We can return null from this method.
+                    // This will signal to Table Control to request current snapshot.
+                    return null;
+                }
+                else // versionNumber > this.currentVersionNumber
+                {
+                    throw new InvalidOperationException($"Invalid GetSnapshot request. Requested version: {versionNumber}. Current version: {_currentVersionNumber}");
+                }
+            }
+        }
+
+        protected abstract TEntriesSnapshot CreateSnapshot(ImmutableArray<T> data, int currentVersionNumber);
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsViewModelBase.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsViewModelBase.cs
@@ -69,9 +69,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
             return new RemoveSinkWhenDisposed(TableSinks, sink);
         }
 
-        public Task<IReadOnlyList<TextChange>?> GetChangesAsync()
-            => _data.GetChangedEditorConfigAsync();
-
         public IWpfTableControl4 GetTableControl()
         {
             var initialColumnStates = GetInitialColumnStates();
@@ -83,9 +80,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
                     fixedColumns);
         }
 
-        public void ShutDown()
-        {
-            _tableManager.RemoveSource(this);
-        }
+        public void ShutDown() => _ = _tableManager.RemoveSource(this);
+
+        public Task<SourceText> UpdateEditorConfigAsync(SourceText sourceText) => _data.GetChangedEditorConfigAsync(sourceText);
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsViewModelBase.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsViewModelBase.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
+{
+    internal abstract partial class SettingsViewModelBase<T, TSnapshotFactory, TEntriesSnapshot> : IWpfSettingsEditorViewModel, ITableDataSource
+        where TSnapshotFactory : SettingsSnapshotFactoryBase<T, TEntriesSnapshot>
+        where TEntriesSnapshot : SettingsEntriesSnapshotBase<T>
+    {
+        private readonly ISettingsProvider<T> _data;
+        private readonly IWpfTableControlProvider _controlProvider;
+        private readonly TSnapshotFactory _snapshotFactory;
+        private readonly ITableManager _tableManager;
+
+        private List<ITableDataSink> TableSinks { get; } = new List<ITableDataSink>();
+
+        protected SettingsViewModelBase(ISettingsProvider<T> data,
+                                        IWpfTableControlProvider controlProvider,
+                                        ITableManagerProvider tableMangerProvider)
+        {
+            _data = data;
+            _controlProvider = controlProvider;
+            _data.RegisterViewModel(this);
+            _tableManager = tableMangerProvider.GetTableManager(Identifier);
+            _ = _tableManager.AddSource(this);
+            _snapshotFactory = CreateSnapshotFactory(_data);
+        }
+
+        public abstract string Identifier { get; }
+        protected abstract TSnapshotFactory CreateSnapshotFactory(ISettingsProvider<T> data);
+        protected abstract string[] GetFixedColumns();
+        protected abstract IEnumerable<ColumnState2> GetInitialColumnStates();
+
+        public string SourceTypeIdentifier => "EditorConfigSettings";
+        public string? DisplayName => null;
+
+        public Task NotifyOfUpdateAsync()
+        {
+            _snapshotFactory.NotifyOfUpdate();
+
+            // Notify the sinks. Generally, VS Table Control will request data 500ms after the last notification.
+            foreach (var tableSink in TableSinks)
+            {
+                // Notify that an update is available
+                tableSink.FactorySnapshotChanged(null);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public IDisposable Subscribe(ITableDataSink sink)
+        {
+            sink.AddFactory(_snapshotFactory);
+            TableSinks.Add(sink);
+            return new RemoveSinkWhenDisposed(TableSinks, sink);
+        }
+
+        public Task<IReadOnlyList<TextChange>?> GetChangesAsync()
+            => _data.GetChangedEditorConfigAsync();
+
+        public IWpfTableControl4 GetTableControl()
+        {
+            var initialColumnStates = GetInitialColumnStates();
+            var fixedColumns = GetFixedColumns();
+            return (IWpfTableControl4)_controlProvider.CreateControl(
+                    _tableManager,
+                    true,
+                    initialColumnStates,
+                    fixedColumns);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingCategoryColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingCategoryColumnDefinition.cs
@@ -40,6 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         public override double MinWidth => 80;
         public override bool DefaultVisible => false;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
         public override TextWrapping TextWrapping => TextWrapping.NoWrap;
 
         private static string? GetCategoryName(ITableEntryHandle entry)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingCategoryColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingCategoryColumnDefinition.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Formatting;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View.ColumnDefnitions
+{
+    [Export(typeof(IDefaultColumnGroup))]
+    [Name(nameof(FormattingCategoryGroupingSet))]    // Required, name of the default group
+    [GroupColumns(Category)] // Required, the names of the columns in the grouping
+    internal class FormattingCategoryGroupingSet : IDefaultColumnGroup
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FormattingCategoryGroupingSet()
+        {
+        }
+    }
+
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Category)]
+    internal class FormattingCategoryColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FormattingCategoryColumnDefinition()
+        {
+        }
+
+        public override string Name => Category;
+        public override string DisplayName => ServicesVSResources.Category;
+        public override double MinWidth => 80;
+        public override bool DefaultVisible => false;
+        public override bool IsFilterable => true;
+        public override TextWrapping TextWrapping => TextWrapping.NoWrap;
+
+        private static string? GetCategoryName(ITableEntryHandle entry)
+            => entry.TryGetValue(Category, out string? categoryName)
+                ? categoryName
+                : null;
+
+        public override IEntryBucket? CreateBucketForEntry(ITableEntryHandle entry)
+        {
+            var categoryName = GetCategoryName(entry);
+            return categoryName is not null ? new StringEntryBucket(GetCategoryName(entry)) : null;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingDescriptionColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingDescriptionColumnDefinition.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Formatting;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View.ColumnDefnitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Description)]
+    internal class FormattingDescriptionColumnDefinition : TableColumnDefinitionBase
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FormattingDescriptionColumnDefinition()
+        {
+        }
+
+        public override string Name => Description;
+        public override string DisplayName => ServicesVSResources.Description;
+        public override bool IsFilterable => false;
+        public override double DefaultWidth => 350;
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingDescriptionColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingDescriptionColumnDefinition.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         public override string Name => Description;
         public override string DisplayName => ServicesVSResources.Description;
         public override bool IsFilterable => false;
+        public override bool IsSortable => false;
         public override double DefaultWidth => 350;
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingValueColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingValueColumnDefinition.cs
@@ -33,8 +33,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         public override string DisplayName => ServicesVSResources.Value;
         public override double MinWidth => 80;
         public override bool DefaultVisible => false;
-        public override bool IsFilterable => true;
-        public override bool IsSortable => true;
+        public override bool IsFilterable => false;
+        public override bool IsSortable => false;
         public override TextWrapping TextWrapping => TextWrapping.NoWrap;
 
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingValueColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingValueColumnDefinition.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Windows;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Utilities;
+using static Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common.ColumnDefinitions.Formatting;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View.ColumnDefnitions
+{
+    [Export(typeof(ITableColumnDefinition))]
+    [Name(Value)]
+    internal class FormattingValueColumnDefinition : TableColumnDefinitionBase
+    {
+        private readonly IEnumerable<IEnumSettingViewModelFactory> _factories;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FormattingValueColumnDefinition([ImportMany] IEnumerable<IEnumSettingViewModelFactory> factories)
+        {
+            _factories = factories;
+        }
+
+        public override string Name => Value;
+        public override string DisplayName => ServicesVSResources.Value;
+        public override double MinWidth => 80;
+        public override bool DefaultVisible => false;
+        public override bool IsFilterable => true;
+        public override TextWrapping TextWrapping => TextWrapping.NoWrap;
+
+        public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)
+        {
+            if (!entry.TryGetValue(Value, out FormattingSetting setting))
+            {
+                content = null;
+                return false;
+            }
+            if (setting.Type == typeof(bool))
+            {
+                content = new FormattingBoolSettingView(setting);
+                return true;
+            }
+
+            foreach (var factory in _factories)
+            {
+                if (factory.IsSupported(setting.Key))
+                {
+                    var viewModel = factory.CreateViewModel(setting);
+                    content = new EnumSettingView(viewModel);
+                    return true;
+                }
+            }
+
+            content = null;
+            return false;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingValueColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/ColumnDefnitions/FormattingValueColumnDefinition.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         public override double MinWidth => 80;
         public override bool DefaultVisible => false;
         public override bool IsFilterable => true;
+        public override bool IsSortable => true;
         public override TextWrapping TextWrapping => TextWrapping.NoWrap;
 
         public override bool TryCreateColumnContent(ITableEntryHandle entry, bool singleColumnView, out FrameworkElement? content)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml
@@ -5,6 +5,5 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d" 
              x:ClassModifier="internal">
-    <Grid x:Name="RootGrid">
-    </Grid>
+    <CheckBox x:Name="RootCheckBox" Checked="CheckBoxChanged" Unchecked="CheckBoxChanged" />
 </UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View.FormattingBoolSettingView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid x:Name="RootGrid">
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
@@ -33,7 +33,12 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
 
         private void CheckBoxChanged(object sender, RoutedEventArgs e)
         {
-            _setting.SetValue(RootCheckBox.IsChecked == true);
+            var value = RootCheckBox.IsChecked == true;
+            if (_setting.GetValue() is bool currentValue &&
+                value != currentValue)
+            {
+                _setting.SetValue(value);
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View
+{
+    /// <summary>
+    /// Interaction logic for WhitespaceValueSettingControl.xaml
+    /// </summary>
+    internal partial class FormattingBoolSettingView : UserControl
+    {
+        private readonly FormattingSetting _setting;
+        private readonly CheckBox _checkBox;
+
+        public FormattingBoolSettingView(FormattingSetting setting)
+        {
+            InitializeComponent();
+            _setting = setting;
+            _checkBox = new CheckBox();
+
+            if (setting.GetValue() is bool value)
+            {
+                _checkBox.IsChecked = value;
+            }
+
+            _checkBox.Checked += CheckBoxChanged;
+            _checkBox.Unchecked += CheckBoxChanged;
+
+            _ = RootGrid.Children.Add(_checkBox);
+        }
+
+        private void CheckBoxChanged(object sender, RoutedEventArgs e)
+        {
+            _setting.SetValue(_checkBox.IsChecked == true);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
@@ -14,28 +14,21 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
     internal partial class FormattingBoolSettingView : UserControl
     {
         private readonly FormattingSetting _setting;
-        private readonly CheckBox _checkBox;
 
         public FormattingBoolSettingView(FormattingSetting setting)
         {
             InitializeComponent();
             _setting = setting;
-            _checkBox = new CheckBox();
 
             if (setting.GetValue() is bool value)
             {
-                _checkBox.IsChecked = value;
+                RootCheckBox.IsChecked = value;
             }
-
-            _checkBox.Checked += CheckBoxChanged;
-            _checkBox.Unchecked += CheckBoxChanged;
-
-            _ = RootGrid.Children.Add(_checkBox);
         }
 
         private void CheckBoxChanged(object sender, RoutedEventArgs e)
         {
-            _setting.SetValue(_checkBox.IsChecked == true);
+            _setting.SetValue(RootCheckBox.IsChecked == true);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
 
@@ -18,6 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         public FormattingBoolSettingView(FormattingSetting setting)
         {
             InitializeComponent();
+            RootCheckBox.SetValue(AutomationProperties.NameProperty, ServicesVSResources.Value);
             _setting = setting;
 
             if (setting.GetValue() is bool value)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingBoolSettingView.xaml.cs
@@ -26,6 +26,9 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
             {
                 RootCheckBox.IsChecked = value;
             }
+
+            RootCheckBox.Checked += CheckBoxChanged;
+            RootCheckBox.Unchecked += CheckBoxChanged;
         }
 
         private void CheckBoxChanged(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml
@@ -8,7 +8,7 @@
              x:ClassModifier="internal">
     <Grid>
         <Border
-            x:Name="WhitespaceTable"
+            x:Name="FormattingTable"
             Grid.Row="0"
             BorderThickness="1"
             Margin="12 0"

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View.FormattingSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View"
+             mc:Ignorable="d" 
+             x:ClassModifier="internal">
+    <Grid>
+        <Border
+            x:Name="WhitespaceTable"
+            Grid.Row="0"
+            BorderThickness="1"
+            Margin="12 0"
+            VerticalAlignment="Stretch"
+            HorizontalAlignment="Stretch" />
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
 using Microsoft.VisualStudio.Shell.TableControl;
@@ -16,20 +18,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
     /// </summary>
     internal partial class FormattingSettingsView : UserControl, ISettingsEditorView
     {
-        private readonly IVsTextLines _vsTextLines;
-        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
-        private readonly IThreadingContext _threadingContext;
         private readonly IWpfSettingsEditorViewModel _viewModel;
 
-        public FormattingSettingsView(IVsTextLines vsTextLines,
-                                      IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
-                                      IThreadingContext threadingContext,
-                                      IWpfSettingsEditorViewModel viewModel)
+        public FormattingSettingsView(IWpfSettingsEditorViewModel viewModel)
         {
             InitializeComponent();
-            _vsTextLines = vsTextLines;
-            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
-            _threadingContext = threadingContext;
             _viewModel = viewModel;
             TableControl = _viewModel.GetTableControl();
             FormattingTable.Child = TableControl.Control;
@@ -37,18 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
 
         public UserControl SettingControl => this;
         public IWpfTableControl TableControl { get; }
-
-        public void OnClose()
-        {
-            _viewModel.ShutDown();
-        }
-
-        public void Synchronize()
-        {
-            if (IsKeyboardFocusWithin)
-            {
-                EditorTextUpdater.UpdateText(_threadingContext, _vsEditorAdaptersFactoryService, _vsTextLines, _viewModel);
-            }
-        }
+        public Task<SourceText> UpdateEditorConfigAsync(SourceText sourceText) => _viewModel.UpdateEditorConfigAsync(sourceText);
+        public void OnClose() => _viewModel.ShutDown();
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
             _threadingContext = threadingContext;
             _viewModel = viewModel;
             TableControl = _viewModel.GetTableControl();
-            WhitespaceTable.Child = TableControl.Control;
+            FormattingTable.Child = TableControl.Control;
         }
 
         public UserControl SettingControl => this;

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View
+{
+    /// <summary>
+    /// Interaction logic for FormattingSettingsView.xaml
+    /// </summary>
+    internal partial class FormattingSettingsView : UserControl, ISettingsEditorView
+    {
+        private readonly IVsTextLines _vsTextLines;
+        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
+        private readonly IThreadingContext _threadingContext;
+        private readonly IWpfSettingsEditorViewModel _viewModel;
+
+        public FormattingSettingsView(IVsTextLines vsTextLines,
+                                      IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
+                                      IThreadingContext threadingContext,
+                                      IWpfSettingsEditorViewModel viewModel)
+        {
+            InitializeComponent();
+            _vsTextLines = vsTextLines;
+            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
+            _threadingContext = threadingContext;
+            _viewModel = viewModel;
+            TableControl = _viewModel.GetTableControl();
+            WhitespaceTable.Child = TableControl.Control;
+        }
+
+        public UserControl SettingControl => this;
+        public IWpfTableControl TableControl { get; }
+
+        public void Synchronize()
+        {
+            if (IsKeyboardFocusWithin)
+            {
+                EditorTextUpdater.UpdateText(_threadingContext, _vsEditorAdaptersFactoryService, _vsTextLines, _viewModel);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/View/FormattingSettingsView.xaml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -37,6 +37,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
 
         public UserControl SettingControl => this;
         public IWpfTableControl TableControl { get; }
+
+        public void OnClose()
+        {
+            _viewModel.ShutDown();
+        }
 
         public void Synchronize()
         {

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/FormattingViewModel.SettingsEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/FormattingViewModel.SettingsEntriesSnapshot.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    internal partial class FormattingViewModel
+    {
+        internal sealed class SettingsEntriesSnapshot : SettingsEntriesSnapshotBase<FormattingSetting>
+        {
+            public SettingsEntriesSnapshot(ImmutableArray<FormattingSetting> data, int currentVersionNumber) : base(data, currentVersionNumber) { }
+
+            protected override bool TryGetValue(FormattingSetting result, string keyName, out object? content)
+            {
+                content = keyName switch
+                {
+                    ColumnDefinitions.Formatting.Description => result.Description,
+                    ColumnDefinitions.Formatting.Category => result.Category,
+                    ColumnDefinitions.Formatting.Value => result,
+                    _ => null,
+                };
+
+                return content is not null;
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/FormattingViewModel.SettingsSnapshotFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/FormattingViewModel.SettingsSnapshotFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    internal partial class FormattingViewModel
+    {
+        internal sealed class SettingsSnapshotFactory : SettingsSnapshotFactoryBase<FormattingSetting, SettingsEntriesSnapshot>
+        {
+            public SettingsSnapshotFactory(ISettingsProvider<FormattingSetting> data) : base(data) { }
+
+            protected override SettingsEntriesSnapshot CreateSnapshot(ImmutableArray<FormattingSetting> data, int currentVersionNumber)
+                => new(data, currentVersionNumber);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/FormattingViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/FormattingViewModel.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider;
+using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    internal partial class FormattingViewModel : SettingsViewModelBase<
+        FormattingSetting,
+        FormattingViewModel.SettingsSnapshotFactory,
+        FormattingViewModel.SettingsEntriesSnapshot>
+    {
+        public FormattingViewModel(ISettingsProvider<FormattingSetting> data,
+                                   IWpfTableControlProvider controlProvider,
+                                   ITableManagerProvider tableMangerProvider)
+            : base(data, controlProvider, tableMangerProvider)
+        { }
+
+        public override string Identifier => "Whitespace";
+
+        protected override SettingsSnapshotFactory CreateSnapshotFactory(ISettingsProvider<FormattingSetting> data)
+            => new(data);
+
+        protected override IEnumerable<ColumnState2> GetInitialColumnStates()
+            => new[]
+            {
+                new ColumnState2(ColumnDefinitions.Formatting.Category, isVisible: false, width: 0, groupingPriority: 1),
+                new ColumnState2(ColumnDefinitions.Formatting.Description, isVisible: true, width: 0),
+                new ColumnState2(ColumnDefinitions.Formatting.Value, isVisible: true, width: 0)
+            };
+
+        protected override string[] GetFixedColumns()
+            => new[]
+            {
+                ColumnDefinitions.Formatting.Category,
+                ColumnDefinitions.Formatting.Description,
+                ColumnDefinitions.Formatting.Value
+            };
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/IndentationSizeViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/IndentationSizeViewModel.cs
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         public bool IsSupported(OptionKey2 key) => _key == key;
     }
 
-    // TODO(jmarolf): do not do this thing
     internal enum IndentationSizeSetting
     {
         _1,

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/IndentationSizeViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/IndentationSizeViewModel.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    [Export(typeof(IEnumSettingViewModelFactory)), Shared]
+    internal class IndentationSizeVViewModelFactory : IEnumSettingViewModelFactory
+    {
+        private readonly OptionKey2 _key;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public IndentationSizeVViewModelFactory()
+        {
+            _key = new OptionKey2(FormattingOptions2.IndentationSize, LanguageNames.CSharp);
+        }
+
+        public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
+        {
+            return new IndentationSizeViewModel(setting);
+        }
+
+        public bool IsSupported(OptionKey2 key) => _key == key;
+    }
+
+    // TODO(jmarolf): do not do this thing
+    internal enum IndentationSizeSetting
+    {
+        _1,
+        _2,
+        _3,
+        _4,
+        _5,
+        _6,
+        _7,
+        _8,
+    }
+
+    internal class IndentationSizeViewModel : EnumSettingViewModel<IndentationSizeSetting>
+    {
+        private readonly FormattingSetting _setting;
+
+        public IndentationSizeViewModel(FormattingSetting setting)
+        {
+            _setting = setting;
+        }
+
+        protected override void ChangePropertyTo(IndentationSizeSetting newValue)
+        {
+            switch (newValue)
+            {
+                case IndentationSizeSetting._1:
+                    _setting.SetValue(1);
+                    break;
+                case IndentationSizeSetting._2:
+                    _setting.SetValue(2);
+                    break;
+                case IndentationSizeSetting._3:
+                    _setting.SetValue(3);
+                    break;
+                case IndentationSizeSetting._4:
+                    _setting.SetValue(4);
+                    break;
+                case IndentationSizeSetting._5:
+                    _setting.SetValue(5);
+                    break;
+                case IndentationSizeSetting._6:
+                    _setting.SetValue(6);
+                    break;
+                case IndentationSizeSetting._7:
+                    _setting.SetValue(7);
+                    break;
+                case IndentationSizeSetting._8:
+                    _setting.SetValue(8);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        protected override IndentationSizeSetting GetCurrentValue()
+        {
+            return _setting.GetValue() switch
+            {
+                1 => IndentationSizeSetting._1,
+                2 => IndentationSizeSetting._2,
+                3 => IndentationSizeSetting._3,
+                4 => IndentationSizeSetting._4,
+                5 => IndentationSizeSetting._5,
+                6 => IndentationSizeSetting._6,
+                7 => IndentationSizeSetting._7,
+                _ => IndentationSizeSetting._8,
+            };
+        }
+
+        protected override IReadOnlyDictionary<string, IndentationSizeSetting> GetValuesAndDescriptions()
+        {
+            return EnumerateOptions().ToDictionary(x => x.description, x => x.value);
+
+            static IEnumerable<(string description, IndentationSizeSetting value)> EnumerateOptions()
+            {
+                yield return ("1", IndentationSizeSetting._1);
+                yield return ("2", IndentationSizeSetting._2);
+                yield return ("3", IndentationSizeSetting._3);
+                yield return ("4", IndentationSizeSetting._4);
+                yield return ("5", IndentationSizeSetting._5);
+                yield return ("6", IndentationSizeSetting._6);
+                yield return ("7", IndentationSizeSetting._7);
+                yield return ("8", IndentationSizeSetting._8);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/NewLineViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/NewLineViewModel.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    [Export(typeof(IEnumSettingViewModelFactory)), Shared]
+    internal class NewLineViewModelFactory : IEnumSettingViewModelFactory
+    {
+        private readonly OptionKey2 _key;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public NewLineViewModelFactory()
+        {
+            _key = new OptionKey2(FormattingOptions2.NewLine, LanguageNames.CSharp);
+        }
+
+        public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSupported(OptionKey2 key) => _key == key;
+    }
+
+    internal enum NewLineSetting
+    {
+        Newline,
+        CarrageReturn,
+        CarrageReturnNewline,
+        NotSet
+    }
+
+    internal class NewLineViewModel : EnumSettingViewModel<NewLineSetting>
+    {
+        private readonly FormattingSetting _setting;
+
+        public NewLineViewModel(FormattingSetting setting)
+        {
+            _setting = setting;
+        }
+
+        protected override void ChangePropertyTo(NewLineSetting newValue)
+        {
+            switch (newValue)
+            {
+                case NewLineSetting.Newline:
+                    _setting.SetValue("lf");
+                    break;
+                case NewLineSetting.CarrageReturn:
+                    _setting.SetValue("cr");
+                    break;
+                case NewLineSetting.CarrageReturnNewline:
+                    _setting.SetValue("crlf");
+                    break;
+                case NewLineSetting.NotSet:
+                default:
+                    break;
+            }
+        }
+
+        protected override NewLineSetting GetCurrentValue()
+        {
+            return _setting.GetValue() switch
+            {
+                "lf" => NewLineSetting.Newline,
+                "cr" => NewLineSetting.CarrageReturn,
+                "crlf" => NewLineSetting.CarrageReturnNewline,
+                _ => NewLineSetting.NotSet,
+            };
+        }
+
+        protected override IReadOnlyDictionary<string, NewLineSetting> GetValuesAndDescriptions()
+        {
+            return EnumerateOptions().ToDictionary(x => x.description, x => x.value);
+
+            static IEnumerable<(string description, NewLineSetting value)> EnumerateOptions()
+            {
+                yield return (ServicesVSResources.Newline_n, NewLineSetting.Newline);
+                yield return (ServicesVSResources.Carrage_Return_r, NewLineSetting.CarrageReturn);
+                yield return (ServicesVSResources.Carrage_Return_Newline_rn, NewLineSetting.CarrageReturnNewline);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/NewLineViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/NewLineViewModel.cs
@@ -57,13 +57,13 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
             switch (newValue)
             {
                 case NewLineSetting.Newline:
-                    _setting.SetValue("lf");
+                    _setting.SetValue("\n");
                     break;
                 case NewLineSetting.CarrageReturn:
-                    _setting.SetValue("cr");
+                    _setting.SetValue("\r");
                     break;
                 case NewLineSetting.CarrageReturnNewline:
-                    _setting.SetValue("crlf");
+                    _setting.SetValue("\r\n");
                     break;
                 case NewLineSetting.NotSet:
                 default:
@@ -75,9 +75,9 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         {
             return _setting.GetValue() switch
             {
-                "lf" => NewLineSetting.Newline,
-                "cr" => NewLineSetting.CarrageReturn,
-                "crlf" => NewLineSetting.CarrageReturnNewline,
+                "\n" => NewLineSetting.Newline,
+                "\r" => NewLineSetting.CarrageReturn,
+                "\r\n" => NewLineSetting.CarrageReturnNewline,
                 _ => NewLineSetting.NotSet,
             };
         }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/NewLineViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/NewLineViewModel.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
 
         public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
         {
-            throw new NotImplementedException();
+            return new NewLineViewModel(setting);
         }
 
         public bool IsSupported(OptionKey2 key) => _key == key;

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeSettings.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeSettings.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    internal enum TabSizeSettings
+    {
+        _1 = 1,
+        _2,
+        _3,
+        _4,
+        _5,
+        _6,
+        _7,
+        _8,
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeViewModel.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    [Export(typeof(IEnumSettingViewModelFactory)), Shared]
+    internal class TabSizeViewModelFactory : IEnumSettingViewModelFactory
+    {
+        private readonly OptionKey2 _key;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public TabSizeViewModelFactory()
+        {
+            _key = new OptionKey2(FormattingOptions2.TabSize, LanguageNames.CSharp);
+        }
+
+        public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
+        {
+            return new TabSizeViewModel(setting);
+        }
+
+        public bool IsSupported(OptionKey2 key) => _key == key;
+    }
+
+    internal enum TabSizeSettings
+    {
+        _1,
+        _2,
+        _3,
+        _4,
+        _5,
+        _6,
+        _7,
+        _8,
+    }
+
+    internal class TabSizeViewModel : EnumSettingViewModel<TabSizeSettings>
+    {
+        private readonly FormattingSetting _setting;
+
+        public TabSizeViewModel(FormattingSetting setting)
+        {
+            _setting = setting;
+        }
+
+        protected override void ChangePropertyTo(TabSizeSettings newValue)
+        {
+            switch (newValue)
+            {
+                case TabSizeSettings._1:
+                    _setting.SetValue(1);
+                    break;
+                case TabSizeSettings._2:
+                    _setting.SetValue(2);
+                    break;
+                case TabSizeSettings._3:
+                    _setting.SetValue(3);
+                    break;
+                case TabSizeSettings._4:
+                    _setting.SetValue(4);
+                    break;
+                case TabSizeSettings._5:
+                    _setting.SetValue(5);
+                    break;
+                case TabSizeSettings._6:
+                    _setting.SetValue(6);
+                    break;
+                case TabSizeSettings._7:
+                    _setting.SetValue(7);
+                    break;
+                case TabSizeSettings._8:
+                    _setting.SetValue(8);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        protected override TabSizeSettings GetCurrentValue()
+        {
+            return _setting.GetValue() switch
+            {
+                1 => TabSizeSettings._1,
+                2 => TabSizeSettings._2,
+                3 => TabSizeSettings._3,
+                4 => TabSizeSettings._4,
+                5 => TabSizeSettings._5,
+                6 => TabSizeSettings._6,
+                7 => TabSizeSettings._7,
+                _ => TabSizeSettings._8,
+            };
+        }
+
+        protected override IReadOnlyDictionary<string, TabSizeSettings> GetValuesAndDescriptions()
+        {
+            return EnumerateOptions().ToDictionary(x => x.description, x => x.value);
+
+            static IEnumerable<(string description, TabSizeSettings value)> EnumerateOptions()
+            {
+                yield return ("1", TabSizeSettings._1);
+                yield return ("2", TabSizeSettings._2);
+                yield return ("3", TabSizeSettings._3);
+                yield return ("4", TabSizeSettings._4);
+                yield return ("5", TabSizeSettings._5);
+                yield return ("6", TabSizeSettings._6);
+                yield return ("7", TabSizeSettings._7);
+                yield return ("8", TabSizeSettings._8);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeViewModel.cs
@@ -2,51 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
-using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
 
 namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
 {
-    [Export(typeof(IEnumSettingViewModelFactory)), Shared]
-    internal class TabSizeViewModelFactory : IEnumSettingViewModelFactory
-    {
-        private readonly OptionKey2 _key;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public TabSizeViewModelFactory()
-        {
-            _key = new OptionKey2(FormattingOptions2.TabSize, LanguageNames.CSharp);
-        }
-
-        public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
-        {
-            return new TabSizeViewModel(setting);
-        }
-
-        public bool IsSupported(OptionKey2 key) => _key == key;
-    }
-
-    internal enum TabSizeSettings
-    {
-        _1,
-        _2,
-        _3,
-        _4,
-        _5,
-        _6,
-        _7,
-        _8,
-    }
-
     internal class TabSizeViewModel : EnumSettingViewModel<TabSizeSettings>
     {
         private readonly FormattingSetting _setting;
@@ -57,37 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formattin
         }
 
         protected override void ChangePropertyTo(TabSizeSettings newValue)
-        {
-            switch (newValue)
-            {
-                case TabSizeSettings._1:
-                    _setting.SetValue(1);
-                    break;
-                case TabSizeSettings._2:
-                    _setting.SetValue(2);
-                    break;
-                case TabSizeSettings._3:
-                    _setting.SetValue(3);
-                    break;
-                case TabSizeSettings._4:
-                    _setting.SetValue(4);
-                    break;
-                case TabSizeSettings._5:
-                    _setting.SetValue(5);
-                    break;
-                case TabSizeSettings._6:
-                    _setting.SetValue(6);
-                    break;
-                case TabSizeSettings._7:
-                    _setting.SetValue(7);
-                    break;
-                case TabSizeSettings._8:
-                    _setting.SetValue(8);
-                    break;
-                default:
-                    break;
-            }
-        }
+            => _setting.SetValue((int)newValue);
 
         protected override TabSizeSettings GetCurrentValue()
         {

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeViewModelFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Formatting/ViewModel/TabSizeViewModelFactory.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel
+{
+    [Export(typeof(IEnumSettingViewModelFactory)), Shared]
+    internal class TabSizeViewModelFactory : IEnumSettingViewModelFactory
+    {
+        private readonly OptionKey2 _key;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public TabSizeViewModelFactory()
+        {
+            _key = new OptionKey2(FormattingOptions2.TabSize, LanguageNames.CSharp);
+        }
+
+        public IEnumSettingViewModel CreateViewModel(FormattingSetting setting)
+        {
+            return new TabSizeViewModel(setting);
+        }
+
+        public bool IsSupported(OptionKey2 key) => _key == key;
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/ISettingsEditorView.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/ISettingsEditorView.cs
@@ -12,5 +12,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
         UserControl SettingControl { get; }
         IWpfTableControl TableControl { get; }
         void Synchronize();
+        void OnClose();
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/ISettingsEditorView.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/ISettingsEditorView.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell.TableControl;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    internal interface ISettingsEditorView
+    {
+        UserControl SettingControl { get; }
+        IWpfTableControl TableControl { get; }
+        void Synchronize();
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/ISettingsEditorView.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/ISettingsEditorView.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using System.Windows.Controls;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Shell.TableControl;
 
 namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
@@ -11,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
     {
         UserControl SettingControl { get; }
         IWpfTableControl TableControl { get; }
-        void Synchronize();
+        Task<SourceText> UpdateEditorConfigAsync(SourceText sourceText);
         void OnClose();
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/IWpfSettingsEditorViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/IWpfSettingsEditorViewModel.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.VisualStudio.Shell.TableControl;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    internal interface IWpfSettingsEditorViewModel : ISettingsEditorViewModel
+    {
+        IWpfTableControl4 GetTableControl();
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/IWpfSettingsEditorViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/IWpfSettingsEditorViewModel.cs
@@ -10,5 +10,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
     internal interface IWpfSettingsEditorViewModel : ISettingsEditorViewModel
     {
         IWpfTableControl4 GetTableControl();
+        void ShutDown();
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/ServiceProviderExtensions.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/ServiceProviderExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
         public static bool TryGetService<TInterface>(this IServiceProvider sp, [NotNullWhen(true)] out TInterface? @interface)
                 where TInterface : class
         {
-            @interface = sp.GetService<TInterface, TInterface>(throwOnFailure: false);
+            @interface = sp.GetService<TInterface>();
             return @interface is not null;
         }
 

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/ServiceProviderExtensions.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/ServiceProviderExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    internal static class ServiceProviderExtensions
+    {
+        public static bool TryGetService<TService, TInterface>(this IServiceProvider sp, [NotNullWhen(true)] out TInterface? @interface)
+            where TInterface : class
+        {
+            @interface = sp.GetService<TService, TInterface>(throwOnFailure: false);
+            return @interface is not null;
+        }
+
+        public static bool TryGetService<TInterface>(this IServiceProvider sp, [NotNullWhen(true)] out TInterface? @interface)
+                where TInterface : class
+        {
+            @interface = sp.GetService<TInterface, TInterface>(throwOnFailure: false);
+            return @interface is not null;
+        }
+
+        public static TInterface? GetService<TInterface>(this IServiceProvider sp)
+            where TInterface : class
+        {
+            return sp.GetService<TInterface, TInterface>(throwOnFailure: false);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.SettingsEditorControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             x:ClassModifier="internal"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Styles\ThemedDialogResources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TabControl TabStripPlacement="Top"
+            Grid.Row="0">
+            <TabItem x:Name="FormattingTab" Header="{Binding Formatting}"/>
+            <TabItem x:Name="CodeStyleTab" Header="{Binding CodeStyle}" />
+            <TabItem x:Name="AnalyzersTab" Header="{Binding Analyzers}" />
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell.TableControl;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    /// <summary>
+    /// Interaction logic for SettingsEditorControl.xaml
+    /// </summary>
+    internal partial class SettingsEditorControl : UserControl
+    {
+        private readonly ISettingsEditorView _formattingView;
+        private readonly ISettingsEditorView _codeStyleView;
+        private readonly ISettingsEditorView _analyzerSettingsView;
+
+        public static string Formatting => ServicesVSResources.Formatting;
+        public static string CodeStyle => ServicesVSResources.Code_Style;
+        public static string Analyzers => ServicesVSResources.Analyzers;
+
+        public SettingsEditorControl(ISettingsEditorView formattingView,
+                                     ISettingsEditorView codeStyleView,
+                                     ISettingsEditorView analyzerSettingsView)
+        {
+            InitializeComponent();
+            DataContext = this;
+            _formattingView = formattingView;
+            FormattingTab.Content = _formattingView.SettingControl;
+            _codeStyleView = codeStyleView;
+            CodeStyleTab.Content = _codeStyleView.SettingControl;
+            _analyzerSettingsView = analyzerSettingsView;
+            AnalyzersTab.Content = _analyzerSettingsView.SettingControl;
+        }
+
+        internal void SynchronizeSettings()
+        {
+            _formattingView.Synchronize();
+            _codeStyleView.Synchronize();
+            _analyzerSettingsView.Synchronize();
+        }
+
+        internal IWpfTableControl[] GetTableControls()
+            => new[]
+            {
+                _formattingView.TableControl,
+                _codeStyleView.TableControl,
+                _analyzerSettingsView.TableControl,
+            };
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
@@ -2,8 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Linq;
 using System.Windows.Controls;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common;
 using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
 {
@@ -15,6 +22,9 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
         private readonly ISettingsEditorView _formattingView;
         private readonly ISettingsEditorView _codeStyleView;
         private readonly ISettingsEditorView _analyzerSettingsView;
+        private readonly Workspace _workspace;
+        private readonly string _filepath;
+        private readonly EditorTextUpdater _textUpdater;
 
         public static string Formatting => ServicesVSResources.Formatting;
         public static string CodeStyle => ServicesVSResources.Code_Style;
@@ -22,10 +32,17 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
 
         public SettingsEditorControl(ISettingsEditorView formattingView,
                                      ISettingsEditorView codeStyleView,
-                                     ISettingsEditorView analyzerSettingsView)
+                                     ISettingsEditorView analyzerSettingsView,
+                                     Workspace workspace,
+                                     string filepath,
+                                     IVsEditorAdaptersFactoryService editorAdaptersFactoryService,
+                                     IVsTextLines textLines)
         {
             InitializeComponent();
             DataContext = this;
+            _workspace = workspace;
+            _filepath = filepath;
+            _textUpdater = new EditorTextUpdater(editorAdaptersFactoryService, textLines);
             _formattingView = formattingView;
             FormattingTab.Content = _formattingView.SettingControl;
             _codeStyleView = codeStyleView;
@@ -36,9 +53,24 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
 
         internal void SynchronizeSettings()
         {
-            _formattingView.Synchronize();
-            _codeStyleView.Synchronize();
-            _analyzerSettingsView.Synchronize();
+            if (!IsKeyboardFocusWithin)
+            {
+                return;
+            }
+
+            var solution = _workspace.CurrentSolution;
+            var analyzerConfigDocument = solution.Projects
+                .Select(p => p.TryGetExistingAnalyzerConfigDocumentAtPath(_filepath)).FirstOrDefault();
+            if (analyzerConfigDocument is null)
+            {
+                return;
+            }
+
+            var originalText = analyzerConfigDocument.GetTextSynchronously(default);
+            var updatedText = _formattingView.UpdateEditorConfig(originalText);
+            updatedText = _codeStyleView.UpdateEditorConfig(updatedText);
+            updatedText = _analyzerSettingsView.UpdateEditorConfig(updatedText);
+            _textUpdater.UpdateText(updatedText.GetTextChanges(originalText))
         }
 
         internal IWpfTableControl[] GetTableControls()

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
@@ -48,5 +48,12 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                 _codeStyleView.TableControl,
                 _analyzerSettingsView.TableControl,
             };
+
+        internal void OnClose()
+        {
+            _formattingView.OnClose();
+            _codeStyleView.OnClose();
+            _analyzerSettingsView.OnClose();
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
         public const string Extension = ".editorconfig";
 
         private readonly ISettingsAggregator _settingsDataProviderFactory;
+        private readonly VisualStudioWorkspace _workspace;
         private readonly IWpfTableControlProvider _controlProvider;
         private readonly ITableManagerProvider _tableMangerProvider;
         private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
@@ -43,6 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                                      IThreadingContext threadingContext)
         {
             _settingsDataProviderFactory = workspace.Services.GetRequiredService<ISettingsAggregator>();
+            _workspace = workspace;
             _controlProvider = controlProvider;
             _tableMangerProvider = tableMangerProvider;
             _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
@@ -128,7 +130,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                                                    _controlProvider,
                                                    _tableMangerProvider,
                                                    pszMkDocument,
-                                                   textBuffer);
+                                                   textBuffer,
+                                                   _workspace);
             ppunkDocView = Marshal.GetIUnknownForObject(newEditor);
             ppunkDocData = Marshal.GetIUnknownForObject(textBuffer);
             pbstrEditorCaption = "";

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
@@ -1,0 +1,161 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.TextManager.Interop;
+using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    [Export(typeof(SettingsEditorFactory))]
+    [Guid(SettingsEditorFactoryGuidString)]
+    internal sealed class SettingsEditorFactory : IVsEditorFactory, IDisposable
+    {
+        public static readonly Guid SettingsEditorFactoryGuid = new(SettingsEditorFactoryGuidString);
+        public const string SettingsEditorFactoryGuidString = "68b46364-d378-42f2-9e72-37d86c5f4468";
+        public const string Extension = ".editorconfig";
+
+        private readonly ISettingsAggregator _settingsDataProviderFactory;
+        private readonly IWpfTableControlProvider _controlProvider;
+        private readonly ITableManagerProvider _tableMangerProvider;
+        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
+        private readonly IThreadingContext _threadingContext;
+        private ServiceProvider? _vsServiceProvider;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public SettingsEditorFactory(VisualStudioWorkspace workspace,
+                                     IWpfTableControlProvider controlProvider,
+                                     ITableManagerProvider tableMangerProvider,
+                                     IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
+                                     IThreadingContext threadingContext)
+        {
+            _settingsDataProviderFactory = workspace.Services.GetRequiredService<ISettingsAggregator>();
+            _controlProvider = controlProvider;
+            _tableMangerProvider = tableMangerProvider;
+            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
+            _threadingContext = threadingContext;
+        }
+
+        public void Dispose()
+        {
+            if (_vsServiceProvider is not null)
+            {
+                _vsServiceProvider.Dispose();
+                _vsServiceProvider = null;
+            }
+        }
+
+        public int CreateEditorInstance(uint grfCreateDoc,
+                                        string pszMkDocument,
+                                        string pszPhysicalView,
+                                        IVsHierarchy pvHier,
+                                        uint itemid,
+                                        IntPtr punkDocDataExisting,
+                                        out IntPtr ppunkDocView,
+                                        out IntPtr ppunkDocData,
+                                        out string? pbstrEditorCaption,
+                                        out Guid pguidCmdUI,
+                                        out int pgrfCDW)
+        {
+            // Initialize to null
+            ppunkDocView = IntPtr.Zero;
+            ppunkDocData = IntPtr.Zero;
+            pguidCmdUI = SettingsEditorFactoryGuid;
+            pgrfCDW = 0;
+            pbstrEditorCaption = null;
+
+            // Validate inputs
+            if ((grfCreateDoc & (VSConstants.CEF_OPENFILE | VSConstants.CEF_SILENT)) == 0)
+            {
+                return VSConstants.E_INVALIDARG;
+            }
+
+            IVsTextLines? textBuffer = null;
+            if (punkDocDataExisting == IntPtr.Zero)
+            {
+                Assumes.NotNull(_vsServiceProvider);
+                if (_vsServiceProvider.TryGetService<SLocalRegistry, ILocalRegistry>(out var localRegistry))
+                {
+                    var textLinesGuid = typeof(IVsTextLines).GUID;
+                    _ = localRegistry.CreateInstance(typeof(VsTextBufferClass).GUID, null, ref textLinesGuid, 1 /*CLSCTX_INPROC_SERVER*/, out var ptr);
+                    try
+                    {
+                        textBuffer = Marshal.GetObjectForIUnknown(ptr) as IVsTextLines;
+                    }
+                    finally
+                    {
+                        _ = Marshal.Release(ptr); // Release RefCount from CreateInstance call
+                    }
+
+                    if (textBuffer is IObjectWithSite objectWithSite)
+                    {
+                        var oleServiceProvider = _vsServiceProvider.GetService<IOleServiceProvider>();
+                        objectWithSite.SetSite(oleServiceProvider);
+                    }
+                }
+            }
+            else
+            {
+                textBuffer = Marshal.GetObjectForIUnknown(punkDocDataExisting) as IVsTextLines;
+                if (textBuffer == null)
+                {
+                    return VSConstants.VS_E_INCOMPATIBLEDOCDATA;
+                }
+            }
+
+            if (textBuffer is null)
+            {
+                throw new InvalidOperationException("unable to acquire text buffer");
+            }
+
+            // Create the editor
+            var newEditor = new SettingsEditorPane(_vsEditorAdaptersFactoryService,
+                                                   _threadingContext,
+                                                   _settingsDataProviderFactory,
+                                                   _controlProvider,
+                                                   _tableMangerProvider,
+                                                   pszMkDocument,
+                                                   textBuffer);
+            ppunkDocView = Marshal.GetIUnknownForObject(newEditor);
+            ppunkDocData = Marshal.GetIUnknownForObject(textBuffer);
+            pbstrEditorCaption = "";
+            return VSConstants.S_OK;
+        }
+
+        public int SetSite(IOleServiceProvider psp)
+        {
+            _vsServiceProvider = new ServiceProvider(psp);
+            return VSConstants.S_OK;
+        }
+
+        public int Close() => VSConstants.S_OK;
+
+        public int MapLogicalView(ref Guid rguidLogicalView, out string? pbstrPhysicalView)
+        {
+            pbstrPhysicalView = null;    // initialize out parameter
+
+            // we support only a single physical view
+            if (VSConstants.LOGVIEWID_Primary == rguidLogicalView)
+            {
+                return VSConstants.S_OK;        // primary view uses NULL as pbstrPhysicalView
+            }
+            else
+            {
+                return VSConstants.E_NOTIMPL;   // you must return E_NOTIMPL for any unrecognized rguidLogicalView values
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.SearchFilter.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.SearchFilter.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableControl;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    internal sealed partial class SettingsEditorPane
+    {
+        internal class SearchFilter : IEntryFilter
+        {
+            private readonly IEnumerable<IVsSearchToken> _searchTokens;
+            private readonly IReadOnlyList<ITableColumnDefinition>? _visibleColumns;
+
+            public SearchFilter(IVsSearchQuery searchQuery, IWpfTableControl control)
+            {
+                _searchTokens = SearchUtilities.ExtractSearchTokens(searchQuery);
+                if (_searchTokens == null)
+                {
+                    _searchTokens = Array.Empty<IVsSearchToken>();
+                }
+
+                var newVisibleColumns = new List<ITableColumnDefinition>();
+                foreach (var c in control.ColumnStates)
+                {
+                    if (c.IsVisible || ((c as ColumnState2)?.GroupingPriority > 0))
+                    {
+                        var definition = control.ColumnDefinitionManager.GetColumnDefinition(c.Name);
+                        if (definition != null)
+                        {
+                            newVisibleColumns.Add(definition);
+                        }
+                    }
+                }
+
+                _visibleColumns = newVisibleColumns;
+            }
+
+            public bool Match(ITableEntryHandle entry)
+            {
+                if (_visibleColumns is null)
+                {
+                    return false;
+                }
+
+                // An entry is considered matching a search query if all tokens in the search query are matching at least one of entry's columns.
+                // Reserve one more column for details content
+                var cachedColumnValues = new string[_visibleColumns.Count + 1];
+
+                foreach (var searchToken in _searchTokens)
+                {
+                    // No support for filters yet
+                    if (searchToken is IVsSearchFilterToken)
+                    {
+                        continue;
+                    }
+
+                    if (!AtLeastOneColumnOrDetailsContentMatches(entry, searchToken, cachedColumnValues))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            private bool AtLeastOneColumnOrDetailsContentMatches(ITableEntryHandle entry, IVsSearchToken searchToken, string[] cachedColumnValues)
+            {
+                // Check details content for any matches
+                if (cachedColumnValues[0] == null)
+                {
+                    cachedColumnValues[0] = GetDetailsContentAsString(entry);
+                }
+
+                var detailsContent = cachedColumnValues[0];
+                if (detailsContent != null && Match(detailsContent, searchToken))
+                {
+                    // Found match in details content
+                    return true;
+                }
+
+                if (_visibleColumns is null)
+                {
+                    return false;
+                }
+
+                // Check each column for any matches
+                for (var i = 0; i < _visibleColumns.Count; i++)
+                {
+                    if (cachedColumnValues[i + 1] == null)
+                    {
+                        cachedColumnValues[i + 1] = GetColumnValueAsString(entry, _visibleColumns[i]);
+                    }
+
+                    var columnValue = cachedColumnValues[i + 1];
+
+                    if (columnValue != null && Match(columnValue, searchToken))
+                    {
+                        // Found match in this column
+                        return true;
+                    }
+                }
+
+                // No match found in this entry
+                return false;
+            }
+
+            private static string GetColumnValueAsString(ITableEntryHandle entry, ITableColumnDefinition column)
+                => (entry.TryCreateStringContent(column, truncatedText: false, singleColumnView: false, content: out var columnValue) && columnValue is not null)
+                    ? columnValue
+                    : string.Empty;
+
+            private static string GetDetailsContentAsString(ITableEntryHandle entry)
+            {
+                string? detailsString = null;
+
+                if (entry.CanShowDetails)
+                {
+                    if (entry is IWpfTableEntry wpfEntry)
+                    {
+                        _ = wpfEntry.TryCreateDetailsStringContent(out detailsString);
+                    }
+                }
+
+                return detailsString ?? string.Empty;
+            }
+
+            private static bool Match(string columnValue, IVsSearchToken searchToken)
+                => (columnValue is not null) && (columnValue.IndexOf(searchToken.ParsedTokenText, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.SearchTask.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.SearchTask.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    internal sealed partial class SettingsEditorPane
+    {
+        internal class SearchTask : VsSearchTask
+        {
+            private readonly IThreadingContext _threadingContext;
+            private readonly IWpfTableControl[] _controls;
+
+            public SearchTask(uint dwCookie,
+                              IVsSearchQuery pSearchQuery,
+                              IVsSearchCallback pSearchCallback,
+                              IWpfTableControl[] controls,
+                              IThreadingContext threadingContext)
+                : base(dwCookie, pSearchQuery, pSearchCallback)
+            {
+                _threadingContext = threadingContext;
+                _controls = controls;
+            }
+
+            protected override void OnStartSearch()
+            {
+                _ = _threadingContext.JoinableTaskFactory.RunAsync(
+                    async () =>
+                    {
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        foreach (var control in _controls)
+                        {
+                            _ = control.SetFilter(string.Empty, new SearchFilter(SearchQuery, control));
+                        }
+
+                        await TaskScheduler.Default;
+                        uint resultCount = 0;
+                        foreach (var control in _controls)
+                        {
+                            var results = await control.ForceUpdateAsync().ConfigureAwait(false);
+                            resultCount += (uint)results.FilteredAndSortedEntries.Count;
+                        }
+
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        SearchCallback.ReportComplete(this, dwResultsFound: resultCount);
+                    });
+            }
+
+            protected override void OnStopSearch()
+            {
+                _ = _threadingContext.JoinableTaskFactory.RunAsync(
+                    async () =>
+                    {
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        foreach (var control in _controls)
+                        {
+                            _ = control.SetFilter(string.Empty, null);
+                        }
+                    });
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
@@ -218,6 +218,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                 _ = componentManager.FRevokeComponent(_componentId);
             }
 
+            _control?.OnClose();
+
             Dispose(true);
 
             base.OnClose();

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
 
         private void ViewCode()
         {
-            var sourceCodeTextEditorGuid = new Guid("8B382828-6202-11D1-8870-0000F87579D2");
+            var sourceCodeTextEditorGuid = VsEditorFactoryGuid.TextEditor_guid;
 
             // Open the referenced document using our editor.
             VsShellUtilities.OpenDocumentWithSpecificEditor(this, _fileName,

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
@@ -5,6 +5,7 @@
 using System;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -37,6 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
         private readonly ITableManagerProvider _tableMangerProvider;
         private readonly string _fileName;
         private readonly IVsTextLines _textBuffer;
+        private readonly Workspace _workspace;
         private uint _componentId;
         private IOleUndoManager? _undoManager;
         private SettingsEditorControl? _control;
@@ -47,7 +49,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                                   IWpfTableControlProvider controlProvider,
                                   ITableManagerProvider tableMangerProvider,
                                   string fileName,
-                                  IVsTextLines textBuffer)
+                                  IVsTextLines textBuffer,
+                                  Workspace workspace)
             : base(null)
         {
             _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
@@ -57,6 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
             _tableMangerProvider = tableMangerProvider;
             _fileName = fileName;
             _textBuffer = textBuffer;
+            _workspace = workspace;
         }
 
         protected override void Initialize()
@@ -94,7 +98,12 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
             _control = new SettingsEditorControl(
                 GetFormattingView(),
                 GetCodeStyleView(),
-                GetAnalyzerView());
+                GetAnalyzerView(),
+                _workspace,
+                _fileName,
+                _threadingContext,
+                _vsEditorAdaptersFactoryService,
+                _textBuffer);
             Content = _control;
 
             RegisterIndependentView(true);
@@ -114,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                     throw new InvalidOperationException("Unable to get formatter settings");
                 }
                 var viewModel = new FormattingViewModel(dataProvider, _controlProvider, _tableMangerProvider);
-                return new FormattingSettingsView(_textBuffer, _vsEditorAdaptersFactoryService, _threadingContext, viewModel);
+                return new FormattingSettingsView(viewModel);
             }
 
             ISettingsEditorView GetCodeStyleView()
@@ -125,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                     throw new InvalidOperationException("Unable to get code style settings");
                 }
                 var viewModel = new CodeStyleSettingsViewModel(dataProvider, _controlProvider, _tableMangerProvider);
-                return new CodeStyleSettingsView(_textBuffer, _vsEditorAdaptersFactoryService, _threadingContext, viewModel);
+                return new CodeStyleSettingsView(viewModel);
             }
 
             ISettingsEditorView GetAnalyzerView()
@@ -137,7 +146,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                 }
 
                 var viewModel = new AnalyzerSettingsViewModel(dataProvider, _controlProvider, _tableMangerProvider);
-                return new AnalyzerSettingsView(_textBuffer, _vsEditorAdaptersFactoryService, _threadingContext, viewModel);
+                return new AnalyzerSettingsView(viewModel);
             }
         }
 

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
@@ -1,0 +1,556 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings;
+using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.Internal.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.View;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers.ViewModel;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.View;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle.ViewModel;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.View;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Formatting.ViewModel;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Threading;
+using static Microsoft.VisualStudio.VSConstants;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
+{
+    internal sealed class SettingsEditorPane : WindowPane, IOleComponent, IVsDeferredDocView, IVsLinkedUndoClient, IVsWindowSearch
+    {
+        private readonly IVsEditorAdaptersFactoryService _vsEditorAdaptersFactoryService;
+        private readonly IThreadingContext _threadingContext;
+        private readonly ISettingsAggregator _settingsDataProviderService;
+        private readonly IWpfTableControlProvider _controlProvider;
+        private readonly ITableManagerProvider _tableMangerProvider;
+        private readonly string _fileName;
+        private readonly IVsTextLines _textBuffer;
+        private uint _componentId;
+        private IOleUndoManager? _undoManager;
+        private SettingsEditorControl? _control;
+
+        public SettingsEditorPane(IVsEditorAdaptersFactoryService vsEditorAdaptersFactoryService,
+                                  IThreadingContext threadingContext,
+                                  ISettingsAggregator settingsDataProviderService,
+                                  IWpfTableControlProvider controlProvider,
+                                  ITableManagerProvider tableMangerProvider,
+                                  string fileName,
+                                  IVsTextLines textBuffer)
+            : base(null)
+        {
+            _vsEditorAdaptersFactoryService = vsEditorAdaptersFactoryService;
+            _threadingContext = threadingContext;
+            _settingsDataProviderService = settingsDataProviderService;
+            _controlProvider = controlProvider;
+            _tableMangerProvider = tableMangerProvider;
+            _fileName = fileName;
+            _textBuffer = textBuffer;
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            // Create and initialize the editor
+            if (_componentId == default && this.TryGetService<SOleComponentManager, IOleComponentManager>(out var componentManager))
+            {
+                var componentRegistrationInfo = new[]
+                {
+                    new OLECRINFO
+                    {
+                        cbSize = (uint)Marshal.SizeOf(typeof(OLECRINFO)),
+                        grfcrf = (uint)_OLECRF.olecrfNeedIdleTime | (uint)_OLECRF.olecrfNeedPeriodicIdleTime,
+                        grfcadvf = (uint)_OLECADVF.olecadvfModal | (uint)_OLECADVF.olecadvfRedrawOff | (uint)_OLECADVF.olecadvfWarningsOff,
+                        uIdleTimeInterval = 100
+                    }
+                };
+
+                var hr = componentManager.FRegisterComponent(this, componentRegistrationInfo, out _componentId);
+                _ = ErrorHandler.Succeeded(hr);
+            }
+
+            if (this.TryGetService<SOleUndoManager, IOleUndoManager>(out _undoManager))
+            {
+                var linkCapableUndoMgr = (IVsLinkCapableUndoManager)_undoManager;
+                if (linkCapableUndoMgr is not null)
+                {
+                    _ = linkCapableUndoMgr.AdviseLinkedUndoClient(this);
+                }
+            }
+
+            // hook up our panel
+            _control = new SettingsEditorControl(
+                GetFormattingView(),
+                GetCodeStyleView(),
+                GetAnalyzerView());
+            Content = _control;
+
+            RegisterIndependentView(true);
+            if (this.TryGetService<IMenuCommandService>(out var menuCommandService))
+            {
+                AddCommand(menuCommandService, GUID_VSStandardCommandSet97, (int)VSStd97CmdID.NewWindow,
+                                new EventHandler(OnNewWindow), new EventHandler(OnQueryNewWindow));
+                AddCommand(menuCommandService, GUID_VSStandardCommandSet97, (int)VSStd97CmdID.ViewCode,
+                                new EventHandler(OnViewCode), new EventHandler(OnQueryViewCode));
+            }
+
+            ISettingsEditorView GetFormattingView()
+            {
+                var dataProvider = _settingsDataProviderService.GetSettingsProvider<FormattingSetting>(_fileName);
+                if (dataProvider is null)
+                {
+                    throw new InvalidOperationException("Unable to get formatter settings");
+                }
+                var viewModel = new FormattingViewModel(dataProvider, _controlProvider, _tableMangerProvider);
+                return new FormattingSettingsView(_textBuffer, _vsEditorAdaptersFactoryService, _threadingContext, viewModel);
+            }
+
+            ISettingsEditorView GetCodeStyleView()
+            {
+                var dataProvider = _settingsDataProviderService.GetSettingsProvider<CodeStyleSetting>(_fileName);
+                if (dataProvider is null)
+                {
+                    throw new InvalidOperationException("Unable to get code style settings");
+                }
+                var viewModel = new CodeStyleSettingsViewModel(dataProvider, _controlProvider, _tableMangerProvider);
+                return new CodeStyleSettingsView(_textBuffer, _vsEditorAdaptersFactoryService, _threadingContext, viewModel);
+            }
+
+            ISettingsEditorView GetAnalyzerView()
+            {
+                var dataProvider = _settingsDataProviderService.GetSettingsProvider<AnalyzerSetting>(_fileName);
+                if (dataProvider is null)
+                {
+                    throw new InvalidOperationException("Unable to get analyzer settings");
+                }
+
+                var viewModel = new AnalyzerSettingsViewModel(dataProvider, _controlProvider, _tableMangerProvider);
+                return new AnalyzerSettingsView(_textBuffer, _vsEditorAdaptersFactoryService, _threadingContext, viewModel);
+            }
+        }
+
+        private void OnQueryNewWindow(object sender, EventArgs e)
+        {
+            var command = (OleMenuCommand)sender;
+            command.Enabled = true;
+        }
+
+        private void OnNewWindow(object sender, EventArgs e)
+        {
+            NewWindow();
+        }
+
+        private void OnQueryViewCode(object sender, EventArgs e)
+        {
+            var command = (OleMenuCommand)sender;
+            command.Enabled = true;
+        }
+
+        private void OnViewCode(object sender, EventArgs e)
+        {
+            ViewCode();
+        }
+
+        private void NewWindow()
+        {
+            if (this.TryGetService<SVsUIShellOpenDocument, IVsUIShellOpenDocument>(out var uishellOpenDocument) &&
+                this.TryGetService<SVsWindowFrame, IVsWindowFrame>(out var windowFrameOrig))
+            {
+                var logicalView = Guid.Empty;
+                var hr = uishellOpenDocument.OpenCopyOfStandardEditor(windowFrameOrig, ref logicalView, out var windowFrameNew);
+                if (windowFrameNew != null)
+                {
+                    hr = windowFrameNew.Show();
+                }
+
+                _ = ErrorHandler.ThrowOnFailure(hr);
+            }
+        }
+
+        private void ViewCode()
+        {
+            var sourceCodeTextEditorGuid = new Guid("8B382828-6202-11D1-8870-0000F87579D2");
+
+            // Open the referenced document using our editor.
+            VsShellUtilities.OpenDocumentWithSpecificEditor(this, _fileName,
+                sourceCodeTextEditorGuid, LOGVIEWID_Primary, out _, out _, out var frame);
+            _ = ErrorHandler.ThrowOnFailure(frame.Show());
+        }
+
+        protected override void OnClose()
+        {
+            // unhook from Undo related services
+            if (_undoManager != null)
+            {
+                var linkCapableUndoMgr = (IVsLinkCapableUndoManager)_undoManager;
+                if (linkCapableUndoMgr != null)
+                {
+                    _ = linkCapableUndoMgr.UnadviseLinkedUndoClient();
+                }
+
+                // Throw away the undo stack etc.
+                // It is important to â€œzombifyâ€ the undo manager when the owning object is shutting down.
+                // This is done by calling IVsLifetimeControlledObject.SeverReferencesToOwner on the undoManager.
+                // This call will clear the undo and redo stacks. This is particularly important to do if
+                // your undo units hold references back to your object. It is also important if you use
+                // "mdtStrict" linked undo transactions as this sample does (see IVsLinkedUndoTransactionManager). 
+                // When one object involved in linked undo transactions clears its undo/redo stacks, then 
+                // the stacks of the other documents involved in the linked transaction will also be cleared. 
+                var lco = (IVsLifetimeControlledObject)_undoManager;
+                _ = lco.SeverReferencesToOwner();
+                _undoManager = null;
+            }
+
+            if (this.TryGetService<SOleComponentManager, IOleComponentManager>(out var componentManager))
+            {
+                _ = componentManager.FRevokeComponent(_componentId);
+            }
+
+            Dispose(true);
+
+            base.OnClose();
+        }
+
+        public int FDoIdle(uint grfidlef)
+        {
+            if (_control is not null)
+            {
+                _control.SynchronizeSettings();
+            }
+            return S_OK;
+        }
+
+        /// <summary>
+        /// Registers an independent view with the IVsTextManager so that it knows
+        /// the user is working with a view over the text buffer. This will trigger
+        /// the text buffer to prompt the user whether to reload the file if it is
+        /// edited outside of the environment.
+        /// </summary>
+        /// <param name="subscribe">True to subscribe, false to unsubscribe</param>
+        private void RegisterIndependentView(bool subscribe)
+        {
+            if (this.TryGetService<SVsTextManager, IVsTextManager>(out var textManager))
+            {
+                _ = subscribe
+                    ? textManager.RegisterIndependentView(this, _textBuffer)
+                    : textManager.UnregisterIndependentView(this, _textBuffer);
+            }
+        }
+
+        /// <summary>
+        /// Helper function used to add commands using IMenuCommandService
+        /// </summary>
+        /// <param name="menuCommandService"> The IMenuCommandService interface.</param>
+        /// <param name="menuGroup"> This guid represents the menu group of the command.</param>
+        /// <param name="cmdID"> The command ID of the command.</param>
+        /// <param name="commandEvent"> An EventHandler which will be called whenever the command is invoked.</param>
+        /// <param name="queryEvent"> An EventHandler which will be called whenever we want to query the status of
+        /// the command.  If null is passed in here then no EventHandler will be added.</param>
+        private static void AddCommand(IMenuCommandService menuCommandService,
+                                       Guid menuGroup,
+                                       int cmdID,
+                                       EventHandler commandEvent,
+                                       EventHandler queryEvent)
+        {
+            // Create the OleMenuCommand from the menu group, command ID, and command event
+            var menuCommandID = new CommandID(menuGroup, cmdID);
+            var command = new OleMenuCommand(commandEvent, menuCommandID);
+
+            // Add an event handler to BeforeQueryStatus if one was passed in
+            if (null != queryEvent)
+            {
+                command.BeforeQueryStatus += queryEvent;
+            }
+
+            // Add the command using our IMenuCommandService instance
+            menuCommandService.AddCommand(command);
+        }
+
+        public int get_DocView(out IntPtr ppUnkDocView)
+        {
+            ppUnkDocView = Marshal.GetIUnknownForObject(this);
+            return S_OK;
+        }
+
+        public int get_CmdUIGuid(out Guid pGuidCmdId)
+        {
+            pGuidCmdId = SettingsEditorFactory.SettingsEditorFactoryGuid;
+            return S_OK;
+        }
+
+        public int FReserved1(uint dwReserved, uint message, IntPtr wParam, IntPtr lParam) => S_OK;
+        public int FPreTranslateMessage(MSG[] pMsg) => S_OK;
+        public void OnEnterState(uint uStateID, int fEnter) { }
+        public void OnAppActivate(int fActive, uint dwOtherThreadID) { }
+        public void OnLoseActivation() { }
+        public void OnActivationChange(IOleComponent pic, int fSameComponent, OLECRINFO[] pcrinfo, int fHostIsActivating, OLECHOSTINFO[] pchostinfo, uint dwReserved) { }
+        public int FContinueMessageLoop(uint uReason, IntPtr pvLoopData, MSG[] pMsgPeeked) => S_OK;
+        public int FQueryTerminate(int fPromptUser) => 1; //true
+        public void Terminate() { }
+        public IntPtr HwndGetWindow(uint dwWhich, uint dwReserved) => IntPtr.Zero;
+        public int OnInterveningUnitBlockingLinkedUndo() => E_FAIL;
+
+        public IVsSearchTask? CreateSearch(uint dwCookie, IVsSearchQuery pSearchQuery, IVsSearchCallback pSearchCallback)
+        {
+            if (_control is not null)
+            {
+                var tables = _control.GetTableControls();
+                return new SearchTask(dwCookie, pSearchQuery, pSearchCallback, tables, _threadingContext);
+            }
+
+            return null;
+        }
+
+        public void ClearSearch()
+        {
+            if (_control is not null)
+            {
+                var tables = _control.GetTableControls();
+                // remove filter on tablar data controls
+                _ = _threadingContext.JoinableTaskFactory.RunAsync(
+                    async () =>
+                    {
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        foreach (var tableControl in tables)
+                        {
+                            _ = tableControl.SetFilter(string.Empty, null);
+                        }
+                    });
+            }
+        }
+
+        public void ProvideSearchSettings(IVsUIDataSource pSearchSettings)
+        {
+            SetIntValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.ControlMaxWidth, 200);
+            SetIntValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.SearchStartType, (int)VSSEARCHSTARTTYPE.SST_DELAYED);
+            SetIntValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.SearchStartDelay, 100);
+            SetBoolValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.SearchUseMRU, true);
+            SetBoolValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.PrefixFilterMRUItems, false);
+            SetIntValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.MaximumMRUItems, 25);
+            SetStringValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.SearchWatermark, ServicesVSResources.Search_Settings);
+            SetBoolValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.SearchPopupAutoDropdown, false);
+            SetStringValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.ControlBorderThickness, "1");
+            SetIntValue(pSearchSettings, SearchSettingsDataSource.PropertyNames.SearchProgressType, (int)VSSEARCHPROGRESSTYPE.SPT_INDETERMINATE);
+
+            void SetBoolValue(IVsUIDataSource source, string property, bool value)
+            {
+                var valueProp = BuiltInPropertyValue.FromBool(value);
+                _ = source.SetValue(property, valueProp);
+            }
+
+            void SetIntValue(IVsUIDataSource source, string property, int value)
+            {
+                var valueProp = BuiltInPropertyValue.Create(value);
+                _ = source.SetValue(property, valueProp);
+            }
+
+            void SetStringValue(IVsUIDataSource source, string property, string value)
+            {
+                var valueProp = BuiltInPropertyValue.Create(value);
+                _ = source.SetValue(property, valueProp);
+            }
+        }
+
+        public bool OnNavigationKeyDown(uint dwNavigationKey, uint dwModifiers) => false;
+
+        public bool SearchEnabled { get; } = true;
+
+        public Guid Category { get; } = new Guid("1BE8950F-AF27-4B71-8D54-1F7FFEFDC237");
+        public IVsEnumWindowSearchFilters? SearchFiltersEnum => null;
+        public IVsEnumWindowSearchOptions? SearchOptionsEnum => null;
+
+        internal class SearchTask : VsSearchTask
+        {
+            private readonly IThreadingContext _threadingContext;
+            private readonly IWpfTableControl[] _controls;
+
+            public SearchTask(uint dwCookie,
+                              IVsSearchQuery pSearchQuery,
+                              IVsSearchCallback pSearchCallback,
+                              IWpfTableControl[] controls,
+                              IThreadingContext threadingContext)
+                : base(dwCookie, pSearchQuery, pSearchCallback)
+            {
+                _threadingContext = threadingContext;
+                _controls = controls;
+            }
+
+            protected override void OnStartSearch()
+            {
+                _ = _threadingContext.JoinableTaskFactory.RunAsync(
+                    async () =>
+                    {
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        foreach (var control in _controls)
+                        {
+                            _ = control.SetFilter(string.Empty, new SearchFilter(SearchQuery, control));
+                        }
+
+                        await TaskScheduler.Default;
+                        uint resultCount = 0;
+                        foreach (var control in _controls)
+                        {
+                            var results = await control.ForceUpdateAsync().ConfigureAwait(false);
+                            resultCount += (uint)results.FilteredAndSortedEntries.Count;
+                        }
+
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        SearchCallback.ReportComplete(this, dwResultsFound: resultCount);
+                    });
+            }
+
+            protected override void OnStopSearch()
+            {
+                _ = _threadingContext.JoinableTaskFactory.RunAsync(
+                    async () =>
+                    {
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        foreach (var control in _controls)
+                        {
+                            _ = control.SetFilter(string.Empty, null);
+                        }
+                    });
+            }
+        }
+
+        internal class SearchFilter : IEntryFilter
+        {
+            private readonly IEnumerable<IVsSearchToken> _searchTokens;
+            private readonly IReadOnlyList<ITableColumnDefinition>? _visibleColumns;
+
+            public SearchFilter(IVsSearchQuery searchQuery, IWpfTableControl control)
+            {
+                _searchTokens = SearchUtilities.ExtractSearchTokens(searchQuery);
+                if (_searchTokens == null)
+                {
+                    _searchTokens = Array.Empty<IVsSearchToken>();
+                }
+
+                var newVisibleColumns = new List<ITableColumnDefinition>();
+                foreach (var c in control.ColumnStates)
+                {
+                    if (c.IsVisible || ((c as ColumnState2)?.GroupingPriority > 0))
+                    {
+                        var definition = control.ColumnDefinitionManager.GetColumnDefinition(c.Name);
+                        if (definition != null)
+                        {
+                            newVisibleColumns.Add(definition);
+                        }
+                    }
+                }
+
+                _visibleColumns = newVisibleColumns;
+            }
+
+            public bool Match(ITableEntryHandle entry)
+            {
+                if (_visibleColumns is null)
+                {
+                    return false;
+                }
+
+                // An entry is considered matching a search query if all tokens in the search query are matching at least one of entry's columns.
+                // Reserve one more column for details content
+                var cachedColumnValues = new string[_visibleColumns.Count + 1];
+
+                foreach (var searchToken in _searchTokens)
+                {
+                    // No support for filters yet
+                    if (searchToken is IVsSearchFilterToken)
+                    {
+                        continue;
+                    }
+
+                    if (!AtLeastOneColumnOrDetailsContentMatches(entry, searchToken, cachedColumnValues))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            private bool AtLeastOneColumnOrDetailsContentMatches(ITableEntryHandle entry, IVsSearchToken searchToken, string[] cachedColumnValues)
+            {
+                // Check details content for any matches
+                if (cachedColumnValues[0] == null)
+                {
+                    cachedColumnValues[0] = GetDetailsContentAsString(entry);
+                }
+
+                var detailsContent = cachedColumnValues[0];
+                if (detailsContent != null && Match(detailsContent, searchToken))
+                {
+                    // Found match in details content
+                    return true;
+                }
+
+                if (_visibleColumns is null)
+                {
+                    return false;
+                }
+
+                // Check each column for any matches
+                for (var i = 0; i < _visibleColumns.Count; i++)
+                {
+                    if (cachedColumnValues[i + 1] == null)
+                    {
+                        cachedColumnValues[i + 1] = GetColumnValueAsString(entry, _visibleColumns[i]);
+                    }
+
+                    var columnValue = cachedColumnValues[i + 1];
+
+                    if (columnValue != null && Match(columnValue, searchToken))
+                    {
+                        // Found match in this column
+                        return true;
+                    }
+                }
+
+                // No match found in this entry
+                return false;
+            }
+
+            private static string GetColumnValueAsString(ITableEntryHandle entry, ITableColumnDefinition column)
+            {
+                return (entry.TryCreateStringContent(column, truncatedText: false, singleColumnView: false, content: out var columnValue) && (columnValue != null))
+                       ? columnValue : string.Empty;
+            }
+
+            private static string GetDetailsContentAsString(ITableEntryHandle entry)
+            {
+                string? detailsString = null;
+
+                if (entry.CanShowDetails)
+                {
+                    if (entry is IWpfTableEntry wpfEntry)
+                    {
+                        _ = wpfEntry.TryCreateDetailsStringContent(out detailsString);
+                    }
+                }
+
+                return detailsString ?? string.Empty;
+            }
+
+            private static bool Match(string columnValue, IVsSearchToken searchToken)
+            {
+                return (columnValue != null) && (columnValue.IndexOf(searchToken.ParsedTokenText, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Styles/FontSizeConverter.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Styles/FontSizeConverter.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Styles
+{
+    internal class FontSizeConverter : IValueConverter
+    {
+        // Scaling percentage. E.g. 122 means 122%.
+        public int Scale { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => (double)value * Scale / 100.0;
+
+        public object? ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => null;
+    }
+}

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Styles/ThemedDialogResources.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Styles/ThemedDialogResources.xaml
@@ -37,7 +37,7 @@
         </Setter>
     </Style>
     <Style TargetType="TabItem">
-        <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.BrandedUIBackgroundKey}}" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}" />
         <Setter Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.BrandedUITextKey}}" />
         <Setter Property="Padding" Value="20,0,20,0" />

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Styles/ThemedDialogResources.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Styles/ThemedDialogResources.xaml
@@ -1,0 +1,85 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+                    xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+                    xmlns:styles="clr-namespace:Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Styles">
+    <!-- Inherit Themed Dialog styles -->
+    <Style TargetType="Button" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogButtonStyleKey}}" />
+    <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogCheckBoxStyleKey}}" />
+    <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogComboBoxStyleKey}}" />
+    <Style TargetType="GridViewColumnHeader" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogGridViewColumnHeaderStyleKey}}" />
+    <Style TargetType="Hyperlink" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogHyperlinkStyleKey}}" />
+    <Style TargetType="Label" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogLabelStyleKey}}" />
+    <Style TargetType="ListBox" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListBoxStyleKey}}" />
+    <Style TargetType="ListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" />
+    <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewItemStyleKey}}" />
+    <Style TargetType="RadioButton" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogRadioButtonStyleKey}}" />
+    <Style TargetType="ScrollBar" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ScrollBarStyleKey}}"/>
+    <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTextBoxStyleKey}}" />
+    <Style TargetType="TreeView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTreeViewStyleKey}}" />
+    <Style TargetType="TreeViewItem" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTreeViewItemStyleKey}}" />
+    <Style TargetType="TabControl" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTabControlNavigationStyleKey}}" />
+    
+    <!-- Custom tab theme -->
+    <styles:FontSizeConverter Scale="122" x:Key="Font122PercentSizeConverter" />
+    <Style x:Key="ControlsFocusVisualStyle" TargetType="{x:Type Control}">
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.BrandedUITextKey}}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle x:Name="ControlFocusVisualRectangle"
+              Stroke="{TemplateBinding Foreground}"
+              StrokeThickness="1"
+              StrokeDashArray="1 2"
+              SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style TargetType="TabItem">
+        <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.BrandedUIBackgroundKey}}" />
+        <Setter Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl},Converter={StaticResource Font122PercentSizeConverter}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.BrandedUITextKey}}" />
+        <Setter Property="Padding" Value="20,0,20,0" />
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlsFocusVisualStyle}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TabItem}">
+                    <Grid x:Name="templateRoot" SnapsToDevicePixels="true">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                        </Grid.RowDefinitions>
+                        <Border x:Name="mainBorder" Background="{TemplateBinding Background}" BorderThickness="0" Margin="0">
+                        </Border>
+                        <ContentPresenter  Grid.Row="0" x:Name="contentPresenter" ContentSource="Header" Focusable="False" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+                        <!-- the line under the text to indicate that this label is selected -->
+                        <Rectangle
+                            x:Name="_underline"
+                            Grid.Row="1"
+                            Height="3"
+                            Visibility="Collapsed"
+                            Width="{Binding ActualWidth, ElementName=contentPresenter}"
+                            HorizontalAlignment="Center"
+                            Fill="{DynamicResource {x:Static vsui:CommonDocumentColors.InnerTabInactiveHoverTextBrushKey}}"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:CommonDocumentColors.InnerTabInactiveHoverTextBrushKey }}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Visibility" TargetName="_underline" Value="Visible" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:CommonDocumentColors.InnerTabTextFocusedBrushKey }}" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -33,7 +33,7 @@
     <RoslynPackageGuid>6cf2e545-6109-4730-8883-cf43d7aec3e1</RoslynPackageGuid>
   </PropertyGroup>
   <ItemGroup Label="PkgDef">
-    <PkgDefPackageRegistration Include="{$(RoslynPackageGuid)}" Name="RoslynPackage" Class="Microsoft.VisualStudio.LanguageServices.Setup.RoslynPackage" AllowsBackgroundLoad="true"/>
+    <PkgDefPackageRegistration Include="{$(RoslynPackageGuid)}" Name="RoslynPackage" Class="Microsoft.VisualStudio.LanguageServices.Setup.RoslynPackage" AllowsBackgroundLoad="true" />
     <None Include="PackageRegistration.pkgdef" PkgDefEntry="FileContent" />
     <None Include=".\ColorSchemes\VisualStudio2019.pkgdef" PkgDefEntry="FileContent" />
   </ItemGroup>
@@ -199,8 +199,7 @@
   </ItemGroup>
   <Import Project="$(RepositoryEngineeringDir)targets\Vsdconfig.targets" />
 
-  <Target Name="GeneratePkgDefServiceRegistrations"
-          BeforeTargets="GeneratePkgDef">
+  <Target Name="GeneratePkgDefServiceRegistrations" BeforeTargets="GeneratePkgDef">
     <ItemGroup>
       <!-- Add registrations for 32-bit, 64-bit, and 64-bit Server GC -->
       <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" />

--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -24,3 +24,14 @@
 "Value"=dword:00000000
 "Title"="Enable experimental C#/VB LSP completion experience"
 "PreviewPaneChannels"="IntPreview,int.main"
+
+// 68b46364-d378-42f2-9e72-37d86c5f4468 is the guid for SettingsEditorFactory
+// 6cf2e545-6109-4730-8883-cf43d7aec3e1 is the guid for RoslynPackage
+[$RootKey$\Editors\{68b46364-d378-42f2-9e72-37d86c5f4468}]
+"Package"="{6cf2e545-6109-4730-8883-cf43d7aec3e1}"
+[$RootKey$\Editors\{68b46364-d378-42f2-9e72-37d86c5f4468}\Extensions]
+// dword must be larger that 26 (the priority of the textmate editor)
+// we set it to 100 (64 in hex) here
+"editorconfig"=dword:00000064
+[$RootKey$\Editors\{68b46364-d378-42f2-9e72-37d86c5f4468}\LogicalViews]
+"{7651a703-06e5-11d1-8ebd-00a0c90f26ea}"=""

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -24,6 +24,7 @@ using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Versions;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.ColorSchemes;
+using Microsoft.VisualStudio.LanguageServices.EditorConfigSettings;
 using Microsoft.VisualStudio.LanguageServices.Experimentation;
 using Microsoft.VisualStudio.LanguageServices.Implementation;
 using Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribute;
@@ -136,6 +137,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             _solutionEventMonitor = new SolutionEventMonitor(_workspace);
 
             TrackBulkFileOperations();
+
+            var settingsEditorFactory = _componentModel.GetService<SettingsEditorFactory>();
+            RegisterEditorFactory(settingsEditorFactory);
         }
 
         private void InitializeColors()

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1653,4 +1653,55 @@ I agree to all of the foregoing:</value>
   <data name="This_action_cannot_be_undone_Do_you_wish_to_continue" xml:space="preserve">
     <value>This action cannot be undone. Do you wish to continue?</value>
   </data>
+  <data name="Analyzers" xml:space="preserve">
+    <value>Analyzers</value>
+  </data>
+  <data name="Carrage_Return_Newline_rn" xml:space="preserve">
+    <value>Carrage Return + Newline (\\r\\n)</value>
+  </data>
+  <data name="Carrage_Return_r" xml:space="preserve">
+    <value>Carrage Return (\\r)</value>
+  </data>
+  <data name="Category" xml:space="preserve">
+    <value>Category</value>
+  </data>
+  <data name="Code_Style" xml:space="preserve">
+    <value>Code Style</value>
+  </data>
+  <data name="Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Formatting" xml:space="preserve">
+    <value>Formatting</value>
+  </data>
+  <data name="Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="Newline_n" xml:space="preserve">
+    <value>Newline (\\n)</value>
+  </data>
+  <data name="Refactoring_Only" xml:space="preserve">
+    <value>Refactoring Only</value>
+  </data>
+  <data name="Suggestion" xml:space="preserve">
+    <value>Suggestion</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="Search_Settings" xml:space="preserve">
+    <value>Search Settings</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Vždy kvůli srozumitelnosti</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Lokalita volání</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Aktuální parametr</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Při podržení kláves Alt+F1 zobrazit všechny nápovědy</target>
@@ -267,6 +297,11 @@
         <target state="translated">Povolit diagnostiku pull (experimentální, vyžaduje restart)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Zadejte hodnotu místa volání, nebo zvolte jiný druh vložení hodnoty.</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Celé řešení</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Generovat soubor .editorconfig z nastavení</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Zvýrazňovat související komponenty pod kurzorem</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Stáhnout členy</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">Uložit soubor .editorconfig</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Vybrat cíl</target>
@@ -917,6 +982,11 @@
         <target state="translated">Některé barvy barevného schématu se přepsaly změnami na stránce možností Prostředí &gt; Písma a barvy. Pokud chcete zrušit všechna přizpůsobení, vyberte na stránce Písma a barvy možnost Použít výchozí.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Potlačit nápovědy, když název parametru odpovídá záměru metody</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Toto je neplatný obor názvů.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Použít pojmenovaný argument</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">Zde přiřazená hodnota se nikdy nepoužije.</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Immer zur besseren Unterscheidung</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Aufrufsite</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Aktueller Parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Alle Hinweise beim Drücken von ALT+F1 anzeigen</target>
@@ -267,6 +297,11 @@
         <target state="translated">Pull-Diagnose aktivieren (experimentell, Neustart erforderlich)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Geben Sie einen Aufrufsitewert ein, oder wählen Sie eine andere Art der Werteingabe aus.</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Gesamte Projektmappe</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">EDITORCONFIG-Datei aus Einstellungen generieren</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Zugehörige Komponenten unter dem Cursor markieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Member nach oben ziehen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">EDITORCONFIG-Datei speichern</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Ziel auswählen</target>
@@ -917,6 +982,11 @@
         <target state="translated">Einige Farbschemafarben werden durch Änderungen überschrieben, die auf der Optionsseite "Umgebung" &gt; "Schriftarten und Farben" vorgenommen wurden. Wählen Sie auf der Seite "Schriftarten und Farben" die Option "Standardwerte verwenden" aus, um alle Anpassungen rückgängig zu machen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Hinweise unterdrücken, wenn der Parametername mit der Methodenabsicht übereinstimmt</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Dies ist ein ungültiger Namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Benanntes Argument verwenden</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">Der hier zugewiesene Wert wird nie verwendet.</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Siempre por claridad</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Sitio de llamada</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Parámetro actual</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Mostrar todas las sugerencias al presionar Alt+F1</target>
@@ -267,6 +297,11 @@
         <target state="translated">Habilitar diagnósticos "pull" (experimental, requiere reiniciar)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Escriba un valor de sitio de llamada o elija otro tipo de inserción de valor.</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Toda la solución</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Generar archivo .editorconfig a partir de la configuración</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Resaltar componentes relacionados bajo el cursor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Extraer miembros</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">Guardar archivo .editorconfig</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Seleccionar destino</target>
@@ -917,6 +982,11 @@
         <target state="translated">Algunos de los colores de la combinación se reemplazan por los cambios realizados en la página de opciones de Entorno &gt; Fuentes y colores. Elija "Usar valores predeterminados" en la página Fuentes y colores para revertir todas las personalizaciones.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Suprimir las sugerencias cuando el nombre del parámetro coincida con la intención del método</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Este espacio de nombres no es válido</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Usar argumento con nombre</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">El valor asignado aquí no se usa nunca</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Toujours pour plus de clarté</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Site d'appel</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Paramètre actuel</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Afficher tous les indicateurs en appuyant sur Alt+F1</target>
@@ -267,6 +297,11 @@
         <target state="translated">Activer les diagnostics de 'tirage (pull)' (expérimental, nécessite un redémarrage)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Entrer une valeur de site d'appel ou choisir un autre type d'injection de valeur</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Solution complète</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Générer le fichier .editorconfig à partir des paramètres</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Surligner les composants liés sous le curseur</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Élever les membres</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">Enregistrer le fichier .editorconfig</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Sélectionner la destination</target>
@@ -917,6 +982,11 @@
         <target state="translated">Certaines couleurs du modèle de couleurs sont substituées à la suite des changements apportés dans la page d'options Environnement &gt; Polices et couleurs. Choisissez Utiliser les valeurs par défaut dans la page Polices et couleurs pour restaurer toutes les personnalisations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Supprimer les indicateurs quand le nom de paramètre correspond à l'intention de la méthode</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Ceci est un espace de noms non valide</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Utiliser un argument nommé</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">La valeur affectée ici n'est jamais utilisée</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Sempre per chiarezza</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Sito di chiamata</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Parametro corrente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Visualizza tutti i suggerimenti quando si preme ALT+F1</target>
@@ -267,6 +297,11 @@
         <target state="translated">Abilita diagnostica 'pull' (sperimentale, richiede il riavvio)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Immettere un valore per il sito di chiamata o scegliere un tipo di inserimento valori diverso</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Intera soluzione</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Genera file con estensione editorconfig dalle impostazioni</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Evidenzia i componenti correlati sotto il cursore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Recupera membri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">Salva file con estensione editorconfig</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Seleziona destinazione</target>
@@ -917,6 +982,11 @@
         <target state="translated">Alcuni colori della combinazione colori sono sostituiti dalle modifiche apportate nella pagina di opzioni Ambiente &gt; Tipi di carattere e colori. Scegliere `Usa impostazioni predefinite` nella pagina Tipi di carattere e colori per ripristinare tutte le personalizzazioni.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Non visualizzare suggerimenti quando il nome del parametro corrisponde alla finalità del metodo</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Questo è uno spazio dei nomi non valido</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Usa l'argomento denominato</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">Il valore assegnato qui non viene mai usato</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -77,6 +77,11 @@
         <target state="translated">わかりやすくするために常に</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">呼び出しサイト</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">現在のパラメーター</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Alt+F1 を押しながらすべてのヒントを表示する</target>
@@ -267,6 +297,11 @@
         <target state="translated">'pull' 診断を有効にする (試験段階、再起動が必要)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">呼び出しサイトの値を入力するか、別の値の挿入の種類を選択してください</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">ソリューション全体</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">設定から .editorconfig ファイルを生成</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">カーソルの下にある関連コンポーネントをハイライトする</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">メンバーをプルアップ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">.editorconfig ファイルの保存</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">宛先の選択</target>
@@ -917,6 +982,11 @@
         <target state="translated">一部の配色パターンの色は、[環境] &gt; [フォントおよび色] オプション ページで行われた変更によって上書きされます。[フォントおよび色] オプション ページで [既定値を使用] を選択すると、すべてのカスタマイズが元に戻ります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">パラメーター名がメソッドの意図と一致する場合にヒントを非表示にする</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">これは無効な名前空間です</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">名前付き引数を使用する</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">ここで割り当てた値は一度も使用されません</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -77,6 +77,11 @@
         <target state="translated">명확하게 하기 위해 항상</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">호출 사이트</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">현재 매개 변수</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Alt+F1을 누른 채 모든 힌트 표시</target>
@@ -267,6 +297,11 @@
         <target state="translated">'풀' 진단 사용(실험적, 다시 시작 필요)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">호출 사이트 값을 입력하거나 다른 값 삽입 종류를 선택하세요.</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">전체 솔루션</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">설정에서 .editorconfig 파일 생성</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">커서 아래의 관련 구성 요소 강조</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">멤버 풀하기</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">editorconfig 파일 저장</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">대상 선택</target>
@@ -917,6 +982,11 @@
         <target state="translated">색 구성표의 일부 색이 [환경] &gt; [글꼴 및 색] 옵션 페이지에서 변경한 내용에 따라 재정의됩니다. 모든 사용자 지정을 되돌리려면 [글꼴 및 색] 페이지에서 '기본값 사용'을 선택하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">매개 변수 이름이 메서드의 의도와 일치하는 경우 힌트 표시 안 함</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">잘못된 네임스페이스입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">명명된 인수 사용</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">여기에 할당된 값은 사용되지 않습니다.</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Zawsze w celu zachowania jednoznaczności</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Miejsce wywołania</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Bieżący parametr</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Wyświetl wszystkie wskazówki po naciśnięciu klawiszy Alt+F1</target>
@@ -267,6 +297,11 @@
         <target state="translated">Włącz diagnostykę operacji „pull” (eksperymentalne, wymaga ponownego uruchomienia)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Wprowadź wartość lokalizacji wywołania lub wybierz inny rodzaj iniekcji wartości</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Całe rozwiązanie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Wygeneruj plik .editorconfig na podstawie ustawień</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Wyróżnij powiązane składniki pod kursorem</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Podciągnij składowe w górę</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">Zapisz plik .editorconfig</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Wybierz miejsce docelowe</target>
@@ -917,6 +982,11 @@
         <target state="translated">Niektóre kolory w schemacie kolorów są przesłaniane przez zmiany wprowadzone na stronie opcji Środowisko &gt; Czcionki i kolory. Wybierz pozycję „Użyj ustawień domyślnych” na stronie Czcionki i kolory, aby wycofać wszystkie dostosowania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Pomiń wskazówki, gdy nazwa parametru pasuje do intencji metody</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">To jest nieprawidłowa przestrzeń nazw</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Użyj nazwanego argumentu</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">Przypisana tu wartość nigdy nie jest używana</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Sempre para esclarecimento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Chamar site</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Parâmetro atual</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Exibir todas as dicas ao pressionar Alt+F1</target>
@@ -267,6 +297,11 @@
         <target state="translated">Habilitar o diagnóstico de 'pull' (experimental, exige uma reinicialização)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Insira um valor de site de chamada ou escolha um tipo de injeção de valor diferente</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Solução Inteira</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Gerar o arquivo .editorconfig das configurações</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Realçar componentes relacionados usando o cursor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Levantar os membros</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">Salvar arquivo .editorconfig</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Selecionar destino</target>
@@ -917,6 +982,11 @@
         <target state="translated">Algumas cores do esquema de cores estão sendo substituídas pelas alterações feitas na página de Ambiente &gt; Opções de Fontes e Cores. Escolha 'Usar Padrões' na página Fontes e Cores para reverter todas as personalizações.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Suprimir as dicas quando o nome do parâmetro corresponder à intenção do método</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Este é um namespace inválido</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Usar argumento nomeado</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">O valor atribuído aqui nunca é usado</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Всегда использовать для ясности</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Место вызова</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Текущий параметр</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Отображать все подсказки при нажатии клавиш ALT+F1</target>
@@ -267,6 +297,11 @@
         <target state="translated">Включить диагностику "pull" (экспериментальная функция, требуется перезапуск)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Введите значение места вызова или выберите другой тип введения значения</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Все решение</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Создать файл EDITORCONFIG на основе параметров</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">Выделить связанные компоненты под курсором</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Повышение элементов</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">Сохранить файл EDITORCONFIG</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Выбрать место назначения</target>
@@ -917,6 +982,11 @@
         <target state="translated">Некоторые цвета цветовой схемы переопределяются изменениями, сделанными на странице "Среда" &gt; "Шрифты и цвета". Выберите "Использовать значения по умолчанию" на странице "Шрифты и цвета", чтобы отменить все настройки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Скрывать подсказки, если имя параметра соответствует намерению метода.</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Это недопустимое пространство имен.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Использовать именованный аргумент</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">Заданное здесь значение не используется.</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Açıklık sağlamak için her zaman</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">Çağrı konumu</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">Geçerli parametre</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">Alt+F1 tuşlarına basılırken tüm ipuçlarını görüntüle</target>
@@ -267,6 +297,11 @@
         <target state="translated">'Pull' tanılamasını etkinleştir (deneysel, yeniden başlatma gerekir)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">Bir çağrı sitesi değeri girin veya farklı bir değer yerleştirme tipi seçin</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">Tüm çözüm</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Ayarlardan .editorconfig dosyası oluştur</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">İmlecin altında ilgili bileşenleri vurgula</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">Üyeleri Yukarı Çek</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">.editorconfig dosyasını kaydet</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">Hedef seçin</target>
@@ -917,6 +982,11 @@
         <target state="translated">Bazı renk düzeni renkleri, Ortam &gt; Yazı Tipleri ve Renkler seçenek sayfasında yapılan değişiklikler tarafından geçersiz kılınıyor. Tüm özelleştirmeleri geri döndürmek için Yazı Tipleri ve Renkler sayfasında `Varsayılanları Kullan` seçeneğini belirleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">Parametre adı metodun hedefi ile eşleştiğinde ipuçlarını gizle</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">Bu geçersiz bir ad alanı</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">Adlandırılmış bağımsız değişken kullan</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">Burada atanan değer hiçbir zaman kullanılmadı</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -77,6 +77,11 @@
         <target state="translated">为始终保持清楚起见</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">调用站点</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">当前参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">按 Alt+F1 时显示所有提示</target>
@@ -267,6 +297,11 @@
         <target state="translated">启用“拉取”诊断(实验性，需要重启)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">输入调用站点值或选择其他值注入类型</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">整个解决方案</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">基于设置生成 .editorconfig 文件</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">突出显示光标下的相关组件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">拉取成员</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">保存 .editorconfig 文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">选择目标</target>
@@ -917,6 +982,11 @@
         <target state="translated">在“环境”&gt;“字体和颜色”选项页中所做的更改将替代某些配色方案颜色。在“字体和颜色”页中选择“使用默认值”，还原所有自定义项。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">当参数名称与方法的意图匹配时禁止显示提示</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">这是一个无效的命名空间</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">使用命名参数</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">此处分配的值从未使用过</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -77,6 +77,11 @@
         <target state="translated">一律使用以明確表示</target>
         <note />
       </trans-unit>
+      <trans-unit id="Analyzers">
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Analyzing_project_references">
         <source>Analyzing project references...</source>
         <target state="new">Analyzing project references...</target>
@@ -157,9 +162,29 @@
         <target state="translated">呼叫網站</target>
         <note />
       </trans-unit>
+      <trans-unit id="Carrage_Return_Newline_rn">
+        <source>Carrage Return + Newline (\\r\\n)</source>
+        <target state="new">Carrage Return + Newline (\\r\\n)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Carrage_Return_r">
+        <source>Carrage Return (\\r)</source>
+        <target state="new">Carrage Return (\\r)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category">
+        <source>Category</source>
+        <target state="new">Category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Choose_which_action_you_would_like_to_perform_on_the_unused_references">
         <source>Choose which action you would like to perform on the unused references.</source>
         <target state="new">Choose which action you would like to perform on the unused references.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_Style">
+        <source>Code Style</source>
+        <target state="new">Code Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_analysis_completed_for_0">
@@ -217,6 +242,11 @@
         <target state="translated">目前的參數</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabled">
+        <source>Disabled</source>
+        <target state="new">Disabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Display_all_hints_while_pressing_Alt_F1">
         <source>Display all hints while pressing Alt+F1</source>
         <target state="translated">按 Alt+F1 時顯示所有提示</target>
@@ -267,6 +297,11 @@
         <target state="translated">啟用 'pull' 診斷 (實驗性，需要重新啟動)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enabled">
+        <source>Enabled</source>
+        <target state="new">Enabled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enter_a_call_site_value_or_choose_a_different_value_injection_kind">
         <source>Enter a call site value or choose a different value injection kind</source>
         <target state="translated">請輸入呼叫位置值，或選擇其他值插入種類</target>
@@ -280,6 +315,11 @@
       <trans-unit id="Entire_solution">
         <source>Entire solution</source>
         <target state="translated">整個解決方案</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>Error</source>
+        <target state="new">Error</target>
         <note />
       </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
@@ -302,6 +342,11 @@
         <target state="new">Format document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting">
+        <source>Formatting</source>
+        <target state="new">Formatting</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">從設定產生 .editorconfig 檔案</target>
@@ -310,6 +355,11 @@
       <trans-unit id="Highlight_related_components_under_cursor">
         <source>Highlight related components under cursor</source>
         <target state="translated">反白資料指標下的相關元件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Id">
+        <source>Id</source>
+        <target state="new">Id</target>
         <note />
       </trans-unit>
       <trans-unit id="In_other_operators">
@@ -612,6 +662,11 @@
         <target state="new">New line preferences (experimental):</target>
         <note />
       </trans-unit>
+      <trans-unit id="Newline_n">
+        <source>Newline (\\n)</source>
+        <target state="new">Newline (\\n)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="No_unused_references_were_found">
         <source>No unused references were found.</source>
         <target state="new">No unused references were found.</target>
@@ -757,6 +812,11 @@
         <target state="translated">提升成員</target>
         <note />
       </trans-unit>
+      <trans-unit id="Refactoring_Only">
+        <source>Refactoring Only</source>
+        <target state="new">Refactoring Only</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Reference">
         <source>Reference</source>
         <target state="new">Reference</target>
@@ -842,6 +902,11 @@
         <target state="translated">儲存 .editorconfig 檔案</target>
         <note />
       </trans-unit>
+      <trans-unit id="Search_Settings">
+        <source>Search Settings</source>
+        <target state="new">Search Settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Select_destination">
         <source>Select destination</source>
         <target state="translated">選取目的地</target>
@@ -917,6 +982,11 @@
         <target state="translated">[環境] &gt; [字型和色彩選項] 頁面中所做的變更覆寫了某些色彩配置的色彩。請選擇 [字型和色彩] 頁面中的 [使用預設] 來還原所有自訂。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Suggestion">
+        <source>Suggestion</source>
+        <target state="new">Suggestion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Suppress_hints_when_parameter_name_matches_the_method_s_intent">
         <source>Suppress hints when parameter name matches the method's intent</source>
         <target state="translated">當參數名稱符合方法的意圖時，不出現提示</target>
@@ -965,6 +1035,11 @@
       <trans-unit id="This_is_an_invalid_namespace">
         <source>This is an invalid namespace</source>
         <target state="translated">這是無效的命名空間</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Title">
+        <source>Title</source>
+        <target state="new">Title</target>
         <note />
       </trans-unit>
       <trans-unit id="Type_Name">
@@ -1027,6 +1102,11 @@
         <target state="translated">使用具名引數</target>
         <note>"argument" is a programming term for a value passed to a function</note>
       </trans-unit>
+      <trans-unit id="Value">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Value_assigned_here_is_never_used">
         <source>Value assigned here is never used</source>
         <target state="translated">這裡指派的值從未使用過</target>
@@ -1055,6 +1135,11 @@
       <trans-unit id="Visual_Studio_2019">
         <source>Visual Studio 2019</source>
         <target state="translated">Visual Studio 2019</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source>Warning</source>
+        <target state="new">Warning</target>
         <note />
       </trans-unit>
       <trans-unit id="Warning_colon_duplicate_parameter_name">

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -304,10 +304,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             public AnalyzerConfigOptions GetOptionsForSourcePath(string path)
-            {
-                // TODO: correctly find the file path, since it looks like we give this the document's .Name under the covers if we don't have one
-                return new WorkspaceAnalyzerConfigOptions(_projectState._lazyAnalyzerConfigSet.GetValue(CancellationToken.None).GetOptionsForSourcePath(path));
-            }
+                => new WorkspaceAnalyzerConfigOptions(_projectState._lazyAnalyzerConfigSet.GetValue(CancellationToken.None).GetOptionsForSourcePath(path));
 
             private sealed class WorkspaceAnalyzerConfigOptions : AnalyzerConfigOptions
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis
             return _lazyAnalyzerConfigSet.GetValue(CancellationToken.None).GetOptionsForSourcePath(sourceFilePath);
         }
 
-        private sealed class WorkspaceAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+        internal sealed class WorkspaceAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
         {
             private readonly ProjectState _projectState;
 
@@ -301,6 +301,12 @@ namespace Microsoft.CodeAnalysis
             {
                 // TODO: correctly find the file path, since it looks like we give this the document's .Name under the covers if we don't have one
                 return new WorkspaceAnalyzerConfigOptions(_projectState._lazyAnalyzerConfigSet.GetValue(CancellationToken.None).GetOptionsForSourcePath(textFile.Path));
+            }
+
+            public AnalyzerConfigOptions GetOptionsForSourcePath(string path)
+            {
+                // TODO: correctly find the file path, since it looks like we give this the document's .Name under the covers if we don't have one
+                return new WorkspaceAnalyzerConfigOptions(_projectState._lazyAnalyzerConfigSet.GetValue(CancellationToken.None).GetOptionsForSourcePath(path));
             }
 
             private sealed class WorkspaceAnalyzerConfigOptions : AnalyzerConfigOptions


### PR DESCRIPTION
This is the new UI that will appear when a developer opens an editorconfig file (note a user can still get to the old file view via "Open With..")

- fixes https://github.com/dotnet/roslyn/issues/40365
- fixes https://github.com/dotnet/roslyn/issues/39414
- fixes https://github.com/dotnet/roslyn/issues/42695

## Feature walkthrough:
 - Searching

![search](https://user-images.githubusercontent.com/9797472/109322053-afd46000-7806-11eb-99a0-5a4a4fdba62a.gif)

- Filtering

![filter](https://user-images.githubusercontent.com/9797472/109322304-ffb32700-7806-11eb-8516-40002453f334.gif)

 - Sorting

![sort](https://user-images.githubusercontent.com/9797472/109322635-60dafa80-7807-11eb-9ea0-ff5daaf83b0b.gif)

- Saving

![saving](https://user-images.githubusercontent.com/9797472/109323523-684ed380-7808-11eb-9b04-25c2b76c3ba7.gif)

## Formatting Tab
![image](https://user-images.githubusercontent.com/9797472/109321161-b0202b80-7805-11eb-895e-cc9ba7cdd681.png)

## Code Style Tab
![image](https://user-images.githubusercontent.com/9797472/109321238-c4642880-7805-11eb-827c-4721e93ebb3f.png)

## Analyzers Tab
![image](https://user-images.githubusercontent.com/9797472/109321396-f37a9a00-7805-11eb-85d3-e99df64c1b6c.png)

TODO:
- [x] Finish adding tests for editorconfig saving helpers
- [ ] Update Tools -> Options window to use new services
- [ ] Unify editorconfig saving types
- [x] Remove/fix all `//TODO(jmarolf)` comments


