### PR TITLE
Return an empty navbar result on OOP failure.

### DIFF
--- a/eng/targets/Services.props
+++ b/eng/targets/Services.props
@@ -24,7 +24,7 @@
     <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.SymbolFinder" ClassName="Microsoft.CodeAnalysis.Remote.RemoteSymbolFinderService+Factory" IsBrokered="true" />
     <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.FindUsages" ClassName="Microsoft.CodeAnalysis.Remote.RemoteFindUsagesService+Factory" IsBrokered="true" />
     <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.NavigateToSearch" ClassName="Microsoft.CodeAnalysis.Remote.RemoteNavigateToSearchService+Factory" IsBrokered="true" />
-    <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.NavigationBar" ClassName="Microsoft.CodeAnalysis.Remote.RemoteNavigationBarItemService+Factory" IsBrokered="true" />
+    <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.NavigationBarItem" ClassName="Microsoft.CodeAnalysis.Remote.RemoteNavigationBarItemService+Factory" IsBrokered="true" />
     <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.MissingImportDiscovery" ClassName="Microsoft.CodeAnalysis.Remote.RemoteMissingImportDiscoveryService+Factory" IsBrokered="true" />
     <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.ExtensionMethodImportCompletion" ClassName="Microsoft.CodeAnalysis.Remote.RemoteExtensionMethodImportCompletionService+Factory" IsBrokered="true" />
     <ServiceHubService Include="Microsoft.VisualStudio.LanguageServices.DependentTypeFinder" ClassName="Microsoft.CodeAnalysis.Remote.RemoteDependentTypeFinderService+Factory" IsBrokered="true" />

--- a/src/Features/Core/Portable/NavigationBar/AbstractNavigationBarItemService.cs
+++ b/src/Features/Core/Portable/NavigationBar/AbstractNavigationBarItemService.cs
@@ -25,8 +25,9 @@ namespace Microsoft.CodeAnalysis.NavigationBar
                     (service, solutionInfo, cancellationToken) => service.GetItemsAsync(solutionInfo, document.Id, supportsCodeGeneration, cancellationToken),
                     cancellationToken).ConfigureAwait(false);
 
-                if (result.HasValue)
-                    return result.Value.SelectAsArray(v => v.Rehydrate());
+                return result.HasValue
+                    ? result.Value.SelectAsArray(v => v.Rehydrate())
+                    : ImmutableArray<RoslynNavigationBarItem>.Empty;
             }
 
             var items = await GetItemsInCurrentProcessAsync(document, supportsCodeGeneration, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Followup to: https://github.com/dotnet/roslyn/pull/51072