### PR TITLE
EnC - Add rude edits for local functions attributes and type parameters

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -106,13 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             string bodySource,
             MethodKind kind = MethodKind.Regular)
         {
-            var source = kind switch
-            {
-                MethodKind.Iterator => "class C { IEnumerable<int> F() { " + bodySource + " } }",
-                MethodKind.Async => "class C { async Task<int> F() { " + bodySource + " } }",
-                MethodKind.ConstructorWithParameters => "class C { C" + bodySource + " }",
-                _ => "class C { void F() { " + bodySource + " } }",
-            };
+            var source = WrapMethodBodyWithClass(bodySource, kind);
 
             var tree = ParseSource(source);
             var root = tree.GetRoot();
@@ -130,6 +124,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 
             return (BlockSyntax)SyntaxFactory.SyntaxTree(declaration.Body).GetRoot();
         }
+
+        internal static string WrapMethodBodyWithClass(string bodySource, MethodKind kind = MethodKind.Regular)
+             => kind switch
+             {
+                 MethodKind.Iterator => "class C { IEnumerable<int> F() { " + bodySource + " } }",
+                 MethodKind.Async => "class C { async Task<int> F() { " + bodySource + " } }",
+                 MethodKind.ConstructorWithParameters => "class C { C" + bodySource + " }",
+                 _ => "class C { void F() { " + bodySource + " } }",
+             };
 
         internal static ActiveStatementsDescription GetActiveStatements(string oldSource, string newSource)
             => new ActiveStatementsDescription(oldSource, newSource);

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -1841,7 +1841,10 @@ foreach (var (a, b) in e1) { }
 
             edits.VerifyEdits(
                 "Update [a => a]@13 -> [(a) => a]@13",
-                "Update [b => b]@25 -> [b => b + 1]@27");
+                "Update [b => b]@25 -> [b => b + 1]@27",
+                "Insert [(a)]@13",
+                "Insert [a]@14",
+                "Delete [a]@13");
         }
 
         [Fact]
@@ -1894,7 +1897,7 @@ foreach (var (a, b) in e1) { }
 
             // changes were made to the outer lambda signature:
             edits.VerifyEdits(
-                "Update [() => { G(x => y); }]@4 -> [q => { G(() => y); }]@4");
+                "Update [() => { G(x => y); }]@4 -> [q => { G(() => y); }]@4", "Insert [q]@4", "Delete [()]@4");
         }
 
         [Fact]
@@ -1918,7 +1921,7 @@ foreach (var (a, b) in e1) { }
             var edits = GetMethodEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Update [(ref int a) => a = 1]@4 -> [(out int a) => a = 1]@4");
+                "Update [ref int a]@5 -> [out int a]@5");
         }
 
         [Fact]
@@ -4745,7 +4748,10 @@ class Program
             edits.VerifyEdits(
                 "Update [a => a]@4 -> [int x(int a) => a + 1;]@2",
                 "Move [a => a]@4 -> @2",
-                "Update [F(a => a, b => b);]@2 -> [F(b => b, x);]@25");
+                "Update [F(a => a, b => b);]@2 -> [F(b => b, x);]@25",
+                "Insert [(int a)]@7",
+                "Insert [int a]@8",
+                "Delete [a]@4");
         }
 
         [Fact]
@@ -4774,7 +4780,10 @@ class Program
                 "Update [int x(int a) => a + 1;]@28 -> [a => a]@11",
                 "Move [int x(int a) => a + 1;]@28 -> @11",
                 "Move [{ /*1*/ }]@5 -> @20",
-                "Delete [do { /*1*/ } while (F(x));]@2");
+                "Insert [a]@11",
+                "Delete [do { /*1*/ } while (F(x));]@2",
+                "Delete [(int a)]@33",
+                "Delete [int a]@34");
         }
 
         [Fact]
@@ -4796,8 +4805,7 @@ class Program
 
             var edits = GetMethodEdits(src1, src2);
             // changes were made to the outer local function signature:
-            edits.VerifyEdits(
-                "Update [int x() { int y(int a) => a; return y(b); }]@2 -> [int x(int z) { int y() => c; return y(); }]@2");
+            edits.VerifyEdits("Insert [int z]@8");
         }
 
         [Fact]
@@ -4809,7 +4817,9 @@ class Program
             var edits = GetMethodEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Update [() => { int y(int a) => a; G(y); }]@4 -> [q => { G(() => y); }]@4");
+                "Update [() => { int y(int a) => a; G(y); }]@4 -> [q => { G(() => y); }]@4",
+                "Insert [q]@4",
+                "Delete [()]@4");
         }
 
         [Fact]
@@ -4821,7 +4831,7 @@ class Program
             var edits = GetMethodEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Update [void f(ref int a) => a = 1;]@2 -> [void f(out int a) => a = 1;]@2");
