### PR TITLE
Add SQLitePCLRaw.nativelibrary.dll to signing props

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -30,6 +30,7 @@
     <FileSignInfo Include="SQLitePCLRaw.core.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="SQLitePCLRaw.batteries_v2.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="SQLitePCLRaw.batteries_green.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="SQLitePCLRaw.nativelibrary.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="SQLitePCLRaw.provider.e_sqlite3.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="MessagePack.Annotations.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="MessagePack.dll" CertificateName="3PartySHA2" />


### PR DESCRIPTION
Fixes a new warning in CI builds.

> warning SIGN001: Signing 3rd party library 'D:\workspace\_work\1\s\artifacts\tmp\Debug\ContainerSigning\1573\SQLitePCLRaw.nativelibrary.dll' with Microsoft certificate 'Microsoft400'. The library is considered 3rd party library due to its copyright: 'Copyright 2014-2020 SourceGear, LLC'.
