### PR TITLE
Change micro build pool

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -50,7 +50,7 @@ stages:
     # Conditionally set build pool so we can share this YAML when building with different pipeline (devdiv vs dnceng) 
     pool:      
       ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-        name: VSEng-MicroBuildVS2017
+        name: VSEngSS-MicroBuild2017
         demands: 
         - msbuild
         - visualstudio


### PR DESCRIPTION
Change our microbuild pool to Scale Set pool

According to this [page](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_wiki/wikis/DevDiv.wiki/12566/Using-Scale-Set-pools-for-Build-Pipelines)
These operations need an update if moves to Scale Set pool

1. Consume OptProf Data
2. Drop to File Share
3. Symbols Archiving (shouldn't be done during build in general)
4. Localization Data from File Share
5. Index Sources and Publish Symbols Task

I tested the build here but it looks like we don't need to change anything for OptProf Data
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4450426&view=results