+                "Update [ref int a]@9 -> [out int a]@9");
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -1897,7 +1897,9 @@ foreach (var (a, b) in e1) { }
 
             // changes were made to the outer lambda signature:
             edits.VerifyEdits(
-                "Update [() => { G(x => y); }]@4 -> [q => { G(() => y); }]@4", "Insert [q]@4", "Delete [()]@4");
+                "Update [() => { G(x => y); }]@4 -> [q => { G(() => y); }]@4",
+                "Insert [q]@4",
+                "Delete [()]@4");
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -7225,6 +7225,118 @@ interface I
             edits.VerifyRudeDiagnostics();
         }
 
+        [Fact]
+        public void LocalFunctions_TypeParameter_Insert1()
+        {
+            var src1 = @"void L() {}";
+            var src2 = @"void L<A>() {} ";
+
+            var edits = GetMethodEdits(src1, src2);
+            edits.VerifyEdits(
+                "Insert [<A>]@8",
+                "Insert [A]@9");
+
+            // Get top edits so we can validate rude edits
+            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
+
+            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "<A>", FeaturesResources.type_parameter));
+        }
+
+        [Fact]
+        public void LocalFunctions_TypeParameter_Insert2()
+        {
+            var src1 = @"void L<A>() {}";
+            var src2 = @"void L<A,B>() {} ";
+
+            var edits = GetMethodEdits(src1, src2);
+            edits.VerifyEdits(
+                "Update [<A>]@8 -> [<A,B>]@8",
+                "Insert [B]@11");
+
+            // Get top edits so we can validate rude edits
+            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
+
+            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "B", FeaturesResources.type_parameter));
+        }
+
+        [Fact]
+        public void LocalFunctions_TypeParameter_Delete1()
+        {
+            var src1 = @"void L<A>() {}";
+            var src2 = @"void L() {} ";
+
+            var edits = GetMethodEdits(src1, src2);
+            edits.VerifyEdits(
+                "Delete [<A>]@8",
+                "Delete [A]@9");
+
+            // Get top edits so we can validate rude edits
+            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
+
+            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.type_parameter));
+        }
+
+        [Fact]
+        public void LocalFunctions_TypeParameter_Delete2()
+        {
+            var src1 = @"void L<A,B>() {}";
+            var src2 = @"void L<B>() {} ";
+
+            var edits = GetMethodEdits(src1, src2);
+            edits.VerifyEdits(
+                "Update [<A,B>]@8 -> [<B>]@8",
+                "Delete [A]@9");
+
+            // Get top edits so we can validate rude edits
+            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
+
+            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.type_parameter));
+        }
+
+        [Fact]
+        public void LocalFunctions_TypeParameter_Update()
+        {
+            var src1 = @"void L<A>() {}";
+            var src2 = @"void L<B>() {} ";
+
+            var edits = GetMethodEdits(src1, src2);
+            edits.VerifyEdits(
+                "Update [A]@9 -> [B]@9");
+
+            // Get top edits so we can validate rude edits
+            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
+
+            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Renamed, "B", FeaturesResources.type_parameter));
+        }
+
+        [Fact]
+        public void LocalFunctions_TypeParameter_Reorder()
+        {
+            var src1 = @"void L<A,B>() {}";
+            var src2 = @"void L<B,A>() {} ";
+
+            var edits = GetMethodEdits(src1, src2);
+            edits.VerifyEdits(
+                "Reorder [B]@11 -> @9");
+
+            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter));
+        }
+
+        [Fact]
+        public void LocalFunctions_TypeParameter_ReorderAndUpdate()
+        {
+            var src1 = @"void L<A,B>() {}";
+            var src2 = @"void L<B,C>() {} ";
+
+            var edits = GetMethodEdits(src1, src2);
+            edits.VerifyEdits(
+                "Reorder [B]@11 -> @9",
+                "Update [A]@9 -> [C]@11");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter),
+                Diagnostic(RudeEditKind.Renamed, "C", FeaturesResources.type_parameter));
+        }
         #endregion
 
         #region Queries

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
@@ -225,6 +225,7 @@ return (2, () => {
                 { "return (10, e, 22);", "return (10, e);" },
                 { "return (2, () => {      int a = 6;     return 1; });", "return (2, () => {     int a = 6;     return 5; });" },
                 { "() => {      int a = 6;     return 1; }", "() => {     int a = 6;     return 5; }" },
+                { "()", "()" },
                 { "{      int a = 6;     return 1; }", "{     int a = 6;     return 5; }" },
                 { "int a = 6;", "int a = 6;" },
                 { "int a = 6", "int a = 6" },
@@ -521,6 +522,7 @@ var (a1, a3) = (1, () => { return 8; });
                 { "a1", "a1" },
                 { "a2", "a3" },
                 { "() => { return 7; }", "() => { return 8; }" },
+                { "()", "()" },
                 { "{ return 7; }", "{ return 8; }" },
                 { "return 7;", "return 8;" }
             };
@@ -594,6 +596,8 @@ ref int32 a = ref G1(new int[] { 1, 2 });
                 { "ref int a = ref G(new int[] { 1, 2 })", "ref int32 a = ref G1(new int[] { 1, 2 })" },
                 { "a = ref G(new int[] { 1, 2 })", "a = ref G1(new int[] { 1, 2 })" },
                 { "ref int G(int[] p)     {         return ref p[1];     }", "ref int G1(int[] p)     {         return ref p[2];     }" },
+                { "(int[] p)", "(int[] p)" },
+                { "int[] p", "int[] p" },
                 { "{         return ref p[1];     }", "{         return ref p[2];     }" },
                 { "return ref p[1];", "return ref p[2];" }
             };
