### PR TITLE
Remove redundant msbuild property

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -255,7 +255,6 @@
     -->
     <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
     <StreamJsonRpcVersion>2.7.66-alpha</StreamJsonRpcVersion>
-    <MicrosoftBclAsyncInterfacesVersion>1.1.1</MicrosoftBclAsyncInterfacesVersion>
     <!--
       When updating the S.C.I or S.R.M version please let the MSBuild team know in advance so they
       can update to the same version. Version changes require a VS test insertion for validation.


### PR DESCRIPTION
`MicrosoftBclAsyncInterfacesVersion` is specified twice in this file, so I removed the earlier instance. Peeking in the binlog it seems like the earlier value is just ignored.
