### PR TITLE
Remove space before directory name in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -237,7 +237,7 @@ csharp_preserve_single_line_statements = true
 # warning RS0005: Do not use generic CodeAction.Create to create CodeAction
 dotnet_diagnostic.RS0005.severity = none
 
-[src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures, VisualStudio}/**/*.{cs,vb}]
+[src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio}/**/*.{cs,vb}]
 
 # IDE0011: Add braces
 csharp_prefer_braces = when_multiline:warning


### PR DESCRIPTION
This prevents this section from applying to the VisualStudio directory since the matching presumes there will be a space before the directory name.