@@ -642,9 +646,13 @@ F(y => y + 1, G(), x => x + 1, (int x) => x, u => u, async (u, v) => u + v);
             {
                 { "F(x => x + 1, 1, y => y + 1, delegate(int x) { return x; }, async u => u);", "F(y => y + 1, G(), x => x + 1, (int x) => x, u => u, async (u, v) => u + v);" },
                 { "x => x + 1", "x => x + 1" },
+                { "x", "x" },
                 { "y => y + 1", "y => y + 1" },
+                { "y", "y" },
                 { "delegate(int x) { return x; }", "(int x) => x" },
-                { "async u => u", "async (u, v) => u + v" },
+                { "(int x)", "(int x)" },
+                { "int x", "int x" },
+                { "async u => u", "async (u, v) => u + v" }
             };
 
             expected.AssertEqual(actual);
@@ -688,7 +696,8 @@ a += u => u;
             var expected = new MatchingPairs
             {
                 { "a += async u => u;", "a += u => u;" },
-                { "async u => u", "u => u" }
+                { "async u => u", "u => u" },
+                { "u", "u" }
             };
 
             expected.AssertEqual(actual);
@@ -722,6 +731,7 @@ foreach (var a in z)
                 { "e = from q in a.Where(l => l > 10) select q + 1", "e = from q in a.Where(l => l < 0) select q + 1" },
                 { "from q in a.Where(l => l > 10)", "from q in a.Where(l => l < 0)" },
                 { "l => l > 10", "l => l < 0" },
+                { "l", "l" },
                 { "select q + 1", "select q + 1" },  // select clause
                 { "select q + 1", "select q + 1" }   // query body
             };
@@ -746,8 +756,11 @@ F(a => b => c => d);
             {
                 { "F(a => b => c => d);", "F(a => b => c => d);" },
                 { "a => b => c => d", "a => b => c => d" },
+                { "a", "a" },
                 { "b => c => d", "b => c => d" },
-                { "c => d", "c => d" }
+                { "b", "b" },
+                { "c => d", "c => d" },
+                { "c", "c" }
             };
 
             expected.AssertEqual(actual);
@@ -770,8 +783,11 @@ F(a => G(b => H(c => I(d))));
             {
                 { "F(a => b => c => d);", "F(a => G(b => H(c => I(d))));" },
                 { "a => b => c => d", "a => G(b => H(c => I(d)))" },
+                { "a", "a" },
                 { "b => c => d", "b => H(c => I(d))" },
-                { "c => d", "c => I(d)" }
+                { "b", "b" },
+                { "c => d", "c => I(d)" },
+                { "c", "c" }
             };
 
             expected.AssertEqual(actual);
@@ -812,18 +828,27 @@ F(a =>
                   "F(a =>  {      F(c => /*1*/d + 1);     F((u, v) =>      {         F((w) => c => /*2*/d + 1);         F(p => p*2);     }); });" },
                 { "a =>  {      F(c => /*1*/d);     F((u, v) =>      {         F((w) => c => /*2*/d);         F(p => p);     }); }",
                   "a =>  {      F(c => /*1*/d + 1);     F((u, v) =>      {         F((w) => c => /*2*/d + 1);         F(p => p*2);     }); }" },
+                { "a", "a" },
                 { "{      F(c => /*1*/d);     F((u, v) =>      {         F((w) => c => /*2*/d);         F(p => p);     }); }",
                   "{      F(c => /*1*/d + 1);     F((u, v) =>      {         F((w) => c => /*2*/d + 1);         F(p => p*2);     }); }" },
                 { "F(c => /*1*/d);", "F(c => /*1*/d + 1);" },
                 { "c => /*1*/d", "c => /*1*/d + 1" },
+                { "c", "c" },
                 { "F((u, v) =>      {         F((w) => c => /*2*/d);         F(p => p);     });", "F((u, v) =>      {         F((w) => c => /*2*/d + 1);         F(p => p*2);     });" },
                 { "(u, v) =>      {         F((w) => c => /*2*/d);         F(p => p);     }", "(u, v) =>      {         F((w) => c => /*2*/d + 1);         F(p => p*2);     }" },
