### PR TITLE
EE: Don't register certain display class variables conflicting with parameter

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalFunctionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalFunctionTests.cs
@@ -345,6 +345,7 @@ class C
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out var typeName, testData: testData);
                 Assert.Equal(new[] { "this", "x", "something" }, locals.SelectAsArray(l => l.LocalName));
+                Assert.Equal("<>x.<>m1(C, string, ref C.<>c__DisplayClass1_0)", testData.GetMethodData("<>x.<>m1").Method.ToString());
                 VerifyLocal(testData, typeName, locals[1], "<>m1", "x", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -358,6 +359,7 @@ class C
                 testData = new CompilationTestData();
                 context.CompileExpression("x", out var error, testData);
                 Assert.Null(error);
+                Assert.Equal("<>x.<>m0(C, string, ref C.<>c__DisplayClass1_0)", testData.GetMethodData("<>x.<>m0").Method.ToString());
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        2 (0x2)
@@ -414,6 +416,7 @@ class C
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out var typeName, testData: testData);
                 Assert.Equal(new[] { "this", "x" }, locals.SelectAsArray(l => l.LocalName));
+                Assert.Equal("<>x.<>m1(C, int)", testData.GetMethodData("<>x.<>m1").Method.ToString());
                 VerifyLocal(testData, typeName, locals[1], "<>m1", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -429,6 +432,7 @@ class C
                 context.CompileExpression("x", out var error, testData);
                 Assert.Null(error);
 
+                Assert.Equal("<>x.<>m0(C, int)", testData.GetMethodData("<>x.<>m0").Method.ToString());
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        7 (0x7)
@@ -480,6 +484,7 @@ class C
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out var typeName, testData: testData);
                 Assert.Equal(new[] { "x" }, locals.SelectAsArray(l => l.LocalName));
+                Assert.Equal("<>x.<>m0(string)", testData.GetMethodData("<>x.<>m0").Method.ToString());
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -492,6 +497,7 @@ class C
                 testData = new CompilationTestData();
                 context.CompileExpression("x", out var error, testData);
                 Assert.Null(error);
+                Assert.Equal("<>x.<>m0(string)", testData.GetMethodData("<>x.<>m0").Method.ToString());
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size        2 (0x2)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51056

Description of the fix:

There are two scenarios for EE: 
1. displaying all locals, 
2. evaluating a specific expression.

For displaying all locals, we're producing a method with a `return BoundParameter` body. But `CapturedVariableRewriter` would replace the reference to parameter named "x" with a reference to display class variable of the same name (from outer context). The fix is that our list of display class variables now excludes variables named "x" that come from outer scopes.
Note that display variables named "x" from inner scope still wins over the parameter.

For evaluating a specific expression, we are constructing a special binder, and using the list of known display class variables to use. By excluding variables named "x" from display class variables from outer scopes, we allow binding to find the method parameter named "x".