### PR TITLE
Initial version of LSP request perf metrics

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
@@ -88,18 +88,18 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 try
                 {
                     await _callbackAsync(context, cancellationToken).ConfigureAwait(false);
-                    Metrics.RecordSuccess();
+                    this.Metrics.RecordSuccess();
                 }
                 catch (OperationCanceledException)
                 {
                     _logger.TraceInformation($"{MethodName} - Canceled");
-                    Metrics.RecordCancellation();
+                    this.Metrics.RecordCancellation();
                     throw;
                 }
                 catch (Exception ex)
                 {
                     _logger.TraceException(ex);
-                    Metrics.RecordFailure();
+                    this.Metrics.RecordFailure();
                     throw;
                 }
                 finally

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestMetrics.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestMetrics.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+{
+    internal partial class RequestExecutionQueue
+    {
+        internal class RequestMetrics
+        {
+            private readonly string _methodName;
+            private readonly SharedStopwatch _sharedStopWatch;
+            private TimeSpan? _queuedDuration;
+
+            private readonly RequestTelemetryLogger _requestTelemetryLogger;
+
+            public RequestMetrics(string methodName, RequestTelemetryLogger requestTelemetryLogger)
+            {
+                _methodName = methodName;
+                _requestTelemetryLogger = requestTelemetryLogger;
+                _sharedStopWatch = SharedStopwatch.StartNew();
+            }
+
+            public void RecordExecutionStart()
+            {
+                // Request has de-queued and is starting execution.  Record the time it spent in queue.
+                _queuedDuration = _sharedStopWatch.Elapsed;
+            }
+
+            public void RecordSuccess()
+            {
+                RecordCompletion(RequestTelemetryLogger.Result.Succeeded);
+            }
+
+            public void RecordFailure()
+            {
+                RecordCompletion(RequestTelemetryLogger.Result.Failed);
+            }
+
+            public void RecordCancellation()
+            {
+                RecordCompletion(RequestTelemetryLogger.Result.Cancelled);
+            }
+
+            private void RecordCompletion(RequestTelemetryLogger.Result result)
+            {
+                Contract.ThrowIfNull(_queuedDuration, "RecordExecutionStart was not called");
+                var overallDuration = _sharedStopWatch.Elapsed;
+                _requestTelemetryLogger.UpdateTelemetryData(_methodName, _queuedDuration.Value, overallDuration, result);
+            }
+        }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
@@ -20,7 +20,21 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             private const string QueuedDurationKey = "QueuedDuration";
 
             private readonly string _serverTypeName;
-            private HistogramLogAggregator? _histogramLogAggregator;
+
+            /// <summary>
+            /// Histogram to aggregate the time in queue metrics.
+            /// </summary>
+            private HistogramLogAggregator? _queuedDurationLogAggregator;
+
+            /// <summary>
+            /// Histogram to aggregate total request duration metrics.
+            /// This histogram is log based as request latencies can be highly variable depending
+            /// on the request being handled.  As such, we apply the log based function
+            /// defined by ComputeLogValue to the request latencies for storing in the histogram.
+            /// This provides highly detailed buckets when duration is in MS, but less detailed
+            /// when the duration is in terms of seconds or minutes.
+            /// </summary>
+            private HistogramLogAggregator? _requestDurationLogAggregator;
 
             /// <summary>
             /// Store request counters in a concurrent dictionary as non-mutating LSP requests can
@@ -32,18 +46,36 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             {
                 _serverTypeName = serverTypeName;
                 _requestCounters = new ConcurrentDictionary<string, Counter>();
-                _histogramLogAggregator = CreateLogAggregator();
+
+                // Buckets queued duration into 50ms buckets with the last bucket starting at 5000ms.
+                // Queue times should generally be relatively short so tracking beyond 5000ms isn't that useful.
+                _queuedDurationLogAggregator = new HistogramLogAggregator(bucketSize: 50, maxBucketValue: 5000);
+
+                // Since this is a log based histogram, these are appropriate bucket sizes for the log data.
+                // A bucket at 1 corresponds to ~26ms, while the max bucket value corresponds to ~17minutes
+                _requestDurationLogAggregator = new HistogramLogAggregator(bucketSize: 1, maxBucketValue: 40);
             }
 
             public void UpdateTelemetryData(string methodName, TimeSpan queuedDuration, TimeSpan requestDuration, Result result)
             {
                 // Find the bucket corresponding to the queued duration and update the count of durations in that bucket.
                 // This is not broken down per method as time in queue is not specific to an LSP method.
-                _histogramLogAggregator?.IncreaseCount(QueuedDurationKey, Convert.ToDecimal(queuedDuration.TotalMilliseconds));
+                _queuedDurationLogAggregator?.IncreaseCount(QueuedDurationKey, Convert.ToDecimal(queuedDuration.TotalMilliseconds));
 
                 // Store the request time metrics per LSP method.
-                _histogramLogAggregator?.IncreaseCount(methodName, Convert.ToDecimal(requestDuration.TotalMilliseconds));
+                _requestDurationLogAggregator?.IncreaseCount(methodName, Convert.ToDecimal(ComputeLogValue(requestDuration.TotalMilliseconds)));
                 _requestCounters.GetOrAdd(methodName, (_) => new Counter()).IncrementCount(result);
+            }
+
+            /// <summary>
+            /// Given an input duration in MS, this transforms it using
+            /// the log function below to put in reasonable log based buckets
+            /// from 50ms to 1 hour.  Similar transformations must be done to read
+            /// the data from kusto.
+            /// </summary>
+            private static double ComputeLogValue(double durationInMS)
+            {
+                return 10d * Math.Log10((durationInMS / 100d) + 1);
             }
 
             /// <summary>
@@ -52,24 +84,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             /// </summary>
             public void Dispose()
             {
-                if (_histogramLogAggregator is null || _histogramLogAggregator.IsEmpty)
+                if (_queuedDurationLogAggregator is null || _queuedDurationLogAggregator.IsEmpty
+                    || _requestDurationLogAggregator is null || _requestDurationLogAggregator.IsEmpty)
                 {
                     return;
                 }
 
-                var queuedDurationCounter = _histogramLogAggregator.GetValue(QueuedDurationKey);
+                var queuedDurationCounter = _queuedDurationLogAggregator.GetValue(QueuedDurationKey);
                 Logger.Log(FunctionId.LSP_TimeInQueue, KeyValueLogMessage.Create(LogType.Trace, m =>
                 {
                     m["server"] = _serverTypeName;
-                    m["bucketsize"] = queuedDurationCounter?.BucketSize;
-                    m["maxbucketvalue"] = queuedDurationCounter?.MaxBucketValue;
+                    m["bucketsize_ms"] = queuedDurationCounter?.BucketSize;
+                    m["maxbucketvalue_ms"] = queuedDurationCounter?.MaxBucketValue;
                     m["buckets"] = queuedDurationCounter?.GetBucketsAsString();
                 }));
 
                 foreach (var kvp in _requestCounters)
                 {
-                    var requestExecutionDuration = _histogramLogAggregator.GetValue(kvp.Key);
-
                     Logger.Log(FunctionId.LSP_RequestCounter, KeyValueLogMessage.Create(LogType.Trace, m =>
                     {
                         m["server"] = _serverTypeName;
@@ -79,26 +110,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         m["cancelled"] = kvp.Value.CancelledCount;
                     }));
 
+                    var requestExecutionDuration = _requestDurationLogAggregator.GetValue(kvp.Key);
                     Logger.Log(FunctionId.LSP_RequestDuration, KeyValueLogMessage.Create(LogType.Trace, m =>
                     {
                         m["server"] = _serverTypeName;
                         m["method"] = kvp.Key;
-                        m["bucketsize_ms"] = requestExecutionDuration?.BucketSize;
-                        m["maxbucketvalue_ms"] = requestExecutionDuration?.MaxBucketValue;
-                        m["bucketdata"] = requestExecutionDuration?.GetBucketsAsString();
+                        m["bucketsize_logms"] = requestExecutionDuration?.BucketSize;
+                        m["maxbucketvalue_logms"] = requestExecutionDuration?.MaxBucketValue;
+                        m["bucketdata_logms"] = requestExecutionDuration?.GetBucketsAsString();
                     }));
                 }
 
                 // Clear telemetry we've published in case dispose is called multiple times.
                 _requestCounters.Clear();
-                _histogramLogAggregator = null;
+                _queuedDurationLogAggregator = null;
+                _requestDurationLogAggregator = null;
             }
-
-            /// <summary>
-            /// Creates a histogram log aggregator where request durations (ms) are distributed into buckets of
-            /// size 50ms, with the largets bucket starting at 5000ms.
-            /// </summary>
-            private static HistogramLogAggregator CreateLogAggregator() => new HistogramLogAggregator(bucketSize: 50, maxBucketValue: 5000);
 
             private class Counter
             {

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -149,6 +149,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 textDocument,
                 Trace.CorrelationManager.ActivityId,
                 _logger,
+                _requestTelemetryLogger,
                 callbackAsync: async (context, cancellationToken) =>
                 {
                     // Check if cancellation was requested while this was waiting in the queue
@@ -163,23 +164,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     {
                         var result = await handler.HandleRequestAsync(request, context, cancellationToken).ConfigureAwait(false);
                         completion.SetResult(result);
-
-                        // Update success count for the request
-                        _requestTelemetryLogger.LogSuccess(methodName);
                     }
                     catch (OperationCanceledException ex)
                     {
                         completion.TrySetCanceled(ex.CancellationToken);
-                        _requestTelemetryLogger.LogCancel(methodName);
                     }
                     catch (Exception exception)
                     {
                         // Pass the exception to the task completion source, so the caller of the ExecuteAsync method can react
                         completion.SetException(exception);
-
-                        // Update the failure count for the request.
-                        // Failure details are captured separately in a non fatal watson report.
-                        _requestTelemetryLogger.LogFailure(methodName);
 
                         // Also allow the exception to flow back to the request queue to handle as appropriate
                         throw new InvalidOperationException($"Error handling '{methodName}' request: {exception.Message}", exception);
@@ -205,6 +198,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 while (!_cancelSource.IsCancellationRequested)
                 {
                     var work = await _queue.DequeueAsync().ConfigureAwait(false);
+
+                    // Record when the work item was been de-queued and the request context preparation started.
+                    work.Metrics.RecordExecutionStart();
 
                     // Create a linked cancellation token to cancel any requests in progress when this shuts down
                     var cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_cancelSource.Token, work.CancellationToken).Token;

--- a/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -38,6 +36,12 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         {
             var counter = GetCounter(key);
             counter.IncreaseCount(value);
+        }
+
+        public HistogramCounter? GetValue(object key)
+        {
+            TryGetCounter(key, out var counter);
+            return counter;
         }
 
         internal sealed class HistogramCounter

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -22,7 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReferenceEqualityComparer.cs" Link="InternalUtilities\ReferenceEqualityComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\RoslynString.cs" Link="InternalUtilities\RoslynString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.cs" Link="InternalUtilities\SpecializedCollections.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SharedStopwatch.cs" Link="InternalUtilities\SpecializedCollections.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SharedStopwatch.cs" Link="InternalUtilities\SharedStopwatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.Collection.cs" Link="InternalUtilities\SpecializedCollections.Empty.Collection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.cs" Link="InternalUtilities\SpecializedCollections.Empty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.Dictionary.cs" Link="InternalUtilities\SpecializedCollections.Empty.Dictionary.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReferenceEqualityComparer.cs" Link="InternalUtilities\ReferenceEqualityComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\RoslynString.cs" Link="InternalUtilities\RoslynString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.cs" Link="InternalUtilities\SpecializedCollections.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SharedStopwatch.cs" Link="InternalUtilities\SpecializedCollections.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.Collection.cs" Link="InternalUtilities\SpecializedCollections.Empty.Collection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.cs" Link="InternalUtilities\SpecializedCollections.Empty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.Dictionary.cs" Link="InternalUtilities\SpecializedCollections.Empty.Dictionary.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -508,5 +508,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         RegisterWorkspace = 481,
 
         LSP_RequestCounter = 482,
+        LSP_RequestDuration = 483,
+        LSP_TimeInQueue = 484,
     }
 }


### PR DESCRIPTION
This isn't ready to merge quite yet, but I wanted to get early thoughts.

Some things
1.  For project size, I'm planning on joining on other events (using sessionid) to get the project info.
2.  I still haven't figured out a good way to store other dimension data (e.g. document size per request, how many requests have been served).  I'm a little tempted to just write an event for every request but that is a lot of telemetry events (as mentioned in teams I don't have good ideas on how to aggregate with multiple dimensions).  