+                { "(u, v)", "(u, v)" },
+                { "u", "u" },
+                { "v", "v" },
                 { "{         F((w) => c => /*2*/d);         F(p => p);     }", "{         F((w) => c => /*2*/d + 1);         F(p => p*2);     }" },
                 { "F((w) => c => /*2*/d);", "F((w) => c => /*2*/d + 1);" },
                 { "(w) => c => /*2*/d", "(w) => c => /*2*/d + 1" },
+                { "(w)", "(w)" },
+                { "w", "w" },
                 { "c => /*2*/d", "c => /*2*/d + 1" },
+                { "c", "c" },
                 { "F(p => p);", "F(p => p*2);" },
-                { "p => p", "p => p*2" }
+                { "p => p", "p => p*2" },
+                { "p", "p" }
             };
 
             expected.AssertEqual(actual);
@@ -843,7 +868,8 @@ F(a =>
                 { "var x = new int[F(a => 1)];", "var x = new int[F(a => 2)];" },
                 { "var x = new int[F(a => 1)]", "var x = new int[F(a => 2)]" },
                 { "x = new int[F(a => 1)]", "x = new int[F(a => 2)]" },
-                { "a => 1", "a => 2" }
+                { "a => 1", "a => 2" },
+                { "a", "a" }
             };
 
             expected.AssertEqual(actual);
@@ -863,7 +889,8 @@ F(a =>
                 { "var x = new int[] { F(a => 1) };", "var x = new int[] { F(a => 2) };" },
                 { "var x = new int[] { F(a => 1) }", "var x = new int[] { F(a => 2) }" },
                 { "x = new int[] { F(a => 1) }", "x = new int[] { F(a => 2) }" },
-                { "a => 1", "a => 2" }
+                { "a => 1", "a => 2" },
+                { "a", "a" }
             };
 
             expected.AssertEqual(actual);
@@ -883,7 +910,8 @@ F(a =>
                 { "var x = stackalloc int[F(a => 1)];", "var x = stackalloc int[F(a => 2)];" },
                 { "var x = stackalloc int[F(a => 1)]", "var x = stackalloc int[F(a => 2)]" },
                 { "x = stackalloc int[F(a => 1)]", "x = stackalloc int[F(a => 2)]" },
-                { "a => 1", "a => 2" }
+                { "a => 1", "a => 2" },
+                { "a", "a" }
             };
 
             expected.AssertEqual(actual);
@@ -904,6 +932,7 @@ F(a =>
                 { "var x = stackalloc[] { F(a => 1) }", "var x = stackalloc[] { F(a => 2) }" },
                 { "x = stackalloc[] { F(a => 1) }", "x = stackalloc[] { F(a => 2) }" },
                 { "a => 1", "a => 2" },
+                { "a", "a" }
             };
 
             expected.AssertEqual(actual);
@@ -934,12 +963,18 @@ F(a =>
             var expected = new MatchingPairs
             {
                 { "(int a, string c) F1(int i) { return null; }", "(int a, int b) F1(int i) { return null; }" },
+                { "(int i)", "(int i)" },
+                { "int i", "int i" },
                 { "{ return null; }", "{ return null; }" },
                 { "return null;", "return null;" },
                 { "(int a, int b) F2(int i) { return null; }", "(int a, int b, string c) F2(int i) { return null; }" },
+                { "(int i)", "(int i)" },
+                { "int i", "int i" },
                 { "{ return null; }", "{ return null; }" },
                 { "return null;", "return null;" },
                 { "(int a, int b, int c) F3(int i) { return null; }", "(int a, int b) F3(int i) { return null; }" },
+                { "(int i)", "(int i)" },
+                { "int i", "int i" },
                 { "{ return null; }", "{ return null; }" },
                 { "return null;", "return null;" }
             };
@@ -989,6 +1024,8 @@ F(localF1, localF2, G(), localF2, localF3, localF4, localF5);
                 { "x => x + 1", "int localF2(int x) => x + 1;" },
                 { "y => y + 1", "int localF1(int y) => y + 1;" },
                 { "delegate(int x) { return x; }", "int localF3(int x) => x;" },
+                { "(int x)", "(int x)" },
+                { "int x", "int x" },
                 { "async u => u", "int localF4(int u) => u;" }
             };
 
@@ -1054,15 +1091,19 @@ a += localF;
             {
                 { "int a() { int b() { int c() { int d() { return 0; } } return c(); } return b(); }",
                     "int a() { int b() { int c() { int d() { return 0; } } return c(); } return b(); }" },
+                { "()", "()" },
                 { "{ int b() { int c() { int d() { return 0; } } return c(); } return b(); }",
                     "{ int b() { int c() { int d() { return 0; } } return c(); } return b(); }" },
                 { "int b() { int c() { int d() { return 0; } } return c(); }",
                     "int b() { int c() { int d() { return 0; } } return c(); }" },
+                { "()", "()" },
                 { "{ int c() { int d() { return 0; } } return c(); }",
                     "{ int c() { int d() { return 0; } } return c(); }" },
                 { "int c() { int d() { return 0; } }", "int c() { int d() { return 0; } }" },
+                { "()", "()" },
                 { "{ int d() { return 0; } }", "{ int d() { return 0; } }" },
                 { "int d() { return 0; }", "int d() { return 0; }" },
+                { "()", "()" },
                 { "{ return 0; }", "{ return 0; }" },
                 { "return 0;", "return 0;" },
                 { "return c();", "return c();" },
@@ -1120,19 +1161,30 @@ void G6(int a)
             {
                 { "void G6(int a) {      int G5(int c) => /*1*/d;     F(G5);      void G4()     {         void G1(int x) => x;         int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }         F(G3);         F(G1);     };     F(G4); }",
                     "void G6(int a) {      int G5(int c) => /*1*/d + 1;F(G5);      void G4()     {         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     }     F(G4); }" },
+                { "(int a)", "(int a)" },
+                { "int a", "int a" },
                 { "{      int G5(int c) => /*1*/d;     F(G5);      void G4()     {         void G1(int x) => x;         int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }         F(G3);         F(G1);     };     F(G4); }",
                     "{      int G5(int c) => /*1*/d + 1;F(G5);      void G4()     {         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     }     F(G4); }" },
                 { "int G5(int c) => /*1*/d;", "int G5(int c) => /*1*/d + 1;" },
+                { "(int c)", "(int c)" },
+                { "int c", "int c" },
                 { "F(G5);", "F(G5);" },
                 { "void G4()     {         void G1(int x) => x;         int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }         F(G3);         F(G1);     }",
                     "void G4()     {         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     }" },
+                { "()", "()" },
                 { "{         void G1(int x) => x;         int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }         F(G3);         F(G1);     }",
                     "{         int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }         F(G3); F(G1); int G6(int p) => p *2; F(G6);     }" },
                 { "void G1(int x) => x;", "int G6(int p) => p *2;" },
+                { "(int x)", "(int p)" },
+                { "int x", "int p" },
                 { "int G3(int w)         {              int G2(int c) => /*2*/d;             return G2(w);         }",
                     "int G3(int w)         {              int G2(int c) => /*2*/d + 1; return G2(w);         }" },
+                { "(int w)", "(int w)" },
+                { "int w", "int w" },
                 { "{              int G2(int c) => /*2*/d;             return G2(w);         }", "{              int G2(int c) => /*2*/d + 1; return G2(w);         }" },
                 { "int G2(int c) => /*2*/d;", "int G2(int c) => /*2*/d + 1;" },
+                { "(int c)", "(int c)" },
+                { "int c", "int c" },
                 { "return G2(w);", "return G2(w);" },
                 { "F(G3);", "F(G3);" },
                 { "F(G1);", "F(G1);" },
@@ -1154,9 +1206,11 @@ void G6(int a)
             var expected = new MatchingPairs
             {
                 { "int f() { return local(); int local() { return 1; }}", "int f() { return local(); int local() => 2; }" },
+                { "()", "()" },
                 { "{ return local(); int local() { return 1; }}", "{ return local(); int local() => 2; }" },
                 { "return local();", "return local();" },
-                { "int local() { return 1; }", "int local() => 2;" }
+                { "int local() { return 1; }", "int local() => 2;" },
+                { "()", "()" },
             };
 
             expected.AssertEqual(actual);
@@ -1174,9 +1228,11 @@ void G6(int a)
             var expected = new MatchingPairs
             {
                 { "int f() { return local(); int local() => 2; }", "int f() { return local(); int local() { return 1; }}" },
+                { "()", "()" },
                 { "{ return local(); int local() => 2; }", "{ return local(); int local() { return 1; }}" },
                 { "return local();", "return local();" },
-                { "int local() => 2;", "int local() { return 1; }" }
+                { "int local() => 2;", "int local() { return 1; }" },
+                { "()", "()" },
             };
 
             expected.AssertEqual(actual);
@@ -1323,12 +1379,16 @@ var q = from a in await seq1
                 { "join c in await seq2 on F(u => u) equals G(s => s) into g1", "join c in await seq2 on F(u => u + 1) equals G(s => s + 3) into g1" },
                 { "await seq2", "await seq2" },
                 { "u => u", "u => u + 1" },
+                { "u", "u" },
                 { "s => s", "s => s + 3" },
+                { "s", "s" },
                 { "into g1", "into g1" },
                 { "join l in await seq3 on F(v => v) equals G(t => t) into g2", "join c in await seq3 on F(vv => vv + 2) equals G(tt => tt + 4) into g2" },
                 { "await seq3", "await seq3" },
                 { "v => v", "vv => vv + 2" },
+                { "v", "vv" },
                 { "t => t", "tt => tt + 4" },
+                { "t", "tt" },
                 { "into g2", "into g2" },
                 { "select a", "select a + 1" }
             };
@@ -1438,7 +1498,10 @@ foreach (var x in y) { yield return /*3*/ 2; }
 
             var expected = new MatchingPairs
             {
+                { "(int x = 1)", "(int x = 1)" },
+                { "int x = 1", "int x = 1" },
                 { "a => a + 1", "a => a + 1" },
+                { "a", "a" },
                 { "{ Console.WriteLine(1); }", "{ Console.WriteLine(1); }" },
                 { "Console.WriteLine(1);", "Console.WriteLine(1);" }
             };
@@ -1461,6 +1524,7 @@ foreach (var x in y) { yield return /*3*/ 2; }
 
             var expected = new MatchingPairs
             {
+                { "()", "()" },
                 { "{ Console.WriteLine(1); }", "{ Console.WriteLine(1); }" },
                 { "Console.WriteLine(1);", "Console.WriteLine(1);" }
             };

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -638,6 +638,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
         }
 
+        protected override void ReportLocalFunctionsDeclarationRudeEdits(Match<SyntaxNode> bodyMatch, List<RudeEditDiagnostic> diagnostics)
+        {
+        }
+
         protected override bool TryMatchActiveStatement(
             SyntaxNode oldStatement,
             int statementPart,

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1386,14 +1386,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.AttributeList:
                     var attributeList = (AttributeListSyntax)node;
-                    if (editKind == EditKind.Update)
-                    {
-                        return (attributeList.Target != null) ? attributeList.Target.Span : attributeList.Span;
-                    }
-                    else
-                    {
-                        return attributeList.Span;
-                    }
+                    return attributeList.Span;
 
                 case SyntaxKind.Attribute:
                     return node.Span;
@@ -1723,10 +1716,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return FeaturesResources.parameter;
 
                 case SyntaxKind.AttributeList:
-                    return (editKind == EditKind.Update) ? CSharpFeaturesResources.attribute_target : FeaturesResources.attribute;
+                    return FeaturesResources.attribute;
 
                 case SyntaxKind.Attribute:
                     return FeaturesResources.attribute;
+
+                case SyntaxKind.AttributeTargetSpecifier:
+                    return CSharpFeaturesResources.attribute_target;
 
                 // statement:
 
@@ -2912,7 +2908,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             {
                 if (!SyntaxFactory.AreEquivalent(oldNode.Target, newNode.Target))
                 {
-                    ReportError(RudeEditKind.Update);
+                    var spanNode = ((SyntaxNode?)newNode.Target) ?? newNode;
+                    ReportError(RudeEditKind.Update, spanNode: spanNode, displayNode: spanNode);
                     return;
                 }
 

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1973,6 +1973,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyMove()
             {
+                if (_newNode.IsKind(SyntaxKind.LocalFunctionStatement))
+                {
+                    return;
+                }
+
                 // We could perhaps allow moving a type declaration to a different namespace syntax node
                 // as long as it represents semantically the same namespace as the one of the original type declaration.
                 ReportError(RudeEditKind.Move);
@@ -1980,6 +1985,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyReorder(SyntaxNode newNode)
             {
+                if (_newNode.IsKind(SyntaxKind.LocalFunctionStatement))
+                {
+                    return;
+                }
+
                 switch (newNode.Kind())
                 {
                     case SyntaxKind.GlobalStatement:

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -2148,6 +2148,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         ClassifyFieldInsert((VariableDeclarationSyntax)node);
                         return;
 
+                    case SyntaxKind.Parameter when !_classifyStatementSyntax:
+                        // Parameter inserts are allowed for local functions
+                        ReportError(RudeEditKind.Insert);
+                        return;
+
                     case SyntaxKind.EnumMemberDeclaration:
                     case SyntaxKind.TypeParameter:
                     case SyntaxKind.TypeParameterConstraintClause:
@@ -2347,14 +2352,16 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                     case SyntaxKind.TypeParameter:
                     case SyntaxKind.TypeParameterList:
-                    case SyntaxKind.Parameter:
-                    case SyntaxKind.ParameterList:
                     case SyntaxKind.TypeParameterConstraintClause:
                         ReportError(RudeEditKind.Delete);
                         return;
 
                     default:
                         throw ExceptionUtilities.UnexpectedValue(oldNode.Kind());
+                    case SyntaxKind.Parameter when !_classifyStatementSyntax:
+                    case SyntaxKind.ParameterList when !_classifyStatementSyntax:
+                        ReportError(RudeEditKind.Delete);
+                        return;
                 }
             }
 
@@ -2465,6 +2472,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         return;
 
                     case SyntaxKind.Parameter:
+                    case SyntaxKind.Parameter when !_classifyStatementSyntax:
+                        // Parameter updates are allowed for local functions
                         ClassifyUpdate((ParameterSyntax)oldNode, (ParameterSyntax)newNode);
                         return;
 

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -2157,14 +2157,16 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     case SyntaxKind.TypeParameter:
                     case SyntaxKind.TypeParameterConstraintClause:
                     case SyntaxKind.TypeParameterList:
-                    case SyntaxKind.Parameter:
                     case SyntaxKind.Attribute:
                     case SyntaxKind.AttributeList:
                         ReportError(RudeEditKind.Insert);
                         return;
+                }
 
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(node.Kind());
+                // When classifying statement syntax we could see potentially any node as an edit
+                if (!_classifyStatementSyntax)
+                {
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
                 }
             }
 
@@ -2356,12 +2358,16 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         ReportError(RudeEditKind.Delete);
                         return;
 
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(oldNode.Kind());
                     case SyntaxKind.Parameter when !_classifyStatementSyntax:
                     case SyntaxKind.ParameterList when !_classifyStatementSyntax:
                         ReportError(RudeEditKind.Delete);
                         return;
+                }
+
+                // When classifying statement syntax we could see potentially any node as an edit
+                if (!_classifyStatementSyntax)
+                {
+                    throw ExceptionUtilities.UnexpectedValue(oldNode.Kind());
                 }
             }
 
@@ -2471,7 +2477,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         ClassifyUpdate((TypeParameterSyntax)oldNode, (TypeParameterSyntax)newNode);
                         return;
 
-                    case SyntaxKind.Parameter:
                     case SyntaxKind.Parameter when !_classifyStatementSyntax:
                         // Parameter updates are allowed for local functions
                         ClassifyUpdate((ParameterSyntax)oldNode, (ParameterSyntax)newNode);
@@ -2493,8 +2498,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     case SyntaxKind.AccessorList:
                         return;
 
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(newNode.Kind());
+                }
+
+                // When classifying statement syntax we could see potentially any node as an edit
+                if (!_classifyStatementSyntax)
+                {
+                    throw ExceptionUtilities.UnexpectedValue(newNode.Kind());
                 }
             }
 

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1379,10 +1379,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     }
 
                 case SyntaxKind.Parameter:
-                    // We ignore anonymous methods and lambdas, 
-                    // we only care about parameters of member declarations.
                     var parameter = (ParameterSyntax)node;
-                    return GetDiagnosticSpan(parameter.Modifiers, parameter.Type, parameter);
+                    // Lambda parameters don't have types or modifiers, so the parameter is the only node
+                    var startNode = parameter.Type ?? (SyntaxNode)parameter;
+                    return GetDiagnosticSpan(parameter.Modifiers, startNode, parameter);
 
                 case SyntaxKind.AttributeList:
                     var attributeList = (AttributeListSyntax)node;

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -101,8 +101,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         protected internal override IEnumerable<SyntaxNode>? GetChildren(SyntaxNode node)
         {
-            Debug.Assert(HasLabel(node));
-
             if (node == _oldRoot)
             {
                 return _oldRootChildren;

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -505,6 +505,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.BracketedParameterList:
                     return Label.BracketedParameterList;
 
+                case SyntaxKind.ParameterList:
+                    return Label.ParameterList;
+
+                case SyntaxKind.Parameter:
+                    return Label.Parameter;
+
                 case SyntaxKind.AttributeList:
                     return Label.AttributeList;
 
@@ -768,15 +774,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                     case SyntaxKind.ConstructorDeclaration:
                         return Label.ConstructorDeclaration;
-
-                    case SyntaxKind.ParameterList:
-                        return Label.ParameterList;
-
-                    case SyntaxKind.Parameter:
-                        // Top syntax only as we ignore anonymous methods and lambdas,
-                        // we only care about parameters of member declarations.
-                        // children: attributes
-                        return Label.Parameter;
                 }
             }
 

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -977,6 +977,26 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     distance = ComputeWeightedDistance((SingleVariableDesignationSyntax)leftNode, (SingleVariableDesignationSyntax)rightNode);
                     return true;
 
+                case SyntaxKind.TypeParameterConstraintClause:
+                    distance = ComputeDistance((TypeParameterConstraintClauseSyntax)leftNode, (TypeParameterConstraintClauseSyntax)rightNode);
+                    return true;
+
+                case SyntaxKind.TypeParameter:
+                    distance = ComputeDistance((TypeParameterSyntax)leftNode, (TypeParameterSyntax)rightNode);
+                    return true;
+
+                case SyntaxKind.Parameter:
+                    distance = ComputeDistance((ParameterSyntax)leftNode, (ParameterSyntax)rightNode);
+                    return true;
+
+                case SyntaxKind.AttributeList:
+                    distance = ComputeDistance((AttributeListSyntax)leftNode, (AttributeListSyntax)rightNode);
+                    return true;
+
+                case SyntaxKind.Attribute:
+                    distance = ComputeDistance((AttributeSyntax)leftNode, (AttributeSyntax)rightNode);
+                    return true;
+
                 default:
                     var leftName = TryGetName(leftNode);
                     var rightName = TryGetName(rightNode);
@@ -1125,6 +1145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ParenthesizedLambdaExpression:
                 case SyntaxKind.SimpleLambdaExpression:
                 case SyntaxKind.AnonymousMethodExpression:
+                case SyntaxKind.LocalFunctionStatement:
                     // value distance of the block body is included:
                     distance = GetDistance(leftBlock.Parent, rightBlock.Parent);
                     return true;

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1300,10 +1300,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 foreach (var pair in lambdaBodyMatch.Matches)
                 {
-                    // Body match of a lambda whose body is an expression has the lambda as a root.
-                    // The lambda has already been included when enumerating parent body matches.
-                    if (!map.ContainsKey(pair.Key) ||
-                        pair.Key == lambdaBodyMatch.OldRoot && pair.Value == lambdaBodyMatch.NewRoot && IsLambda(pair.Key) && IsLambda(pair.Value))
+                    if (!map.ContainsKey(pair.Key))
                     {
                         map[pair.Key] = pair.Value;
                         reverseMap[pair.Value] = pair.Key;

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -306,6 +306,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected abstract void GetStateMachineInfo(SyntaxNode body, out ImmutableArray<SyntaxNode> suspensionPoints, out StateMachineKinds kinds);
         protected abstract TextSpan GetExceptionHandlingRegion(SyntaxNode node, out bool coversAllChildren);
 
+        protected abstract void ReportLocalFunctionsDeclarationRudeEdits(Match<SyntaxNode> bodyMatch, List<RudeEditDiagnostic> diagnostics);
+
         internal abstract void ReportSyntacticRudeEdits(List<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, Edit<SyntaxNode> edit, Dictionary<SyntaxNode, EditKind> editMap);
         internal abstract void ReportEnclosingExceptionHandlingRudeEdits(List<RudeEditDiagnostic> diagnostics, IEnumerable<Edit<SyntaxNode>> exceptionHandlingEdits, SyntaxNode oldStatement, TextSpan newStatementSpan);
         internal abstract void ReportOtherRudeEditsAroundActiveStatement(List<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode oldStatement, SyntaxNode newStatement, bool isNonLeaf);
@@ -1380,6 +1382,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             var match = ComputeBodyMatch(oldBody, newBody, lazyKnownMatches);
+
+            if (IsLocalFunction(match.OldRoot) && IsLocalFunction(match.NewRoot))
+            {
+                ReportLocalFunctionsDeclarationRudeEdits(match, diagnostics);
+            }
 
             if (lazyRudeEdits != null)
             {

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1302,12 +1302,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     // Body match of a lambda whose body is an expression has the lambda as a root.
                     // The lambda has already been included when enumerating parent body matches.
-                    Debug.Assert(
-                        !map.ContainsKey(pair.Key) ||
-                        pair.Key == lambdaBodyMatch.OldRoot && pair.Value == lambdaBodyMatch.NewRoot && IsLambda(pair.Key) && IsLambda(pair.Value));
-
-                    map[pair.Key] = pair.Value;
-                    reverseMap[pair.Value] = pair.Key;
+                    if (!map.ContainsKey(pair.Key) ||
+                        pair.Key == lambdaBodyMatch.OldRoot && pair.Value == lambdaBodyMatch.NewRoot && IsLambda(pair.Key) && IsLambda(pair.Value))
+                    {
+                        map[pair.Key] = pair.Value;
+                        reverseMap[pair.Value] = pair.Key;
+                    }
                 }
             }
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -1157,6 +1157,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return True
             End Select
         End Function
+
+        Protected Overrides Sub ReportLocalFunctionsDeclarationRudeEdits(bodyMatch As Match(Of SyntaxNode), diagnostics As List(Of RudeEditDiagnostic))
+            ' VB has no local functions so we don't have anything to report
+        End Sub
 #End Region
 
 #Region "Diagnostic Info"


### PR DESCRIPTION
Fixes #48636
Fixes #49822
Replaces https://github.com/dotnet/roslyn/pull/49027

This builds on https://github.com/dotnet/roslyn/pull/51021, hence the merge target. Once that PR is merged, this will be updated to point to main. The first 3 commits are bringing over the test changes from the original PR, the rest should make sense individually.