### PR TITLE
Support for partial type EnC and moving declarations across files

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -311,10 +311,16 @@ namespace Microsoft.CodeAnalysis.Emit
                 symbolMap = MapToMetadataSymbolMatcher;
             }
 
+            var previousMethod = mappedMethod.PreviousMethod;
+            if (previousMethod is null)
+            {
+                previousMethod = (IMethodSymbolInternal)symbolMap.MapDefinitionOrNamespace(topLevelMethod);
+            }
+
             return new EncVariableSlotAllocator(
                 symbolMap,
                 mappedMethod.SyntaxMap,
-                mappedMethod.PreviousMethod,
+                previousMethod,
                 methodId,
                 previousLocals,
                 lambdaMap,

--- a/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
+++ b/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </summary>
         /// <param name="kind">The type of edit.</param>
         /// <param name="oldSymbol">
-        /// The symbol from the earlier compilation, or null if the edit represents an addition.
+        /// The symbol from the earlier compilation, or null if the edit represents an addition or an update of the symbol from the previous compilation that exactly matches <paramref name="newSymbol"/>.
         /// </param>
         /// <param name="newSymbol">
         /// The symbol from the later compilation, or null if the edit represents a deletion.
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </exception>
         public SemanticEdit(SemanticEditKind kind, ISymbol? oldSymbol, ISymbol? newSymbol, Func<SyntaxNode, SyntaxNode?>? syntaxMap = null, bool preserveLocalVariables = false)
         {
-            if (oldSymbol == null && kind != SemanticEditKind.Insert)
+            if (oldSymbol == null && kind is not (SemanticEditKind.Insert or SemanticEditKind.Update))
             {
                 throw new ArgumentNullException(nameof(oldSymbol));
             }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -10582,7 +10582,7 @@ class C
                         }),
                     DocumentResults(
                         activeStatements: GetActiveStatements(srcB1, srcB2),
-                        diagnostics: new[] { Diagnostic(RudeEditKind.DeleteActiveStatement, "partial class C", "method 'F()'") })
+                        diagnostics: new[] { Diagnostic(RudeEditKind.DeleteActiveStatement, "partial class C", DeletedSymbolDisplay(FeaturesResources.method, "F()")) })
                 });
         }
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -292,8 +292,8 @@ class C
             var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray<TextSpan>.Empty, CancellationToken.None);
 
             Assert.True(result.HasChanges);
-            Assert.True(result.SemanticEdits[0].PreserveLocalVariables);
             var syntaxMap = result.SemanticEdits[0].SyntaxMap;
+            Assert.NotNull(syntaxMap);
 
             var newStatementSpan = result.ActiveStatements[0].Span;
             var newStatementTextSpan = newText.Lines.GetTextSpan(newStatementSpan);
@@ -685,13 +685,16 @@ namespace N
 }
 ";
             var source2 = @"
+class D
+{
+}
 ";
 
             using var workspace = TestWorkspace.CreateCSharp(source1, composition: s_composition);
 
-            var oldProject = workspace.CurrentSolution.Projects.Single();
-            var newDocId = DocumentId.CreateNewId(oldProject.Id);
             var oldSolution = workspace.CurrentSolution;
+            var oldProject = oldSolution.Projects.Single();
+            var newDocId = DocumentId.CreateNewId(oldProject.Id);
             var newSolution = oldSolution.AddDocument(newDocId, "goo.cs", SourceText.From(source2));
 
             workspace.TryApplyChanges(newSolution);
@@ -715,8 +718,7 @@ namespace N
             }
 
             Assert.True(result.IsSingle());
-            Assert.Equal(1, result.Single().RudeEditErrors.Count());
-            Assert.Equal(RudeEditKind.InsertFile, result.Single().RudeEditErrors.Single().Kind);
+            Assert.Empty(result.Single().RudeEditErrors);
         }
 
         [Theory, CombinatorialData]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
@@ -5,39 +5,28 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
     internal sealed class CSharpEditAndContinueTestHelpers : EditAndContinueTestHelpers
     {
-        private readonly ImmutableArray<MetadataReference> _fxReferences;
         private readonly CSharpEditAndContinueAnalyzer _analyzer;
 
-        public CSharpEditAndContinueTestHelpers(TargetFramework targetFramework, Action<SyntaxNode> faultInjector = null)
+        public CSharpEditAndContinueTestHelpers(Action<SyntaxNode> faultInjector = null)
         {
-            _fxReferences = TargetFrameworkUtil.GetReferences(targetFramework);
             _analyzer = new CSharpEditAndContinueAnalyzer(faultInjector);
         }
 
-        internal static CSharpEditAndContinueTestHelpers CreateInstance(Action<SyntaxNode> faultInjector = null)
-            => new CSharpEditAndContinueTestHelpers(TargetFramework.Mscorlib46Extended, faultInjector);
-
-        internal static CSharpEditAndContinueTestHelpers CreateInstance40(Action<SyntaxNode> faultInjector = null)
-            => new CSharpEditAndContinueTestHelpers(TargetFramework.Mscorlib40AndSystemCore, faultInjector);
-
         public override AbstractEditAndContinueAnalyzer Analyzer => _analyzer;
-
-        public override Compilation CreateLibraryCompilation(string name, IEnumerable<SyntaxTree> trees)
-            => CSharpCompilation.Create("New", trees, _fxReferences, TestOptions.UnsafeReleaseDll);
+        public override string LanguageName => LanguageNames.CSharp;
+        public override TreeComparer<SyntaxNode> TopSyntaxComparer => SyntaxComparer.TopLevel;
 
         public override SyntaxTree ParseText(string source)
             => SyntaxFactory.ParseSyntaxTree(source, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
@@ -39,17 +37,23 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         internal static RudeEditDiagnosticDescription Diagnostic(RudeEditKind rudeEditKind, string squiggle, params string[] arguments)
             => new(rudeEditKind, squiggle, arguments, firstLine: null);
 
-        internal static SemanticEditDescription SemanticEdit(SemanticEditKind kind, Func<Compilation, ISymbol> symbolProvider, IEnumerable<KeyValuePair<TextSpan, TextSpan>> syntaxMap)
-        {
-            Assert.NotNull(syntaxMap);
-            return new SemanticEditDescription(kind, symbolProvider, syntaxMap, preserveLocalVariables: true);
-        }
+        internal static SemanticEditDescription SemanticEdit(SemanticEditKind kind, Func<Compilation, ISymbol> symbolProvider, IEnumerable<KeyValuePair<TextSpan, TextSpan>>? syntaxMap, string? partialType = null)
+            => new(kind, symbolProvider, (partialType != null) ? c => c.GetMember<INamedTypeSymbol>(partialType) : null, syntaxMap, hasSyntaxMap: syntaxMap != null);
 
-        internal static SemanticEditDescription SemanticEdit(SemanticEditKind kind, Func<Compilation, ISymbol> symbolProvider, bool preserveLocalVariables = false)
-            => new(kind, symbolProvider, syntaxMap: null, preserveLocalVariables);
+        internal static SemanticEditDescription SemanticEdit(SemanticEditKind kind, Func<Compilation, ISymbol> symbolProvider, string? partialType = null, bool preserveLocalVariables = false)
+            => new(kind, symbolProvider, (partialType != null) ? c => c.GetMember<INamedTypeSymbol>(partialType) : null, syntaxMap: null, preserveLocalVariables);
+
+        internal static string DeletedSymbolDisplay(string kind, string displayName)
+            => string.Format(FeaturesResources.member_kind_and_name, kind, displayName);
+
+        internal static DocumentAnalysisResultsDescription DocumentResults(
+            ActiveStatementsDescription? activeStatements = null,
+            SemanticEditDescription[]? semanticEdits = null,
+            RudeEditDiagnosticDescription[]? diagnostics = null)
+            => new(activeStatements, semanticEdits, diagnostics);
 
         private static SyntaxTree ParseSource(string source)
-            => CSharpEditAndContinueTestHelpers.CreateInstance().ParseText(ActiveStatementsDescription.ClearTags(source));
+            => new CSharpEditAndContinueTestHelpers().ParseText(ActiveStatementsDescription.ClearTags(source));
 
         internal static EditScript<SyntaxNode> GetTopEdits(string src1, string src2)
         {
@@ -61,6 +65,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 
             var match = SyntaxComparer.TopLevel.ComputeMatch(tree1.GetRoot(), tree2.GetRoot());
             return match.GetTreeEdits();
+        }
+
+        public static EditScript<SyntaxNode> GetTopEdits(EditScript<SyntaxNode> methodEdits)
+        {
+            var oldMethodSource = methodEdits.Match.OldRoot.ToFullString();
+            var newMethodSource = methodEdits.Match.NewRoot.ToFullString();
+
+            return GetTopEdits(WrapMethodBodyWithClass(oldMethodSource), WrapMethodBodyWithClass(newMethodSource));
         }
 
         /// <summary>
@@ -102,6 +114,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 
         public static MatchingPairs ToMatchingPairs(IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>> matches)
             => EditAndContinueTestHelpers.ToMatchingPairs(matches);
+
+#nullable disable
 
         internal static BlockSyntax MakeMethodBody(
             string bodySource,

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
@@ -9,10 +9,12 @@ using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
+    [UseExportProvider]
     public class LineEditTests : EditingTestBase
     {
         #region Methods
@@ -1419,6 +1421,45 @@ class C
             var edits = GetTopEdits(src1, src2);
             edits.VerifyLineEdits(
                 new[] { new SourceLineUpdate(4, 3), new SourceLineUpdate(5, 3) },
+                Array.Empty<string>());
+        }
+
+        #endregion
+
+        #region Types
+
+        [Fact]
+        public void Type_Reorder1()
+        {
+            var src1 = @"
+class C
+{
+    static int F1() => 1;
+    static int F2() => 1;
+}
+
+class D
+{
+    static int G1() => 1;
+    static int G2() => 1;
+}
+";
+            var src2 = @"
+class D
+{
+    static int G1() => 1;
+    static int G2() => 1;
+}
+
+class C
+{
+    static int F1() => 1;
+    static int F2() => 1;
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                new[] { new SourceLineUpdate(3, 9), new SourceLineUpdate(4, 10), new SourceLineUpdate(9, 3), new SourceLineUpdate(10, 4) },
                 Array.Empty<string>());
         }
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
+    [UseExportProvider]
     public class StatementEditingTests : EditingTestBase
     {
         #region Strings
@@ -6813,7 +6814,8 @@ class Program
             edits.VerifyEdits(
                 "Update [void M() { void local() { throw null; } }]@13 -> [void M() { void local(in int b) { throw null; } }]@13");
 
-            edits.VerifyRudeDiagnostics();
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ChangingLambdaParameters, "local", CSharpFeaturesResources.local_function));
         }
 
         [Fact]
@@ -6827,7 +6829,8 @@ class Program
             edits.VerifyEdits(
                 "Update [void M() { void local(int b) { throw null; } }]@13 -> [void M() { void local(in int b) { throw null; } }]@13");
 
-            edits.VerifyRudeDiagnostics();
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ChangingLambdaParameters, "local", CSharpFeaturesResources.local_function));
         }
 
         [Fact]
@@ -7000,9 +7003,8 @@ interface I
                 "Insert [A]@3");
 
             // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "[A]", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "[A]", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7018,9 +7020,8 @@ interface I
                 "Delete [A]@3");
 
             // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7034,9 +7035,7 @@ interface I
             edits.VerifyEdits("Reorder [B]@6 -> @3");
 
             // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics();
+            GetTopEdits(edits).VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -7054,9 +7053,7 @@ interface I
                 "Delete [B]@6");
 
             // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(
+            GetTopEdits(edits).VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Insert, "B", FeaturesResources.attribute),
                 Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.attribute));
         }
@@ -7075,10 +7072,8 @@ interface I
                 "Insert [B]@6",
                 "Delete [B]@6");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "[B]", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "[B]", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7091,10 +7086,8 @@ interface I
 
             edits.VerifyEdits("Update [[return: A]]@2 -> [[A]]@2");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Update, "[A]", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Update, "[A]", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7107,10 +7100,8 @@ interface I
 
             edits.VerifyEdits("Update [[A]]@2 -> [[return: A]]@2");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Update, "return:", CSharpFeaturesResources.attribute_target));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Update, "return:", CSharpFeaturesResources.attribute_target));
         }
 
         [Fact]
@@ -7125,10 +7116,8 @@ interface I
                 "Insert [[return: A]]@2",
                 "Insert [A]@11");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "[return: A]", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "[return: A]", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7143,10 +7132,8 @@ interface I
                 "Delete [[return: A]]@2",
                 "Delete [A]@11");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7159,10 +7146,7 @@ interface I
 
             edits.VerifyEdits("Reorder [B]@14 -> @11");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics();
+            GetTopEdits(edits).VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -7177,10 +7161,8 @@ interface I
                 "Insert [[A]]@9",
                 "Insert [A]@10");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "[A]", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "[A]", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7195,10 +7177,8 @@ interface I
                 "Delete [[A]]@9",
                 "Delete [A]@10");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "int i", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "int i", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7211,10 +7191,7 @@ interface I
 
             edits.VerifyEdits("Reorder [B]@13 -> @10");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics();
+            GetTopEdits(edits).VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -7229,10 +7206,8 @@ interface I
                 "Insert [[A]]@9",
                 "Insert [A]@10");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "[A]", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "[A]", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7247,10 +7222,8 @@ interface I
                 "Delete [[A]]@9",
                 "Delete [A]@10");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "T", FeaturesResources.attribute));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "T", FeaturesResources.attribute));
         }
 
         [Fact]
@@ -7263,10 +7236,7 @@ interface I
 
             edits.VerifyEdits("Reorder [B]@13 -> @10");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics();
+            GetTopEdits(edits).VerifyRudeDiagnostics();
         }
 
         [Fact]
@@ -7280,10 +7250,8 @@ interface I
                 "Insert [<A>]@8",
                 "Insert [A]@9");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "<A>", FeaturesResources.type_parameter));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "<A>", FeaturesResources.type_parameter));
         }
 
         [Fact]
@@ -7297,10 +7265,8 @@ interface I
                 "Update [<A>]@8 -> [<A,B>]@8",
                 "Insert [B]@11");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Insert, "B", FeaturesResources.type_parameter));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "B", FeaturesResources.type_parameter));
         }
 
         [Fact]
@@ -7314,10 +7280,8 @@ interface I
                 "Delete [<A>]@8",
                 "Delete [A]@9");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.type_parameter));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.type_parameter));
         }
 
         [Fact]
@@ -7331,10 +7295,8 @@ interface I
                 "Update [<A,B>]@8 -> [<B>]@8",
                 "Delete [A]@9");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.type_parameter));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "L", FeaturesResources.type_parameter));
         }
 
         [Fact]
@@ -7347,10 +7309,8 @@ interface I
             edits.VerifyEdits(
                 "Update [A]@9 -> [B]@9");
 
-            // Get top edits so we can validate rude edits
-            edits = GetTopEdits(WrapMethodBodyWithClass(src1), WrapMethodBodyWithClass(src2));
-
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Renamed, "B", FeaturesResources.type_parameter));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Renamed, "B", FeaturesResources.type_parameter));
         }
 
         [Fact]
@@ -7363,7 +7323,8 @@ interface I
             edits.VerifyEdits(
                 "Reorder [B]@11 -> @9");
 
-            edits.VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter));
+            GetTopEdits(edits).VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter));
         }
 
         [Fact]
@@ -7377,10 +7338,11 @@ interface I
                 "Reorder [B]@11 -> @9",
                 "Update [A]@9 -> [C]@11");
 
-            edits.VerifyRudeDiagnostics(
+            GetTopEdits(edits).VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter),
                 Diagnostic(RudeEditKind.Renamed, "C", FeaturesResources.type_parameter));
         }
+
         #endregion
 
         #region Queries
@@ -8908,13 +8870,9 @@ class C
 ";
             var edits = GetTopEdits(src1, src2);
 
-            CSharpEditAndContinueTestHelpers.CreateInstance40().VerifySemantics(
-                new[] { edits },
-                ActiveStatementsDescription.Empty,
-                expectedDiagnostics: new[]
-                {
-                    Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "static IEnumerable<int> F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute")
-                });
+            edits.VerifySemanticDiagnostics(
+                targetFrameworks: new[] { TargetFramework.Mscorlib40AndSystemCore },
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "static IEnumerable<int> F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute"));
         }
 
         [Fact]
@@ -8944,7 +8902,8 @@ class C
 ";
             var edits = GetTopEdits(src1, src2);
 
-            CSharpEditAndContinueTestHelpers.CreateInstance40().VerifySemantics(new[] { edits });
+            edits.VerifySemanticDiagnostics(
+                targetFrameworks: new[] { TargetFramework.Mscorlib40AndSystemCore });
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxComparerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxComparerTests.cs
@@ -7,11 +7,13 @@
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Differencing;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
+    [UseExportProvider]
     public class SyntaxComparerTests
     {
         private static SyntaxNode MakeLiteral(int n)

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -4,8 +4,8 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.EditAndContinue;
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
+    [UseExportProvider]
     public class TopLevelEditingTests : EditingTestBase
     {
         #region Usings
@@ -39,20 +40,21 @@ using System.Diagnostics;
         public void UsingDelete2()
         {
             var src1 = @"
-using System.Diagnostics;
+using D = System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 ";
             var src2 = @"
-using System.Diagnostics;
 using System.Collections.Generic;
 ";
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Delete [using System.Collections;]@29");
+                "Delete [using D = System.Diagnostics;]@2",
+                "Delete [using System.Collections;]@33");
 
             edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, null, CSharpFeaturesResources.using_directive),
                 Diagnostic(RudeEditKind.Delete, null, CSharpFeaturesResources.using_directive));
         }
 
@@ -60,20 +62,21 @@ using System.Collections.Generic;
         public void UsingInsert()
         {
             var src1 = @"
-using System.Diagnostics;
 using System.Collections.Generic;
 ";
             var src2 = @"
-using System.Diagnostics;
+using D = System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 ";
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Insert [using System.Collections;]@29");
+                "Insert [using D = System.Diagnostics;]@2",
+                "Insert [using System.Collections;]@33");
 
             edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "using D = System.Diagnostics;", CSharpFeaturesResources.using_directive),
                 Diagnostic(RudeEditKind.Insert, "using System.Collections;", CSharpFeaturesResources.using_directive));
         }
 
@@ -213,6 +216,55 @@ namespace N
             edits.VerifyEdits(
                 "Insert [using System.Collections;]@2",
                 "Delete [using System.Collections;]@22");
+        }
+
+        #endregion
+
+        #region Extern Alias
+
+        [Fact]
+        public void ExternAliasUpdate()
+        {
+            var src1 = "extern alias X;";
+            var src2 = "extern alias Y;";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [extern alias X;]@0 -> [extern alias Y;]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Update, "extern alias Y;", CSharpFeaturesResources.extern_alias));
+        }
+
+        [Fact]
+        public void ExternAliasInsert()
+        {
+            var src1 = "";
+            var src2 = "extern alias Y;";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Insert [extern alias Y;]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "extern alias Y;", CSharpFeaturesResources.extern_alias));
+        }
+
+        [Fact]
+        public void ExternAliasDelete()
+        {
+            var src1 = "extern alias Y;";
+            var src2 = "";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Delete [extern alias Y;]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, null, CSharpFeaturesResources.extern_alias));
         }
 
         #endregion
@@ -735,6 +787,7 @@ public abstract class C<T>
 public interface I 
 { 
     void F(); 
+    static void G() {}
 }";
 
             var edits = GetTopEdits(src1, src2);
@@ -867,7 +920,7 @@ public class SubClass : BaseClass, IConflict
 
         [WorkItem(37128, "https://github.com/dotnet/roslyn/issues/37128")]
         [Fact]
-        public void Interface_AddMembersWithImplementation()
+        public void Interface_InsertMembers()
         {
             var src1 = @"
 using System;
@@ -915,42 +968,407 @@ interface I
     abstract event Action AbstractEvent;
     sealed event Action NonVirtualEvent { add { } remove { } }
 
+    abstract class C { }
     interface J { }
+    enum E { }
+    delegate void D();
 }
 ";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyRudeDiagnostics(
+            // TODO: InsertIntoInterface errors are reported due to https://github.com/dotnet/roslyn/issues/37128.
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertIntoInterface, "static void StaticMethod()", FeaturesResources.method),
                 Diagnostic(RudeEditKind.InsertVirtual, "void VirtualMethod1()", FeaturesResources.method),
                 Diagnostic(RudeEditKind.InsertVirtual, "virtual void VirtualMethod2()", FeaturesResources.method),
                 Diagnostic(RudeEditKind.InsertVirtual, "abstract void AbstractMethod()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertIntoInterface, "sealed void NonVirtualMethod()", FeaturesResources.method),
                 Diagnostic(RudeEditKind.InsertOperator, "public static int operator +(I a, I b)", FeaturesResources.operator_),
+                Diagnostic(RudeEditKind.InsertIntoInterface, "static int StaticProperty1", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertIntoInterface, "static int StaticProperty2", FeaturesResources.property_),
                 Diagnostic(RudeEditKind.InsertVirtual, "virtual int VirtualProperty1", FeaturesResources.auto_property),
                 Diagnostic(RudeEditKind.InsertVirtual, "virtual int VirtualProperty2", FeaturesResources.auto_property),
                 Diagnostic(RudeEditKind.InsertVirtual, "int VirtualProperty3", FeaturesResources.auto_property),
                 Diagnostic(RudeEditKind.InsertVirtual, "int VirtualProperty4", FeaturesResources.auto_property),
                 Diagnostic(RudeEditKind.InsertVirtual, "abstract int AbstractProperty1", FeaturesResources.property_),
                 Diagnostic(RudeEditKind.InsertVirtual, "abstract int AbstractProperty2", FeaturesResources.property_),
+                Diagnostic(RudeEditKind.InsertIntoInterface, "sealed int NonVirtualProperty", FeaturesResources.property_),
                 Diagnostic(RudeEditKind.InsertVirtual, "int this[byte virtualIndexer]", FeaturesResources.indexer_),
                 Diagnostic(RudeEditKind.InsertVirtual, "int this[sbyte virtualIndexer]", FeaturesResources.indexer_),
                 Diagnostic(RudeEditKind.InsertVirtual, "virtual int this[ushort virtualIndexer]", FeaturesResources.indexer_),
                 Diagnostic(RudeEditKind.InsertVirtual, "virtual int this[short virtualIndexer]", FeaturesResources.indexer_),
                 Diagnostic(RudeEditKind.InsertVirtual, "abstract int this[uint abstractIndexer]", FeaturesResources.indexer_),
                 Diagnostic(RudeEditKind.InsertVirtual, "abstract int this[int abstractIndexer]", FeaturesResources.indexer_),
-                Diagnostic(RudeEditKind.InsertVirtual, "event Action VirtualEvent", FeaturesResources.event_),
-                Diagnostic(RudeEditKind.InsertVirtual, "abstract event Action AbstractEvent", CSharpFeaturesResources.event_field),
-                // TODO: The following errors are reported due to https://github.com/dotnet/roslyn/issues/37128.
-                Diagnostic(RudeEditKind.InsertIntoInterface, "static int StaticField = 10", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertIntoInterface, "static void StaticMethod()", FeaturesResources.method),
-                Diagnostic(RudeEditKind.InsertIntoInterface, "sealed void NonVirtualMethod()", FeaturesResources.method),
-                Diagnostic(RudeEditKind.InsertIntoInterface, "static int StaticProperty1", FeaturesResources.auto_property),
-                Diagnostic(RudeEditKind.InsertIntoInterface, "static int StaticProperty2", FeaturesResources.property_),
-                Diagnostic(RudeEditKind.InsertIntoInterface, "sealed int NonVirtualProperty", FeaturesResources.property_),
                 Diagnostic(RudeEditKind.InsertIntoInterface, "sealed int this[ulong nonVirtualIndexer]", FeaturesResources.indexer_),
                 Diagnostic(RudeEditKind.InsertIntoInterface, "sealed int this[long nonVirtualIndexer]", FeaturesResources.indexer_),
-                Diagnostic(RudeEditKind.InsertIntoInterface, "static event Action StaticEvent", CSharpFeaturesResources.event_field),
                 Diagnostic(RudeEditKind.InsertIntoInterface, "static event Action StaticEvent2", FeaturesResources.event_),
-                Diagnostic(RudeEditKind.InsertIntoInterface, "sealed event Action NonVirtualEvent", FeaturesResources.event_));
+                Diagnostic(RudeEditKind.InsertVirtual, "event Action VirtualEvent", FeaturesResources.event_),
+                Diagnostic(RudeEditKind.InsertIntoInterface, "sealed event Action NonVirtualEvent", FeaturesResources.event_),
+                Diagnostic(RudeEditKind.InsertIntoInterface, "StaticField = 10", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoInterface, "StaticEvent", CSharpFeaturesResources.event_field),
+                Diagnostic(RudeEditKind.InsertVirtual, "AbstractEvent", CSharpFeaturesResources.event_field));
+        }
+
+        [Fact]
+        public void Interface_InsertDelete()
+        {
+            var srcA1 = @"
+interface I
+{
+    static void M() { }
+}
+";
+            var srcB1 = @"
+";
+
+            var srcA2 = @"
+";
+            var srcB2 = @"
+interface I
+{
+    static void M() { }
+}
+";
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("I").GetMember("M"))
+                        }),
+                });
+        }
+
+        [Fact]
+        public void GenericType_InsertMembers()
+        {
+            var src1 = @"
+using System;
+class C<T>
+{
+}
+";
+            var src2 = @"
+using System;
+class C<T>
+{
+    void M() {}
+    int P1 { get; set; }
+    int P2 { get => 1; set {} }
+    int this[int i] { get => 1; set {} }
+    event Action E { add {} remove {} }
+    event Action EF;
+    int F1, F2;
+
+    enum E {}
+    interface I {} 
+    class D {}
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "void M()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "int P1", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "int P2", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "int this[int i]", FeaturesResources.indexer_),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "event Action E", FeaturesResources.event_),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "EF", CSharpFeaturesResources.event_field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F1", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F2", FeaturesResources.field));
+        }
+
+        [Fact]
+        public void Type_Delete()
+        {
+            var src1 = @"
+class C { void F() {} }
+struct S { void F() {} }
+interface I { void F() {} }
+";
+            var src2 = "";
+
+            GetTopEdits(src1, src2).VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, null, DeletedSymbolDisplay(FeaturesResources.class_, "C")),
+                Diagnostic(RudeEditKind.Delete, null, DeletedSymbolDisplay(CSharpFeaturesResources.struct_, "S")),
+                Diagnostic(RudeEditKind.Delete, null, DeletedSymbolDisplay(FeaturesResources.interface_, "I")));
+        }
+
+        [Fact]
+        public void PartialType_Delete()
+        {
+            var srcA1 = "partial class C { void F() {} void M() { } }";
+            var srcB1 = "partial class C { void G() {} }";
+            var srcA2 = "";
+            var srcB2 = "partial class C { void G() {} void M() { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Delete, null, DeletedSymbolDisplay(FeaturesResources.method, "C.F()")) }),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("M")),
+                        })
+                });
+        }
+
+        [Fact]
+        public void PartialType_InsertFirstDeclaration()
+        {
+            var src1 = "";
+            var src2 = "partial class C { void F() {}  }";
+
+            GetTopEdits(src1, src2).VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[] { SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C"), preserveLocalVariables: false) });
+        }
+
+        [Fact]
+        public void PartialType_InsertSecondDeclaration()
+        {
+            var srcA1 = "partial class C { void F() {} }";
+            var srcB1 = "";
+            var srcA2 = "partial class C { void F() {}  }";
+            var srcB2 = "partial class C { void G() {} }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").GetMember("G"), preserveLocalVariables: false)
+                        }),
+                });
+        }
+
+        [Fact]
+        public void Type_DeleteInsert()
+        {
+            var srcA1 = @"
+class C { void F() {} }
+struct S { void F() {} }
+interface I { void F() {} }
+";
+            var srcB1 = "";
+
+            var srcA2 = srcB1;
+            var srcB2 = srcA1;
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F")),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("S").GetMember("F")),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("I").GetMember("F")),
+                        })
+                });
+        }
+
+        [Fact]
+        public void GenericType_DeleteInsert()
+        {
+            var srcA1 = @"
+class C<T> { void F() {} }
+struct S<T> { void F() {} }
+interface I<T> { void F() {} }
+";
+            var srcB1 = "";
+
+            var srcA2 = srcB1;
+            var srcB2 = srcA1;
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[]
+                        {
+                            Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, "void F()", FeaturesResources.method),
+                            Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, "void F()", FeaturesResources.method),
+                            Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, "void F()", FeaturesResources.method),
+                        })
+                });
+        }
+
+        [Fact]
+        public void Type_DeleteInsert_NonInsertableMembers()
+        {
+            var srcA1 = @"
+abstract class C
+{
+    public abstract void AbstractMethod();
+    public virtual void VirtualMethod() {}
+    public override string ToString() => null;
+    public void I.G() {}
+}
+
+interface I
+{
+    void G();
+    void F() {}
+}
+";
+            var srcB1 = "";
+
+            var srcA2 = srcB1;
+            var srcB2 = srcA1;
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("VirtualMethod")),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("ToString")),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("I.G")),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("I").GetMember("F")),
+                        })
+                });
+        }
+
+        [Fact]
+        public void Type_DeleteInsert_DataMembers()
+        {
+            var srcA1 = @"
+class C
+{
+    public int x = 1;
+    public int y = 2;
+    public int P { get; set; } = 3;
+    public event System.Action E = new System.Action(null);
+}
+";
+            var srcB1 = "";
+
+            var srcA2 = "";
+            var srcB2 = @"
+class C
+{
+    public int x = 1;
+    public int y = 2;
+    public int P { get; set; } = 3;
+    public event System.Action E = new System.Action(null);
+}
+";
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true),
+                        })
+                });
+        }
+
+        [Fact]
+        public void Type_DeleteInsert_DataMembers_PartialSplit()
+        {
+            var srcA1 = @"
+class C
+{
+    public int x = 1;
+    public int y = 2;
+    public int P { get; set; } = 3;
+}
+";
+            var srcB1 = "";
+
+            var srcA2 = @"
+partial class C
+{
+    public int x = 1;
+    public int y = 2;
+}
+";
+            var srcB2 = @"
+partial class C
+{
+    public int P { get; set; } = 3;
+}
+";
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true),
+                        })
+                });
+        }
+
+        [Fact]
+        public void Type_DeleteInsert_DataMembers_PartialMerge()
+        {
+            var srcA1 = @"
+partial class C
+{
+    public int x = 1;
+    public int y = 2;
+}
+";
+            var srcB1 = @"
+partial class C
+{
+    public int P { get; set; } = 3;
+}";
+
+            var srcA2 = @"
+class C
+{
+    public int x = 1;
+    public int y = 2;
+    public int P { get; set; } = 3;
+}
+";
+
+            var srcB2 = @"
+";
+            // note that accessors are not updated since they do not have bodies
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true),
+                        }),
+
+                    DocumentResults()
+                });
         }
 
         #endregion
@@ -1276,7 +1694,7 @@ interface I
                 "Delete [Blue]@18");
 
             edits.VerifyRudeDiagnostics(
-                 Diagnostic(RudeEditKind.Delete, "enum Color", FeaturesResources.enum_value));
+                 Diagnostic(RudeEditKind.Delete, "enum Color", DeletedSymbolDisplay(FeaturesResources.enum_value, "Blue")));
         }
 
         [Fact]
@@ -1290,7 +1708,7 @@ interface I
             edits.VerifyEdits("Delete [Blue]@18");
 
             edits.VerifyRudeDiagnostics(
-                 Diagnostic(RudeEditKind.Delete, "enum Color", FeaturesResources.enum_value));
+                 Diagnostic(RudeEditKind.Delete, "enum Color", DeletedSymbolDisplay(FeaturesResources.enum_value, "Blue")));
         }
 
         [WorkItem(754916, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/754916"), WorkItem(793197, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/793197")]
@@ -1433,8 +1851,8 @@ interface I
                 "Delete [private delegate void D();]@10",
                 "Delete [()]@33");
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.delegate_));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.delegate_, "D")));
         }
 
         [Fact]
@@ -1540,6 +1958,21 @@ interface I
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.TypeUpdate, "byte a", FeaturesResources.parameter));
+        }
+
+        [Fact]
+        public void Delegates_ParameterOptionalParameter_Update()
+        {
+            var src1 = "public delegate int D(int a = 1);";
+            var src2 = "public delegate int D(int a = 2);";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [int a = 1]@22 -> [int a = 2]@22");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.InitializerUpdate, "int a = 2", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -1934,7 +2367,7 @@ class C
     {
         public extern D();
 
-        public static extern int P { [DllImport(""msvcrt.dll"")]get; }
+        public static extern int P { [DllImport(""msvcrt.dll"")]get; [DllImport(""msvcrt.dll"")]set; }
 
         [DllImport(""msvcrt.dll"")]
         public static extern int puts(string c);
@@ -1950,7 +2383,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             // Adding P/Invoke is not supported by the CLR.
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertExtern, "public extern D()", FeaturesResources.constructor),
                 Diagnostic(RudeEditKind.InsertExtern, "public static extern int P", FeaturesResources.property_),
                 Diagnostic(RudeEditKind.InsertExtern, "public static extern int puts(string c)", FeaturesResources.method),
@@ -2023,8 +2456,8 @@ class C
                 "Delete [public void goo() {}]@17",
                 "Delete [()]@32");
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "public class C", FeaturesResources.method));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "public class C", DeletedSymbolDisplay(FeaturesResources.method, "goo()")));
         }
 
         [Fact]
@@ -2043,9 +2476,491 @@ class C
                  Diagnostic(RudeEditKind.Move, "public class X", FeaturesResources.class_));
         }
 
+        /// <summary>
+        /// A new generic type can be added whether it's nested and inherits generic parameters from the containing type, or top-level.
+        /// </summary>
+        [Fact]
+        public void NestedClassGeneric_Insert()
+        {
+            var src1 = @"
+using System;
+class C<T>
+{
+}
+";
+            var src2 = @"
+using System;
+class C<T>
+{
+    class D {}
+    struct S {}
+    enum N {}
+    interface I {}
+    delegate void D();
+}
+
+class D<T>
+{
+    
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void NestedEnum_InsertMember()
+        {
+            var src1 = "struct S { enum N { A = 1 } }";
+            var src2 = "struct S { enum N { A = 1, B = 2 } }";
+
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyEdits(
+                "Update [enum N { A = 1 }]@11 -> [enum N { A = 1, B = 2 }]@11",
+                "Insert [B = 2]@27");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "B = 2", FeaturesResources.enum_value));
+        }
+
+        [Fact, WorkItem(50876, "https://github.com/dotnet/roslyn/issues/50876")]
+        public void NestedEnumInPartialType_InsertDelete()
+        {
+            var srcA1 = "partial struct S { }";
+            var srcB1 = "partial struct S { enum N { A = 1 } }";
+            var srcA2 = "partial struct S { enum N { A = 1 } }";
+            var srcB2 = "partial struct S { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                });
+        }
+
+        [Fact, WorkItem(50876, "https://github.com/dotnet/roslyn/issues/50876")]
+        public void NestedEnumInPartialType_InsertDeleteAndUpdateMember()
+        {
+            var srcA1 = "partial struct S { }";
+            var srcB1 = "partial struct S { enum N { A = 1 } }";
+            var srcA2 = "partial struct S { enum N { A = 2 } }";
+            var srcB2 = "partial struct S { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        diagnostics: new[]
+                        {
+                            Diagnostic(RudeEditKind.InitializerUpdate, "A = 2", FeaturesResources.enum_value),
+                        }),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact, WorkItem(50876, "https://github.com/dotnet/roslyn/issues/50876")]
+        public void NestedEnumInPartialType_InsertDeleteAndUpdateBase()
+        {
+            var srcA1 = "partial struct S { }";
+            var srcB1 = "partial struct S { enum N : uint { A = 1 } }";
+            var srcA2 = "partial struct S { enum N : int { A = 1 } }";
+            var srcB2 = "partial struct S { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        diagnostics: new[]
+                        {
+                            Diagnostic(RudeEditKind.EnumUnderlyingTypeUpdate, "enum N", FeaturesResources.enum_),
+                        }),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact, WorkItem(50876, "https://github.com/dotnet/roslyn/issues/50876")]
+        public void NestedEnumInPartialType_InsertDeleteAndInsertMember()
+        {
+            var srcA1 = "partial struct S { }";
+            var srcB1 = "partial struct S { enum N { A = 1 } }";
+            var srcA2 = "partial struct S { enum N { A = 1, B = 2 } }";
+            var srcB2 = "partial struct S { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Insert, "B = 2", FeaturesResources.enum_value) }),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact]
+        public void NestedDelegateInPartialType_InsertDelete()
+        {
+            var srcA1 = "partial struct S { }";
+            var srcB1 = "partial struct S { delegate void D(); }";
+            var srcA2 = "partial struct S { delegate void D(); }";
+            var srcB2 = "partial struct S { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        // delegate does not have any user-defined method body and this does not need a PDB update
+                        semanticEdits: NoSemanticEdits),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact]
+        public void NestedDelegateInPartialType_InsertDeleteAndChangeSignature()
+        {
+            var srcA1 = "partial struct S { }";
+            var srcB1 = "partial struct S { delegate void D(); }";
+            var srcA2 = "partial struct S { delegate void D(int x); }";
+            var srcB2 = "partial struct S { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        diagnostics: new[]
+                        {
+                            Diagnostic(RudeEditKind.Insert, "int x", FeaturesResources.parameter)
+                        }),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact]
+        public void NestedDelegateInPartialType_InsertDeleteAndChangeOptionalParameterValue()
+        {
+            var srcA1 = "partial struct S { }";
+            var srcB1 = "partial struct S { delegate void D(int x = 1); }";
+            var srcA2 = "partial struct S { delegate void D(int x = 2); }";
+            var srcB2 = "partial struct S { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        diagnostics: new[]
+                        {
+                            Diagnostic(RudeEditKind.InitializerUpdate, "int x = 2", FeaturesResources.parameter)
+                        }),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteAndChange()
+        {
+            var srcA1 = "partial struct S { partial class C { void F1() {} } }";
+            var srcB1 = "partial struct S { partial class C { void F2(byte x) {} } }";
+            var srcC1 = "partial struct S { }";
+
+            var srcA2 = "partial struct S { partial class C { void F1() {} } }";
+            var srcB2 = "partial struct S { }";
+            var srcC2 = "partial struct S { partial class C { void F2(int x) {} } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Delete, "partial struct S", DeletedSymbolDisplay(FeaturesResources.method, "F2(byte)")) }),
+
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("S").GetMember<INamedTypeSymbol>("C").GetMember("F2")) })
+                });
+        }
+
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteAndChange_BaseType()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "";
+            var srcC1 = "partial class C { }";
+
+            var srcA2 = "";
+            var srcB2 = "partial class C : D { }";
+            var srcC2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.BaseTypeOrInterfaceUpdate, "partial class C", FeaturesResources.class_) }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteAndChange_Attribute()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "";
+            var srcC1 = "partial class C { }";
+
+            var srcA2 = "";
+            var srcB2 = "[A]partial class C { }";
+            var srcC2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Update, "partial class C", FeaturesResources.class_) }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteAndChange_TypeParameter()
+        {
+            var srcA1 = "partial class C<T> { }";
+            var srcB1 = "";
+            var srcC1 = "partial class C<T> { }";
+
+            var srcA2 = "";
+            var srcB2 = "partial class C<[A]T> { }";
+            var srcC2 = "partial class C<T> { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Update, "partial class C<[A]T>", FeaturesResources.class_) }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteAndChange_Constraint()
+        {
+            var srcA1 = "partial class C<T> { }";
+            var srcB1 = "";
+            var srcC1 = "partial class C<T> { }";
+
+            var srcA2 = "";
+            var srcB2 = "partial class C<T> where T : new() { }";
+            var srcC2 = "partial class C<T> { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Update, "partial class C<T>", FeaturesResources.class_) }),
+
+                    DocumentResults(),
+                });
+        }
+
+        /// <summary>
+        /// Moves partial classes to different files while moving around their attributes and base interfaces.
+        /// </summary>
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteRefactor()
+        {
+            var srcA1 = "partial class C : I { void F() { } }";
+            var srcB1 = "[A][B]partial class C : J { void G() { } }";
+            var srcC1 = "";
+            var srcD1 = "";
+
+            var srcA2 = "";
+            var srcB2 = "";
+            var srcC2 = "[A]partial class C : I, J { void F() { } }";
+            var srcD2 = "[B]partial class C { void G() { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F")) }),
+
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("G")) }),
+                });
+        }
+
+        /// <summary>
+        /// Moves partial classes to different files while moving around their attributes and base interfaces.
+        /// Currently we do not support splitting attribute lists.
+        /// </summary>
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteRefactor_AttributeListSplitting()
+        {
+            var srcA1 = "partial class C { void F() { } }";
+            var srcB1 = "[A,B]partial class C { void G() { } }";
+            var srcC1 = "";
+            var srcD1 = "";
+
+            var srcA2 = "";
+            var srcB2 = "";
+            var srcC2 = "[A]partial class C { void F() { } }";
+            var srcD2 = "[B]partial class C { void G() { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(diagnostics: new[] { Diagnostic(RudeEditKind.Update, "partial class C", FeaturesResources.class_) }),
+                    DocumentResults(diagnostics: new[] { Diagnostic(RudeEditKind.Update, "partial class C", FeaturesResources.class_) }),
+                });
+        }
+
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteChangeMember()
+        {
+            var srcA1 = "partial class C { void F(int y = 1) { } }";
+            var srcB1 = "partial class C { void G(int x = 1) { } }";
+            var srcC1 = "";
+
+            var srcA2 = "";
+            var srcB2 = "partial class C { void G(int x = 2) { } }";
+            var srcC2 = "partial class C { void F(int y = 2) { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics: new[] { Diagnostic(RudeEditKind.InitializerUpdate, "int x = 2", FeaturesResources.parameter) }),
+                    DocumentResults(diagnostics: new[] { Diagnostic(RudeEditKind.InitializerUpdate, "int y = 2", FeaturesResources.parameter) }),
+                });
+        }
+
+        [Fact]
+        public void NestedPartialTypeInPartialType_InsertDeleteAndInsertVirtual()
+        {
+            var srcA1 = "partial interface I { partial class C { virtual void F1() {} } }";
+            var srcB1 = "partial interface I { partial class C { virtual void F2() {} } }";
+            var srcC1 = "partial interface I { partial class C { } }";
+            var srcD1 = "partial interface I { partial class C { } }";
+            var srcE1 = "partial interface I { }";
+            var srcF1 = "partial interface I { }";
+
+            var srcA2 = "partial interface I { partial class C { } }";
+            var srcB2 = "";
+            var srcC2 = "partial interface I { partial class C { virtual void F1() {} } }"; // move existing virtual into existing partial decl
+            var srcD2 = "partial interface I { partial class C { virtual void N1() {} } }"; // insert new virtual into existing partial decl
+            var srcE2 = "partial interface I { partial class C { virtual void F2() {} } }"; // move existing virtual into a new partial decl
+            var srcF2 = "partial interface I { partial class C { virtual void N2() {} } }"; // insert new virtual into new partial decl
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2), GetTopEdits(srcE1, srcE2), GetTopEdits(srcF1, srcF2) },
+                new[]
+                {
+                    // A
+                    DocumentResults(),
+
+                    // B
+                    DocumentResults(),
+
+                    // C
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("I").GetMember<INamedTypeSymbol>("C").GetMember("F1")) }),
+
+                    // D
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.InsertVirtual, "virtual void N1()", FeaturesResources.method) }),
+
+                    // E
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("I").GetMember<INamedTypeSymbol>("C").GetMember("F2")) }),
+
+                    // F
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.InsertVirtual, "virtual void N2()", FeaturesResources.method) }),
+                });
+        }
+
         #endregion
 
         #region Namespaces
+
+        [Fact]
+        public void Namespace_Insert()
+        {
+            var src1 = @"";
+            var src2 = @"namespace C { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Insert [namespace C { }]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "namespace C", FeaturesResources.namespace_));
+
+        }
+        [Fact]
+        public void Namespace_InsertNested()
+        {
+            var src1 = @"namespace C { }";
+            var src2 = @"namespace C { namespace D { } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Insert [namespace D { }]@14");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "namespace D", FeaturesResources.namespace_));
+        }
+
+        [Fact]
+        public void NamespaceDelete()
+        {
+            var src1 = @"namespace C { namespace D { } }";
+            var src2 = @"namespace C { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Delete [namespace D { }]@14");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "namespace C", FeaturesResources.namespace_));
+        }
 
         [Fact]
         public void NamespaceMove1()
@@ -2189,6 +3104,458 @@ struct S
                 Diagnostic(RudeEditKind.ModifiersUpdate, "readonly set", CSharpFeaturesResources.property_setter),
                 Diagnostic(RudeEditKind.ModifiersUpdate, "readonly add", FeaturesResources.event_accessor),
                 Diagnostic(RudeEditKind.ModifiersUpdate, "readonly remove", FeaturesResources.event_accessor));
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_SingleDocument()
+        {
+            var src1 = @"
+using System;
+
+partial class C
+{
+    void M() {}
+    int P1 { get; set; }
+    int P2 { get => 1; set {} }
+    int this[int i] { get => 1; set {} }
+    int this[byte i] { get => 1; set {} }
+    event Action E { add {} remove {} }
+    event Action EF;
+    int F1;
+    int F2;
+}
+
+partial class C
+{
+}
+";
+            var src2 = @"
+using System;
+
+partial class C
+{
+}
+
+partial class C
+{
+    void M() {}
+    int P1 { get; set; }
+    int P2 { get => 1; set {} }
+    int this[int i] { get => 1; set {} }
+    int this[byte i] { get => 1; set {} }
+    event Action E { add {} remove {} }
+    event Action EF;
+    int F1, F2;
+}
+";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Insert [void M() {}]@68",
+                "Insert [int P1 { get; set; }]@85",
+                "Insert [int P2 { get => 1; set {} }]@111",
+                "Insert [int this[int i] { get => 1; set {} }]@144",
+                "Insert [int this[byte i] { get => 1; set {} }]@186",
+                "Insert [event Action E { add {} remove {} }]@229",
+                "Insert [event Action EF;]@270",
+                "Insert [int F1, F2;]@292",
+                "Insert [()]@74",
+                "Insert [{ get; set; }]@92",
+                "Insert [{ get => 1; set {} }]@118",
+                "Insert [[int i]]@152",
+                "Insert [{ get => 1; set {} }]@160",
+                "Insert [[byte i]]@194",
+                "Insert [{ get => 1; set {} }]@203",
+                "Insert [{ add {} remove {} }]@244",
+                "Insert [Action EF]@276",
+                "Insert [int F1, F2]@292",
+                "Insert [get;]@94",
+                "Insert [set;]@99",
+                "Insert [get => 1;]@120",
+                "Insert [set {}]@130",
+                "Insert [int i]@153",
+                "Insert [get => 1;]@162",
+                "Insert [set {}]@172",
+                "Insert [byte i]@195",
+                "Insert [get => 1;]@205",
+                "Insert [set {}]@215",
+                "Insert [add {}]@246",
+                "Insert [remove {}]@253",
+                "Insert [EF]@283",
+                "Insert [F1]@296",
+                "Insert [F2]@300",
+                "Delete [void M() {}]@43",
+                "Delete [()]@49",
+                "Delete [int P1 { get; set; }]@60",
+                "Delete [{ get; set; }]@67",
+                "Delete [get;]@69",
+                "Delete [set;]@74",
+                "Delete [int P2 { get => 1; set {} }]@86",
+                "Delete [{ get => 1; set {} }]@93",
+                "Delete [get => 1;]@95",
+                "Delete [set {}]@105",
+                "Delete [int this[int i] { get => 1; set {} }]@119",
+                "Delete [[int i]]@127",
+                "Delete [int i]@128",
+                "Delete [{ get => 1; set {} }]@135",
+                "Delete [get => 1;]@137",
+                "Delete [set {}]@147",
+                "Delete [int this[byte i] { get => 1; set {} }]@161",
+                "Delete [[byte i]]@169",
+                "Delete [byte i]@170",
+                "Delete [{ get => 1; set {} }]@178",
+                "Delete [get => 1;]@180",
+                "Delete [set {}]@190",
+                "Delete [event Action E { add {} remove {} }]@204",
+                "Delete [{ add {} remove {} }]@219",
+                "Delete [add {}]@221",
+                "Delete [remove {}]@228",
+                "Delete [event Action EF;]@245",
+                "Delete [Action EF]@251",
+                "Delete [EF]@258",
+                "Delete [int F1;]@267",
+                "Delete [int F1]@267",
+                "Delete [F1]@271",
+                "Delete [int F2;]@280",
+                "Delete [int F2]@280",
+                "Delete [F2]@284");
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { edits },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("M"), preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P2").GetMethod, preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P2").SetMethod, preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMembers("this[]").Cast<IPropertySymbol>().Single(m => m.GetParameters().Single().Type.Name == "Int32").GetMethod, preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMembers("this[]").Cast<IPropertySymbol>().Single(m => m.GetParameters().Single().Type.Name == "Int32").SetMethod, preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMembers("this[]").Cast<IPropertySymbol>().Single(m => m.GetParameters().Single().Type.Name == "Byte").GetMethod, preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMembers("this[]").Cast<IPropertySymbol>().Single(m => m.GetParameters().Single().Type.Name == "Byte").SetMethod, preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E").AddMethod, preserveLocalVariables: false),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E").RemoveMethod, preserveLocalVariables: false),
+                        })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_InsertDelete_MultipleDocuments()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { void F() {} }";
+            var srcA2 = "partial class C { void F() {} }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F"), preserveLocalVariables: false)
+                        }),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_MultipleDocuments()
+        {
+            var srcA1 = "partial class C { void F() {} }";
+            var srcB1 = "partial class C { }";
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { void F() {} }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("F"), preserveLocalVariables: false)
+                        })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_GenericMethod()
+        {
+            var srcA1 = "partial class C { void F<T>() {} }";
+            var srcB1 = "partial class C { }";
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { void F<T>() {} }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics: new[]
+                    {
+                        // TODO: better message
+                        Diagnostic(RudeEditKind.GenericMethodTriviaUpdate, "void F<T>()", FeaturesResources.method)
+                    })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_GenericType()
+        {
+            var srcA1 = "partial class C<T> { void F() {} }";
+            var srcB1 = "partial class C<T> { }";
+            var srcA2 = "partial class C<T> { }";
+            var srcB2 = "partial class C<T> { void F() {} }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics: new[]
+                    {
+                        // TODO: better message
+                        Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, "void F()", FeaturesResources.method)
+                    })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_Destructor()
+        {
+            var srcA1 = "partial class C { ~C() {} }";
+            var srcB1 = "partial class C { }";
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { ~C() {} }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("Finalize"), preserveLocalVariables: false),
+                        })
+                });
+        }
+
+        [Fact]
+        public void PartialNestedType_InsertDeleteAndChange()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { class D { void M() {} } interface I { } }";
+
+            var srcA2 = "partial class C { class D : I { void M() {} } interface I { } }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        diagnostics: new[]
+                        {
+                            Diagnostic(RudeEditKind.BaseTypeOrInterfaceUpdate, "class D", FeaturesResources.class_),
+                        }),
+
+                    DocumentResults()
+                });
+        }
+
+        [Fact, WorkItem(51011, "https://github.com/dotnet/roslyn/issues/51011")]
+        public void PartialMember_RenameInsertDelete()
+        {
+            // The syntactic analysis for A and B produce rename edits since it  doesn't see that the member was in fact moved.
+            // TODO: Currently, we don't even pass rename edits to semantic analysis where we could handle them as updates.
+
+            var srcA1 = "partial class C { void F1() {} }";
+            var srcB1 = "partial class C { void F2() {} }";
+            var srcA2 = "partial class C { void F2() {} }";
+            var srcB2 = "partial class C { void F1() {} }";
+
+            // current outcome:
+            GetTopEdits(srcA1, srcA2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Renamed, "void F2()", FeaturesResources.method));
+            GetTopEdits(srcB1, srcB2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Renamed, "void F1()", FeaturesResources.method));
+
+            // correct outcome:
+            //EditAndContinueValidation.VerifySemantics(
+            //    new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+            //    new[]
+            //    {
+            //        DocumentResults(semanticEdits: new[]
+            //            {
+            //                SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F2")),
+            //            }),
+
+            //        DocumentResults(
+            //            semanticEdits: new[]
+            //            {
+            //                SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F1")),
+            //            })
+            //    });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_UpdateMethodBodyError()
+        {
+            var srcA1 = @"
+using System.Collections.Generic;
+
+partial class C
+{
+    IEnumerable<int> F() { yield return 1; }
+}
+";
+            var srcB1 = @"
+using System.Collections.Generic;
+
+partial class C
+{
+}
+";
+
+            var srcA2 = @"
+using System.Collections.Generic;
+
+partial class C
+{
+}
+";
+            var srcB2 = @"
+using System.Collections.Generic;
+
+partial class C
+{
+    IEnumerable<int> F() { yield return 1; yield return 2; }
+}
+";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics: new[]
+                    {
+                        Diagnostic(RudeEditKind.Insert, "yield return 2;", CSharpFeaturesResources.yield_return_statement)
+                    })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_UpdatePropertyAccessors()
+        {
+            var srcA1 = "partial class C { int P { get => 1; set { Console.WriteLine(1); } } }";
+            var srcB1 = "partial class C { }";
+
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { int P { get => 2; set { Console.WriteLine(2); } } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").GetMethod),
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").SetMethod)
+                    })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_UpdateAutoProperty()
+        {
+            var srcA1 = "partial class C { int P => 1; }";
+            var srcB1 = "partial class C { }";
+
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { int P => 2; }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").GetMethod)
+                    })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_AddFieldInitializer()
+        {
+            var srcA1 = "partial class C { int f; }";
+            var srcB1 = "partial class C { }";
+
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { int f = 1; }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_RemoveFieldInitializer()
+        {
+            var srcA1 = "partial class C { int f = 1; }";
+            var srcB1 = "partial class C { }";
+
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { int f; }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    })
+                });
+        }
+
+        [Fact]
+        public void PartialMember_DeleteInsert_ConstructorWithInitializers()
+        {
+            var srcA1 = "partial class C { int f = 1; C(int x) { f = x; } }";
+            var srcB1 = "partial class C { }";
+
+            var srcA2 = "partial class C { int f = 1; }";
+            var srcB2 = "partial class C { C(int x) { f = x + 1; } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    })
+                });
         }
 
         #endregion
@@ -2380,20 +3747,11 @@ class C
 class C
 {
     void goo() { }
-
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }
 ";
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }";
             var edits = GetTopEdits(src1, src2);
 
@@ -2401,8 +3759,8 @@ class C
                 "Delete [void goo() { }]@18",
                 "Delete [()]@26");
 
-            edits.VerifyRudeDiagnostics(
-                 Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.method));
+            edits.VerifySemanticDiagnostics(
+                 Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.method, "goo()")));
         }
 
         [Fact]
@@ -2412,20 +3770,11 @@ class C
 class C
 {
     int goo() => 1;
-
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }
 ";
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }";
             var edits = GetTopEdits(src1, src2);
 
@@ -2433,66 +3782,24 @@ class C
                 "Delete [int goo() => 1;]@18",
                 "Delete [()]@25");
 
-            edits.VerifyRudeDiagnostics(
-                 Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.method));
-        }
-
-        [Fact]
-        public void MethodDelete_WithParameters()
-        {
-            var src1 = @"
-class C
-{
-    void goo(int a) { }
-
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
-}
-";
-            var src2 = @"
-class C
-{
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
-}";
-            var edits = GetTopEdits(src1, src2);
-
-            edits.VerifyEdits(
-                "Delete [void goo(int a) { }]@18",
-                "Delete [(int a)]@26",
-                "Delete [int a]@27");
-
-            edits.VerifyRudeDiagnostics(
-                 Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.method));
+            edits.VerifySemanticDiagnostics(
+                 Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.method, "goo()")));
         }
 
         [WorkItem(754853, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/754853")]
         [Fact]
-        public void MethodDelete_WithAttribute()
+        public void MethodDelete_WithParameterAndAttribute()
         {
             var src1 = @"
 class C
 {
     [Obsolete]
     void goo(int a) { }
-
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }
 ";
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }";
             var edits = GetTopEdits(src1, src2);
 
@@ -2504,8 +3811,8 @@ class C
                 "Delete [(int a)]@42",
                 "Delete [int a]@43");
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.method));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.method, "goo(int)")));
         }
 
         [WorkItem(754853, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/754853")]
@@ -2520,11 +3827,6 @@ class C
 {
     [DllImport(""msvcrt.dll"")]
     public static extern int puts(string c);
-
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }
 ";
             var src2 = @"
@@ -2533,10 +3835,6 @@ using System.Runtime.InteropServices;
 
 class C
 {
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }";
 
             var edits = GetTopEdits(src1, src2);
@@ -2549,8 +3847,8 @@ class C
                  "Delete [(string c)]@134",
                  "Delete [string c]@135");
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.method));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.method, "puts(string)")));
         }
 
         [Fact]
@@ -2675,7 +3973,7 @@ class C
 ";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertVirtual, "public virtual void F()", FeaturesResources.method));
         }
 
@@ -2694,7 +3992,7 @@ abstract class C
 ";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertVirtual, "public abstract void F()", FeaturesResources.method));
         }
 
@@ -2713,13 +4011,13 @@ class C
 ";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertVirtual, "public override void F()", FeaturesResources.method));
         }
 
         [WorkItem(755784, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755784"), WorkItem(835827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/835827")]
         [Fact]
-        public void PrivateMethodInsert_PInvoke1()
+        public void ExternMethodInsert()
         {
             var src1 = @"
 using System;
@@ -2727,10 +4025,6 @@ using System.Runtime.InteropServices;
 
 class C
 {
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }";
             var src2 = @"
 using System;
@@ -2740,11 +4034,6 @@ class C
 {
     [DllImport(""msvcrt.dll"")]
     private static extern int puts(string c);
-
-    static void Main(string[] args)
-    {
-        Console.ReadLine();
-    }
 }
 ";
             var edits = GetTopEdits(src1, src2);
@@ -2758,8 +4047,49 @@ class C
                  "Insert [string c]@136");
 
             // CLR doesn't support methods without a body
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertExtern, "private static extern int puts(string c)", FeaturesResources.method));
+        }
+
+        [WorkItem(755784, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755784"), WorkItem(835827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/835827")]
+        [Fact]
+        public void ExternMethodDeleteInsert()
+        {
+            var srcA1 = @"
+using System;
+using System.Runtime.InteropServices;
+
+class C
+{
+    [DllImport(""msvcrt.dll"")]
+    private static extern int puts(string c);
+}";
+            var srcA2 = @"
+using System;
+using System.Runtime.InteropServices;
+";
+
+            var srcB1 = @"
+using System;
+using System.Runtime.InteropServices;
+";
+            var srcB2 = @"
+using System;
+using System.Runtime.InteropServices;
+
+class C
+{
+    [DllImport(""msvcrt.dll"")]
+    private static extern int puts(string c);
+}
+";
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                });
         }
 
         [Fact]
@@ -3983,8 +5313,160 @@ public class SubClass : BaseClass, IConflict
                 "Insert [string IConflict.Get() => String.Empty;]@325",
                 "Insert [()]@345");
 
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertMethodWithExplicitInterfaceSpecifier, "string IConflict.Get()", FeaturesResources.method));
+        }
+
+        [Fact]
+        public void PartialMethod_DeleteInsert_DefinitionPart()
+        {
+            var srcA1 = "partial class C { partial void F(); }";
+            var srcB1 = "partial class C { partial void F() { } }";
+            var srcC1 = "partial class C { }";
+
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { partial void F() { } }";
+            var srcC2 = "partial class C { partial void F(); }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void PartialMethod_DeleteInsert_ImplementationPart()
+        {
+            var srcA1 = "partial class C { partial void F(); }";
+            var srcB1 = "partial class C { partial void F() { } }";
+            var srcC1 = "partial class C { }";
+
+            var srcA2 = "partial class C { partial void F(); }";
+            var srcB2 = "partial class C { }";
+            var srcC2 = "partial class C { partial void F() { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("F").PartialImplementationPart) }),
+                });
+        }
+
+        [Fact, WorkItem(51011, "https://github.com/dotnet/roslyn/issues/51011")]
+        public void PartialMethod_Swap_ImplementationAndDefinitionParts()
+        {
+            var srcA1 = "partial class C { partial void F(); }";
+            var srcB1 = "partial class C { partial void F() { } }";
+
+            var srcA2 = "partial class C { partial void F() { } }";
+            var srcB2 = "partial class C { partial void F(); }";
+
+            // current:
+            GetTopEdits(srcA1, srcA2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.MethodBodyAdd, "partial void F()", FeaturesResources.method));
+            GetTopEdits(srcB1, srcB2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.MethodBodyDelete, "partial void F()", FeaturesResources.method));
+
+            // correct: TODO
+            //EditAndContinueValidation.VerifySemantics(
+            //    new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+            //    new[]
+            //    {
+            //        DocumentResults(),
+            //        DocumentResults(
+            //            semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F")) }),
+            //    });
+        }
+
+        [Fact]
+        public void PartialMethod_DeleteImplementation()
+        {
+            var srcA1 = "partial class C { partial void F(); }";
+            var srcB1 = "partial class C { partial void F() { } }";
+
+            var srcA2 = "partial class C { partial void F(); }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Delete, "partial class C", DeletedSymbolDisplay(FeaturesResources.method, "F()")) })
+                });
+        }
+
+        [Fact]
+        public void PartialMethod_DeleteBoth()
+        {
+            var srcA1 = "partial class C { partial void F(); }";
+            var srcB1 = "partial class C { partial void F() { } }";
+
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.Delete, "partial class C", DeletedSymbolDisplay(FeaturesResources.method, "F()")) })
+                });
+        }
+
+        [Fact]
+        public void PartialMethod_DeleteInsertBoth()
+        {
+            var srcA1 = "partial class C { partial void F(); }";
+            var srcB1 = "partial class C { partial void F() { } }";
+            var srcC1 = "partial class C { }";
+            var srcD1 = "partial class C { }";
+
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { }";
+            var srcC2 = "partial class C { partial void F(); }";
+            var srcD2 = "partial class C { partial void F() { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("F").PartialImplementationPart) })
+                });
+        }
+
+        [Fact]
+        public void PartialMethod_Insert()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { }";
+
+            var srcA2 = "partial class C { partial void F(); }";
+            var srcB2 = "partial class C { partial void F() { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("F").PartialImplementationPart) }),
+                });
         }
 
         #endregion
@@ -4014,7 +5496,7 @@ class C
 }";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertOperator, "public static implicit operator bool (C c)", CSharpFeaturesResources.conversion_operator),
                 Diagnostic(RudeEditKind.InsertOperator, "public static C operator +(C c, C d)", FeaturesResources.operator_));
         }
@@ -4042,9 +5524,46 @@ class C
 }";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", CSharpFeaturesResources.conversion_operator),
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.operator_));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(CSharpFeaturesResources.conversion_operator, "implicit operator bool(C)")),
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.operator_, "operator +(C, C)")));
+        }
+
+        [Fact]
+        public void OperatorInsertDelete()
+        {
+            var srcA1 = @"
+partial class C
+{
+    public static implicit operator bool (C c)  => false;
+}
+";
+            var srcB1 = @"
+partial class C
+{
+    public static C operator +(C c, C d) => c;
+}
+";
+
+            var srcA2 = srcB1;
+            var srcB2 = srcA1;
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("op_Addition"))
+                        }),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("op_Implicit"))
+                        }),
+                });
         }
 
         [Fact]
@@ -4204,7 +5723,7 @@ class C
                 "Insert [(in Test b)]@42",
                 "Insert [in Test b]@43");
 
-            edits.VerifyRudeDiagnostics(
+            edits.VerifySemanticDiagnostics(
                  Diagnostic(RudeEditKind.InsertOperator, "public static bool operator !(in Test b)", FeaturesResources.operator_));
         }
 
@@ -4321,21 +5840,11 @@ class C<T>
 class C
 {
     public C(int a) { }
-
-    static void Main(string[] args)
-    {
-        C c = new C(5);        
-    }
 }";
             var src2 = @"
 class C
 {
     public C(int a, int b) { }
-
-    static void Main(string[] args)
-    {
-        C c = new C(5);                
-    }
 }";
             var edits = GetTopEdits(src1, src2);
 
@@ -4350,108 +5859,35 @@ class C
         [Fact]
         public void DestructorDelete()
         {
-            var src1 = @"
-class C
-{
-    static void Main(string[] args)
-    {
-        B b = new B();
-        b = null;
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-    }
-}
-class B
-{
-    ~B()
-    {
-        Console.WriteLine(""B's destructor"");
-    }
-}";
-            var src2 = @"
-class C
-{
-    static void Main(string[] args)
-    {
-        B b = new B();
-        b = null;
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-    }
-}
-class B
-{
+            var src1 = @"class B { ~B() { } }";
+            var src2 = @"class B { }";
 
-}";
-
-            var expectedEdit1 = @"Delete [~B()
-    {
-        Console.WriteLine(""B's destructor"");
-    }]@190";
+            var expectedEdit1 = @"Delete [~B() { }]@10";
 
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(expectedEdit1);
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class B", CSharpFeaturesResources.destructor));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class B", DeletedSymbolDisplay(CSharpFeaturesResources.destructor, "~B()")));
         }
 
         [Fact]
         public void DestructorDelete_InsertConstructor()
         {
-            var src1 = @"
-class C
-{
-    static void Main(string[] args)
-    {
-        B b = new B();
-        b = null;
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-    }
-}
-class B
-{
-    ~B()
-    {
-        Console.WriteLine(""B's destructor"");
-    }
-}";
-            var src2 = @"
-class C
-{
-    static void Main(string[] args)
-    {
-        B b = new B();
-        b = null;
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-    }
-}
-class B
-{
-    B()
-    {
-        Console.WriteLine(""B's destructor"");
-    }
-}";
-            var expectedEdit1 = @"Insert [B()
-    {
-        Console.WriteLine(""B's destructor"");
-    }]@190";
-
-            var expectedEdit2 = @"Delete [~B()
-    {
-        Console.WriteLine(""B's destructor"");
-    }]@190";
+            var src1 = @"class B { ~B() { } }";
+            var src2 = @"class B { B() { } }";
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits(expectedEdit1, "Insert [()]@191", expectedEdit2);
+            edits.VerifyEdits(
+                "Insert [B() { }]@10",
+                "Insert [()]@11",
+                "Delete [~B() { }]@10");
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class B", CSharpFeaturesResources.destructor));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.ChangingVisibility, "B()", FeaturesResources.constructor),
+                Diagnostic(RudeEditKind.Delete, "class B", DeletedSymbolDisplay(CSharpFeaturesResources.destructor, "~B()")));
         }
 
         [Fact]
@@ -4475,7 +5911,7 @@ class B
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.static_constructor, "C()")));
         }
 
         [Fact]
@@ -4488,67 +5924,46 @@ class B
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
-        [Fact]
-        public void InstanceCtorDelete_Private1()
+        [Theory]
+        [InlineData("")]
+        [InlineData("private")]
+        [InlineData("protected")]
+        [InlineData("internal")]
+        [InlineData("private protected")]
+        [InlineData("protected internal")]
+        public void InstanceCtorDelete_NonPublic(string visibility)
         {
-            var src1 = "class C { C() { } }";
+            var src1 = "class C { " + visibility + " C() { } }";
             var src2 = "class C { }";
 
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.ChangingVisibility, "class C", DeletedSymbolDisplay(FeaturesResources.constructor, "C()")));
         }
 
         [Fact]
-        public void InstanceCtorDelete_Private2()
+        public void InstanceCtorDelete_Public_PartialWithInitializerUpdate()
         {
-            var src1 = "class C { private C() { } }";
-            var src2 = "class C { }";
+            var srcA1 = "partial class C { public C() { } }";
+            var srcB1 = "partial class C { int x = 1; }";
 
-            var edits = GetTopEdits(src1, src2);
+            var srcA2 = "partial class C { }";
+            var srcB2 = "partial class C { int x = 2; }";
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
-        }
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), partialType: "C", preserveLocalVariables: true) }),
 
-        [Fact]
-        public void InstanceCtorDelete_Protected()
-        {
-            var src1 = "class C { protected C() { } }";
-            var src2 = "class C { }";
-
-            var edits = GetTopEdits(src1, src2);
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
-        }
-
-        [Fact]
-        public void InstanceCtorDelete_Internal()
-        {
-            var src1 = "class C { internal C() { } }";
-            var src2 = "class C { }";
-
-            var edits = GetTopEdits(src1, src2);
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
-        }
-
-        [Fact]
-        public void InstanceCtorDelete_ProtectedInternal()
-        {
-            var src1 = "class C { protected internal C() { } }";
-            var src2 = "class C { }";
-
-            var edits = GetTopEdits(src1, src2);
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), partialType: "C", preserveLocalVariables: true) })
+                });
         }
 
         [Fact]
@@ -4588,9 +6003,13 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    // no change in document A
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) }),
                 });
         }
 
@@ -4621,9 +6040,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(c => c.Parameters.IsEmpty))
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(c => c.Parameters.IsEmpty))
+                        }),
+
+                    // no change in document B
+                    DocumentResults(),
                 });
         }
 
@@ -4636,7 +6062,7 @@ class B
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "private C()"));
+                Diagnostic(RudeEditKind.ChangingVisibility, "private C()", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -4648,7 +6074,7 @@ class B
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "C()"));
+                Diagnostic(RudeEditKind.ChangingVisibility, "C()", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -4660,7 +6086,7 @@ class B
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "protected C()"));
+                Diagnostic(RudeEditKind.ChangingVisibility, "protected C()", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -4672,7 +6098,7 @@ class B
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "internal C()"));
+                Diagnostic(RudeEditKind.ChangingVisibility, "internal C()", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -4684,7 +6110,7 @@ class B
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "internal C()"));
+                Diagnostic(RudeEditKind.ChangingVisibility, "internal C()", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -4764,11 +6190,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                targetFrameworks: null,
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true)
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true)
+                        }),
                 });
         }
 
@@ -4783,10 +6214,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
                 });
         }
 
@@ -4801,10 +6238,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
                 });
         }
 
@@ -4819,10 +6262,14 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedDiagnostics: new[]
+                new[]
                 {
-                    Diagnostic(RudeEditKind.ChangingConstructorVisibility, "public C()")
+                    // delete of the constructor in partial part will be reported as rude edit in the other document where it was inserted back with changed visibility
+                    DocumentResults(
+                        semanticEdits: NoSemanticEdits),
+
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.ModifiersUpdate, "public C()", FeaturesResources.constructor) }),
                 });
         }
 
@@ -4837,10 +6284,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true)
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true)
+                        }),
+
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
                 });
         }
 
@@ -4855,10 +6308,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
+
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
                 });
         }
 
@@ -4873,10 +6332,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
+
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
                 });
         }
 
@@ -4891,9 +6356,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
+
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
                 });
         }
 
@@ -4908,9 +6380,16 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                expectedSemanticEdits: new[]
+                new[]
                 {
-                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
+
+                    // delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+                    DocumentResults(),
                 });
         }
 
@@ -4925,10 +6404,13 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedDiagnostics: new[]
+                new[]
                 {
-                    Diagnostic(RudeEditKind.ChangingConstructorVisibility, "public C()")
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.ModifiersUpdate, "public C()", FeaturesResources.constructor) }),
+
+                    // delete of the constructor in partial part will be reported as rude in the the other document where it was inserted with changed visibility
+                    DocumentResults(),
                 });
         }
 
@@ -4943,10 +6425,12 @@ class B
 
             EditAndContinueValidation.VerifySemantics(
                 new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-                activeStatements: ActiveStatementsDescription.Empty,
-                expectedDiagnostics: new[]
+                new[]
                 {
-                    Diagnostic(RudeEditKind.ChangingConstructorVisibility, "internal C()")
+                    DocumentResults(
+                        diagnostics: new[] { Diagnostic(RudeEditKind.ModifiersUpdate, "internal C()", FeaturesResources.constructor) }),
+
+                    DocumentResults(),
                 });
         }
 
@@ -5105,7 +6589,7 @@ partial class C : I, J
                 new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
         }
 
-        [Fact]
+        [Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")]
         public void InstanceCtor_Partial_Insert_Parameterless_LambdaInInitializer1()
         {
             var src1 = @"
@@ -5144,11 +6628,16 @@ partial class C
 }
 ";
             var edits = GetTopEdits(src1, src2);
-            var syntaxMap = GetSyntaxMap(src1, src2);
 
-            edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "public C()"));
+
+            // TODO: 
+            //var syntaxMap = GetSyntaxMap(src1, src2);
+
+            //edits.VerifySemantics(
+            //    ActiveStatementsDescription.Empty,
+            //    new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
         }
 
         [Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")]
@@ -5201,6 +6690,123 @@ partial class C
             //    new[] { SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0]) });
         }
 
+        [Fact]
+        public void PartialTypes_ConstructorWithInitializerUpdates()
+        {
+            var srcA1 = @"
+using System;
+
+partial class C
+{
+    C(int arg) => Console.WriteLine(0);
+    C(bool arg) => Console.WriteLine(1);
+}
+";
+            var srcB1 = @"
+using System;
+
+partial class C
+{
+    int a <N:0.0>= 1</N:0.0>;
+
+    C(uint arg) => Console.WriteLine(2);
+}
+";
+
+            var srcA2 = @"
+using System;
+
+partial class C
+{
+    C(int arg) => Console.WriteLine(0);
+    C(bool arg) => Console.WriteLine(1);
+}
+";
+            var srcB2 = @"
+using System;
+
+partial class C
+{
+    int a <N:0.0>= 2</N:0.0>;             // updated field initializer
+
+    C(uint arg) => Console.WriteLine(2);
+    C(byte arg) => Console.WriteLine(3);  // new ctor
+}
+";
+            var syntaxMapB = GetSyntaxMap(srcB1, srcB2)[0];
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    // No changes in document A
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                           SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(c => c.Parameters.Single().Type.Name == "Int32"), syntaxMap: syntaxMapB),
+                           SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(c => c.Parameters.Single().Type.Name == "Boolean"), syntaxMap: syntaxMapB),
+                           SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(c => c.Parameters.Single().Type.Name == "UInt32"), syntaxMap: syntaxMapB),
+                           SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(c => c.Parameters.Single().Type.Name == "Byte"), syntaxMap: null),
+                        })
+                });
+        }
+
+        [Fact]
+        public void PartialTypes_ConstructorWithInitializerUpdates_SemanticErrors()
+        {
+            var srcA1 = @"
+using System;
+
+partial class C
+{
+    C(int arg) => Console.WriteLine(0);
+    C(int arg) => Console.WriteLine(1);
+}
+";
+            var srcB1 = @"
+using System;
+
+partial class C
+{
+    int a = 1;
+}
+";
+
+            var srcA2 = @"
+using System;
+
+partial class C
+{
+    C(int arg) => Console.WriteLine(0);
+    C(int arg) => Console.WriteLine(1);
+}
+";
+            var srcB2 = @"
+using System;
+
+partial class C
+{
+    int a = 2;
+
+    C(int arg) => Console.WriteLine(2);
+}
+";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    // No changes in document A
+                    DocumentResults(),
+
+                    // The actual edits do not matter since there are semantic errors in the compilation.
+                    // We just should not crash.
+                    DocumentResults(diagnostics: Array.Empty<RudeEditDiagnosticDescription>())
+                });
+        }
+
         [WorkItem(2068, "https://github.com/dotnet/roslyn/issues/2068")]
         [Fact]
         public void Insert_ExternConstruct()
@@ -5214,11 +6820,11 @@ partial class C
                 "Insert [public extern C();]@10",
                 "Insert [()]@25");
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.InsertExtern, "public extern C()", FeaturesResources.constructor));
+            // The compiler generates an empty constructor.
+            edits.VerifySemanticDiagnostics();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/18940")]
+        [Fact]
         public void ParameterlessConstructor_SemanticError_Delete1()
         {
             var src1 = @"
@@ -5234,19 +6840,9 @@ class C
 ";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyRudeDiagnostics();
-        }
-
-        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/18940")]
-        public void ParameterlessConstructor_SemanticError_Delete_OutsideOfClass1()
-        {
-            var src1 = @"
-C() {}
-";
-            var src2 = @"
-";
-            var edits = GetTopEdits(src1, src2);
-            edits.VerifyRudeDiagnostics();
+            // The compiler interprets D() as a constructor declaration.
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.ChangingVisibility, "class C", DeletedSymbolDisplay(FeaturesResources.constructor, "C()")));
         }
 
         [Fact]
@@ -5286,6 +6882,56 @@ partial class C
             {
                 SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("C").PartialImplementationPart)
             });
+        }
+
+        [Fact]
+        public void PartialDeclaration_Delete()
+        {
+            var srcA1 = "partial class C { public C() { } void F() { } }";
+            var srcB1 = "partial class C { int x = 1; }";
+
+            var srcA2 = "";
+            var srcB2 = "partial class C { int x = 2; void F() { } }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), partialType: "C", preserveLocalVariables: true) }),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("F"), partialType: "C"),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), partialType: "C", preserveLocalVariables: true)
+                        }),
+                });
+        }
+
+        [Fact]
+        public void PartialDeclaration_Insert()
+        {
+            var srcA1 = "";
+            var srcB1 = "partial class C { int x = 1; void F() { } }";
+
+            var srcA2 = "partial class C { public C() { } void F() { } }";
+            var srcB2 = "partial class C { int x = 2; }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IMethodSymbol>("F"), partialType: "C"),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), partialType: "C", preserveLocalVariables: true)
+                        }),
+
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), partialType: "C", preserveLocalVariables: true) }),
+                });
         }
 
         [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
@@ -5625,7 +7271,7 @@ public class C
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -5638,7 +7284,7 @@ public class C
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -5650,7 +7296,7 @@ public class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.ChangingVisibility, "class C", DeletedSymbolDisplay(FeaturesResources.constructor, "C()")));
         }
 
         [Fact]
@@ -5662,7 +7308,7 @@ public class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.ChangingVisibility, "class C", DeletedSymbolDisplay(FeaturesResources.constructor, "C()")));
         }
 
         [Fact]
@@ -5675,7 +7321,7 @@ public class C
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -5688,7 +7334,7 @@ public class C
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single()) });
+                new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) });
         }
 
         [Fact]
@@ -5948,7 +7594,6 @@ public class C
             edits.VerifyEdits(
                 "Update [a = 1]@21 -> [a = 2]@21");
 
-            // TODO (tomat): diagnostic should point to the field initializer
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
         }
@@ -6128,8 +7773,12 @@ public class C
             edits.VerifyEdits(
                 "Update [a = 1]@22 -> [a = 2]@22");
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.field));
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), preserveLocalVariables: true)
+                });
         }
 
         [Fact]
@@ -6140,8 +7789,12 @@ public class C
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "int a { get; } = 2;", FeaturesResources.auto_property));
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), preserveLocalVariables: true)
+                });
         }
 
         [Fact]
@@ -6155,8 +7808,12 @@ public class C
             edits.VerifyEdits(
                 "Update [a = 1]@22 -> [a = 2]@22");
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.field));
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), preserveLocalVariables: true)
+                });
         }
 
         [Fact]
@@ -6167,8 +7824,12 @@ public class C
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "int a { get; } = 2;", FeaturesResources.auto_property));
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), preserveLocalVariables: true)
+                });
         }
 
         [Fact]
@@ -6837,6 +8498,53 @@ class C : B
         }
 
         [Fact]
+        public void FieldInitializerUpdate_Lambdas_PartialDeclarationDelete_SingleDocument()
+        {
+            var src1 = @"
+partial class C
+{
+    int x = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int y = F(<N:0.1>a => a + 10</N:0.1>);
+}
+
+partial class C
+{
+    public C() { }
+    static int F(Func<int, int> x) => 1;
+}
+";
+
+            var src2 = @"
+partial class C
+{
+    int x = F(<N:0.0>a => a + 1</N:0.0>);
+}
+
+partial class C
+{
+    int y = F(<N:0.1>a => a + 10</N:0.1>);
+
+    static int F(Func<int, int> x) => 1;
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            var syntaxMap = GetSyntaxMap(src1, src2);
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F"), partialType: "C"),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), syntaxMap[0], partialType: "C"),
+                });
+        }
+
+        [Fact]
         public void FieldInitializerUpdate_ActiveStatements1()
         {
             var src1 = @"
@@ -6844,7 +8552,7 @@ using System;
 
 class C
 {
-    <AS:0>int A = <N:0.0>1</N:0.0></AS:0>;
+    <AS:0>int A = <N:0.0>1</N:0.0>;</AS:0>
     int B = 1;
 
     public C(int a) { Console.WriteLine(1); }
@@ -6856,7 +8564,7 @@ using System;
 
 class C
 {
-    <AS:0>int A = <N:0.0>1</N:0.0></AS:0>;
+    <AS:0>int A = <N:0.0>1</N:0.0>;</AS:0>
     int B = 2;
 
     public C(int a) { Console.WriteLine(1); }
@@ -6907,9 +8615,31 @@ partial class C
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty, expectedSemanticEdits: new[]
             {
-                SemanticEdit(SemanticEditKind.Update, c => ((IPropertySymbol)c.GetMember<INamedTypeSymbol>("C").GetMembers("P").Skip(1).First()).GetMethod),
+                SemanticEdit(SemanticEditKind.Update, c => ((IPropertySymbol)c.GetMember<INamedTypeSymbol>("C").GetMembers("P").First()).GetMethod),
                 SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
             });
+        }
+
+        [Fact]
+        public void Field_Partial_DeleteInsert_InitializerRemoval()
+        {
+            var srcA1 = "partial class C { int F = 1; }";
+            var srcB1 = "partial class C { }";
+
+            var srcA2 = "partial class C {  }";
+            var srcB2 = "partial class C { int F; }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
+                });
         }
 
         #endregion
@@ -7234,7 +8964,7 @@ class C
         }
 
         [Fact]
-        public void FieldInsert_ParameterlessConstructorInsert_WithInitializersAndLambdas1()
+        public void FieldInsert_ConstructorReplacingImplicitConstructor_WithInitializersAndLambdas()
         {
             var src1 = @"
 using System;
@@ -7256,7 +8986,7 @@ class C
     int A = F(<N:0.0>a => a + 1</N:0.0>);
     int B = F(b => b + 1);                    // new field
 
-    public C()                                // new ctor
+    public C()                                // new ctor replacing existing implicit constructor
     {
         F(c => c + 1);
     }
@@ -7272,6 +9002,52 @@ class C
                     SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.B")),
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0])
                 });
+        }
+
+        [Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")]
+        public void FieldInsert_ParameterlessConstructorInsert_WithInitializersAndLambdas()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+
+    public C(int x) {}
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    static int F(Func<int, int> x) => 1;
+
+    int A = F(<N:0.0>a => a + 1</N:0.0>);
+
+    public C(int x) {}
+
+    public C()                                // new ctor
+    {
+        F(c => c + 1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "public C()"));
+
+            // TODO (bug https://github.com/dotnet/roslyn/issues/2504):
+            //edits.VerifySemantics(
+            //    ActiveStatementsDescription.Empty,
+            //    new[]
+            //    {
+            //        SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap[0])
+            //    });
         }
 
         [Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")]
@@ -7373,8 +9149,8 @@ class C
                 "Delete [int a = 1]@10",
                 "Delete [a = 1]@14");
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "class C", FeaturesResources.field));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.field, "a")));
         }
 
         [Fact]
@@ -7451,6 +9227,29 @@ class C
                 Diagnostic(RudeEditKind.Move, "event int c = 2", CSharpFeaturesResources.event_field));
         }
 
+        [Fact]
+        public void EventField_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { event int E = 2; }";
+
+            var srcA2 = "partial class C { event int E = 2; }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                        }),
+
+                    DocumentResults(),
+                });
+        }
+
         #endregion
 
         #region Properties
@@ -7469,6 +9268,20 @@ class C
             {
                 SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.get_P"), preserveLocalVariables: false)
             });
+        }
+
+        [Fact, WorkItem(48628, "https://github.com/dotnet/roslyn/issues/48628")]
+        public void PropertyWithExpressionBody_ModifierUpdate()
+        {
+            var src1 = "class C { int P => 1; }";
+            var src2 = "class C { unsafe int P => 1; }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Update [int P => 1;]@10 -> [unsafe int P => 1;]@10");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "unsafe int P", FeaturesResources.property_));
         }
 
         [Fact]
@@ -7545,7 +9358,7 @@ class C
                 "Delete [set { }]@36");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "int P", CSharpFeaturesResources.property_setter));
+                Diagnostic(RudeEditKind.Delete, "int P", DeletedSymbolDisplay(CSharpFeaturesResources.property_setter, "P.set")));
         }
 
         [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
@@ -7597,6 +9410,38 @@ class C
             edits.VerifySemantics(ActiveStatementsDescription.Empty, new[]
             {
                 SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.get_P"), preserveLocalVariables: false),
+            });
+        }
+
+        [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
+        public void Property_SetterBlockBodyToSetterExpressionBody()
+        {
+            var src1 = "class C { int P { set { } } }";
+            var src2 = "class C { int P { set => F(); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Update [set { }]@18 -> [set => F();]@18");
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty, new[]
+            {
+                SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").SetMethod),
+            });
+        }
+
+        [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
+        public void Property_InitBlockBodyToInitExpressionBody()
+        {
+            var src1 = "class C { int P { init { } } }";
+            var src2 = "class C { int P { init => F(); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Update [init { }]@18 -> [init => F();]@18");
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty, new[]
+            {
+                SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").SetMethod, preserveLocalVariables: false),
             });
         }
 
@@ -7705,7 +9550,7 @@ class C
         }
 
         [Fact]
-        public void PropertyAccessorReorder()
+        public void PropertyAccessorReorder_GetSet()
         {
             var src1 = "class C { int P { get { return 1; } set { } } }";
             var src2 = "class C { int P { set { } get { return 1; } } }";
@@ -7714,6 +9559,20 @@ class C
 
             edits.VerifyEdits(
                 "Reorder [set { }]@36 -> @18");
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void PropertyAccessorReorder_GetInit()
+        {
+            var src1 = "class C { int P { get { return 1; } init { } } }";
+            var src2 = "class C { int P { init { } get { return 1; } } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [init { }]@36 -> @18");
 
             edits.VerifyRudeDiagnostics();
         }
@@ -7733,6 +9592,18 @@ class C
                 Diagnostic(RudeEditKind.TypeUpdate, "char P", FeaturesResources.auto_property));
         }
 
+        [Fact]
+        public void PropertyInsert()
+        {
+            var src1 = "class C { }";
+            var src2 = "class C { int P { get => 1; set { } } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemantics(
+                SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").GetMember("P")));
+        }
+
         [WorkItem(835827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/835827")]
         [Fact]
         public void PropertyInsert_PInvoke()
@@ -7750,18 +9621,22 @@ using System.Runtime.InteropServices;
 
 class C
 {
-    private static extern int P { [DllImport(""msvcrt.dll"")]get; }
+    private static extern int P1 { [DllImport(""x.dll"")]get; }
+    private static extern int P2 { [DllImport(""x.dll"")]set; }
+    private static extern int P3 { [DllImport(""x.dll"")]get; [DllImport(""x.dll"")]set; }
 }
 ";
             var edits = GetTopEdits(src1, src2);
 
             // CLR doesn't support methods without a body
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.InsertExtern, "private static extern int P", FeaturesResources.property_));
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertExtern, "private static extern int P1", FeaturesResources.property_),
+                Diagnostic(RudeEditKind.InsertExtern, "private static extern int P2", FeaturesResources.property_),
+                Diagnostic(RudeEditKind.InsertExtern, "private static extern int P3", FeaturesResources.property_));
         }
 
         [Fact]
-        public void Property_InsertIntoStruct()
+        public void PropertyInsert_IntoStruct()
         {
             var src1 = @"
 struct S 
@@ -7862,7 +9737,7 @@ class C
             edits.VerifyEdits("Delete [set { _p = value; }]@44");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "int P", CSharpFeaturesResources.property_setter));
+                Diagnostic(RudeEditKind.Delete, "int P", DeletedSymbolDisplay(CSharpFeaturesResources.property_setter, "P.set")));
         }
 
         [Fact]
@@ -7930,9 +9805,22 @@ class C
             edits.VerifyRudeDiagnostics();
         }
 
+        [Fact]
+        public void PrivateAutoPropertyAccessorAdd_Init()
+        {
+            var src1 = "class C { int P { get; } = 1; }";
+            var src2 = "class C { int P { get; init; } = 1; }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Insert [init;]@23");
+
+            edits.VerifyRudeDiagnostics();
+        }
+
         [WorkItem(755975, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755975")]
         [Fact]
-        public void PrivateAutoPropertyAccessorDelete1()
+        public void PrivateAutoPropertyAccessorDelete_Get()
         {
             var src1 = "class C { int P { get; set; } }";
             var src2 = "class C { int P { set; } }";
@@ -7942,21 +9830,67 @@ class C
             edits.VerifyEdits("Delete [get;]@18");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "int P", CSharpFeaturesResources.property_getter));
+                Diagnostic(RudeEditKind.Delete, "int P", DeletedSymbolDisplay(CSharpFeaturesResources.property_getter, "P.get")));
         }
 
         [Fact]
-        public void PrivateAutoPropertyAccessorDelete2()
+        public void AutoPropertyAccessor_SetToInit()
         {
-            var src1 = "class C { int P { get; set; } = 1; }";
-            var src2 = "class C { int P { set; } = 1; }";
+            var src1 = "class C { int P { get; set; } }";
+            var src2 = "class C { int P { get; init; } }";
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits("Delete [get;]@18");
+            edits.VerifyEdits(
+                "Update [set;]@23 -> [init;]@23");
+
+            // not allowed since it changes the backing field readonly-ness and the signature of the setter (modreq)
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.AccessorKindUpdate, "init", CSharpFeaturesResources.property_setter));
+        }
+
+        [Fact]
+        public void AutoPropertyAccessor_InitToSet()
+        {
+            var src1 = "class C { int P { get; init; } }";
+            var src2 = "class C { int P { get; set; } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [init;]@23 -> [set;]@23");
+
+            // not allowed since it changes the backing field readonly-ness and the signature of the setter (modreq)
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.AccessorKindUpdate, "set", CSharpFeaturesResources.property_setter));
+        }
+
+        [Fact]
+        public void PrivateAutoPropertyAccessorDelete_Set()
+        {
+            var src1 = "class C { int P { get; set; } = 1; }";
+            var src2 = "class C { int P { get; } = 1; }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Delete [set;]@23");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "int P", CSharpFeaturesResources.property_getter));
+                Diagnostic(RudeEditKind.Delete, "int P", DeletedSymbolDisplay(CSharpFeaturesResources.property_setter, "P.set")));
+        }
+
+        [Fact]
+        public void PrivateAutoPropertyAccessorDelete_Init()
+        {
+            var src1 = "class C { int P { get; init; } = 1; }";
+            var src2 = "class C { int P { get; } = 1; }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Delete [init;]@23");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "int P", DeletedSymbolDisplay(CSharpFeaturesResources.property_setter, "P.init")));
         }
 
         [Fact]
@@ -7991,13 +9925,14 @@ class C
         public void Property_ReadOnlyRef_Insert()
         {
             var src1 = "class Test { }";
-            var src2 = "class Test { ref readonly int M() { get; } }";
+            var src2 = "class Test { ref readonly int P { get; } }";
 
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Insert [ref readonly int M() { get; }]@13",
-                "Insert [()]@31");
+                "Insert [ref readonly int P { get; }]@13",
+                "Insert [{ get; }]@32",
+                "Insert [get;]@34");
 
             edits.VerifyRudeDiagnostics();
         }
@@ -8005,16 +9940,122 @@ class C
         [Fact]
         public void Property_ReadOnlyRef_Update()
         {
-            var src1 = "class Test { int M() { get; } }";
-            var src2 = "class Test { ref readonly int M() { get; } }";
+            var src1 = "class Test { int P { get; } }";
+            var src2 = "class Test { ref readonly int P { get; } }";
 
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
-                "Update [int M() { get; }]@13 -> [ref readonly int M() { get; }]@13");
+                "Update [int P { get; }]@13 -> [ref readonly int P { get; }]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int M()", FeaturesResources.method));
+                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int P", FeaturesResources.auto_property));
+        }
+
+        [Fact]
+        public void Property_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int P { get => 1; set { } } }";
+
+            var srcA2 = "partial class C { int P { get => 1; set { } } }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").GetMethod),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").SetMethod)
+                        }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void PropertyInit_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int Q { get => 1; init { } }}";
+
+            var srcA2 = "partial class C { int Q { get => 1; init { } }}";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("Q").GetMethod),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("Q").SetMethod)
+                        }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void AutoProperty_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int P { get; set; } int Q { get; init; } }";
+
+            var srcA2 = "partial class C { int P { get; set; } int Q { get; init; } }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void AutoPropertyWithInitializer_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int P { get; set; } = 1; }";
+
+            var srcA2 = "partial class C { int P { get; set; } = 1; }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true) }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void PropertyWithExpressionBody_Partial_InsertDeleteUpdate()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int P => 1; }";
+
+            var srcA2 = "partial class C { int P => 2; }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("P").GetMethod) }),
+
+                    DocumentResults(),
+                });
         }
 
         #endregion
@@ -8056,6 +10097,23 @@ class C
         }
 
         [Fact]
+        public void Indexer_InitUpdate()
+        {
+            var src1 = "class C { int this[int a] { get { return 1; } init { System.Console.WriteLine(value); } } }";
+            var src2 = "class C { int this[int a] { get { return 1; } init { System.Console.WriteLine(value + 1); } } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [init { System.Console.WriteLine(value); }]@46 -> [init { System.Console.WriteLine(value + 1); }]@46");
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty, new[]
+            {
+                SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.set_Item"), preserveLocalVariables: false)
+            });
+        }
+
+        [Fact]
         public void IndexerWithExpressionBody_Update()
         {
             var src1 = "class C { int this[int a] => 1; }";
@@ -8070,6 +10128,37 @@ class C
             {
                 SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.get_Item"), preserveLocalVariables: false)
             });
+        }
+
+        [Fact, WorkItem(51297, "https://github.com/dotnet/roslyn/issues/51297")]
+        public void IndexerWithExpressionBody_Update_LiftedParameter()
+        {
+            // TODO: https://github.com/dotnet/roslyn/issues/51297
+            // The test fails if "+ 10" and "+ 11" are removed. 
+
+            var src1 = @"
+using System;
+
+class C
+{
+    int this[int a] => new Func<int>(() => a + 1)() + 10;
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    int this[int a] => new Func<int>(() => 2)() + 11;   // not capturing a anymore
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [int this[int a] => new Func<int>(() => a + 1)() + 10;]@35 -> [int this[int a] => new Func<int>(() => 2)() + 11;]@35");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.NotCapturingVariable, "a", "a"));
         }
 
         [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
@@ -8191,6 +10280,40 @@ class C
         }
 
         [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
+        public void Indexer_SetterBlockBodyToSetterExpressionBody()
+        {
+            var src1 = "class C { int this[int a] { set { } } void F() { } }";
+            var src2 = "class C { int this[int a] { set => F(); } void F() { } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Update [set { }]@28 -> [set => F();]@28");
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty, new[]
+            {
+                SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.set_Item")),
+                SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F")),
+            });
+        }
+
+        [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
+        public void Indexer_InitBlockBodyToInitExpressionBody()
+        {
+            var src1 = "class C { int this[int a] { init { } } void F() { } }";
+            var src2 = "class C { int this[int a] { init => F(); } void F() { } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Update [init { }]@28 -> [init => F();]@28");
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty, new[]
+            {
+                SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.set_Item")),
+                SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F")),
+            });
+        }
+
+        [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
         public void Indexer_GetterExpressionBodyToGetterBlockBody()
         {
             var src1 = "class C { int this[int a] { get => 1; set { Console.WriteLine(0); } } }";
@@ -8221,7 +10344,7 @@ class C
                 "Delete [set { Console.WriteLine(0); }]@46");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "int this[int a]", CSharpFeaturesResources.indexer_setter));
+                Diagnostic(RudeEditKind.Delete, "int this[int a]", DeletedSymbolDisplay(CSharpFeaturesResources.indexer_setter, "this[int].set")));
         }
 
         [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
@@ -8416,54 +10539,50 @@ class SampleCollection<T>
 
             edits.VerifyEdits("Insert [get { return arr[i]; }]@304");
 
-            edits.VerifyRudeDiagnostics();
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "get", CSharpFeaturesResources.indexer_getter));
         }
 
         [Fact]
         public void Indexer_AddSetAccessor()
         {
             var src1 = @"
-class Test
+class C
 {
-    static void Main(string[] args)
-    {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        System.Console.Write(stringCollection[0]);
-    }
-}
-
-class SampleCollection<T>
-{
-    private T[] arr = new T[100];
-    public T this[int i]
-    {
-        get { return arr[i]; }
-    }
+    public int this[int i] { get { return default; } }
 }";
             var src2 = @"
-class Test
+class C
 {
-    static void Main(string[] args)
-    {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        System.Console.Write(stringCollection[0]);
-    }
-}
-
-class SampleCollection<T>
-{
-    private T[] arr = new T[100];
-    public T this[int i]
-    {
-        get { return arr[i]; }
-        set { arr[i] = value; }
-    }
+    public int this[int i] { get { return default; } set { } }
 }";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits("Insert [set { arr[i] = value; }]@348");
+            edits.VerifyEdits("Insert [set { }]@67");
 
-            edits.VerifyRudeDiagnostics();
+            edits.VerifySemantics(
+                SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("this[]").SetMethod));
+        }
+
+        [Fact]
+        public void Indexer_AddSetAccessor_GenericType()
+        {
+            var src1 = @"
+class C<T>
+{
+    public T this[int i] { get { return default; } }
+}";
+            var src2 = @"
+class C<T>
+{
+    public T this[int i] { get { return default; } set { } }
+}";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Insert [set { }]@68");
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "set", CSharpFeaturesResources.indexer_setter));
         }
 
         [WorkItem(750109, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/750109")]
@@ -8471,18 +10590,8 @@ class SampleCollection<T>
         public void Indexer_DeleteGetAccessor()
         {
             var src1 = @"
-class Test
+class C<T>
 {
-    static void Main(string[] args)
-    {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-    }
-}
-
-class SampleCollection<T>
-{
-    private T[] arr = new T[100];
     public T this[int i]
     {
         get { return arr[i]; }
@@ -8490,18 +10599,8 @@ class SampleCollection<T>
     }
 }";
             var src2 = @"
-class Test
+class C<T>
 {
-    static void Main(string[] args)
-    {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-    }
-}
-
-class SampleCollection<T>
-{
-    private T[] arr = new T[100];
     public T this[int i]
     {
         set { arr[i] = value; }
@@ -8509,58 +10608,31 @@ class SampleCollection<T>
 }";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits("Delete [get { return arr[i]; }]@304");
+            edits.VerifyEdits("Delete [get { return arr[i]; }]@58");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "public T this[int i]", CSharpFeaturesResources.indexer_getter));
+                Diagnostic(RudeEditKind.Delete, "public T this[int i]", DeletedSymbolDisplay(CSharpFeaturesResources.indexer_getter, "this[int].get")));
         }
 
         [Fact]
         public void Indexer_DeleteSetAccessor()
         {
             var src1 = @"
-class Test
+class C
 {
-    static void Main(string[] args)
-    {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-    }
-}
-
-class SampleCollection<T>
-{
-    private T[] arr = new T[100];
-    public T this[int i]
-    {
-        get { return arr[i]; }
-        set { arr[i] = value; }
-    }
+    public int this[int i] { get { return 0; } set { } }
 }";
             var src2 = @"
-class Test
+class C
 {
-    static void Main(string[] args)
-    {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-    }
-}
-
-class SampleCollection<T>
-{
-    private T[] arr = new T[100];
-    public T this[int i]
-    {
-        get { return arr[i]; }
-    }
+    public int this[int i] { get { return 0; } }
 }";
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifyEdits("Delete [set { arr[i] = value; }]@336");
+            edits.VerifyEdits("Delete [set { }]@61");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "public T this[int i]", CSharpFeaturesResources.indexer_setter));
+                Diagnostic(RudeEditKind.Delete, "public int this[int i]", DeletedSymbolDisplay(CSharpFeaturesResources.indexer_setter, "this[int].set")));
         }
 
         [Fact, WorkItem(1174850, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1174850")]
@@ -8678,6 +10750,107 @@ class SampleCollection<T>
                 Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int this[int i]", FeaturesResources.indexer_));
         }
 
+        [Fact]
+        public void Indexer_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int this[int x] { get => 1; set { } } }";
+
+            var srcA2 = "partial class C { int this[int x] { get => 1; set { } } }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("this[]").GetMethod),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("this[]").SetMethod)
+                        }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void IndexerInit_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int this[int x] { get => 1; init { } }}";
+
+            var srcA2 = "partial class C { int this[int x] { get => 1; init { } }}";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("this[]").GetMethod),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IPropertySymbol>("this[]").SetMethod)
+                        }),
+
+                    DocumentResults(),
+                });
+        }
+
+        [Fact]
+        public void AutoIndexer_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { int this[int x] { get; set; } int Q { get; init; } }";
+
+            var srcA2 = "partial class C { int this[int x] { get; set; } int Q { get; init; } }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                });
+        }
+
+        [Fact, WorkItem(51297, "https://github.com/dotnet/roslyn/issues/51297")]
+        public void IndexerWithExpressionBody_Partial_InsertDeleteUpdate_LiftedParameter()
+        {
+            // TODO: https://github.com/dotnet/roslyn/issues/51297
+            // The test fails if "+ 10" and "+ 11" are removed. 
+
+            var srcA1 = @"
+partial class C
+{
+}";
+            var srcB1 = @"
+partial class C
+{
+    int this[int a] => new System.Func<int>(() => a + 1) + 10;
+}";
+
+            var srcA2 = @"
+partial class C
+{
+    int this[int a] => new System.Func<int>(() => 2) + 11; // no capture
+}";
+            var srcB2 = @"
+partial class C
+{
+}";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(diagnostics: new[] { Diagnostic(RudeEditKind.NotCapturingVariable, "a", "a") }),
+                    DocumentResults(),
+                });
+        }
+
         #endregion
 
         #region Events
@@ -8723,6 +10896,30 @@ class SampleCollection<T>
                 "Reorder [event int E2 { add { } remove { } }]@49 -> @10",
                 "Reorder [remove { }]@72 -> @25",
                 "Reorder [remove { }]@33 -> @64");
+        }
+
+        [Fact]
+        public void EventInsert()
+        {
+            var src1 = "class C { }";
+            var src2 = "class C { event int E { remove { } add { } } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemantics(
+                SemanticEdit(SemanticEditKind.Insert, c => c.GetMember<INamedTypeSymbol>("C").GetMember("E")));
+        }
+
+        [Fact]
+        public void EventDelete()
+        {
+            var src1 = "class C { event int E { remove { } add { } } }";
+            var src2 = "class C { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.event_, "E")));
         }
 
         [Fact]
@@ -8805,6 +11002,30 @@ public class C
                 );
 
             edits.VerifySemanticDiagnostics();
+        }
+
+        [Fact]
+        public void Event_Partial_InsertDelete()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { event int E { add { } remove { } } }";
+
+            var srcA2 = "partial class C { event int E { add { } remove { } } }";
+            var srcB2 = "partial class C { }";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E").AddMethod),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E").RemoveMethod)
+                        }),
+
+                    DocumentResults(),
+                });
         }
 
         #endregion

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -28,8 +28,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             {
                 RudeEditKind.ActiveStatementUpdate,
                 RudeEditKind.PartiallyExecutedActiveStatementUpdate,
-                RudeEditKind.PartiallyExecutedActiveStatementDelete,
-                RudeEditKind.DeleteActiveStatement,
                 RudeEditKind.UpdateExceptionHandlerOfActiveTry,
                 RudeEditKind.UpdateTryOrCatchWithActiveFinally,
                 RudeEditKind.UpdateCatchHandlerAroundActiveStatement,
@@ -39,7 +37,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 RudeEditKind.MethodKindUpdate,
                 RudeEditKind.DeclareLibraryUpdate,
                 RudeEditKind.DeclareAliasUpdate,
-                RudeEditKind.ChangingConstructorVisibility,
                 RudeEditKind.InsertDllImport,
                 RudeEditKind.MethodBodyAdd,
                 RudeEditKind.MethodBodyDelete,

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/DocumentAnalysisResultsDescription.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/DocumentAnalysisResultsDescription.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
+{
+    internal readonly struct DocumentAnalysisResultsDescription
+    {
+        public readonly ActiveStatementsDescription ActiveStatements;
+
+        /// <summary>
+        /// Default if semantic edits are not validated by the test.
+        /// </summary>
+        public readonly ImmutableArray<SemanticEditDescription> SemanticEdits;
+
+        public readonly ImmutableArray<RudeEditDiagnosticDescription> Diagnostics;
+
+        public DocumentAnalysisResultsDescription(
+            ActiveStatementsDescription? activeStatements = null,
+            SemanticEditDescription[]? semanticEdits = null,
+            RudeEditDiagnosticDescription[]? diagnostics = null)
+        {
+            // The test must validate semantic edits, diagnostics or both.
+            // If neither is specified then assume the expectation is that
+            // the documents has no edits and no diagnostics.
+            if (semanticEdits is null && diagnostics is null)
+            {
+                SemanticEdits = ImmutableArray<SemanticEditDescription>.Empty;
+                Diagnostics = ImmutableArray<RudeEditDiagnosticDescription>.Empty;
+            }
+            else
+            {
+                SemanticEdits = semanticEdits.AsImmutableOrNull();
+                Diagnostics = diagnostics.AsImmutableOrEmpty();
+            }
+
+            ActiveStatements = activeStatements ?? ActiveStatementsDescription.Empty;
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -5,10 +5,16 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -26,8 +32,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public abstract AbstractEditAndContinueAnalyzer Analyzer { get; }
         public abstract SyntaxNode FindNode(SyntaxNode root, TextSpan span);
         public abstract SyntaxTree ParseText(string source);
-        public abstract Compilation CreateLibraryCompilation(string name, IEnumerable<SyntaxTree> trees);
         public abstract ImmutableArray<SyntaxNode> GetDeclarators(ISymbol method);
+        public abstract string LanguageName { get; }
+        public abstract TreeComparer<SyntaxNode> TopSyntaxComparer { get; }
 
         internal void VerifyUnchangedDocument(
             string source,
@@ -57,92 +64,46 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 actualNewExceptionRegions);
 
             // check active statements:
-            AssertSpansEqual(expectedNewActiveStatements, actualNewActiveStatements.Select(s => s.Span), source, text);
+            AssertSpansEqual(expectedNewActiveStatements, actualNewActiveStatements.Select(s => s.Span), text);
 
             // check new exception regions:
             Assert.Equal(expectedNewExceptionRegions.Length, actualNewExceptionRegions.Count);
             for (var i = 0; i < expectedNewExceptionRegions.Length; i++)
             {
-                AssertSpansEqual(expectedNewExceptionRegions[i], actualNewExceptionRegions[i], source, text);
+                AssertSpansEqual(expectedNewExceptionRegions[i], actualNewExceptionRegions[i], text);
             }
         }
 
-        internal void VerifyRudeDiagnostics(
-            EditScript<SyntaxNode> editScript,
+        private void VerifyActiveStatementsAndExceptionRegions(
             ActiveStatementsDescription description,
-            RudeEditDiagnosticDescription[] expectedDiagnostics)
+            IReadOnlyList<ActiveStatement> oldActiveStatements,
+            SourceText oldText,
+            SourceText newText,
+            SyntaxNode oldRoot,
+            IReadOnlyList<ActiveStatement> actualNewActiveStatements,
+            IReadOnlyList<ImmutableArray<LinePositionSpan>> actualNewExceptionRegions)
         {
-            var oldActiveStatements = description.OldStatements;
-
-            if (description.OldTrackingSpans != null)
-            {
-                Assert.Equal(oldActiveStatements.Length, description.OldTrackingSpans.Length);
-            }
-
-            var newSource = editScript.Match.NewRoot.SyntaxTree.ToString();
-            var oldSource = editScript.Match.OldRoot.SyntaxTree.ToString();
-
-            var oldText = SourceText.From(oldSource);
-            var newText = SourceText.From(newSource);
-
-            var diagnostics = new ArrayBuilder<RudeEditDiagnostic>();
-            var updatedActiveMethodMatches = new ArrayBuilder<UpdatedMemberInfo>();
-            var actualNewActiveStatements = ImmutableArray.CreateBuilder<ActiveStatement>(oldActiveStatements.Length);
-            actualNewActiveStatements.Count = actualNewActiveStatements.Capacity;
-            var actualNewExceptionRegions = ImmutableArray.CreateBuilder<ImmutableArray<LinePositionSpan>>(oldActiveStatements.Length);
-            actualNewExceptionRegions.Count = actualNewExceptionRegions.Capacity;
-            var editMap = BuildEditMap(editScript);
-
-            var documentId = DocumentId.CreateNewId(ProjectId.CreateNewId("TestEnCProject"), "TestEnCDocument");
-            var testAccessor = Analyzer.GetTestAccessor();
-
-            testAccessor.AnalyzeMemberBodiesSyntax(
-                editScript,
-                editMap,
-                oldText,
-                newText,
-                oldActiveStatements.AsImmutable(),
-                description.OldTrackingSpans.ToImmutableArrayOrEmpty(),
-                actualNewActiveStatements,
-                actualNewExceptionRegions,
-                updatedActiveMethodMatches,
-                diagnostics);
-
-            testAccessor.ReportTopLevelSynctactiveRudeEdits(diagnostics, editScript, editMap);
-
-            diagnostics.Verify(newSource, expectedDiagnostics);
-
             // check active statements:
-            AssertSpansEqual(description.NewSpans, actualNewActiveStatements.Select(s => s.Span), newSource, newText);
+            AssertSpansEqual(description.NewSpans, actualNewActiveStatements.Select(s => s.Span), newText);
 
-            if (diagnostics.Count == 0)
+            // check old exception regions:
+            for (var i = 0; i < oldActiveStatements.Count; i++)
             {
-                // check old exception regions:
-                for (var i = 0; i < oldActiveStatements.Length; i++)
-                {
-                    var actualOldExceptionRegions = Analyzer.GetExceptionRegions(
-                        oldText,
-                        editScript.Match.OldRoot,
-                        oldActiveStatements[i].Span,
-                        isNonLeaf: oldActiveStatements[i].IsNonLeaf,
-                        out _);
+                var oldRegions = Analyzer.GetExceptionRegions(
+                    oldText,
+                    oldRoot,
+                    oldActiveStatements[i].Span,
+                    isNonLeaf: oldActiveStatements[i].IsNonLeaf,
+                    out _);
 
-                    AssertSpansEqual(description.OldRegions[i], actualOldExceptionRegions, oldSource, oldText);
-                }
-
-                // check new exception regions:
-                Assert.Equal(description.NewRegions.Length, actualNewExceptionRegions.Count);
-                for (var i = 0; i < description.NewRegions.Length; i++)
-                {
-                    AssertSpansEqual(description.NewRegions[i], actualNewExceptionRegions[i], newSource, newText);
-                }
+                AssertSpansEqual(description.OldRegions[i], oldRegions, oldText);
             }
-            else
+
+            // check new exception regions:
+            Assert.Equal(description.NewRegions.Length, actualNewExceptionRegions.Count);
+            for (var i = 0; i < description.NewRegions.Length; i++)
             {
-                for (var i = 0; i < oldActiveStatements.Length; i++)
-                {
-                    Assert.Equal(0, description.NewRegions[i].Length);
-                }
+                AssertSpansEqual(description.NewRegions[i], actualNewExceptionRegions[i], newText);
             }
         }
 
@@ -174,7 +135,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 diagnostics,
                 default);
 
-            diagnostics.Verify(newSource, expectedDiagnostics);
+            VerifyDiagnostics(expectedDiagnostics, diagnostics, newText);
 
             AssertEx.Equal(expectedLineEdits, actualLineEdits, itemSeparator: ",\r\n");
 
@@ -182,102 +143,97 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             AssertEx.Equal(expectedNodeUpdates, actualNodeUpdates, itemSeparator: ",\r\n");
         }
 
-        internal void VerifySemantics(
-            IEnumerable<EditScript<SyntaxNode>> editScripts,
-            ActiveStatementsDescription? activeStatements = null,
-            SemanticEditDescription[]? expectedSemanticEdits = null,
-            RudeEditDiagnosticDescription[]? expectedDiagnostics = null)
+        internal void VerifySemantics(EditScript<SyntaxNode>[] editScripts, TargetFramework targetFramework, DocumentAnalysisResultsDescription[] expectedResults)
         {
-            activeStatements ??= ActiveStatementsDescription.Empty;
+            Assert.True(editScripts.Length == expectedResults.Length);
+            var documentCount = expectedResults.Length;
 
-            var oldTrees = editScripts.Select(editScript => editScript.Match.OldRoot.SyntaxTree).ToArray();
-            var newTrees = editScripts.Select(editScript => editScript.Match.NewRoot.SyntaxTree).ToArray();
+            using var workspace = new AdhocWorkspace(FeaturesTestCompositions.Features.GetHostServices());
+            CreateProjects(editScripts, workspace, targetFramework, out var oldProject, out var newProject);
 
-            var oldCompilation = CreateLibraryCompilation("Old", oldTrees);
-            var newCompilation = CreateLibraryCompilation("New", newTrees);
+            var oldDocuments = oldProject.Documents.ToArray();
+            var newDocuments = newProject.Documents.ToArray();
 
-            var oldActiveStatements = activeStatements.OldStatements.AsImmutable();
-            var triviaEdits = new ArrayBuilder<(SyntaxNode OldNode, SyntaxNode NewNode)>();
-            var actualLineEdits = new ArrayBuilder<SourceLineUpdate>();
-            var actualSemanticEdits = new ArrayBuilder<SemanticEdit>();
-            var includeFirstLineInDiagnostics = expectedDiagnostics?.Any(d => d.FirstLine != null) == true;
-            var actualDiagnosticDescriptions = new ArrayBuilder<RudeEditDiagnosticDescription>();
-            var actualDeclarationErrors = new ArrayBuilder<Diagnostic>();
+            Debug.Assert(oldDocuments.Length == newDocuments.Length);
 
-            var actualNewActiveStatements = ImmutableArray.CreateBuilder<ActiveStatement>(activeStatements.OldStatements.Length);
-            actualNewActiveStatements.Count = actualNewActiveStatements.Capacity;
-
-            var actualNewExceptionRegions = ImmutableArray.CreateBuilder<ImmutableArray<LinePositionSpan>>(activeStatements.OldStatements.Length);
-            actualNewExceptionRegions.Count = actualNewExceptionRegions.Capacity;
+            var oldTrees = oldDocuments.Select(d => d.GetSyntaxTreeSynchronously(default)!).ToArray();
+            var newTrees = newDocuments.Select(d => d.GetSyntaxTreeSynchronously(default)!).ToArray();
 
             var testAccessor = Analyzer.GetTestAccessor();
 
-            foreach (var editScript in editScripts)
+            for (var documentIndex = 0; documentIndex < documentCount; documentIndex++)
             {
-                var oldRoot = editScript.Match.OldRoot;
-                var newRoot = editScript.Match.NewRoot;
-                var oldSource = oldRoot.SyntaxTree.ToString();
-                var newSource = newRoot.SyntaxTree.ToString();
+                var expectedResult = expectedResults[documentIndex];
 
-                var editMap = BuildEditMap(editScript);
-                var oldText = SourceText.From(oldSource);
-                var newText = SourceText.From(newSource);
-                var oldModel = oldCompilation.GetSemanticModel(oldRoot.SyntaxTree);
-                var newModel = newCompilation.GetSemanticModel(newRoot.SyntaxTree);
+                var oldActiveStatements = expectedResult.ActiveStatements.OldStatements.ToImmutableArray();
 
-                var diagnostics = new ArrayBuilder<RudeEditDiagnostic>();
-                var updatedActiveMethodMatches = new ArrayBuilder<UpdatedMemberInfo>();
+                var includeFirstLineInDiagnostics = expectedResult.Diagnostics.Any(d => d.FirstLine != null) == true;
+                var newActiveStatementSpans = expectedResult.ActiveStatements.OldTrackingSpans.ToImmutableArrayOrEmpty();
 
-                testAccessor.AnalyzeMemberBodiesSyntax(
-                    editScript,
-                    editMap,
-                    oldText,
-                    newText,
-                    oldActiveStatements,
-                    activeStatements.OldTrackingSpans.ToImmutableArrayOrEmpty(),
-                    actualNewActiveStatements,
-                    actualNewExceptionRegions,
-                    updatedActiveMethodMatches,
-                    diagnostics);
+                // we need to rebuild the edit script, so that it operates on nodes associated with the same syntax trees backing the documents:
+                var oldTree = oldTrees[documentIndex];
+                var newTree = newTrees[documentIndex];
+                var oldRoot = oldTree.GetRoot();
+                var newRoot = newTree.GetRoot();
 
-                testAccessor.ReportTopLevelSynctactiveRudeEdits(diagnostics, editScript, editMap);
+                var oldDocument = oldDocuments[documentIndex];
+                var newDocument = newDocuments[documentIndex];
 
-                testAccessor.AnalyzeTrivia(
-                    oldText,
-                    newText,
-                    editScript.Match,
-                    editMap,
-                    triviaEdits,
-                    actualLineEdits,
-                    diagnostics,
-                    CancellationToken.None);
+                var oldModel = oldDocument.GetSemanticModelAsync().Result;
+                var newModel = newDocument.GetSemanticModelAsync().Result;
+                Contract.ThrowIfNull(oldModel);
+                Contract.ThrowIfNull(newModel);
 
-                testAccessor.AnalyzeSemantics(
-                    editScript,
-                    editMap,
-                    oldText,
-                    oldActiveStatements,
-                    triviaEdits,
-                    updatedActiveMethodMatches,
-                    oldModel,
-                    newModel,
-                    actualSemanticEdits,
-                    diagnostics,
-                    CancellationToken.None);
+                var result = Analyzer.AnalyzeDocumentAsync(oldProject, oldActiveStatements, newDocument, newActiveStatementSpans, CancellationToken.None).Result;
 
-                actualDiagnosticDescriptions.AddRange(diagnostics.ToDescription(newSource, includeFirstLineInDiagnostics));
+                var oldText = oldDocument.GetTextSynchronously(default);
+                var newText = newDocument.GetTextSynchronously(default);
+
+                VerifyDiagnostics(expectedResult.Diagnostics, result.RudeEditErrors.ToDescription(newText, includeFirstLineInDiagnostics));
+
+                if (!expectedResult.SemanticEdits.IsDefault)
+                {
+                    VerifySemanticEdits(expectedResult.SemanticEdits, result.SemanticEdits, oldModel.Compilation, newModel.Compilation, oldRoot, newRoot);
+                }
+
+                if (expectedResult.Diagnostics.IsEmpty)
+                {
+                    VerifyActiveStatementsAndExceptionRegions(
+                        expectedResult.ActiveStatements,
+                        oldActiveStatements,
+                        oldText,
+                        newText,
+                        oldRoot,
+                        result.ActiveStatements,
+                        result.ExceptionRegions);
+                }
+                else
+                {
+                    Assert.True(result.ExceptionRegions.IsDefault);
+                }
             }
+        }
 
-            actualDiagnosticDescriptions.Verify(expectedDiagnostics);
+        public static void VerifyDiagnostics(IEnumerable<RudeEditDiagnosticDescription> expected, IEnumerable<RudeEditDiagnostic> actual, SourceText newSource)
+            => VerifyDiagnostics(expected, actual.ToDescription(newSource, expected.Any(d => d.FirstLine != null)));
 
-            if (expectedSemanticEdits == null)
-            {
-                return;
-            }
+        public static void VerifyDiagnostics(IEnumerable<RudeEditDiagnosticDescription> expected, IEnumerable<RudeEditDiagnosticDescription> actual)
+            => AssertEx.SetEqual(expected, actual, itemSeparator: ",\r\n");
 
-            Assert.Equal(expectedSemanticEdits.Length, actualSemanticEdits.Count);
+        private void VerifySemanticEdits(
+            ImmutableArray<SemanticEditDescription> expectedSemanticEdits,
+            ImmutableArray<SemanticEditInfo> actualSemanticEdits,
+            Compilation oldCompilation,
+            Compilation newCompilation,
+            SyntaxNode oldRoot,
+            SyntaxNode newRoot)
+        {
+            // string comparison to simplify understanding why a test failed:
+            AssertEx.Equal(
+                expectedSemanticEdits.Select(e => $"{e.Kind}: {e.SymbolProvider(newCompilation)}"),
+                actualSemanticEdits.NullToEmpty().Select(e => $"{e.Kind}: {e.Symbol.Resolve(newCompilation).Symbol}"));
 
-            for (var i = 0; i < actualSemanticEdits.Count; i++)
+            for (var i = 0; i < actualSemanticEdits.Length; i++)
             {
                 var editKind = expectedSemanticEdits[i].Kind;
 
@@ -285,24 +241,32 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
                 var expectedOldSymbol = (editKind == SemanticEditKind.Update) ? expectedSemanticEdits[i].SymbolProvider(oldCompilation) : null;
                 var expectedNewSymbol = expectedSemanticEdits[i].SymbolProvider(newCompilation);
-                var actualOldSymbol = actualSemanticEdits[i].OldSymbol;
-                var actualNewSymbol = actualSemanticEdits[i].NewSymbol;
+                var symbolKey = actualSemanticEdits[i].Symbol;
 
-                Assert.Equal(expectedOldSymbol, actualOldSymbol);
-                Assert.Equal(expectedNewSymbol, actualNewSymbol);
+                if (editKind == SemanticEditKind.Update)
+                {
+                    Assert.Equal(expectedOldSymbol, symbolKey.Resolve(oldCompilation, ignoreAssemblyKey: true).Symbol);
+                    Assert.Equal(expectedNewSymbol, symbolKey.Resolve(newCompilation, ignoreAssemblyKey: true).Symbol);
+                }
+                else if (editKind == SemanticEditKind.Insert)
+                {
+                    Assert.Equal(expectedNewSymbol, symbolKey.Resolve(newCompilation, ignoreAssemblyKey: true).Symbol);
+                }
+                else
+                {
+                    Assert.False(true, "Only Update or Insert allowed");
+                }
 
-                var expectedSyntaxMap = expectedSemanticEdits[i].SyntaxMap;
-                var syntaxTreeOrdinal = expectedSemanticEdits[i].SyntaxTreeOrdinal;
-                var oldRoot = oldTrees[syntaxTreeOrdinal].GetRoot();
-                var newRoot = newTrees[syntaxTreeOrdinal].GetRoot();
+                // Edit is expected to have a syntax map:
                 var actualSyntaxMap = actualSemanticEdits[i].SyntaxMap;
+                Assert.Equal(expectedSemanticEdits[i].HasSyntaxMap, actualSyntaxMap != null);
 
-                Assert.Equal(expectedSemanticEdits[i].PreserveLocalVariables, actualSemanticEdits[i].PreserveLocalVariables);
+                // If expected map is specified validate its mappings with the actual one:
+                var expectedSyntaxMap = expectedSemanticEdits[i].SyntaxMap;
 
                 if (expectedSyntaxMap != null)
                 {
                     Contract.ThrowIfNull(actualSyntaxMap);
-                    Assert.True(expectedSemanticEdits[i].PreserveLocalVariables);
 
                     foreach (var expectedSpanMapping in expectedSyntaxMap)
                     {
@@ -313,24 +277,41 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                         Assert.Equal(expectedOldNode, actualOldNode);
                     }
                 }
-                else if (!expectedSemanticEdits[i].PreserveLocalVariables)
-                {
-                    Assert.Null(actualSyntaxMap);
-                }
             }
         }
 
-        private static void AssertSpansEqual(IEnumerable<TextSpan> expected, IEnumerable<LinePositionSpan> actual, string newSource, SourceText newText)
+        private void CreateProjects(EditScript<SyntaxNode>[] editScripts, AdhocWorkspace workspace, TargetFramework targetFramework, out Project oldProject, out Project newProject)
+        {
+            oldProject = workspace.AddProject("project", LanguageName).WithMetadataReferences(TargetFrameworkUtil.GetReferences(targetFramework));
+            var documentIndex = 0;
+            foreach (var editScript in editScripts)
+            {
+                oldProject = oldProject.AddDocument(documentIndex.ToString(), editScript.Match.OldRoot).Project;
+                documentIndex++;
+            }
+
+            var newSolution = oldProject.Solution;
+            documentIndex = 0;
+            foreach (var oldDocument in oldProject.Documents)
+            {
+                newSolution = newSolution.WithDocumentSyntaxRoot(oldDocument.Id, editScripts[documentIndex].Match.NewRoot, PreservationMode.PreserveIdentity);
+                documentIndex++;
+            }
+
+            newProject = newSolution.Projects.Single();
+        }
+
+        private static void AssertSpansEqual(IEnumerable<TextSpan> expected, IEnumerable<LinePositionSpan> actual, SourceText newText)
         {
             AssertEx.Equal(
                 expected,
                 actual.Select(span => newText.Lines.GetTextSpan(span)),
                 itemSeparator: "\r\n",
-                itemInspector: s => DisplaySpan(newSource, s));
+                itemInspector: s => DisplaySpan(newText, s));
         }
 
-        private static string DisplaySpan(string source, TextSpan span)
-            => span + ": [" + source.Substring(span.Start, span.Length).Replace("\r\n", " ") + "]";
+        private static string DisplaySpan(SourceText source, TextSpan span)
+            => span + ": [" + source.GetSubText(span).ToString().Replace("\r\n", " ") + "]";
 
         internal static IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>> GetMethodMatches(AbstractEditAndContinueAnalyzer analyzer, Match<SyntaxNode> bodyMatch)
         {

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/Extensions.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/Extensions.cs
@@ -7,38 +7,23 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
     internal static class Extensions
     {
-        public static void Verify(this IEnumerable<RudeEditDiagnostic> diagnostics, string newSource, params RudeEditDiagnosticDescription[] expectedDiagnostics)
-            => diagnostics.ToDescription(newSource, expectedDiagnostics.Any(d => d.FirstLine != null)).Verify(expectedDiagnostics);
-
-        public static void Verify(this IEnumerable<RudeEditDiagnosticDescription> diagnostics, params RudeEditDiagnosticDescription[] expectedDiagnostics)
-        {
-            expectedDiagnostics ??= Array.Empty<RudeEditDiagnosticDescription>();
-            AssertEx.SetEqual(expectedDiagnostics, diagnostics, itemSeparator: ",\r\n");
-        }
-
-        public static IEnumerable<RudeEditDiagnosticDescription> ToDescription(this IEnumerable<RudeEditDiagnostic> diagnostics, string newSource, bool includeFirstLines)
+        public static IEnumerable<RudeEditDiagnosticDescription> ToDescription(this IEnumerable<RudeEditDiagnostic> diagnostics, SourceText newSource, bool includeFirstLines)
         {
             return diagnostics.Select(d => new RudeEditDiagnosticDescription(
                 d.Kind,
-                d.Span == default ? null : newSource.Substring(d.Span.Start, d.Span.Length),
+                d.Span == default ? null : newSource.ToString(d.Span),
                 d.Arguments,
-                firstLine: includeFirstLines ? GetLineAt(newSource, d.Span.Start) : null));
+                firstLine: includeFirstLines ? newSource.Lines.GetLineFromPosition(d.Span.Start).ToString().Trim() : null));
         }
 
         private const string LineSeparator = "\r\n";
-
-        private static string GetLineAt(string source, int position)
-        {
-            var start = source.LastIndexOf(LineSeparator, position, position);
-            var end = source.IndexOf(LineSeparator, position);
-            return source.Substring(start + 1, end - start).Trim();
-        }
 
         public static IEnumerable<string> ToLines(this string str)
         {

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/SemanticEditDescription.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/SemanticEditDescription.cs
@@ -13,22 +13,27 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
     {
         public readonly SemanticEditKind Kind;
         public readonly Func<Compilation, ISymbol> SymbolProvider;
-        public readonly IEnumerable<KeyValuePair<TextSpan, TextSpan>> SyntaxMap;
-        public readonly bool PreserveLocalVariables;
-        public readonly int SyntaxTreeOrdinal;
+        public readonly Func<Compilation, ITypeSymbol>? PartialType;
+
+        /// <summary>
+        /// If specified the node mappings will be validated against the actual syntax map function.
+        /// </summary>
+        public readonly IEnumerable<KeyValuePair<TextSpan, TextSpan>>? SyntaxMap;
+
+        public readonly bool HasSyntaxMap;
 
         public SemanticEditDescription(
             SemanticEditKind kind,
             Func<Compilation, ISymbol> symbolProvider,
-            IEnumerable<KeyValuePair<TextSpan, TextSpan>> syntaxMap,
-            bool preserveLocalVariables,
-            int syntaxTreeOrdinal = 0)
+            Func<Compilation, ITypeSymbol>? partialType,
+            IEnumerable<KeyValuePair<TextSpan, TextSpan>>? syntaxMap,
+            bool hasSyntaxMap)
         {
             Kind = kind;
             SymbolProvider = symbolProvider;
             SyntaxMap = syntaxMap;
-            PreserveLocalVariables = preserveLocalVariables;
-            SyntaxTreeOrdinal = syntaxTreeOrdinal;
+            PartialType = partialType;
+            HasSyntaxMap = hasSyntaxMap;
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
+    <UseExportProvider>
     Public Class ActiveStatementTests
         Inherits EditingTestBase
 
@@ -263,7 +264,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.method, "Goo(Integer)")))
         End Sub
 
         <Fact>
@@ -283,7 +284,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, Nothing, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(FeaturesResources.class_, "C")))
         End Sub
 
         <Fact, WorkItem(755959, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755959")>
@@ -316,7 +317,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Shared Sub Main()"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Shared Sub Main()", FeaturesResources.code))
         End Sub
 
         <Fact, WorkItem(755959, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755959")>
@@ -421,21 +422,21 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Do"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "If True"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Else"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Case 1, 2"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Case Else"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "While True"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Do Until True"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "If True Then"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Else"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "For i = 0 To 10"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "For Each i In {1, 2}"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Using z = New C()"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "With expr"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Shared Sub Main()"),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "SyncLock Nothing"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Do", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "If True", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Else", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Case 1, 2", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Case Else", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "While True", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Do Until True", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "If True Then", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Else", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "For i = 0 To 10", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "For Each i In {1, 2}", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Using z = New C()", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "With expr", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Shared Sub Main()", FeaturesResources.code),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "SyncLock Nothing", FeaturesResources.code))
         End Sub
 
         <Fact>
@@ -476,7 +477,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "If c1 Then"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "If c1 Then", FeaturesResources.code))
         End Sub
 
         <Fact>
@@ -513,7 +514,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "If c1 Then"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "If c1 Then", FeaturesResources.code))
         End Sub
 
         <Fact, WorkItem(755959, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755959")>
@@ -648,7 +649,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Sub Main()"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Sub Main()", FeaturesResources.code))
         End Sub
 
         <Fact, WorkItem(755959, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755959")>
@@ -696,7 +697,7 @@ End Module
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, Nothing, "module"))
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(VBFeaturesResources.module_, "Module1")))
         End Sub
 #End Region
 
@@ -1652,8 +1653,8 @@ End Class
             edits.VerifyRudeDiagnostics(active,
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "c As New D(2)"),
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "e As New D(2)"),
-                Diagnostic(RudeEditKind.Delete, "a As New D(2)", FeaturesResources.field),
-                Diagnostic(RudeEditKind.Delete, "e As New D(2)", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "a As New D(2)", DeletedSymbolDisplay(FeaturesResources.field, "b")),
+                Diagnostic(RudeEditKind.Delete, "e As New D(2)", DeletedSymbolDisplay(FeaturesResources.field, "f")))
         End Sub
 
         <Fact>
@@ -1775,12 +1776,12 @@ End Class
         Public Sub Initializer_Array_Update3()
             Dim src1 = "
 Class C
-    Private <AS:0>a(1)</AS:0>
-    Private <AS:1>e(1)</AS:1>
-    Private f(1)
+    Private <AS:0>a(1,0)</AS:0>
+    Private <AS:1>e(1,0)</AS:1>
+    Private f(1,0)
 
     Sub Main
-        Dim <AS:2>c(1)</AS:2>
+        Dim <AS:2>c(1,0)</AS:2>
     End Sub
 End Class
 "
@@ -1800,11 +1801,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.ActiveStatementUpdate, "c(1,2)"),
-                Diagnostic(RudeEditKind.TypeUpdate, "a(1,2)", FeaturesResources.field),
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "e(1,2)"),
-                Diagnostic(RudeEditKind.TypeUpdate, "e(1,2)", FeaturesResources.field),
-                Diagnostic(RudeEditKind.TypeUpdate, "f(1,2)", FeaturesResources.field))
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "c(1,2)"))
         End Sub
 
         <Fact, WorkItem(849649, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/849649")>
@@ -2091,7 +2089,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.field, "a")))
         End Sub
 
         <Fact>
@@ -2144,7 +2142,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, "a,      c        As New D()", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "a,      c        As New D()", DeletedSymbolDisplay(FeaturesResources.field, "b")))
         End Sub
 
         <Fact>
@@ -2171,7 +2169,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, "a,      b        As New D()", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "a,      b        As New D()", DeletedSymbolDisplay(FeaturesResources.field, "c")))
         End Sub
 
         <Fact>
@@ -2225,7 +2223,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, "a,b As Integer", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "a,b As Integer", DeletedSymbolDisplay(FeaturesResources.field, "c")))
         End Sub
 
         <Fact>
@@ -2328,7 +2326,7 @@ End Class
 Class C
     Dim <AS:0>a As Integer = 1</AS:0>
     Shared b As Integer = 1
-    Dim c(1) As Integer = 1
+    Dim c(1) As Integer
 End Class
 "
 
@@ -2859,7 +2857,7 @@ Class Test
         For Each b In e1
             For Each c In e1
                 Dim a = Sub()
-                    For Each a In e1
+                    For Each z In e1
                         <AS:0>System.Console.Write()</AS:0>
                     Next
                 End Sub
@@ -2874,7 +2872,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "For Each a In e1", VBFeaturesResources.For_Each_block),
+                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "For Each z In e1", VBFeaturesResources.For_Each_block),
                 Diagnostic(RudeEditKind.InsertAroundActiveStatement, "For Each b In e1", VBFeaturesResources.For_Each_block))
         End Sub
 
@@ -3497,7 +3495,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Try"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Try", FeaturesResources.code))
         End Sub
 
         <Fact>
@@ -3561,7 +3559,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Try"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Try", FeaturesResources.code))
         End Sub
 
         <Fact>
@@ -5294,7 +5292,7 @@ Imports System
 Imports System.Threading.Tasks
 Class C
     Sub F()
-        Dim f = Function(a) <AS:0>Function(b) a + b</AS:0>
+        Dim f = Function(a) <AS:0>Task.FromResult(Function(b) 1)</AS:0>
     End Sub
 End Class
 "
@@ -5303,7 +5301,7 @@ Imports System
 Imports System.Threading.Tasks
 Class C
     Sub F()
-        Dim f = Async Function(a) <AS:0>Function(b) a + b</AS:0>
+        Dim f = Async Function(a) <AS:0>Function(b) 1</AS:0>
     End Sub
 End Class
 "
@@ -5322,7 +5320,7 @@ Imports System
 Imports System.Threading.Tasks
 Class C
     Sub F()
-        Dim f = Function(a) <AS:0>Function(b)</AS:0> a + b
+        Dim f = Function(a) Task.FromResult(<AS:0>Function(b)</AS:0> a + b)
     End Sub
 End Class
 "
@@ -5362,7 +5360,7 @@ Class C
     End Function
  
     Sub F()
-        Dim f = <AS:0>Iterator Function()</AS:0>
+        Dim f = <AS:0>Iterator Function() As IEnumerable(Of Integer)</AS:0>
                   G()
                 End Function
     End Sub
@@ -5372,14 +5370,14 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "Iterator Function()"))
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "Iterator Function() As IEnumerable(Of Integer)"))
         End Sub
 
         <Fact>
         Public Sub AsyncLambdaToLambda_WithoutActiveStatement_NoAwait()
             Dim src1 = "
 Class C
-    Function G() As Task(Of Integer)
+    Shared Function G() As Task(Of Integer)
         Return Nothing
     End Function
  
@@ -5391,7 +5389,7 @@ End Class
 "
             Dim src2 = "
 Class C
-    Function G() As Task(Of Integer)
+    Shared Function G() As Task(Of Integer)
         Return Nothing
     End Function
  
@@ -5415,7 +5413,7 @@ End Class
 Imports System
 Imports System.Threading.Tasks
 Class C
-    Function G() As IEnumerable(Of Integer)
+    Shared Function G() As IEnumerable(Of Integer)
         Return Nothing
     End Function
  
@@ -5429,7 +5427,7 @@ End Class
 Imports System
 Imports System.Threading.Tasks
 Class C
-    Function G() As IEnumerable(Of Integer)
+    Shared Function G() As IEnumerable(Of Integer)
         Return Nothing
     End Function
  
@@ -5715,7 +5713,7 @@ End Class
             active.OldStatements(0) = active.OldStatements(0).WithFlags(ActiveStatementFlags.PartiallyExecuted Or ActiveStatementFlags.IsLeafFrame)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.PartiallyExecutedActiveStatementDelete, "Sub F()"))
+                Diagnostic(RudeEditKind.PartiallyExecutedActiveStatementDelete, "Sub F()", FeaturesResources.code))
         End Sub
 
         <Fact>
@@ -5739,7 +5737,7 @@ End Class
             active.OldStatements(0) = active.OldStatements(0).WithFlags(ActiveStatementFlags.IsNonLeafFrame Or ActiveStatementFlags.IsLeafFrame)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "Sub F()"))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "Sub F()", FeaturesResources.code))
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTrackingServiceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTrackingServiceTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
+    <UseExportProvider>
     Public Class ActiveStatementTrackingServiceTests
         Inherits EditingTestBase
 

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EditAndContinue
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
@@ -20,27 +21,56 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Return New VisualBasicEditAndContinueAnalyzer()
         End Function
 
-        Public Enum StateMachineKind
-            None
+        Public Enum MethodKind
+            Regular
             Async
             Iterator
         End Enum
+
+        Friend Shared NoSemanticEdits As SemanticEditDescription() = Array.Empty(Of SemanticEditDescription)
 
         Friend Overloads Shared Function Diagnostic(rudeEditKind As RudeEditKind, squiggle As String, ParamArray arguments As String()) As RudeEditDiagnosticDescription
             Return New RudeEditDiagnosticDescription(rudeEditKind, squiggle, arguments, firstLine:=Nothing)
         End Function
 
-        Friend Shared Function SemanticEdit(kind As SemanticEditKind, symbolProvider As Func(Of Compilation, ISymbol), syntaxMap As IEnumerable(Of KeyValuePair(Of TextSpan, TextSpan))) As SemanticEditDescription
-            Assert.NotNull(syntaxMap)
-            Return New SemanticEditDescription(kind, symbolProvider, syntaxMap, preserveLocalVariables:=True)
+        Friend Shared Function SemanticEdit(kind As SemanticEditKind,
+                                            symbolProvider As Func(Of Compilation, ISymbol),
+                                            syntaxMap As IEnumerable(Of KeyValuePair(Of TextSpan, TextSpan)),
+                                            Optional partialType As String = Nothing) As SemanticEditDescription
+            Return New SemanticEditDescription(
+                kind,
+                symbolProvider,
+                If(partialType Is Nothing, Nothing, Function(c As Compilation) CType(c.GetMember(partialType), ITypeSymbol)),
+                syntaxMap:=Nothing,
+                hasSyntaxMap:=syntaxMap IsNot Nothing)
         End Function
 
-        Friend Shared Function SemanticEdit(kind As SemanticEditKind, symbolProvider As Func(Of Compilation, ISymbol), Optional preserveLocalVariables As Boolean = False) As SemanticEditDescription
-            Return New SemanticEditDescription(kind, symbolProvider, Nothing, preserveLocalVariables)
+        Friend Shared Function SemanticEdit(kind As SemanticEditKind,
+                                            symbolProvider As Func(Of Compilation, ISymbol),
+                                            Optional partialType As String = Nothing,
+                                            Optional preserveLocalVariables As Boolean = False) As SemanticEditDescription
+            Return New SemanticEditDescription(
+                kind,
+                symbolProvider,
+                If(partialType Is Nothing, Nothing, Function(c As Compilation) CType(c.GetMember(partialType), ITypeSymbol)),
+                syntaxMap:=Nothing,
+                hasSyntaxMap:=preserveLocalVariables)
+        End Function
+
+        Friend Shared Function DeletedSymbolDisplay(kind As String, displayName As String) As String
+            Return String.Format(FeaturesResources.member_kind_and_name, kind, displayName)
+        End Function
+
+        Friend Shared Function DocumentResults(
+            Optional activeStatements As ActiveStatementsDescription = Nothing,
+            Optional semanticEdits As SemanticEditDescription() = Nothing,
+            Optional diagnostics As RudeEditDiagnosticDescription() = Nothing) As DocumentAnalysisResultsDescription
+            Return New DocumentAnalysisResultsDescription(activeStatements, semanticEdits, diagnostics)
         End Function
 
         Private Shared Function ParseSource(source As String) As SyntaxTree
-            Return VisualBasicEditAndContinueTestHelpers.CreateInstance().ParseText(ActiveStatementsDescription.ClearTags(source))
+            Dim validator = New VisualBasicEditAndContinueTestHelpers()
+            Return validator.ParseText(ActiveStatementsDescription.ClearTags(source))
         End Function
 
         Friend Shared Function GetTopEdits(src1 As String, src2 As String) As EditScript(Of SyntaxNode)
@@ -54,14 +84,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Return match.GetTreeEdits()
         End Function
 
-        Friend Shared Function GetMethodEdits(src1 As String, src2 As String, Optional stateMachine As StateMachineKind = StateMachineKind.None) As EditScript(Of SyntaxNode)
-            Dim match = GetMethodMatch(src1, src2, stateMachine)
+        Public Shared Function GetTopEdits(methodEdits As EditScript(Of SyntaxNode)) As EditScript(Of SyntaxNode)
+            Dim oldMethodSource = methodEdits.Match.OldRoot.ToFullString()
+            Dim newMethodSource = methodEdits.Match.NewRoot.ToFullString()
+
+            Return GetTopEdits(WrapMethodBodyWithClass(oldMethodSource), WrapMethodBodyWithClass(newMethodSource))
+        End Function
+
+        Friend Shared Function GetMethodEdits(src1 As String, src2 As String, Optional methodKind As MethodKind = MethodKind.Regular) As EditScript(Of SyntaxNode)
+            Dim match = GetMethodMatch(src1, src2, methodKind)
             Return match.GetTreeEdits()
         End Function
 
-        Friend Shared Function GetMethodMatch(src1 As String, src2 As String, Optional stateMachine As StateMachineKind = StateMachineKind.None) As Match(Of SyntaxNode)
-            Dim m1 = MakeMethodBody(src1, stateMachine)
-            Dim m2 = MakeMethodBody(src2, stateMachine)
+        Friend Shared Function GetMethodMatch(src1 As String, src2 As String, Optional methodKind As MethodKind = MethodKind.Regular) As Match(Of SyntaxNode)
+            Dim m1 = MakeMethodBody(src1, methodKind)
+            Dim m2 = MakeMethodBody(src2, methodKind)
 
             Dim diagnostics = New ArrayBuilder(Of RudeEditDiagnostic)()
 
@@ -69,9 +106,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Dim match = CreateAnalyzer().GetTestAccessor().ComputeBodyMatch(m1, m2, Array.Empty(Of AbstractEditAndContinueAnalyzer.ActiveNode)(), diagnostics, oldHasStateMachineSuspensionPoint, newHasStateMachineSuspensionPoint)
             Dim needsSyntaxMap = oldHasStateMachineSuspensionPoint AndAlso newHasStateMachineSuspensionPoint
 
-            Assert.Equal(stateMachine <> StateMachineKind.None, needsSyntaxMap)
+            Assert.Equal(methodKind <> MethodKind.Regular, needsSyntaxMap)
 
-            If stateMachine = StateMachineKind.None Then
+            If methodKind = MethodKind.Regular Then
                 Assert.Empty(diagnostics)
             End If
 
@@ -80,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
 
         Public Shared Function GetMethodMatches(src1 As String,
                                                 src2 As String,
-                                                Optional stateMachine As StateMachineKind = StateMachineKind.None) As IEnumerable(Of KeyValuePair(Of SyntaxNode, SyntaxNode))
+                                                Optional stateMachine As MethodKind = MethodKind.Regular) As IEnumerable(Of KeyValuePair(Of SyntaxNode, SyntaxNode))
             Dim methodMatch = GetMethodMatch(src1, src2, stateMachine)
             Return EditAndContinueTestHelpers.GetMethodMatches(CreateAnalyzer(), methodMatch)
         End Function
@@ -93,18 +130,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Return EditAndContinueTestHelpers.ToMatchingPairs(matches)
         End Function
 
-        Friend Shared Function MakeMethodBody(bodySource As String, Optional stateMachine As StateMachineKind = StateMachineKind.None) As SyntaxNode
-            Dim source As String
-            Select Case stateMachine
-                Case StateMachineKind.Iterator
-                    source = "Class C" & vbLf & "Iterator Function F() As IEnumerable(Of Integer)" & vbLf & bodySource & " : End Function : End Class"
-
-                Case StateMachineKind.Async
-                    source = "Class C" & vbLf & "Async Function F() As Task(Of Integer)" & vbLf & bodySource & " : End Function : End Class"
-
-                Case Else
-                    source = "Class C" & vbLf & "Sub F()" & vbLf & bodySource & " : End Sub : End Class"
-            End Select
+        Friend Shared Function MakeMethodBody(bodySource As String, Optional stateMachine As MethodKind = MethodKind.Regular) As SyntaxNode
+            Dim source = WrapMethodBodyWithClass(bodySource, stateMachine)
 
             Dim tree = ParseSource(source)
             Dim root = tree.GetRoot()
@@ -112,7 +139,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
 
             Dim declaration = DirectCast(DirectCast(root, CompilationUnitSyntax).Members(0), ClassBlockSyntax).Members(0)
             Return SyntaxFactory.SyntaxTree(declaration).GetRoot()
+        End Function
 
+        Private Shared Function WrapMethodBodyWithClass(bodySource As String, Optional kind As MethodKind = MethodKind.Regular) As String
+            Select Case kind
+                Case MethodKind.Iterator
+                    Return "Class C" & vbLf & "Iterator Function F() As IEnumerable(Of Integer)" & vbLf & bodySource & " : End Function : End Class"
+
+                Case MethodKind.Async
+                    Return "Class C" & vbLf & "Async Function F() As Task(Of Integer)" & vbLf & bodySource & " : End Function : End Class"
+
+                Case Else
+                    Return "Class C" & vbLf & "Sub F()" & vbLf & bodySource & " : End Sub : End Class"
+            End Select
         End Function
 
         Friend Shared Function GetActiveStatements(oldSource As String, newSource As String) As ActiveStatementsDescription

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/VisualBasicEditAndContinueTestHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/VisualBasicEditAndContinueTestHelpers.vb
@@ -8,33 +8,17 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.Differencing
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EditAndContinue
 
     Friend NotInheritable Class VisualBasicEditAndContinueTestHelpers
         Inherits EditAndContinueTestHelpers
 
-        Private ReadOnly _analyzer As VisualBasicEditAndContinueAnalyzer = New VisualBasicEditAndContinueAnalyzer()
+        Private ReadOnly _analyzer As VisualBasicEditAndContinueAnalyzer
 
-        Private ReadOnly _fxReferences As ImmutableArray(Of PortableExecutableReference)
-
-        Friend Shared Function CreateInstance() As VisualBasicEditAndContinueTestHelpers
-            Return New VisualBasicEditAndContinueTestHelpers(
-                ImmutableArray.Create(TestMetadata.Net451.mscorlib, TestMetadata.Net451.System, TestMetadata.Net451.SystemCore))
-        End Function
-
-        Friend Shared Function CreateInstance40() As VisualBasicEditAndContinueTestHelpers
-            Return New VisualBasicEditAndContinueTestHelpers(
-                ImmutableArray.Create(TestMetadata.Net40.mscorlib, TestMetadata.Net40.SystemCore))
-        End Function
-
-        Friend Shared Function CreateInstanceMinAsync() As VisualBasicEditAndContinueTestHelpers
-            Return New VisualBasicEditAndContinueTestHelpers(
-                ImmutableArray.Create(TestReferences.NetFx.Minimal.mincorlib, TestReferences.NetFx.Minimal.minasync))
-        End Function
-
-        Public Sub New(fxReferences As ImmutableArray(Of PortableExecutableReference))
-            _fxReferences = fxReferences
+        Public Sub New(Optional faultInjector As Action(Of SyntaxNode) = Nothing)
+            _analyzer = New VisualBasicEditAndContinueAnalyzer(faultInjector)
         End Sub
 
         Public Overrides ReadOnly Property Analyzer As AbstractEditAndContinueAnalyzer
@@ -43,12 +27,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EditAndContinue
             End Get
         End Property
 
-        Public Overrides Function CreateLibraryCompilation(name As String, trees As IEnumerable(Of SyntaxTree)) As Compilation
-            Return VisualBasicCompilation.Create("New",
-                                                 trees,
-                                                 _fxReferences,
-                                                 TestOptions.ReleaseDll.WithEmbedVbCoreRuntime(True))
-        End Function
+        Public Overrides ReadOnly Property LanguageName As String
+            Get
+                Return LanguageNames.VisualBasic
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property TopSyntaxComparer As TreeComparer(Of SyntaxNode)
+            Get
+                Return CodeAnalysis.VisualBasic.EditAndContinue.TopSyntaxComparer.Instance
+            End Get
+        End Property
 
         Public Overrides Function ParseText(source As String) As SyntaxTree
             Return SyntaxFactory.ParseSyntaxTree(source, VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest))

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
+    <UseExportProvider>
     Public Class LineEditTests
         Inherits EditingTestBase
 

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/StatementEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/StatementEditingTests.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
-
+    <UseExportProvider>
     Public Class StatementEditingTests
         Inherits EditingTestBase
 
@@ -506,7 +506,7 @@ Do : Dim a = 14, b = 15, c = 16 : Console.WriteLine(a + b + c) : Loop
             Dim src1 = "Dim result = From a In {Await F(0)}, b In {Q(Async Function() Await F(2))} Select a + b" & vbLf
             Dim src2 = "Dim result = From a In {Await F(1)}, b In {Q(Async Function() Await F(3))} Select a - b" & vbLf
 
-            Dim match = GetMethodMatch(src1, src2, stateMachine:=StateMachineKind.Async)
+            Dim match = GetMethodMatch(src1, src2, methodKind:=MethodKind.Async)
             Dim actual = ToMatchingPairs(match)
 
             ' Note that 
@@ -1261,7 +1261,7 @@ For Each x In {1, 2, 3}
     Yield 2
 Next
 </text>.Value
-            Dim match = GetMethodMatches(src1, src2, stateMachine:=StateMachineKind.Iterator)
+            Dim match = GetMethodMatches(src1, src2, stateMachine:=MethodKind.Iterator)
             Dim actual = ToMatchingPairs(match)
 
             Dim expected = New MatchingPairs From
@@ -1300,7 +1300,7 @@ Catch e As Exception When filter(e)
 End Try
 "
 
-            Dim match = GetMethodMatches(src1, src2, stateMachine:=StateMachineKind.None)
+            Dim match = GetMethodMatches(src1, src2, stateMachine:=MethodKind.Regular)
             Dim actual = ToMatchingPairs(match)
 
             Dim expected = New MatchingPairs From
@@ -4533,7 +4533,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                expectedSemanticEdits:=
+                semanticEdits:=
                 {
                     SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMembers("F").Single(), preserveLocalVariables:=True)
                 })
@@ -5975,7 +5975,7 @@ Yield 2
 Yield 3
 Yield 4
 </text>.Value
-            Dim edits = GetMethodEdits(src1, src2, stateMachine:=StateMachineKind.Iterator)
+            Dim edits = GetMethodEdits(src1, src2, methodKind:=MethodKind.Iterator)
 
             edits.VerifyEdits(
                 "Update [Yield 1]@50 -> [Yield 3]@50",
@@ -5993,7 +5993,7 @@ Yield 2
 Yield 3
 Yield 4
 </text>.Value
-            Dim edits = GetMethodEdits(src1, src2, stateMachine:=StateMachineKind.Iterator)
+            Dim edits = GetMethodEdits(src1, src2, methodKind:=MethodKind.Iterator)
 
             edits.VerifyEdits(
                 "Update [Yield 1]@50 -> [Yield 3]@50",
@@ -6011,7 +6011,7 @@ Yield 1
 Yield 2
 Yield 3
 </text>.Value
-            Dim edits = GetMethodEdits(src1, src2, stateMachine:=StateMachineKind.Iterator)
+            Dim edits = GetMethodEdits(src1, src2, methodKind:=MethodKind.Iterator)
 
             edits.VerifyEdits(
                 "Insert [Yield 3]@66")
@@ -6028,7 +6028,7 @@ Yield 3
 Yield 1
 Yield 2
 </text>.Value
-            Dim edits = GetMethodEdits(src1, src2, stateMachine:=StateMachineKind.Iterator)
+            Dim edits = GetMethodEdits(src1, src2, methodKind:=MethodKind.Iterator)
 
             edits.VerifyEdits(
                 "Delete [Yield 3]@66")
@@ -6055,11 +6055,10 @@ Class C
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
-            VisualBasicEditAndContinueTestHelpers.CreateInstance40().VerifySemantics(
-                editScripts:={edits},
-                activeStatements:=ActiveStatementsDescription.Empty,
-                expectedSemanticEdits:=Nothing,
-                expectedDiagnostics:={Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Iterator Function F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute")})
+            VerifySemantics(
+                edits,
+                diagnostics:={Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Iterator Function F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute")},
+                targetFrameworks:={TargetFramework.Mscorlib40AndSystemCore})
         End Sub
 
         <Fact>
@@ -6083,11 +6082,9 @@ Class C
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
-            VisualBasicEditAndContinueTestHelpers.CreateInstance40().VerifySemantics(
-                editScripts:={edits},
-                activeStatements:=ActiveStatementsDescription.Empty,
-                expectedSemanticEdits:=Nothing,
-                expectedDiagnostics:=Nothing)
+            VerifySemanticDiagnostics(
+                editScript:=edits,
+                targetFrameworks:={TargetFramework.Mscorlib40AndSystemCore})
         End Sub
 
 #End Region
@@ -6103,7 +6100,7 @@ Await F(2)
 Await F(3)
 Await F(4)
 </text>.Value
-            Dim edits = GetMethodEdits(src1, src2, stateMachine:=StateMachineKind.Async)
+            Dim edits = GetMethodEdits(src1, src2, methodKind:=MethodKind.Async)
 
             edits.VerifyEdits(
                 "Update [Await F(1)]@40 -> [Await F(3)]@40",
@@ -6121,7 +6118,7 @@ Await F(1)
 Await F(2)
 Await F(3)
 </text>.Value
-            Dim edits = GetMethodEdits(src1, src2, stateMachine:=StateMachineKind.Async)
+            Dim edits = GetMethodEdits(src1, src2, methodKind:=MethodKind.Async)
 
             edits.VerifyEdits(
                 "Insert [Await F(2)]@51")
@@ -6138,7 +6135,7 @@ Await F(3)
 Await F(1)
 Await F(3)
 </text>.Value
-            Dim edits = GetMethodEdits(src1, src2, stateMachine:=StateMachineKind.Async)
+            Dim edits = GetMethodEdits(src1, src2, methodKind:=MethodKind.Async)
 
             edits.VerifyEdits(
                 "Delete [Await F(2)]@51")
@@ -6167,11 +6164,11 @@ Class C
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
-            VisualBasicEditAndContinueTestHelpers.CreateInstanceMinAsync().VerifySemantics(
-                editScripts:={edits},
-                activeStatements:=ActiveStatementsDescription.Empty,
-                expectedSemanticEdits:=Nothing,
-                expectedDiagnostics:={Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Async Function F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute")})
+
+            VerifySemantics(
+                edits,
+                diagnostics:={Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Async Function F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute")},
+                targetFrameworks:={TargetFramework.MinimalAsync})
         End Sub
 
         <Fact>
@@ -6196,7 +6193,9 @@ Class C
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
-            VisualBasicEditAndContinueTestHelpers.CreateInstanceMinAsync().VerifySemantics({edits})
+            VerifySemanticDiagnostics(
+                edits,
+                targetFrameworks:={TargetFramework.MinimalAsync})
         End Sub
 #End Region
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -9,136 +9,229 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
-    Public Class RudeEditTopLevelTests
+    <UseExportProvider>
+    Public Class TopLevelEditingTests
         Inherits EditingTestBase
 #Region "Imports"
 
         <Fact>
         Public Sub ImportDelete1()
-            Dim src1 As String = <text>
+            Dim src1 = "
 Imports System.Diagnostics
-</text>.Value
+"
             Dim src2 As String = ""
+
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits("Delete [Imports System.Diagnostics]@1")
+            edits.VerifyEdits("Delete [Imports System.Diagnostics]@2")
             Assert.IsType(Of ImportsStatementSyntax)(edits.Edits.First().OldNode)
             Assert.Equal(edits.Edits.First().NewNode, Nothing)
         End Sub
 
         <Fact>
         Public Sub ImportDelete2()
-            Dim src1 As String = <text>
-Imports System.Diagnostics
+            Dim src1 = "
+Imports D = System.Diagnostics
+Imports <xmlns=""http://roslyn/default1"">
 Imports System.Collections
 Imports System.Collections.Generic
-</text>.Value
+"
 
-            Dim src2 As String = <text>
-Imports System.Diagnostics
+            Dim src2 = "
 Imports System.Collections.Generic
-</text>.Value
+"
 
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits("Delete [Imports System.Collections]@28")
+            edits.VerifyEdits(
+                "Delete [Imports D = System.Diagnostics]@2",
+                "Delete [Imports <xmlns=""http://roslyn/default1"">]@34",
+                "Delete [Imports System.Collections]@76")
+
             edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, Nothing, VBFeaturesResources.import),
+                Diagnostic(RudeEditKind.Delete, Nothing, VBFeaturesResources.import),
                 Diagnostic(RudeEditKind.Delete, Nothing, VBFeaturesResources.import))
         End Sub
 
         <Fact>
         Public Sub ImportInsert()
-            Dim src1 As String = <text>
-Imports System.Diagnostics
+            Dim src1 = "
 Imports System.Collections.Generic
-</text>.Value
+"
 
-            Dim src2 As String = <text>
-Imports System.Diagnostics
+            Dim src2 = "
+Imports D = System.Diagnostics
+Imports <xmlns=""http://roslyn/default1"">
 Imports System.Collections
 Imports System.Collections.Generic
-</text>.Value
+"
 
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits("Insert [Imports System.Collections]@28")
+            edits.VerifyEdits(
+                "Insert [Imports D = System.Diagnostics]@2",
+                "Insert [Imports <xmlns=""http://roslyn/default1"">]@34",
+                "Insert [Imports System.Collections]@76")
+
             edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "Imports D = System.Diagnostics", VBFeaturesResources.import),
+                Diagnostic(RudeEditKind.Insert, "Imports <xmlns=""http://roslyn/default1"">", "import"),
                 Diagnostic(RudeEditKind.Insert, "Imports System.Collections", VBFeaturesResources.import))
         End Sub
 
         <Fact>
         Public Sub ImportUpdate1()
-            Dim src1 As String = <text>
+            Dim src1 = "
 Imports System.Diagnostics
 Imports System.Collections
 Imports System.Collections.Generic
-</text>.Value
+"
 
-            Dim src2 As String = <text>
+            Dim src2 = "
 Imports System.Diagnostics
 Imports X = System.Collections
 Imports System.Collections.Generic
-</text>.Value
+"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyEdits("Update [Imports System.Collections]@28 -> [Imports X = System.Collections]@28")
+            edits.VerifyEdits(
+                "Update [Imports System.Collections]@30 -> [Imports X = System.Collections]@30")
+
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Update, "Imports X = System.Collections", VBFeaturesResources.import))
         End Sub
 
-        <Fact>
+        <Fact, WorkItem(51374, "https://github.com/dotnet/roslyn/issues/51374")>
         Public Sub ImportUpdate2()
-            Dim src1 As String = <text>
+            Dim src1 = "
 Imports System.Diagnostics
 Imports X1 = System.Collections
+Imports <xmlns=""http://roslyn/default1"">
 Imports System.Collections.Generic
-</text>.Value
+"
 
-            Dim src2 As String = <text>
+            Dim src2 = "
 Imports System.Diagnostics
 Imports X2 = System.Collections
+Imports <xmlns=""http://roslyn/default2"">
 Imports System.Collections.Generic
-</text>.Value
+"
 
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits("Update [Imports X1 = System.Collections]@28 -> [Imports X2 = System.Collections]@28")
+
+            ' TODO: https://github.com/dotnet/roslyn/issues/51374
+            ' Should be following:
+            'edits.VerifyEdits(
+            '    "Update [Imports X1 = System.Collections]@30 -> [Imports X2 = System.Collections]@30",
+            '    "Update [Imports <xmlns=""http://roslyn/default1"">]@28 -> [Imports <xmlns=""http://roslyn/default2"">]@28")
+            '
+            'edits.VerifyRudeDiagnostics(
+            '    Diagnostic(RudeEditKind.Update, "Imports X2 = System.Collections", VBFeaturesResources.import),
+            '    Diagnostic(RudeEditKind.Update, "Imports <xmlns=""http://roslyn/default2"">", VBFeaturesResources.import))
+
+            edits.VerifyEdits(
+                "Update [Imports X1 = System.Collections]@30 -> [Imports X2 = System.Collections]@30")
+
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Update, "Imports X2 = System.Collections", VBFeaturesResources.import))
         End Sub
 
         <Fact>
         Public Sub ImportUpdate3()
-            Dim src1 As String = <text>
+            Dim src1 = "
 Imports System.Diagnostics
 Imports System.Collections
 Imports System.Collections.Generic
-</text>.Value
+"
 
-            Dim src2 As String = <text>
+            Dim src2 = "
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
-</text>.Value
+"
 
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits("Update [Imports System.Diagnostics]@1 -> [Imports System]@1")
+
+            edits.VerifyEdits(
+                "Update [Imports System.Diagnostics]@2 -> [Imports System]@2")
+
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Update, "Imports System", VBFeaturesResources.import))
         End Sub
 
         <Fact>
         Public Sub ImportReorder1()
-            Dim src1 As String = <text>
+            Dim src1 = "
 Imports System.Diagnostics
 Imports System.Collections
 Imports System.Collections.Generic
-</text>.Value
+"
 
-            Dim src2 As String = <text>
+            Dim src2 = "
 Imports System.Collections
 Imports System.Collections.Generic
 Imports System.Diagnostics
-</text>.Value
+"
 
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits("Reorder [Imports System.Diagnostics]@1 -> @63")
+
+            edits.VerifyEdits(
+                "Reorder [Imports System.Diagnostics]@2 -> @66")
+        End Sub
+#End Region
+
+#Region "Option"
+        <Fact>
+        Public Sub OptionDelete()
+            Dim src1 = "
+Option Strict On
+"
+
+            Dim src2 = "
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Delete [Option Strict On]@2")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, Nothing, VBFeaturesResources.option_))
+        End Sub
+
+        <Fact>
+        Public Sub OptionInsert()
+            Dim src1 = "
+"
+
+            Dim src2 = "
+Option Strict On
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Insert [Option Strict On]@2")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "Option Strict On", VBFeaturesResources.option_))
+        End Sub
+
+        <Fact>
+        Public Sub OptionUpdate()
+            Dim src1 = "
+Option Strict On
+"
+
+            Dim src2 = "
+Option Strict Off
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [Option Strict On]@2 -> [Option Strict Off]@2")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Update, "Option Strict Off", VBFeaturesResources.option_))
         End Sub
 #End Region
 
@@ -339,7 +432,10 @@ Imports System.Diagnostics
             Dim src2 = "Partial Interface C : End Interface"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics()
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C"))
+            })
         End Sub
 
         <Fact>
@@ -348,8 +444,8 @@ Imports System.Diagnostics
             Dim src2 = ""
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, Nothing, FeaturesResources.interface_))
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(FeaturesResources.interface_, "C")))
         End Sub
 
         <Fact>
@@ -379,7 +475,7 @@ Imports System.Diagnostics
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, Nothing, VBFeaturesResources.module_))
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(VBFeaturesResources.module_, "C")))
         End Sub
 
         <Fact>
@@ -419,8 +515,7 @@ Imports System.Diagnostics
             edits.VerifyEdits(
                 "Update [Module C]@0 -> [Partial Module C]@0")
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Partial Module C", VBFeaturesResources.module_))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -432,8 +527,7 @@ Imports System.Diagnostics
             edits.VerifyEdits(
                 "Update [Partial Module C]@0 -> [Module C]@0")
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Module C", VBFeaturesResources.module_))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -471,8 +565,7 @@ Imports System.Diagnostics
             edits.VerifyEdits(
                 "Update [Interface C]@0 -> [Partial Interface C]@0")
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Partial Interface C", FeaturesResources.interface_))
+            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -640,6 +733,486 @@ End Interface
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyRudeDiagnostics()
         End Sub
+
+        <Fact>
+        Public Sub Interface_InsertMembers()
+            Dim src1 = "
+Imports System
+
+Interface I 
+End Interface
+"
+            Dim src2 = "
+Imports System
+
+Interface I
+    Sub VirtualMethod()
+    Property VirtualProperty() As String
+    Property VirtualIndexer(a As Integer) As String
+    Event VirtualEvent As Action
+
+    MustInherit Class C
+    End Class
+
+    Interface J
+    End Interface
+
+    Enum E
+        A
+    End Enum
+
+    Delegate Sub D()
+End Interface
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertVirtual, "Sub VirtualMethod()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertVirtual, "Property VirtualProperty()", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertVirtual, "Property VirtualIndexer(a As Integer)", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertVirtual, "Event VirtualEvent", FeaturesResources.event_))
+        End Sub
+
+        <Fact>
+        Public Sub Interface_InsertDelete()
+            Dim srcA1 = "
+Interface I
+    Sub VirtualMethod()
+    Function VirtualFunction() As Integer
+    Property VirtualProperty() As String
+    ReadOnly Property VirtualReadonlyProperty() As String
+    Property VirtualIndexer(a As Integer) As String
+    Event VirtualEvent As Action
+
+    MustInherit Class C
+    End Class
+
+    Interface J
+    End Interface
+
+    Enum E
+        A
+    End Enum
+
+    Delegate Sub D()
+End Interface
+"
+            Dim srcB1 = "
+"
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub GenericType_InsertMembers()
+            Dim src1 = "
+Imports System
+Class C(Of T)
+End Class
+"
+            Dim src2 = "
+Imports System
+Class C(Of T)
+    Dim F1, F2 As New Object, F3 As Integer, F4 As New Object, F5(1, 2), F6? As Integer
+
+    Sub M()
+    End Sub
+
+    Property P1(i As Integer) As Integer
+        Get
+            Return 1
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+
+    Property P2 As Integer
+    Property P3 As New Object
+
+    Event E1(sender As Object, e As EventArgs)
+
+    Event E2 As Action
+
+    Custom Event E3 As EventHandler
+        AddHandler(value As EventHandler)
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As EventArgs)
+        End RaiseEvent
+    End Event
+
+    Dim WithEvents WE As Object
+
+    Enum N
+        A
+    End Enum
+
+    Interface I
+    End Interface
+
+    Class D
+    End Class
+
+    Delegate Sub G()
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "Sub M()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "Property P1(i As Integer)", FeaturesResources.property_),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "Property P2", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "Property P3", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "Event E1(sender As Object, e As EventArgs)", FeaturesResources.event_),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "Event E2", FeaturesResources.event_),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "Event E3", FeaturesResources.event_),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F3 As Integer", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F4 As New Object", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F1", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F2", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F5(1, 2)", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "F6?", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertIntoGenericType, "WE As Object", VBFeaturesResources.WithEvents_field))
+        End Sub
+
+        <Fact>
+        Public Sub Type_Delete()
+            Dim src1 = "
+Class C
+  Sub F()
+  End Sub
+End Class
+
+Module M
+  Sub F()
+  End Sub
+End Module
+
+Structure S
+  Sub F()
+  End Sub
+End Structure
+
+Interface I
+  Sub F()
+End Interface
+
+Delegate Sub D()
+"
+            Dim src2 = ""
+
+            GetTopEdits(src1, src2).VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(FeaturesResources.class_, "C")),
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(VBFeaturesResources.module_, "M")),
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(VBFeaturesResources.structure_, "S")),
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(FeaturesResources.interface_, "I")),
+                Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(FeaturesResources.delegate_, "D")))
+        End Sub
+
+        <Fact>
+        Public Sub PartialType_Delete()
+            Dim srcA1 = "
+Partial Class C
+  Sub F()
+  End Sub
+  Sub M()
+  End Sub
+End Class"
+            Dim srcB1 = "
+Partial Class C
+  Sub G()
+  End Sub
+End Class
+"
+            Dim srcA2 = ""
+            Dim srcB2 = "
+Partial Class C
+  Sub G()
+  End Sub
+  Sub M()
+  End Sub
+End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(FeaturesResources.method, "C.F()"))}),
+                    DocumentResults(
+                        semanticEdits:={
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("M"))
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialType_InsertFirstDeclaration()
+            Dim src1 = ""
+            Dim src2 = "
+Partial Class C
+  Sub F()
+  End Sub
+End Class"
+
+            GetTopEdits(src1, src2).VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C"), preserveLocalVariables:=False)})
+        End Sub
+
+        <Fact>
+        Public Sub PartialType_InsertSecondDeclaration()
+            Dim srcA1 = "
+Partial Class C
+  Sub F()
+  End Sub
+End Class"
+            Dim srcB1 = ""
+
+            Dim srcA2 = "
+Partial Class C
+  Sub F()
+  End Sub
+End Class"
+            Dim srcB2 = "
+Partial Class C
+  Sub G()
+  End Sub
+End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("G"), preserveLocalVariables:=False)
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub Type_DeleteInsert()
+            Dim srcA1 = "
+Class C
+  Sub F()
+  End Sub
+End Class
+
+Module M
+  Sub F()
+  End Sub
+End Module
+
+Structure S
+  Sub F()
+  End Sub
+End Structure
+
+Interface I
+  Sub F()
+End Interface
+
+Delegate Sub D()
+"
+            Dim srcB1 = ""
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("F")),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("M").GetMember("F")),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("S").GetMember("F"))
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub GenericType_DeleteInsert()
+            Dim srcA1 = "
+Class C(Of T)
+  Sub F()
+  End Sub
+End Class
+
+Structure S(Of T)
+  Sub F()
+  End Sub
+End Structure
+
+Interface I(Of T)
+  Sub F()
+End Interface
+"
+            Dim srcB1 = ""
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:=
+                        {
+                            Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, "Sub F()", FeaturesResources.method),
+                            Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, "Sub F()", FeaturesResources.method),
+                            Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, "Sub F()", FeaturesResources.method)
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub Type_DeleteInsert_NonInsertableMembers()
+            Dim srcA1 = "
+MustInherit Class C
+    Implements I
+    Public MustOverride Sub AbstractMethod()
+
+    Public Overridable Sub VirtualMethod()
+    End Sub
+
+    Public Overrides Function ToString() As String
+        Return Nothing
+    End Function
+
+    Public Sub IG() Implements I.G
+    End Sub
+End Class
+
+Interface I
+    Sub G()
+End Interface
+"
+            Dim srcB1 = ""
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("VirtualMethod")),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("ToString")),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("IG"))
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub Type_DeleteInsert_DataMembers()
+            Dim srcA1 = "
+Class C
+    Dim F1 = 1, F2 As New Object, F3 As Integer, F4 As New Object, F5(1, 2), F6? As Integer
+End Class
+"
+            Dim srcB1 = ""
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub Type_DeleteInsert_DataMembers_PartialSplit()
+            Dim srcA1 = "
+Class C
+    Public x = 1
+    Public y = 2
+    Public z = 2
+End Class
+"
+            Dim srcB1 = ""
+
+            Dim srcA2 = "
+Class C
+    Public x = 1
+    Public y = 2
+End Class
+"
+            Dim srcB2 = "
+Partial Class C
+    Public z = 3
+End Class
+"
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                        })
+                })
+        End sub
+
+        <Fact>
+        Public Sub Type_DeleteInsert_DataMembers_PartialMerge()
+            Dim srcA1 = "
+Partial Class C
+    Public x = 1
+    Public y = 2
+End Class
+"
+            Dim srcB1 = "
+Class C
+    Public z = 1
+End Class
+"
+
+            Dim srcA2 = "
+Class C
+    Public x = 1
+    Public y = 2
+    Public z = 2
+End Class
+"
+
+            Dim srcB2 = "
+"
+            ' note that accessors are not updated since they do not have bodies
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                        }),
+                    DocumentResults()
+                })
+        End sub
 #End Region
 
 #Region "Enums"
@@ -894,7 +1467,7 @@ End Interface
                 "Delete [Blue]@19")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Enum Color", FeaturesResources.enum_value))
+                Diagnostic(RudeEditKind.Delete, "Enum Color", DeletedSymbolDisplay(FeaturesResources.enum_value, "Blue")))
         End Sub
 #End Region
 
@@ -1330,110 +1903,114 @@ End Class
         <WorkItem(835827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/835827")>
         <Fact>
         Public Sub NestedClass_Insert_PInvoke_Syntactic()
-            Dim src1 As String = <![CDATA[
+            Dim src1 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 Class C
 End Class
-]]>.Value
+"
 
-            Dim src2 As String = <![CDATA[
+            Dim src2 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 Class C
     Private MustInherit Class D 
-        Declare Ansi Function A Lib "A" () As Integer
-        Declare Ansi Sub B Lib "B" ()
+        Declare Ansi Function A Lib ""A"" () As Integer
+        Declare Ansi Sub B Lib ""B"" ()
     End Class
 End Class
-]]>.Value
+"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "Declare Ansi Function A Lib ""A"" ()", FeaturesResources.method),
-                Diagnostic(RudeEditKind.Insert, "Declare Ansi Sub B Lib ""B"" ()", FeaturesResources.method))
+                Diagnostic(RudeEditKind.InsertDllImport, "Declare Ansi Function A Lib ""A"" ()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertDllImport, "Declare Ansi Sub B Lib ""B"" ()", FeaturesResources.method))
         End Sub
 
         <WorkItem(835827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/835827")>
         <Fact>
         Public Sub NestedClass_Insert_PInvoke_Semantic1()
-            Dim src1 As String = <![CDATA[
+            Dim src1 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 Class C
-End Class
-]]>.Value
+End Class"
 
-            Dim src2 As String = <![CDATA[
+            Dim src2 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 Class C
     Private MustInherit Class D 
-        <DllImport("msvcrt.dll")>
+        <DllImport(""msvcrt.dll"")>
         Public Shared Function puts(c As String) As Integer
         End Function
 
-        <DllImport("msvcrt.dll")>
+        <DllImport(""msvcrt.dll"")>
         Public Shared Operator +(d As D, g As D) As Integer
         End Operator
 
-        <DllImport("msvcrt.dll")>
+        <DllImport(""msvcrt.dll"")>
         Public Shared Narrowing Operator CType(d As D) As Integer
         End Operator
     End Class
-End Class
-]]>.Value
+End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertDllImport, "puts"),
-                Diagnostic(RudeEditKind.InsertDllImport, "+"),
-                Diagnostic(RudeEditKind.InsertDllImport, "CType"))
+            edits.VerifySemantics(
+                diagnostics:=
+                {
+                    Diagnostic(RudeEditKind.InsertDllImport, "Public Shared Function puts(c As String)", FeaturesResources.method),
+                    Diagnostic(RudeEditKind.InsertDllImport, "Public Shared Operator +(d As D, g As D)", FeaturesResources.operator_),
+                    Diagnostic(RudeEditKind.InsertDllImport, "Public Shared Narrowing Operator CType(d As D)", FeaturesResources.operator_)
+                },
+                targetFrameworks:={TargetFramework.NetStandard20})
         End Sub
 
         <WorkItem(835827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/835827")>
         <Fact>
         Public Sub NestedClass_Insert_PInvoke_Semantic2()
-            Dim src1 As String = <![CDATA[
+            Dim src1 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 Class C
-End Class
-]]>.Value
+End Class"
 
-            Dim src2 As String = <![CDATA[
+            Dim src2 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 Class C
-    <DllImport("msvcrt.dll")>
+    <DllImport(""msvcrt.dll"")>
     Private Shared Function puts(c As String) As Integer
     End Function
-End Class
-]]>.Value
+End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertDllImport, "puts"))
+            edits.VerifySemantics(
+                diagnostics:=
+                {
+                    Diagnostic(RudeEditKind.InsertDllImport, "Private Shared Function puts(c As String)", FeaturesResources.method)
+                },
+                targetFrameworks:={TargetFramework.NetStandard20})
         End Sub
 
         <WorkItem(835827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/835827")>
         <Fact>
         Public Sub NestedClass_Insert_VirtualAbstract()
-            Dim src1 As String = <text>
+            Dim src1 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 Class C
 End Class
-</text>.Value
+"
 
-            Dim src2 As String = <text>
+            Dim src2 = "
 Imports System
 Imports System.Runtime.InteropServices
 
@@ -1454,7 +2031,7 @@ Class C
         End Function
     End Class
 End Class
-</text>.Value
+"
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyRudeDiagnostics()
         End Sub
@@ -1489,7 +2066,7 @@ End Class
                 "Delete [()]@29")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Public Class C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Public Class C", DeletedSymbolDisplay(FeaturesResources.method, "goo()")))
         End Sub
 
         <Fact>
@@ -1507,6 +2084,342 @@ End Class
                 Diagnostic(RudeEditKind.Move, "Public Class X", FeaturesResources.class_))
         End Sub
 
+        ''' <summary>
+        ''' A new generic type can be added whether it's nested and inherits generic parameters from the containing type, or top-level.
+        ''' </summary>
+        <Fact>
+        public Sub NestedClassGeneric_Insert()
+            Dim src1 = "
+Imports System
+Class C(Of T)
+End Class
+"
+            Dim src2 = "
+Imports System
+Class C(Of T)
+    Class C
+    End Class
+
+    Structure S
+    End Structure
+
+    Enum N
+        A
+    End Enum
+
+    Interface I
+    End Interface
+
+    Class D
+    End Class
+
+    Delegate Sub G()
+End Class
+
+Class D(Of T)
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyRudeDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub NestedEnum_InsertMember()
+            Dim src1 = "
+Structure S
+  Enum N
+    A = 1
+  End Enum
+End Structure
+"
+            Dim src2 = "
+Structure S
+  Enum N
+    A = 1
+    B = 2
+  End Enum
+End Structure
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyEdits(
+                "Insert [B = 2]@40")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "B = 2", FeaturesResources.enum_value))
+        End Sub
+
+        <Fact, WorkItem(50876, "https://github.com/dotnet/roslyn/issues/50876")>
+        Public Sub NestedEnumInPartialType_InsertDelete()
+            Dim srcA1 = "Partial Structure S : End Structure"
+            Dim srcB1 = "Partial Structure S : Enum N : A = 1 : End Enum" + vbCrLf + "End Structure"
+            Dim srcA2 = "Partial Structure S : Enum N : A = 1 : End Enum" + vbCrLf + "End Structure"
+            Dim srcB2 = "Partial Structure S : End Structure"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact, WorkItem(50876, "https://github.com/dotnet/roslyn/issues/50876")>
+        Public Sub NestedEnumInPartialType_InsertDeleteAndUpdateMember()
+            Dim srcA1 = "Partial Structure S : End Structure"
+            Dim srcB1 = "Partial Structure S : Enum N : A = 1 : End Enum" + vbCrLf + "End Structure"
+            Dim srcA2 = "Partial Structure S : Enum N : A = 2 : End Enum" + vbCrLf + "End Structure"
+            Dim srcB2 = "Partial Structure S : End Structure"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        diagnostics:=
+                        {
+                            Diagnostic(RudeEditKind.InitializerUpdate, "A = 2", FeaturesResources.enum_value)
+                        }),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact, WorkItem(50876, "https://github.com/dotnet/roslyn/issues/50876")>
+        Public Sub NestedEnumInPartialType_InsertDeleteAndInsertMember()
+            Dim srcA1 = "Partial Structure S : End Structure"
+            Dim srcB1 = "Partial Structure S : Enum N : A = 1 : End Enum" + vbCrLf + "End Structure"
+            Dim srcA2 = "Partial Structure S : Enum N : A = 1 : B = 2 : End Enum" + vbCrLf + "End Structure"
+            Dim srcB2 = "Partial Structure S : End Structure"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.Insert, "B = 2", FeaturesResources.enum_value)}),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        public sub NestedDelegateInPartialType_InsertDelete()
+            Dim srcA1 = "Partial Structure S : End Structure"
+            Dim srcB1 = "Partial Structure S : Delegate Sub D()" + vbCrLf + "End Structure"
+            Dim srcA2 = "Partial Structure S : Delegate Sub D()" + vbCrLf + "End Structure"
+            Dim srcB2 = "Partial Structure S : End Structure"
+
+            ' delegate does not have any user-defined method body and this does not need a PDB update
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        ),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub NestedDelegateInPartialType_InsertDeleteAndChangeSignature()
+            Dim srcA1 = "Partial Structure S : End Structure"
+            Dim srcB1 = "Partial Structure S : Delegate Sub D()" + vbCrLf + "End Structure"
+            Dim srcA2 = "Partial Structure S : Delegate Sub D(a As Integer)" + vbCrLf + "End Structure"
+            Dim srcB2 = "Partial Structure S : End Structure"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        diagnostics:=
+                        {
+                            Diagnostic(RudeEditKind.Insert, "a As Integer", FeaturesResources.parameter)
+                        }),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteAndChange()
+            Dim srcA1 = "Partial Structure S : Partial Class C" + vbCrLf + "Sub F1() : End Sub : End Class : End Structure"
+            Dim srcB1 = "Partial Structure S : Partial Class C" + vbCrLf + "Sub F2(x As Byte) : End Sub : End Class : End Structure"
+            Dim srcC1 = "Partial Structure S : End Structure"
+
+            Dim srcA2 = "Partial Structure S : Partial Class C" + vbCrLf + "Sub F1() : End Sub : End Class : End Structure"
+            Dim srcB2 = "Partial Structure S : End Structure"
+            Dim srcC2 = "Partial Structure S : Partial Class C" + vbCrLf + "Sub F2(x As Integer) : End Sub : End Class : End Structure"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.Delete, "Partial Structure S", DeletedSymbolDisplay(FeaturesResources.method, "F2(Byte)"))}),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("S").GetMember(Of NamedTypeSymbol)("C").GetMember("F2"))})
+                })
+        End Sub
+
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteAndChange_BaseType()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = ""
+            Dim srcC1 = "Partial Class C : End Class"
+
+            Dim srcA2 = ""
+            Dim srcB2 = "Partial Class C : Inherits D" + vbCrLf + "End Class"
+            Dim srcC2 = "Partial Class C : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.BaseTypeOrInterfaceUpdate, "Partial Class C", FeaturesResources.class_)}),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteAndChange_Attribute()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = ""
+            Dim srcC1 = "Partial Class C : End Class"
+
+            Dim srcA2 = ""
+            Dim srcB2 = "<A>Partial Class C : End Class"
+            Dim srcC2 = "Partial Class C : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.Update, "Partial Class C", FeaturesResources.class_)}),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteAndChange_Constraint()
+            Dim srcA1 = "Partial Class C(Of T) : End Class"
+            Dim srcB1 = ""
+            Dim srcC1 = "Partial Class C(Of T) : End Class"
+
+            Dim srcA2 = ""
+            Dim srcB2 = "Partial Class C(Of T As New) : End Class"
+            Dim srcC2 = "Partial Class C(Of T) : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.Update, "Partial Class C(Of T As New)", FeaturesResources.class_)}),
+                    DocumentResults()
+                })
+        End Sub
+
+        ''' <summary>
+        ''' Moves partial classes to different files while moving around their attributes and base interfaces.
+        ''' </summary>
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteRefactor()
+            Dim srcA1 = "Partial Class C : Implements I" + vbCrLf + "Sub F() : End Sub : End Class"
+            Dim srcB1 = "<A><B>Partial Class C : Implements J" + vbCrLf + "Sub G() : End Sub : End Class"
+            Dim srcC1 = ""
+            Dim srcD1 = ""
+
+            Dim srcA2 = ""
+            Dim srcB2 = ""
+            Dim srcC2 = "<A>Partial Class C : Implements I, J" + vbCrLf + "Sub F() : End Sub : End Class"
+            Dim srcD2 = "<B>Partial Class C" + vbCrLf + "Sub G() : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("F"))}),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("G"))})
+                })
+        End Sub
+
+        ''' <summary>
+        ''' Moves partial classes to different files while moving around their attributes and base interfaces.
+        ''' Currently we do not support splitting attribute lists.
+        ''' </summary>
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteRefactor_AttributeListSplitting()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Sub F() : End Sub : End Class"
+            Dim srcB1 = "<A,B>Partial Class C" + vbCrLf + "Sub G() : End Sub : End Class"
+            Dim srcC1 = ""
+            Dim srcD1 = ""
+
+            Dim srcA2 = ""
+            Dim srcB2 = ""
+            Dim srcC2 = "<A>Partial Class C" + vbCrLf + "Sub F() : End Sub : End Class"
+            Dim srcD2 = "<B>Partial Class C" + vbCrLf + "Sub G() : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(diagnostics:={Diagnostic(RudeEditKind.Update, "Partial Class C", FeaturesResources.class_)}),
+                    DocumentResults(diagnostics:={Diagnostic(RudeEditKind.Update, "Partial Class C", FeaturesResources.class_)})
+                })
+        End Sub
+
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteChangeMember()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Sub F(Optional y As Integer = 1) : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Sub G(Optional x As Integer = 1) : End Sub : End Class"
+            Dim srcC1 = ""
+
+            Dim srcA2 = ""
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Sub G(Optional x As Integer = 2) : End Sub : End Class"
+            Dim srcC2 = "Partial Class C" + vbCrLf + "Sub F(Optional y As Integer = 2) : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics:={Diagnostic(RudeEditKind.InitializerUpdate, "Optional x As Integer = 2", FeaturesResources.parameter)}),
+                    DocumentResults(diagnostics:={Diagnostic(RudeEditKind.InitializerUpdate, "Optional y As Integer = 2", FeaturesResources.parameter)})
+                })
+        End Sub
+
+        <Fact>
+        Public Sub NestedPartialTypeInPartialType_InsertDeleteAndInsertVirtual()
+            Dim srcA1 = "Partial Interface I : Partial Class C" + vbCrLf + "Overridable Sub F1()" + vbCrLf + "End Sub : End Class : End Interface"
+            Dim srcB1 = "Partial Interface I : Partial Class C" + vbCrLf + "Overridable Sub F2()" + vbCrLf + "End Sub : End Class : End Interface"
+            Dim srcC1 = "Partial Interface I : Partial Class C" + vbCrLf + "End Class : End Interface"
+            Dim srcD1 = "Partial Interface I : Partial Class C" + vbCrLf + "End Class : End Interface"
+            Dim srcE1 = "Partial Interface I : End Interface"
+            Dim srcF1 = "Partial Interface I : End Interface"
+
+            Dim srcA2 = "Partial Interface I : Partial Class C" + vbCrLf + "End Class : End Interface"
+            Dim srcB2 = ""
+            Dim srcC2 = "Partial Interface I : Partial Class C" + vbCrLf + "Overridable Sub F1()" + vbCrLf + "End Sub : End Class : End Interface" ' move existing virtual into existing partial decl
+            Dim srcD2 = "Partial Interface I : Partial Class C" + vbCrLf + "Overridable Sub N1()" + vbCrLf + "End Sub : End Class : End Interface" ' insert new virtual into existing partial decl
+            Dim srcE2 = "Partial Interface I : Partial Class C" + vbCrLf + "Overridable Sub F2()" + vbCrLf + "End Sub : End Class : End Interface" ' move existing virtual into a new partial decl
+            Dim srcF2 = "Partial Interface I : Partial Class C" + vbCrLf + "Overridable Sub N2()" + vbCrLf + "End Sub : End Class : End Interface" ' insert new virtual into new partial decl
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2), GetTopEdits(srcE1, srcE2), GetTopEdits(srcF1, srcF2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("I").GetMember(Of NamedTypeSymbol)("C").GetMember("F1"))}),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.InsertVirtual, "Overridable Sub N1()", FeaturesResources.method)}),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("I").GetMember(Of NamedTypeSymbol)("C").GetMember("F2"))}),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.InsertVirtual, "Overridable Sub N2()", FeaturesResources.method)})
+                })
+        End Sub
+
 #End Region
 
 #Region "Namespaces"
@@ -1518,6 +2431,16 @@ End Class
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Insert, "Namespace C", FeaturesResources.namespace_))
+        End Sub
+
+        <Fact>
+        Public Sub NamespaceDelete()
+            Dim src1 = "Namespace C : End Namespace"
+            Dim src2 = ""
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, Nothing, FeaturesResources.namespace_))
         End Sub
 
         <Fact>
@@ -1571,6 +2494,410 @@ End Class
                 "Reorder [Namespace E : End Namespace]@129 -> @14")
 
             edits.VerifyRudeDiagnostics()
+        End Sub
+
+#End Region
+
+#Region "Members"
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert()
+            Dim srcA1 = "
+Imports System
+
+Partial Class C
+    Dim F1 = 1, F2 As New Object, F3 As Integer, F4 As New Object, F5(1, 2), F6? As Integer
+
+    Sub M()
+    End Sub
+
+    Property P1(i As Integer) As Integer
+        Get
+            Return 1
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+
+    Property P2 As Integer
+    Property P3 As New Object
+
+    Event E1(sender As Object, e As EventArgs)
+
+    Event E2 As Action
+
+    Custom Event E3 As EventHandler
+        AddHandler(value As EventHandler)
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As EventArgs)
+        End RaiseEvent
+    End Event
+
+    Dim WithEvents WE As Object
+End Class
+"
+            Dim srcB1 = "
+Imports System
+
+Partial Class C
+End Class
+"
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("M")),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of PropertySymbol)("P1").GetMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of PropertySymbol)("P1").SetMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of EventSymbol)("E3").AddMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of EventSymbol)("E3").RemoveMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of EventSymbol)("E3").RaiseMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_InsertDelete_MultipleDocuments()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Sub F() : End Sub : End Class"
+            Dim srcA2 = "Partial Class C" + vbCrLf + "Sub F() : End Sub : End Class"
+            Dim srcB2 = "Partial Class C : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("F"), preserveLocalVariables:=False)
+                        }),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_MultipleDocuments()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Sub F() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Sub F() : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F"), preserveLocalVariables:=False)
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_GenericMethod()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Sub F(Of T)() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Sub F(Of T)() : End Sub : End Class"
+
+            ' TODO better message
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics:=
+                    {
+                        Diagnostic(RudeEditKind.GenericMethodTriviaUpdate, "Sub F(Of T)()", FeaturesResources.method)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_GenericType()
+            Dim srcA1 = "Partial Class C(Of T)" + vbCrLf + "Sub F(Of T)() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C(Of T) : End Class"
+            Dim srcA2 = "Partial Class C(Of T) : End Class"
+            Dim srcB2 = "Partial Class C(Of T)" + vbCrLf + "Sub F(Of T)() : End Sub : End Class"
+
+            ' TODO better message
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics:=
+                    {
+                        Diagnostic(RudeEditKind.GenericMethodTriviaUpdate, "Sub F(Of T)()", FeaturesResources.method)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialNestedType_InsertDeleteAndChange()
+            Dim srcA1 = "
+Partial Class C 
+End Class
+"
+            Dim srcB1 = "
+Partial Class C
+    Class D
+        Sub M()
+        End Sub
+    End Class
+
+    Interface I 
+    End Interface 
+End Class"
+
+            Dim srcA2 = "
+Partial Class C
+    Class D
+        Implements I
+
+        Sub M()
+        End Sub
+    End Class
+
+    Interface I 
+    End Interface 
+End Class"
+
+            Dim srcB2 = "
+Partial Class C 
+End Class
+"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        diagnostics:=
+                        {
+                            Diagnostic(RudeEditKind.BaseTypeOrInterfaceUpdate, "Class D", FeaturesResources.class_)
+                        }),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact, WorkItem(51011, "https://github.com/dotnet/roslyn/issues/51011")>
+        Public Sub PartialMember_RenameInsertDelete()
+            ' The syntactic analysis for A And B produce rename edits since it  doesn't see that the member was in fact moved.
+            ' TODO: Currently, we don't even pass rename edits to semantic analysis where we could handle them as updates.
+
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Sub F1() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Sub F2() : End Sub : End Class"
+            Dim srcA2 = "Partial Class C" + vbCrLf + "Sub F2() : End Sub : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Sub F1() : End Sub : End Class"
+
+            ' current outcome
+            GetTopEdits(srcA1, srcA2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Renamed, "Sub F2()", FeaturesResources.method))
+            GetTopEdits(srcB1, srcB2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.Renamed, "Sub F1()", FeaturesResources.method))
+
+            ' correct outcome
+            'EditAndContinueValidation.VerifySemantics(
+            '     { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+            '    
+            '    {
+            '        DocumentResults(semanticEdits:=
+            '            {
+            '                SemanticEdit(SemanticEditKind.Update, c => c.GetMember(Of NamedTypeSymbol)("C").GetMember("F2")),
+            '            }),
+            '
+            '        DocumentResults(
+            '            semanticEdits:=
+            '            {
+            '                SemanticEdit(SemanticEditKind.Update, c => c.GetMember(Of NamedTypeSymbol)("C").GetMember("F1")),
+            '            })
+            '    });
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_UpdateMethodBodyError()
+            Dim srcA1 = "
+Imports System.Collections.Generic
+
+Partial Class C
+    Iterator Function F() As IEnumerable(Of Integer)
+        Yield 1
+    End Function
+End Class
+"
+            Dim srcB1 = "
+Imports System.Collections.Generic
+
+Partial Class C
+End Class
+"
+
+            Dim srcA2 = "
+Imports System.Collections.Generic
+
+Partial Class C
+End Class
+"
+            Dim srcB2 = "
+Imports System.Collections.Generic
+
+Partial Class C
+    Iterator Function F() As IEnumerable(Of Integer)
+        Yield 1
+        Yield 2
+    End Function
+End Class
+"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics:=
+                    {
+                        Diagnostic(RudeEditKind.Insert, "Yield 2", VBFeaturesResources.Yield_statement)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_UpdatePropertyAccessors()
+            Dim srcA1 = "
+Partial Class C
+    Property P As Integer
+        Get
+            Return 1
+        End Get
+        Set(value As Integer)
+            Console.WriteLine(1)
+        End Set
+    End Property
+End Class
+"
+            Dim srcB1 = "Partial Class C: End Class"
+
+            Dim srcA2 = "Partial Class C: End Class"
+            Dim srcB2 = "
+Partial Class C
+    Property P As Integer
+        Get
+            Return 2
+        End Get
+        Set(value As Integer)
+            Console.WriteLine(2)
+        End Set
+    End Property
+End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of PropertySymbol)("P").GetMethod),
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of PropertySymbol)("P").SetMethod)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_UpdateAutoProperty()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Property P As Integer = 1 : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Property P As Integer = 2 : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_AddFieldInitializer()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Dim P As Integer : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Dim P As Integer = 1 : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_RemoveFieldInitializer()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Dim P As Integer = 1 : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Dim P As Integer : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMember_DeleteInsert_ConstructorWithInitializers()
+            Dim srcA1 = "
+Partial Class C
+    Dim F = 1
+
+    Sub New(x As Integer)
+        F = x
+    End Sub
+End Class"
+            Dim srcB1 = "
+Partial Class C
+End Class"
+
+            Dim srcA2 = "
+Partial Class C
+    Dim F = 1
+End Class"
+            Dim srcB2 = "
+Partial Class C
+    Sub New(x As Integer)
+        F = x + 1
+    End Sub
+End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                    })
+                })
         End Sub
 
 #End Region
@@ -1661,7 +2988,7 @@ End Class
                 "Delete [()]@15")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.method, "goo()")))
         End Sub
 
         <Fact>
@@ -1672,7 +2999,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Interface C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Interface C", DeletedSymbolDisplay(FeaturesResources.method, "Goo()")))
         End Sub
 
         <Fact>
@@ -1691,7 +3018,7 @@ End Class
                 "Delete [As Integer]@18")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.method, "goo(Integer)")))
         End Sub
 
         <Fact>
@@ -1712,7 +3039,7 @@ End Class
                 "Delete [As Integer]@32")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.method, "goo(Integer)")))
         End Sub
 
         <Fact>
@@ -1800,7 +3127,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "MustOverride Sub F", FeaturesResources.method))
+                Diagnostic(RudeEditKind.InsertVirtual, "MustOverride Sub F", FeaturesResources.method))
         End Sub
 
         <Fact>
@@ -1812,6 +3139,36 @@ End Class
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.InsertVirtual, "Overrides Sub F", FeaturesResources.method))
+        End Sub
+
+        <Fact>
+        Public Sub ExternMethodDeleteInsert()
+            Dim srcA1 = "
+Imports System
+Imports System.Runtime.InteropServices
+
+Class C
+    <DllImport(""msvcrt.dll"")>
+    Public Shared Function puts(c As String) As Integer
+    End Function
+End Class"
+            Dim srcA2 = "
+Imports System
+Imports System.Runtime.InteropServices
+"
+
+            Dim srcB1 = srcA2
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("puts"))
+                    })
+                })
         End Sub
 
         <Fact>
@@ -1866,7 +3223,7 @@ End Class
                 "Delete [As Integer]@55")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.method, "f(Integer, Integer)")))
         End Sub
 
         <Fact>
@@ -2442,14 +3799,14 @@ End Class
 
         <Fact>
         Public Sub MethodInsert_Handles_Clause()
-            Dim src1 = "Class C : Event E1 As Action" & vbLf & "End Class"
-            Dim src2 = "Class C : Event E1 As Action" & vbLf & "Private Sub Goo() Handles Me.E1 : End Sub : End Class"
+            Dim src1 = "Class C : Event E1 As System.Action" & vbLf & "End Class"
+            Dim src2 = "Class C : Event E1 As System.Action" & vbLf & "Private Sub Goo() Handles Me.E1 : End Sub : End Class"
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyEdits(
-                "Insert [Private Sub Goo() Handles Me.E1 : End Sub]@29",
-                "Insert [Private Sub Goo() Handles Me.E1]@29",
-                "Insert [()]@44")
+                "Insert [Private Sub Goo() Handles Me.E1 : End Sub]@36",
+                "Insert [Private Sub Goo() Handles Me.E1]@36",
+                "Insert [()]@51")
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.InsertHandlesClause, "Private Sub Goo()", FeaturesResources.method))
@@ -2480,6 +3837,295 @@ End Class
             Dim src1 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Static a = 0 : a = 1 : End Sub : End Module"
             Dim src2 = "Module C : " & vbLf & "Sub Main()" & vbLf & "Dim a = 0 : a = 2 : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub PartialMethod_DeleteInsert_DefinitionPart()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcC1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "partial class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcC2 = "partial class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F").PartialImplementationPart)})
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMethod_DeleteInsert_ImplementationPart()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+            Dim srcC1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB2 = "Partial Class C : End Class"
+            Dim srcC2 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F").PartialImplementationPart)})
+                })
+        End Sub
+
+        <Fact, WorkItem(51011, "https://github.com/dotnet/roslyn/issues/51011")>
+        Public Sub PartialMethod_Swap_ImplementationAndDefinitionParts()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+
+            Dim srcA2 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+
+            ' TODO: current
+            GetTopEdits(srcA1, srcA2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.ModifiersUpdate, "Private Sub F()", FeaturesResources.method))
+            GetTopEdits(srcB1, srcB2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.ModifiersUpdate, "Partial Private Sub F()", FeaturesResources.method))
+
+            ' TODO: correct 
+            ' EditAndContinueValidation.VerifySemantics(
+            '      { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+            '     
+            '     {
+            '         DocumentResults(),
+            '         DocumentResults(
+            '             semanticEdits:= { SemanticEdit(SemanticEditKind.Update, c => c.GetMember(Of NamedTypeSymbol)("C").GetMember("F")) }),
+            '     });
+        End Sub
+
+        <Fact>
+        Public Sub PartialMethod_DeleteImplementation()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+
+            Dim srcA2 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB2 = "Partial Class C : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.Delete, "Partial Class C", DeletedSymbolDisplay(FeaturesResources.method, "F()"))})
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMethod_DeleteBoth()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.Delete, "Partial Class C", DeletedSymbolDisplay(FeaturesResources.method, "F()"))})
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMethod_DeleteInsertBoth()
+            Dim srcA1 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB1 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+            Dim srcC1 = "Partial Class C : End Class"
+            Dim srcD1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C : End Class"
+            Dim srcC2 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcD2 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2), GetTopEdits(srcC1, srcC2), GetTopEdits(srcD1, srcD2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F").PartialImplementationPart)})
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialMethod_Insert()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
+            Dim srcB2 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F").PartialImplementationPart)})
+                })
+        End Sub
+#End Region
+
+#Region "Operators"
+
+        <Fact>
+        Public Sub OperatorInsert()
+            Dim src1 = "
+Class C
+End Class
+"
+            Dim src2 = "
+Class C
+    Public Shared Operator +(d As C, g As C) As Integer
+        Return Nothing
+    End Operator
+
+    Public Shared Narrowing Operator CType(d As C) As Integer
+        Return Nothing
+    End Operator
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertOperator, "Public Shared Operator +(d As C, g As C)", FeaturesResources.operator_),
+                Diagnostic(RudeEditKind.InsertOperator, "Public Shared Narrowing Operator CType(d As C)", FeaturesResources.operator_))
+        End Sub
+
+        <Fact>
+        Public Sub OperatorDelete()
+            Dim src1 = "
+Class C
+    Public Shared Operator +(d As C, g As C) As Integer
+        Return Nothing
+    End Operator
+
+    Public Shared Narrowing Operator CType(d As C) As Integer
+        Return Nothing
+    End Operator
+End Class
+"
+            Dim src2 = "
+Class C
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.operator_, "+(C, C)")),
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.operator_, "CType(C)")))
+        End Sub
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/51011"), WorkItem(51011, "https://github.com/dotnet/roslyn/issues/51011")>
+        Public Sub OperatorInsertDelete()
+            Dim srcA1 = "
+Partial Class C
+    Public Shared Narrowing Operator CType(d As C) As Integer
+        Return Nothing
+    End Operator
+End Class
+"
+            Dim srcB1 = "
+Partial Class C
+    Public Shared Operator +(d As C, g As C) As Integer
+        Return Nothing
+    End Operator
+End Class
+"
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("op_Addition"))
+                        }),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("op_Implicit"))
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub OperatorUpdate()
+            Dim src1 = "
+Class C
+    Public Shared Narrowing Operator CType(d As C) As Integer
+        Return 0
+    End Operator
+
+    Public Shared Operator +(d As C, g As C) As Integer
+        Return 0
+    End Operator
+End Class
+"
+            Dim src2 = "
+Class C
+    Public Shared Narrowing Operator CType(d As C) As Integer
+        Return 1
+    End Operator
+
+    Public Shared Operator +(d As C, g As C) As Integer
+        Return 1
+    End Operator
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemantics(ActiveStatementsDescription.Empty,
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("op_Explicit")),
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("op_Addition"))
+            })
+        End Sub
+
+        <Fact>
+        Public Sub OperatorReorder()
+            Dim src1 = "
+Class C
+    Public Shared Narrowing Operator CType(d As C) As Integer
+        Return 0
+    End Operator
+
+    Public Shared Operator +(d As C, g As C) As Integer
+        Return 0
+    End Operator
+End Class
+"
+            Dim src2 = "
+Class C
+    Public Shared Operator +(d As C, g As C) As Integer
+        Return 0
+    End Operator
+
+    Public Shared Narrowing Operator CType(d As C) As Integer
+        Return 0
+    End Operator
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Reorder [Public Shared Operator +(d As C, g As C) As Integer
+        Return 0
+    End Operator]@116 -> @15")
 
             edits.VerifyRudeDiagnostics()
         End Sub
@@ -2555,7 +4201,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.constructor))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(VBFeaturesResources.Shared_constructor, "New()")))
         End Sub
 
         <Fact>
@@ -2565,7 +4211,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Module C", FeaturesResources.constructor))
+                Diagnostic(RudeEditKind.Delete, "Module C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
         End Sub
 
         <Fact>
@@ -2575,7 +4221,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -2585,47 +4231,39 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
-        <Fact>
-        Public Sub InstanceCtorDelete_Private1()
-            Dim src1 = "Class C" & vbLf & "Private Sub New() : End Sub : End Class"
+        <Theory>
+        <InlineData("Private")>
+        <InlineData("Protected")>
+        <InlineData("Friend")>
+        <InlineData("Protected Friend")>
+        Public Sub InstanceCtorDelete_NonPublic(visibility As String)
+            Dim src1 = "Class C" & vbLf & visibility & " Sub New() : End Sub : End Class"
             Dim src2 = "Class C : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.constructor))
+                Diagnostic(RudeEditKind.ChangingVisibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
         End Sub
 
         <Fact>
-        Public Sub InstanceCtorDelete_Protected()
-            Dim src1 = "Class C" & vbLf & "Protected Sub New() : End Sub : End Class"
-            Dim src2 = "Class C : End Class"
-            Dim edits = GetTopEdits(src1, src2)
+        Public Sub InstanceCtorDelete_Public_PartialWithInitializerUpdate()
+            Dim srcA1 = "Class C" & vbLf & "Public Sub New() : End Sub : End Class"
+            Dim srcB1 = "Class C" & vbLf & "Dim x = 1 : End Class"
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.constructor))
-        End Sub
+            Dim srcA2 = "Class C : End Class"
+            Dim srcB2 = "Class C" & vbLf & "Dim x = 2 : End Class"
 
-        <Fact>
-        Public Sub InstanceCtorDelete_Internal()
-            Dim src1 = "Class C" & vbLf & "Friend Sub New() : End Sub : End Class"
-            Dim src2 = "Class C : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.constructor))
-        End Sub
-
-        <Fact>
-        Public Sub InstanceCtorDelete_ProtectedInternal()
-            Dim src1 = "Class C" & vbLf & "Protected Friend Sub New() : End Sub : End Class"
-            Dim src2 = "Class C : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.constructor))
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), partialType:="C", preserveLocalVariables:=True)}),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), partialType:="C", preserveLocalVariables:=True)})
+                })
         End Sub
 
         <Fact>
@@ -2666,11 +4304,13 @@ End Class
             Dim srcA2 = "Partial Class C" & vbLf & "End Class"
             Dim srcB2 = "Partial Class C" & vbLf & "Sub New() : End Sub : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' no change in document A
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:=
                 {
-                    SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
                 })
         End Sub
 
@@ -2682,7 +4322,7 @@ End Class
 
             edits.VerifySemantics(
                 ActiveStatementsDescription.Empty,
-                expectedSemanticEdits:=
+                semanticEdits:=
                 {
                     SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.Parameters.IsEmpty))
                 })
@@ -2696,52 +4336,28 @@ End Class
             Dim srcA2 = "Partial Class C" & vbLf & "Sub New() : End Sub : End Class"
             Dim srcB2 = "Partial Class C" & vbLf & "Sub New(a As Integer) : End Sub : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' no change in document B
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:=
                 {
-                    SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.Parameters.IsEmpty))
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(Function(m) m.Parameters.IsEmpty))}),
+                    DocumentResults()
                 })
         End Sub
 
-        <Fact>
-        Public Sub InstanceCtorInsert_Private_Implicit1()
+        <Theory>
+        <InlineData("Private")>
+        <InlineData("Protected")>
+        <InlineData("Friend")>
+        <InlineData("Friend Protected")>
+        Public Sub InstanceCtorInsert_Private_Implicit1(visibility As String)
             Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C" & vbLf & "Private Sub New() : End Sub : End Class"
+            Dim src2 = "Class C" & vbLf & visibility & " Sub New() : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Private Sub New()"))
-        End Sub
-
-        <Fact>
-        Public Sub InstanceCtorInsert_Protected_PublicImplicit()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C" & vbLf & "Protected Sub New() : End Sub : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Protected Sub New()"))
-        End Sub
-
-        <Fact>
-        Public Sub InstanceCtorInsert_Internal_PublicImplicit()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C" & vbLf & "Friend Sub New() : End Sub : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Friend Sub New()"))
-        End Sub
-
-        <Fact>
-        Public Sub InstanceCtorInsert_Internal_ProtectedImplicit()
-            Dim src1 = "MustInherit Class C : End Class"
-            Dim src2 = "MustInherit Class C" & vbLf & "Friend Sub New() : End Sub : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Friend Sub New()"))
+                Diagnostic(RudeEditKind.ChangingVisibility, visibility & " Sub New()", FeaturesResources.constructor))
         End Sub
 
         <Fact>
@@ -2765,28 +4381,13 @@ End Class
                                       InstanceConstructors.Single(Function(ctor) ctor.DeclaredAccessibility = Accessibility.Private))})
         End Sub
 
-        <Fact>
-        Public Sub InstanceCtorInsert_Internal_NoImplicit()
+        <Theory>
+        <InlineData("Friend")>
+        <InlineData("Protected")>
+        <InlineData("Friend Protected")>
+        Public Sub InstanceCtorInsert_Internal_NoImplicit(visibility As String)
             Dim src1 = "Class C" & vbLf & "Public Sub New(a As Integer) : End Sub : End Class"
-            Dim src2 = "Class C" & vbLf & "Public Sub New(a As Integer) : End Sub : " & vbLf & "Friend Sub New() : End Sub : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifySemanticDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub InstanceCtorInsert_Protected_NoImplicit()
-            Dim src1 = "Class C" & vbLf & "Public Sub New(a As Integer) : End Sub : End Class"
-            Dim src2 = "Class C" & vbLf & "Public Sub New(a As Integer) : End Sub : " & vbLf & "Protected Sub New() : End Sub : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifySemanticDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub InstanceCtorInsert_FriendProtected_NoImplicit()
-            Dim src1 = "Class C" & vbLf & "Public Sub New(a As Integer) : End Sub : End Class"
-            Dim src2 = "Class C" & vbLf & "Public Sub New(a As Integer) : End Sub : " & vbLf & "Friend Protected Sub New() : End Sub : End Class"
+            Dim src2 = "Class C" & vbLf & "Public Sub New(a As Integer) : End Sub : " & vbLf & visibility & " Sub New() : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics()
@@ -2800,22 +4401,33 @@ End Class
             Dim srcA2 = "Partial Class C : End Class"
             Dim srcB2 = "Partial Class C" & vbLf & "Shared Sub New() : End Sub : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
+                })
         End Sub
 
         <Fact>
-        Public Sub ModuleCtor_Partial_Delete()
+        Public Sub ModuleCtor_Partial_DeleteInsert()
             Dim srcA1 = "Partial Module C" & vbLf & "Sub New() : End Sub : End Module"
             Dim srcB1 = "Partial Module C : End Module"
 
             Dim srcA2 = "Partial Module C : End Module"
             Dim srcB2 = "Partial Module C" & vbLf & "Sub New() : End Sub : End Module"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        ),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
+                })
         End Sub
 
         <Fact>
@@ -2826,9 +4438,15 @@ End Class
             Dim srcA2 = "Partial Class C : End Class"
             Dim srcB2 = "Partial Class C" & vbLf & "Private Sub New() : End Sub : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        ),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                })
         End Sub
 
         <Fact>
@@ -2839,9 +4457,14 @@ End Class
             Dim srcA2 = "Partial Class C : End Class"
             Dim srcB2 = "Partial Class C" & vbLf & "Public Sub New() : End Sub : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                })
         End Sub
 
         <Fact>
@@ -2852,9 +4475,14 @@ End Class
             Dim srcA2 = "Partial Class C : End Class"
             Dim srcB2 = "Partial Class C" & vbLf & "Public Sub New() : End Sub : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be reported as rude edit in the other document where it was inserted back with changed visibility
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedDiagnostics:={Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Public Sub New()")})
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.ModifiersUpdate, "Public Sub New()", FeaturesResources.constructor)})
+                })
         End Sub
 
         <Fact>
@@ -2865,9 +4493,15 @@ End Class
             Dim srcA2 = "Partial Class C" & vbLf & "Shared Sub New() : End Sub : End Class"
             Dim srcB2 = "Partial Class C : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be reported as rude edit in the other document where it was inserted back with changed visibility
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)}),
+                    DocumentResults(
+                        )
+                })
         End Sub
 
         <Fact>
@@ -2878,9 +4512,15 @@ End Class
             Dim srcA2 = "Partial Module C" & vbLf & "Sub New() : End Sub : End Module"
             Dim srcB2 = "Partial Module C : End Module"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)}),
+                    DocumentResults(
+                        )
+                })
         End Sub
 
         <Fact>
@@ -2891,9 +4531,15 @@ End Class
             Dim srcA2 = "Partial Class C" & vbLf & "Sub New() : End Sub : End Class"
             Dim srcB2 = "Partial Class C : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)}),
+                    DocumentResults(
+                        )
+                })
         End Sub
 
         <Fact>
@@ -2904,9 +4550,15 @@ End Class
             Dim srcA2 = "Partial Class C" & vbLf & "Private Sub New() : End Sub : End Class"
             Dim srcB2 = "Partial Class C : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)}),
+                    DocumentResults(
+                        )
+                })
         End Sub
 
         <Fact>
@@ -2917,9 +4569,15 @@ End Class
             Dim srcA2 = "Partial Class C" & vbLf & "Friend Sub New() : End Sub : End Class"
             Dim srcB2 = "Partial Class C : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)}),
+                    DocumentResults(
+                        )
+                })
         End Sub
 
         <Fact>
@@ -2930,35 +4588,39 @@ End Class
             Dim srcA2 = "Partial Class C" & vbLf & "Friend Sub New()" & vbLf & "Console.WriteLine(1) : End Sub : End Class"
             Dim srcB2 = "Partial Class C : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be represented as a semantic update in the other document where it was inserted back
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedSemanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)}),
+                    DocumentResults()
+                })
         End Sub
 
-        <Fact>
-        Public Sub InstanceCtor_Partial_InsertPublicDeletePrivate()
+        <Theory>
+        <InlineData("")>
+        <InlineData("Friend")>
+        <InlineData("Public")>
+        Public Sub InstanceCtor_Partial_VisibilityUpdate(visibility As String)
+            If visibility.Length > 0 Then
+                visibility &= " "
+            End If
+
             Dim srcA1 = "Partial Class C : End Class"
             Dim srcB1 = "Partial Class C" & vbLf & "Private Sub New() : End Sub : End Class"
 
-            Dim srcA2 = "Partial Class C" & vbLf & "Sub New() : End Sub : End Class"
+            Dim srcA2 = "Partial Class C" & vbLf & visibility & "Sub New() : End Sub : End Class"
             Dim srcB2 = "Partial Class C : End Class"
 
-            EditAndContinueValidation.VerifySemantics(
+            ' delete of the constructor in partial part will be reported as rude edit in the other document where it was inserted back with changed visibility
+            VerifySemantics(
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedDiagnostics:={Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Sub New()")})
-        End Sub
-
-        <Fact>
-        Public Sub InstanceCtor_Partial_InsertInternalDeletePrivate()
-            Dim srcA1 = "Partial Class C : End Class"
-            Dim srcB1 = "Partial Class C" & vbLf & "Private Sub New() : End Sub : End Class"
-
-            Dim srcA2 = "Partial Class C" & vbLf & "Friend Sub New() : End Sub : End Class"
-            Dim srcB2 = "Partial Class C : End Class"
-
-            EditAndContinueValidation.VerifySemantics(
-                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
-                expectedDiagnostics:={Diagnostic(RudeEditKind.ChangingConstructorVisibility, "Friend Sub New()")})
+                {
+                    DocumentResults(
+                        diagnostics:={Diagnostic(RudeEditKind.ModifiersUpdate, visibility & "Sub New()", FeaturesResources.constructor)}),
+                    DocumentResults()
+                })
         End Sub
 
         <Fact>
@@ -3175,9 +4837,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim syntaxMap = GetSyntaxMap(src1, src2)
 
-            edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+            edits.VerifySemanticDiagnostics(
+                {Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "Sub New()")})
         End Sub
 
         <Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")>
@@ -3230,6 +4891,136 @@ End Class
         End Sub
 
         <Fact>
+        public sub PartialTypes_ConstructorWithInitializerUpdates()
+            Dim srcA1 = "
+Imports System
+
+Partial Class C
+    Sub New(arg As Integer)
+        Console.WriteLine(0)
+    End Sub
+
+    Sub New(arg As Boolean)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim srcB1 = "
+Imports System
+
+Partial Class C
+    Dim <N:0.0>a = 1</N:0.0>
+
+    Sub New(arg As UInteger)
+        Console.WriteLine(2)
+    End Sub
+End Class
+"
+
+            Dim srcA2 = "
+Imports System
+
+Partial Class C
+    Sub New(arg As Integer)
+        Console.WriteLine(0)
+    End Sub
+
+    Sub New(arg As Boolean)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim srcB2 = "
+Imports System
+
+Partial Class C
+    Dim <N:0.0>a = 2</N:0.0>    ' updated field initializer
+
+    Sub New(arg As UInteger)
+        Console.WriteLine(2)
+    End Sub
+
+    Sub New(arg As Byte)
+        Console.WriteLine(3)    ' new ctor
+    End Sub
+End Class
+"
+            Dim syntaxMapB = GetSyntaxMap(srcB1, srcB2)(0)
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                           SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(m) m.Parameters.Single().Type.Name = "Int32"), syntaxMap:=syntaxMapB),
+                           SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(m) m.Parameters.Single().Type.Name = "Boolean"), syntaxMap:=syntaxMapB),
+                           SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(m) m.Parameters.Single().Type.Name = "UInt32"), syntaxMap:=syntaxMapB),
+                           SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(Function(m) m.Parameters.Single().Type.Name = "Byte"), syntaxMap:=Nothing)
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialTypes_ConstructorWithInitializerUpdates_SemanticErrors()
+            Dim srcA1 = "
+Imports System
+
+Partial Class C
+    Sub New(arg As Integer)
+        Console.WriteLine(0)
+    End Sub
+
+    Sub New(arg As Integer)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim srcB1 = "
+Imports System
+
+Partial Class C
+    Dim a = 1
+End Class
+"
+
+            Dim srcA2 = "
+Imports System
+
+Partial Class C
+    Sub New(arg As Integer)
+        Console.WriteLine(0)
+    End Sub
+
+    Sub New(arg As Integer)
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim srcB2 = "
+Imports System
+
+Partial Class C
+    Dim a = 1
+
+    Sub New(arg As Integer)
+        Console.WriteLine(2)
+    End Sub
+End Class
+"
+
+            ' The actual edits do not matter since there are semantic errors in the compilation.
+            ' We just should not crash.
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics:=Array.Empty(Of RudeEditDiagnosticDescription)())
+                })
+        End Sub
+
+        <Fact>
         Public Sub Constructor_SemanticError_Partial()
             Dim src1 = "
 Partial Class C
@@ -3242,7 +5033,6 @@ Class C
         System.Console.WriteLine(1)
     End Sub
 End Class
-
 "
             Dim src2 = "
 Partial Class C
@@ -3257,10 +5047,89 @@ Class C
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifySemantics(ActiveStatementsDescription.Empty, expectedSemanticEdits:=
+            edits.VerifySemantics(ActiveStatementsDescription.Empty, semanticEdits:=
             {
-                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Skip(1).First(), preserveLocalVariables:=True)
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.First(), preserveLocalVariables:=True)
             })
+        End Sub
+
+        <Fact>
+        public sub PartialDeclaration_Delete()
+            Dim srcA1 = "
+Partial Class C
+    Sub New()
+    End Sub
+
+    Sub F()
+    End Sub
+End Class
+"
+            Dim srcB1 = "
+Partial Class C
+    Dim x = 1
+End Class
+"
+
+            Dim srcA2 = ""
+            Dim srcB2 = "
+Partial Class C
+    Dim x = 2
+
+    Sub F()
+    End Sub
+End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), partialType:="C", preserveLocalVariables:=True)}),
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F"), partialType:="C"),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), partialType:="C", preserveLocalVariables:=True)
+                        })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub PartialDeclaration_Insert()
+            Dim srcA1 = ""
+            Dim srcB1 = "
+Partial Class C
+    Dim x = 1
+
+    Sub F()
+    End Sub
+End Class
+"
+            Dim srcA2 = "
+Partial Class C
+    Public Sub New()
+    End Sub
+
+    Sub F()
+    End Sub
+End Class"
+            Dim srcB2 = "
+Partial Class C
+    Dim x = 2
+End Class
+"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F"), partialType:="C"),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), partialType:="C", preserveLocalVariables:=True)
+                        }),
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), partialType:="C", preserveLocalVariables:=True)})
+                })
         End Sub
 
 #End Region
@@ -3330,7 +5199,7 @@ End Class
                 "Delete [As Integer]@49")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.method, "Goo()")))
         End Sub
 
         <Fact>
@@ -3345,7 +5214,7 @@ End Class
                 "Insert [As Integer]@49")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "Declare Ansi Function Goo Lib ""Bar"" ()", FeaturesResources.method))
+                Diagnostic(RudeEditKind.InsertDllImport, "Declare Ansi Function Goo Lib ""Bar"" ()", FeaturesResources.method))
         End Sub
 
         <Fact>
@@ -3360,7 +5229,7 @@ End Class
                 "Insert [As Integer]@57")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "Private Declare Ansi Function Goo Lib ""Bar"" ()", FeaturesResources.method))
+                Diagnostic(RudeEditKind.InsertDllImport, "Private Declare Ansi Function Goo Lib ""Bar"" ()", FeaturesResources.method))
         End Sub
 
         <Fact>
@@ -3370,7 +5239,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "Declare Ansi Sub ExternSub Lib ""ExternDLL""()", FeaturesResources.method))
+                Diagnostic(RudeEditKind.InsertDllImport, "Declare Ansi Sub ExternSub Lib ""ExternDLL""()", FeaturesResources.method))
         End Sub
 
         <Fact>
@@ -3380,7 +5249,23 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "Declare Ansi Sub ExternSub Lib ""ExternDLL""", FeaturesResources.method))
+                Diagnostic(RudeEditKind.InsertDllImport, "Declare Ansi Sub ExternSub Lib ""ExternDLL""", FeaturesResources.method))
+        End Sub
+
+        <Fact>
+        Public Sub Declare_DeleteInsert()
+            Dim srcA1 = "Module M : Declare Ansi Sub ExternSub Lib ""ExternDLL"" : End Module"
+            Dim srcB1 = "Module M : End Module"
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                })
         End Sub
 #End Region
 
@@ -3398,7 +5283,7 @@ End Class
                 Diagnostic(RudeEditKind.Renamed, "b", FeaturesResources.field))
         End Sub
 
-        <Fact>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/51373"), WorkItem(51373, "https://github.com/dotnet/roslyn/issues/51373")>
         Public Sub FieldUpdate_Rename2()
             Dim src1 = "Class C : Dim a1(), b1? As Integer, c1(1,2) As New D() : End Class"
             Dim src2 = "Class C : Dim a2(), b2? As Integer, c2(1,2) As New D() : End Class"
@@ -3440,9 +5325,7 @@ End Class
                 "Move [c]@27 -> @17",
                 "Delete [c]@27")
 
-            ' TODO: We could check that the types and order of b and c haven't changed. 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Move, "c", FeaturesResources.field))
+            edits.VerifySemantics()
         End Sub
 
         <Fact>
@@ -3458,9 +5341,7 @@ End Class
                 "Delete [c As Object]@27",
                 "Delete [As Object]@29")
 
-            ' TODO: We could check that the types and order of b and c haven't changed. 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Move, "c", FeaturesResources.field))
+            edits.VerifySemantics()
         End Sub
 
         <Fact>
@@ -3476,9 +5357,7 @@ End Class
                 "Move [c]@17 -> @27",
                 "Insert [As Object]@29")
 
-            ' TODO: We could check that the types and order of b and c haven't changed. 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Move, "c", FeaturesResources.field))
+            edits.VerifySemantics()
         End Sub
 
         <Fact>
@@ -3492,9 +5371,7 @@ End Class
                 "Update [c As Object]@30 -> [b, c As Object]@27",
                 "Move [b]@17 -> @27")
 
-            ' TODO: We could check that the types and order of b and c haven't changed. 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Move, "b", FeaturesResources.field))
+            edits.VerifySemantics()
         End Sub
 
         <Fact>
@@ -3508,9 +5385,7 @@ End Class
                 "Update [b, c As Object]@27 -> [c As Object]@30",
                 "Move [b]@27 -> @17")
 
-            ' TODO: We could check that the types and order of b and c haven't changed. 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Move, "b", FeaturesResources.field))
+            edits.VerifySemantics()
         End Sub
 
         <Fact>
@@ -3522,8 +5397,7 @@ End Class
             edits.VerifyEdits(
                 "Reorder [b As Object]@27 -> @14")
 
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Move, "b As Object", FeaturesResources.field))
+            edits.VerifySemantics()
         End Sub
 
         <Fact>
@@ -3535,8 +5409,17 @@ End Class
             edits.VerifyEdits(
                 "Reorder [b, c As Object]@27 -> @14")
 
+            edits.VerifySemantics()
+        End Sub
+
+        <Fact>
+        Public Sub Field_VariableMove_TypeChange()
+            Dim src1 = "Class C : Dim a As Object, b, c As Object : End Class"
+            Dim src2 = "Class C : Dim a, b As Integer, c As Object : End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Move, "b, c As Object", FeaturesResources.field))
+                Diagnostic(RudeEditKind.TypeUpdate, "a, b As Integer", FeaturesResources.field))
         End Sub
 
         <Fact>
@@ -3552,7 +5435,7 @@ End Class
                 "Delete [As Object]@29")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Dim b As Object", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "Dim b As Object", DeletedSymbolDisplay(FeaturesResources.field, "c")))
         End Sub
 
         <Fact>
@@ -3665,7 +5548,7 @@ End Class
                 "Delete [As Action]@16")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.field, "a")))
         End Sub
 
         <Fact>
@@ -3683,7 +5566,7 @@ End Class
                 "Delete [As Action]@18")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.event_))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.event_, "a")))
         End Sub
 
         <Fact>
@@ -3736,6 +5619,22 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub EventField_Partial_InsertDelete()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = "Partial Class C" & vbCrLf & "Event E As System.Action : End Class"
+
+            Dim srcA2 = "Partial Class C" & vbCrLf & "Event E As System.Action : End Class"
+            Dim srcB2 = "Partial Class C : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
         Public Sub FieldInsert1()
             Dim src1 = "Class C : End Class"
             Dim src2 = "Class C : Dim _private1 = 1 : Private _private2 : Public _public = 2 : Protected _protected : Friend _f : Protected Friend _pf : End Class"
@@ -3751,7 +5650,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "WithEvents F As C", VBFeaturesResources.WithEvents_field))
+                Diagnostic(RudeEditKind.InsertVirtual, "F As C", VBFeaturesResources.WithEvents_field))
         End Sub
 
         <Fact>
@@ -3761,7 +5660,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "G", VBFeaturesResources.WithEvents_field))
+                Diagnostic(RudeEditKind.InsertVirtual, "G", VBFeaturesResources.WithEvents_field))
         End Sub
 
         <Fact>
@@ -3771,25 +5670,25 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "G", VBFeaturesResources.WithEvents_field))
+                Diagnostic(RudeEditKind.InsertVirtual, "G As C", VBFeaturesResources.WithEvents_field))
         End Sub
 
         <Fact>
         Public Sub FieldInsert_IntoStruct()
             Dim src1 = "Structure S : Private a As Integer : End Structure"
-            Dim src2 = <text>
+            Dim src2 = "
 Structure S 
     Private a As Integer
     Private b As Integer
     Private Shared c As Integer
     Private Event d As System.Action
 End Structure
-</text>.Value
+"
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertIntoStruct, "Private Event d As System.Action", FeaturesResources.event_, VBFeaturesResources.structure_),
-                Diagnostic(RudeEditKind.InsertIntoStruct, "b", FeaturesResources.field, VBFeaturesResources.structure_),
-                Diagnostic(RudeEditKind.InsertIntoStruct, "c", FeaturesResources.field, VBFeaturesResources.structure_))
+                Diagnostic(RudeEditKind.InsertIntoStruct, "b As Integer", FeaturesResources.field, VBFeaturesResources.structure_),
+                Diagnostic(RudeEditKind.InsertIntoStruct, "c As Integer", FeaturesResources.field, VBFeaturesResources.structure_))
         End Sub
 
         <Fact>
@@ -3852,9 +5751,9 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d As Integer", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -3882,9 +5781,71 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d As Integer", FeaturesResources.field, FeaturesResources.class_))
+        End Sub
+
+        <Fact>
+        Public Sub Field_DeleteInsert_LayoutClass_Sequential_OrderPreserved()
+            Dim src1 = "
+Imports System.Runtime.InteropServices
+
+<StructLayoutAttribute(LayoutKind.Sequential)>
+Partial Class C
+    Private a As Integer
+    Private b As Integer
+End Class
+"
+
+            Dim src2 = "
+Imports System.Runtime.InteropServices
+
+<StructLayoutAttribute(LayoutKind.Sequential)>
+Partial Class C
+    Private a As Integer
+End Class
+
+Partial Class C
+    Private b As Integer
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            ' TODO: We don't compare the ordering currently. We could allow this edit if the ordering is preserved.
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_))
+        End Sub
+
+        <Fact>
+        Public Sub Field_DeleteInsert_LayoutClass_Sequential_OrderChanged()
+            Dim src1 = "
+Imports System.Runtime.InteropServices
+
+<StructLayoutAttribute(LayoutKind.Sequential)>
+Partial Class C
+    Private a As Integer
+    Private b As Integer
+End Class
+"
+
+            Dim src2 = "
+Imports System.Runtime.InteropServices
+
+<StructLayoutAttribute(LayoutKind.Sequential)>
+Partial Class C
+    Private b As Integer
+End Class
+
+Partial Class C
+    Private a As Integer
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "a As Integer", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -3930,7 +5891,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub FieldInsert_ParameterlessConstructorInsert_WithInitializersAndLambdas1()
+        Public Sub FieldInsert_ConstructorReplacingImplicitConstructor_WithInitializersAndLambdas()
             Dim src1 = "
 Imports System
 
@@ -3954,7 +5915,7 @@ Class C
 
     Dim B As Integer = F(Function(b) b + 1)   ' new field
 
-    Sub New()                                 ' new ctor
+    Sub New()                                 ' new ctor replacing existing implicit constructor
         F(Function(c) c + 1)
     End Sub
 End Class
@@ -3967,6 +5928,53 @@ End Class
                 ActiveStatementsDescription.Empty,
                 {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.B")),
                  SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))})
+        End Sub
+
+        <Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")>
+        Public Sub FieldInsert_ParameterlessConstructorInsert_WithInitializersAndLambdas()
+            Dim src1 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 1
+    End Function
+
+    Dim A = F(<N:0.0>Function(a) a + 1</N:0.0>)
+
+    Public Sub New(x As Integer)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+    Shared Function F(x As Func(Of Integer, Integer)) As Integer
+        Return 1
+    End Function
+
+    Dim A = F(<N:0.0>Function(a) a + 1</N:0.0>)
+
+    Public Sub New(x As Integer)
+    End Sub
+
+    Public Sub New                           ' new ctor
+        F(Function(c) c + 1)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "Public Sub New"))
+
+            '  TODO (bug https//github.com/dotnet/roslyn/issues/2504):
+            ' edits.VerifySemantics(
+            '     ActiveStatementsDescription.Empty,
+            '     {
+            '         SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap(0))
+            '     })
         End Sub
 
         <Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")>
@@ -4002,17 +6010,15 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             Dim syntaxMap = GetSyntaxMap(src1, src2)
-            edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.B")),
-                 SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single())})
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, "Sub New(x As Integer)"))
 
-            ' TODO (bug https//github.com/dotnet/roslyn/issues/2504):
+            ' TODO (bug https://github.com/dotnet/roslyn/issues/2504):
             'edits.VerifySemantics(
             '    ActiveStatementsDescription.Empty,
             '    {
-            '        SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.B")),
-            '        SemanticEdit(SemanticEditKind.Insert, c => c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))
+            '        SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.B")),
+            '        SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors.Single(), syntaxMap(0))
             '    })
 
         End Sub
@@ -4115,6 +6121,27 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub PropertyInsert()
+            Dim src1 = "Class C : End Class"
+            Dim src2 = "
+Class C 
+    Property P
+        Get
+            Return 1
+        End Get
+        Set(value)
+        End Set
+    End Property
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemantics(
+                semanticEdits:={SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("P"))})
+        End Sub
+
+        <Fact>
         Public Sub PrivatePropertyAccessorAddSetter()
             Dim src1 = "Class C : Private _p As Integer : Private ReadOnly Property P As Integer" & vbLf & "Get" & vbLf & "Return 1 : End Get : End Property : End Class"
             Dim src2 = "Class C : Private _p As Integer : Private Property P As Integer" & vbLf & "Get" & vbLf & "Return 1 : End Get" & vbLf & "Set(value As Integer)" & vbLf & "_p = value : End Set : End Property : End Class"
@@ -4162,7 +6189,7 @@ End Class
                 "Delete [As Integer]@97")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Private ReadOnly Property P", VBFeaturesResources.property_accessor))
+                Diagnostic(RudeEditKind.Delete, "Private ReadOnly Property P", DeletedSymbolDisplay(VBFeaturesResources.property_accessor, "P(Integer)")))
         End Sub
 
         <Fact>
@@ -4271,6 +6298,110 @@ End Class
                 Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "Private Shared Property c As Integer", FeaturesResources.auto_property, FeaturesResources.class_))
         End Sub
 
+        <Fact>
+        Public Sub Property_Partial_InsertDelete()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = "
+Partial Class C
+    Private Property P As Integer
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+"
+
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of PropertySymbol)("P").GetMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of PropertySymbol)("P").SetMethod)
+                        }),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub AutoProperty_Partial_InsertDelete()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = "
+Partial Class C
+    Private Property P As Integer
+End Class
+"
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub AutoPropertyWithInitializer_Partial_InsertDelete()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = "
+Partial Class C
+    Private Property P As Integer = 1
+End Class
+"
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)}),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Fact>
+        Public Sub Property_Update_LiftedParameter()
+            Dim src1 = "
+Imports System
+
+Partial Class C
+    Private Property P(a As Integer) As Integer
+        Get
+            Return New Func(Of Integer)(Function() a + 1).Invoke()
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Partial Class C
+    Private Property P(a As Integer) As Integer
+        Get
+            Return New Func(Of Integer)(Function() 2).Invoke()
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.NotCapturingVariable, "a", "a"))
+        End Sub
 #End Region
 
 #Region "Field And Property Initializers"
@@ -4337,6 +6468,56 @@ End Class
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+        End Sub
+
+        ''' <summary>
+        ''' It's a semantic error to specify array bunds and initializer at the same time.
+        ''' EnC analysis needs to handle this case without failing.
+        ''' </summary>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/51373"), WorkItem(51373, "https://github.com/dotnet/roslyn/issues/51373")>
+        Public Sub Field_InitializerUpdate_InitializerAndArrayBounds()
+            Dim src1 = "
+Class C
+    Dim x(1) As Integer = 1
+End Class
+"
+
+            Dim src2 = "
+Class C
+    Dim x(2) As Integer = 2
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+            })
+        End Sub
+
+        ''' <summary>
+        ''' It's a semantic error to specify array bunds and initializer at the same time.
+        ''' EnC analysis needs to handle this case without failing.
+        ''' </summary>
+        <Fact>
+        Public Sub Field_InitializerUpdate_AsNewAndArrayBounds()
+            Dim src1 = "
+Class C
+    Dim x(1) As New C
+End Class
+"
+
+            Dim src2 = "
+Class C
+    Dim x(2) As New C
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+            })
         End Sub
 
         <Fact(), WorkItem(2543, "https://github.com/dotnet/roslyn/issues/2543")>
@@ -4471,7 +6652,7 @@ End Class
                 "Delete [()]@47")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4487,7 +6668,7 @@ End Class
                 "Delete [()]@51")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4503,7 +6684,7 @@ End Class
                 "Delete [()]@38")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4519,7 +6700,7 @@ End Class
                 "Delete [()]@56")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4535,7 +6716,7 @@ End Class
                 "Delete [()]@43")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4545,7 +6726,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.constructor))
+                Diagnostic(RudeEditKind.ChangingVisibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
         End Sub
 
         <Fact>
@@ -4555,7 +6736,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.constructor))
+                Diagnostic(RudeEditKind.ChangingVisibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
         End Sub
 
         <Fact>
@@ -4565,7 +6746,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4575,7 +6756,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single())})
+                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
         <Fact>
@@ -4948,8 +7129,10 @@ End Class
             Dim src2 = "Partial Class C : Dim a = 2 : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.field))
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single, preserveLocalVariables:=True)
+            })
         End Sub
 
         <Fact>
@@ -4958,8 +7141,10 @@ End Class
             Dim src2 = "Partial Class C : Property a = 2 : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2", FeaturesResources.auto_property))
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single, preserveLocalVariables:=True)
+            })
         End Sub
 
         <Fact>
@@ -4968,8 +7153,10 @@ End Class
             Dim src2 = "Partial Class C : Dim a = 2 : End Class : Class C : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.field))
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single, preserveLocalVariables:=True)
+            })
         End Sub
 
         <Fact>
@@ -4978,8 +7165,10 @@ End Class
             Dim src2 = "Partial Class C : Property a = 2 : End Class : Class C : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2", FeaturesResources.auto_property))
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single, preserveLocalVariables:=True)
+            })
         End Sub
 
         <Fact>
@@ -4988,8 +7177,10 @@ End Class
             Dim src2 = "Class C : Dim a = 2 : End Class : Partial Class C : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "a = 2", FeaturesResources.field))
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single, preserveLocalVariables:=True)
+            })
         End Sub
 
         <Fact>
@@ -4998,29 +7189,53 @@ End Class
             Dim src2 = "Class C : Property a = 2 : End Class : Partial Class C : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.PartialTypeInitializerUpdate, "Property a = 2", FeaturesResources.auto_property))
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single, preserveLocalVariables:=True)
+            })
         End Sub
 
-        <Fact>
-        Public Sub PrivateFieldInsert1()
+        <Theory>
+        <InlineData("Dim")>
+        <InlineData("Private")>
+        <InlineData("Public")>
+        <InlineData("Friend")>
+        <InlineData("Protected")>
+        <InlineData("Protected Friend")>
+        <InlineData("Private ReadOnly")>
+        Public Sub Field_Insert(modifiers As String)
             Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : Private a As Integer = 1 : End Class"
+            Dim src2 = "Class C : " & modifiers & " a As Integer = 1 : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
-            edits.VerifyEdits(
-                "Insert [Private a As Integer = 1]@10",
-                "Insert [a As Integer = 1]@18",
-                "Insert [a]@18",
-                "Insert [As Integer]@20")
-
-            edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("a")),
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+            })
         End Sub
 
-        <Fact(), WorkItem(2543, "https://github.com/dotnet/roslyn/issues/2543")>
-        Public Sub PrivateFieldInsert2()
+        <Theory>
+        <InlineData("")>
+        <InlineData("Private")>
+        <InlineData("Public")>
+        <InlineData("Friend")>
+        <InlineData("Protected")>
+        <InlineData("Protected Friend")>
+        Public Sub Property_Insert(accessibility As String)
+            Dim src1 = "Class C : End Class"
+            Dim src2 = "Class C : " & accessibility & " Property a As Integer = 1 : End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("a")),
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+            })
+        End Sub
+
+        <Fact, WorkItem(2543, "https://github.com/dotnet/roslyn/issues/2543")>
+        Public Sub Field_Insert_MultiDeclaration()
             Dim src1 = "Class C : Private a As Integer = 1 : End Class"
             Dim src2 = "Class C : Private a, b As Integer : End Class"
             Dim edits = GetTopEdits(src1, src2)
@@ -5035,22 +7250,109 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub PrivatePropertyInsert()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : Private Property a As Integer = 1 : End Class"
+        Public Sub Field_Insert_MultiDeclaration_AsNew()
+            Dim src1 = "Class C : Private a As C = New C : End Class"
+            Dim src2 = "Class C : Private a, b As New C : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Insert [Private Property a As Integer = 1]@10",
-                "Insert [As Integer]@29")
+                "Update [a As C = New C]@18 -> [a, b As New C]@18",
+                "Insert [b]@21",
+                "Delete [As C]@20")
 
-            edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
+            ' TODO: allow this edit
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "a, b As New C", VBFeaturesResources.as_clause))
         End Sub
 
         <Fact>
-        Public Sub PrivateFieldInsert_Untyped()
+        Public Sub Field_Insert_MultiDeclaration_Split()
+            Dim src1 = "Class C : Private a, b As Integer = 1 : End Class"
+            Dim src2 = "Class C : Private a As Integer : Private b As Integer : End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Insert [Private b As Integer]@33",
+                "Update [a, b As Integer = 1]@18 -> [a As Integer]@18",
+                "Insert [b As Integer]@41",
+                "Move [b]@21 -> @41",
+                "Insert [As Integer]@43")
+
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+            })
+        End Sub
+
+        <Fact>
+        Public Sub Field_DeleteInsert_MultiDeclaration_TypeChange()
+            Dim src1 = "Class C : Private a, b As Integer = 1 : End Class"
+            Dim src2 = "Class C : Private a As Integer : Private b As Byte : End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "b As Byte", FeaturesResources.field))
+        End Sub
+
+        <Fact>
+        Public Sub Field_DeleteInsert_Partial_MultiDeclaration_TypeChange()
+            Dim srcA1 = "Partial Class C : Private a As Integer = 1 : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C : Private a, b As Byte : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(diagnostics:=
+                    {
+                        Diagnostic(RudeEditKind.TypeUpdate, "a, b As Byte", FeaturesResources.field)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub Field_DeleteInsert_MultiDeclaration_Split()
+            Dim srcA1 = "Partial Class C : Private a, b As Integer : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C : Private a As Integer = 1 : Private b As Integer = 2 : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub Field_DeleteInsert_Partial_MultiDeclaration_UpdateArrayBounds()
+            Dim srcA1 = "Partial Class C : Dim F1(1, 2), F2? As Integer : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = "Partial Class C : Dim F1(1, 3), F2? As Integer : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                    })
+                })
+        End Sub
+
+        <Fact>
+        Public Sub FieldInsert_PrivateUntyped()
             Dim src1 = "Class C : End Class"
             Dim src2 = "Class C : Private a = 1 : End Class"
             Dim edits = GetTopEdits(src1, src2)
@@ -5066,7 +7368,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub PrivatePropertyInsert_Untyped()
+        Public Sub PropertyInsert_PrivateUntyped()
             Dim src1 = "Class C : End Class"
             Dim src2 = "Class C : Private Property a = 1 : End Class"
             Dim edits = GetTopEdits(src1, src2)
@@ -5077,59 +7379,6 @@ End Class
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
                                    SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
-        End Sub
-
-        <Fact>
-        Public Sub PrivateReadOnlyFieldInsert()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : Private ReadOnly a As Integer = 1 : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Insert [Private ReadOnly a As Integer = 1]@10",
-                "Insert [a As Integer = 1]@27",
-                "Insert [a]@27",
-                "Insert [As Integer]@29")
-
-            edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.a")),
-                                   SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
-        End Sub
-
-        <Fact>
-        Public Sub PublicFieldInsert()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : Public a As Integer = 1 : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyRudeDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub PublicPropertyInsert()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : Property a As Integer = 1 : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyRudeDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub ProtectedFieldInsert()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : Protected a As Integer = 1 : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyRudeDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub ProtectedPropertyInsert()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : Protected Property a As Integer = 1 : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyRudeDiagnostics()
         End Sub
 
         <Fact>
@@ -5145,7 +7394,7 @@ End Class
                 "Delete [As Integer]@24")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.field, "a")))
         End Sub
 
         <Fact>
@@ -5159,7 +7408,7 @@ End Class
                 "Delete [As Integer]@29")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Class C", FeaturesResources.auto_property))
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.auto_property, "a")))
         End Sub
 
         <Fact>
@@ -5874,12 +8123,58 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub FieldInitializerUpdate_Lambdas_PartialDeclarationDelete_SingleDocument()
+            Dim src1 = "
+Partial Class C
+    Dim x = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    Dim y = F(<N:0.1>Function(a) a + 10</N:0.1>)
+End Class
+
+Partial Class C
+    Public Sub New()
+    End Sub
+
+    Shared Function F(x As Func(Of Integer, Integer))
+        Return 1
+    End Function
+End Class
+"
+
+            Dim src2 = "
+Partial Class C
+    Dim x = F(<N:0.0>Function(a) a + 1</N:0.0>)
+End Class
+
+Partial Class C
+    Dim y = F(<N:0.1>Function(a) a + 10</N:0.1>)
+
+    Shared Function F(x As Func(Of Integer, Integer))
+        Return 1
+    End Function
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+
+            Dim syntaxMap = GetSyntaxMap(src1, src2)
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                {
+                    SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("F"), partialType:="C"),
+                    SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), syntaxMap(0), partialType:="C")
+                })
+        End Sub
+
+        <Fact>
         Public Sub FieldInitializerUpdate_ActiveStatements1()
             Dim src1 As String = "
 Imports System
 
 Class C
-    <AS:0>Dim A As Integer = <N:0.0>1</N:0.0></AS:0>
+    Dim A As Integer = <N:0.0>1</N:0.0>
     Dim B As Integer = 1
 
     Public Sub New(a As Integer) 
@@ -5895,7 +8190,7 @@ End Class
 Imports System
 
 Class C
-    <AS:0>Dim A As Integer = <N:0.0>1</N:0.0></AS:0>
+    Dim A As Integer = <N:0.0>1</N:0.0>
     Dim B As Integer = 2
 
     Public Sub New(a As Integer) 
@@ -5909,12 +8204,12 @@ End Class"
 
             Dim edits = GetTopEdits(src1, src2)
             Dim syntaxMap = GetSyntaxMap(src1, src2)
-            Dim activeStatements = GetActiveStatements(src1, src2)
 
-            edits.VerifySemantics(
-                activeStatements,
-                {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(0), syntaxMap(0)),
-                 SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(1), syntaxMap(0))})
+            edits.VerifySemantics(semanticEdits:=
+            {
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(0), syntaxMap(0)),
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(1), syntaxMap(0))
+            })
         End Sub
 
         <Fact>
@@ -5957,10 +8252,10 @@ Partial Class C
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifySemantics(ActiveStatementsDescription.Empty, expectedSemanticEdits:=
+            edits.VerifySemantics(ActiveStatementsDescription.Empty, semanticEdits:=
             {
-                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True),
-                SemanticEdit(SemanticEditKind.Update, Function(c) CType(c.GetMember(Of NamedTypeSymbol)("C").GetMembers("P").Skip(1).First(), IPropertySymbol).GetMethod)
+                SemanticEdit(SemanticEditKind.Update, Function(c) CType(c.GetMember(Of NamedTypeSymbol)("C").GetMembers("P").First(), IPropertySymbol).GetMethod),
+                SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
             })
         End Sub
 
@@ -6068,7 +8363,7 @@ Imports System.Runtime.InteropServices
 
 <StructLayoutAttribute(LayoutKind.Sequential)>
 Class C
-    Private Custom Event c As Action
+    Private Custom Event E As Action
         AddHandler(value As Action)
         End AddHandler
 
@@ -6081,7 +8376,71 @@ Class C
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
-            edits.VerifySemanticDiagnostics()
+            edits.VerifySemantics(
+                semanticEdits:={SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("E"))})
+        End Sub
+
+        <Fact>
+        Public Sub Event_Delete()
+            Dim src1 = "
+Imports System
+Imports System.Runtime.InteropServices
+
+Class C
+    Private Custom Event E As Action
+        AddHandler(value As Action)
+        End AddHandler
+
+        RemoveHandler(value As Action)
+        End RemoveHandler
+
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Runtime.InteropServices
+
+Class C
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "Class C", DeletedSymbolDisplay(FeaturesResources.event_, "E")))
+        End Sub
+
+        <Fact>
+        Public Sub Event_Partial_InsertDelete()
+            Dim srcA1 = "Partial Class C : End Class"
+            Dim srcB1 = "
+Partial Class C
+    Custom Event E As EventHandler
+        AddHandler(value As EventHandler)
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As EventArgs)
+        End RaiseEvent
+    End Event
+End Class
+"
+            Dim srcA2 = srcB1
+            Dim srcB2 = srcA1
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(
+                        semanticEdits:=
+                        {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of EventSymbol)("E").AddMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of EventSymbol)("E").RemoveMethod),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of EventSymbol)("E").RaiseMethod)
+                        }),
+                    DocumentResults()
+                })
         End Sub
 
 #End Region
@@ -6536,8 +8895,8 @@ End Class
 
         <Fact>
         Public Sub MethodTypeParameterInsert1()
-            Dim src1 = "Class C : " & vbLf & "Public Sub M() : End Sub : End Class"
-            Dim src2 = "Class C : " & vbLf & "Public Sub M(Of A)() : End Sub : End Class"
+            Dim src1 = "Class C : " & vbLf & "Public Sub M()" & vbLf & "End Sub : End Class"
+            Dim src2 = "Class C : " & vbLf & "Public Sub M(Of A)()" & vbLf & "End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
@@ -6550,8 +8909,8 @@ End Class
 
         <Fact>
         Public Sub MethodTypeParameterInsert2()
-            Dim src1 = "Class C : " & vbLf & "Public Sub M(Of A)() : End Sub : End Class"
-            Dim src2 = "Class C : " & vbLf & "Public Sub M(Of A, B)() : End Sub : End Class"
+            Dim src1 = "Class C : " & vbLf & "Public Sub M(Of A)()" & vbLf & "End Sub : End Class"
+            Dim src2 = "Class C : " & vbLf & "Public Sub M(Of A, B)()" & vbLf & "End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
@@ -6578,8 +8937,8 @@ End Class
 
         <Fact>
         Public Sub MethodTypeParameterDelete2()
-            Dim src1 = "Class C : " & vbLf & "Public Sub M(Of A, B)() : End Sub : End Class"
-            Dim src2 = "Class C : " & vbLf & "Public Sub M(Of B)() : End Sub : End Class"
+            Dim src1 = "Class C : " & vbLf & "Public Sub M(Of A, B)()" & vbLf & "End Sub : End Class"
+            Dim src2 = "Class C : " & vbLf & "Public Sub M(Of B)()" & vbLf & "End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -401,8 +401,8 @@
     <value>global statement</value>
     <comment>{Locked="global"} "global" is a C# keyword and should not be localized.</comment>
   </data>
-  <data name="using_namespace" xml:space="preserve">
-    <value>using namespace</value>
+  <data name="extern_alias" xml:space="preserve">
+    <value>extern alias</value>
   </data>
   <data name="using_directive" xml:space="preserve">
     <value>using directive</value>

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -90,6 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     case SyntaxKind.ConversionOperatorDeclaration:
                     case SyntaxKind.OperatorDeclaration:
                     case SyntaxKind.SetAccessorDeclaration:
+                    case SyntaxKind.InitAccessorDeclaration:
                     case SyntaxKind.AddAccessorDeclaration:
                     case SyntaxKind.RemoveAccessorDeclaration:
                     case SyntaxKind.GetAccessorDeclaration:
@@ -130,14 +131,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         /// <returns>
-        /// Given a node representing a declaration (<paramref name="isMember"/> = true) or a top-level match node (<paramref name="isMember"/> = false) returns:
+        /// Given a node representing a declaration or a top-level match node returns:
         /// - <see cref="BlockSyntax"/> for method-like member declarations with block bodies (methods, operators, constructors, destructors, accessors).
         /// - <see cref="ExpressionSyntax"/> for variable declarators of fields, properties with an initializer expression, or 
         ///   for method-like member declarations with expression bodies (methods, properties, indexers, operators)
         /// 
         /// A null reference otherwise.
         /// </returns>
-        internal override SyntaxNode? TryGetDeclarationBody(SyntaxNode node, bool isMember)
+        internal override SyntaxNode? TryGetDeclarationBody(SyntaxNode node)
         {
             if (node.IsKind(SyntaxKind.VariableDeclarator, out VariableDeclaratorSyntax? variableDeclarator))
             {
@@ -493,10 +494,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             if (leftEqualsClause.Parent.IsKind(SyntaxKind.PropertyDeclaration, out PropertyDeclarationSyntax? leftDeclaration))
             {
                 var leftSymbol = leftModel.GetDeclaredSymbol(leftDeclaration, cancellationToken);
-                RoslynDebug.Assert(leftSymbol != null);
+                Contract.ThrowIfNull(leftSymbol);
 
                 var rightProperty = rightType.GetMembers(leftSymbol.Name).Single();
-                var rightDeclaration = (PropertyDeclarationSyntax)GetSymbolSyntax(rightProperty, cancellationToken);
+                var rightDeclaration = (PropertyDeclarationSyntax)rightProperty.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
 
                 rightEqualsClause = rightDeclaration.Initializer;
             }
@@ -504,10 +505,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             {
                 var leftDeclarator = (VariableDeclaratorSyntax)leftEqualsClause.Parent!;
                 var leftSymbol = leftModel.GetDeclaredSymbol(leftDeclarator, cancellationToken);
-                RoslynDebug.Assert(leftSymbol != null);
+                Contract.ThrowIfNull(leftSymbol);
 
                 var rightField = rightType.GetMembers(leftSymbol.Name).Single();
-                var rightDeclarator = (VariableDeclaratorSyntax)GetSymbolSyntax(rightField, cancellationToken);
+                var rightDeclarator = (VariableDeclaratorSyntax)rightField.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken);
 
                 rightEqualsClause = rightDeclarator.Initializer;
             }
@@ -549,6 +550,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         protected override Match<SyntaxNode> ComputeTopLevelMatch(SyntaxNode oldCompilationUnit, SyntaxNode newCompilationUnit)
             => SyntaxComparer.TopLevel.ComputeMatch(oldCompilationUnit, newCompilationUnit);
+
+        protected override Match<SyntaxNode> ComputeTopLevelDeclarationMatch(SyntaxNode oldDeclaration, SyntaxNode newDeclaration)
+        {
+            Contract.ThrowIfNull(oldDeclaration.Parent);
+            Contract.ThrowIfNull(newDeclaration.Parent);
+            var comparer = new SyntaxComparer(oldDeclaration.Parent, newDeclaration.Parent, new[] { oldDeclaration }, new[] { newDeclaration });
+            return comparer.ComputeMatch(oldDeclaration.Parent, newDeclaration.Parent);
+        }
 
         protected override Match<SyntaxNode> ComputeBodyMatch(SyntaxNode oldBody, SyntaxNode newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
         {
@@ -1020,26 +1029,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             => node.IsKind(SyntaxKind.InterfaceDeclaration);
 
         internal override SyntaxNode? TryGetContainingTypeDeclaration(SyntaxNode node)
-            => node.Parent!.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+            => node.Parent!.FirstAncestorOrSelf<BaseTypeDeclarationSyntax>();
 
         internal override bool HasBackingField(SyntaxNode propertyOrIndexerDeclaration)
             => propertyOrIndexerDeclaration.IsKind(SyntaxKind.PropertyDeclaration, out PropertyDeclarationSyntax? propertyDecl) &&
                SyntaxUtilities.HasBackingField(propertyDecl);
 
+        internal override SyntaxNode? TryGetAssociatedMemberDeclaration(SyntaxNode node)
+            => node.Parent.IsParentKind(SyntaxKind.PropertyDeclaration, SyntaxKind.IndexerDeclaration, SyntaxKind.EventDeclaration) ? node.Parent.Parent : null;
+
         internal override bool IsDeclarationWithInitializer(SyntaxNode declaration)
-        {
-            switch (declaration.Kind())
-            {
-                case SyntaxKind.VariableDeclarator:
-                    return ((VariableDeclaratorSyntax)declaration).Initializer != null;
-
-                case SyntaxKind.PropertyDeclaration:
-                    return ((PropertyDeclarationSyntax)declaration).Initializer != null;
-
-                default:
-                    return false;
-            }
-        }
+            => declaration is VariableDeclaratorSyntax { Initializer: not null } || declaration is PropertyDeclarationSyntax { Initializer: not null };
 
         internal override bool IsConstructorWithMemberInitializers(SyntaxNode constructorDeclaration)
             => constructorDeclaration is ConstructorDeclarationSyntax ctor && (ctor.Initializer == null || ctor.Initializer.IsKind(SyntaxKind.BaseConstructorInitializer));
@@ -1048,12 +1048,23 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         {
             var syntaxRefs = type.DeclaringSyntaxReferences;
             return syntaxRefs.Length > 1
-                || ((TypeDeclarationSyntax)syntaxRefs.Single().GetSyntax()).Modifiers.Any(SyntaxKind.PartialKeyword);
+                || ((BaseTypeDeclarationSyntax)syntaxRefs.Single().GetSyntax()).Modifiers.Any(SyntaxKind.PartialKeyword);
         }
 
-        protected override ISymbol? GetSymbolForEdit(SemanticModel model, SyntaxNode node, EditKind editKind, IReadOnlyDictionary<SyntaxNode, EditKind> editMap, CancellationToken cancellationToken)
+        protected override SyntaxNode GetSymbolDeclarationSyntax(SyntaxReference reference, CancellationToken cancellationToken)
+            => reference.GetSyntax(cancellationToken);
+
+        protected override ISymbol? GetSymbolForEdit(
+            SemanticModel model,
+            SyntaxNode node,
+            EditKind editKind,
+            IReadOnlyDictionary<SyntaxNode, EditKind> editMap,
+            out bool isAmbiguous,
+            CancellationToken cancellationToken)
         {
-            if (node.IsKind(SyntaxKind.Parameter))
+            isAmbiguous = false;
+
+            if (node.IsKind(SyntaxKind.Parameter, SyntaxKind.TypeParameter, SyntaxKind.UsingDirective, SyntaxKind.NamespaceDeclaration))
             {
                 return null;
             }
@@ -1066,7 +1077,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return null;
                 }
 
-                if (node.IsKind(SyntaxKind.IndexerDeclaration) || node.IsKind(SyntaxKind.PropertyDeclaration))
+                if (node.IsKind(SyntaxKind.IndexerDeclaration, SyntaxKind.PropertyDeclaration))
                 {
                     // The only legitimate update of an indexer/property declaration is an update of its expression body.
                     // The expression body itself may have been updated, replaced with an explicit getter, or added to replace an explicit getter.
@@ -1081,43 +1092,46 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 return null;
             }
 
-            return model.GetDeclaredSymbol(node, cancellationToken);
+            var symbol = model.GetDeclaredSymbol(node, cancellationToken);
+
+            // Ignore partial method definition parts.
+            // Partial method that does not have implementation part is not emitted to metadata.
+            // Partial method without a definition part is a compilation error.
+            if (symbol is IMethodSymbol { IsPartialDefinition: true })
+            {
+                return null;
+            }
+
+            return symbol;
         }
 
-        protected override bool TryGetDeclarationBodyEdit(Edit<SyntaxNode> edit, IReadOnlyDictionary<SyntaxNode, EditKind> editMap, out SyntaxNode? oldBody, out SyntaxNode? newBody)
+        protected override void GetUpdatedDeclarationBodies(SyntaxNode oldDeclaration, SyntaxNode newDeclaration, out SyntaxNode? oldBody, out SyntaxNode? newBody)
         {
             // Detect a transition between a property/indexer with an expression body and with an explicit getter.
             // int P => old_body;              <->      int P { get { new_body } } 
             // int this[args] => old_body;     <->      int this[args] { get { new_body } }     
 
             // First, return getter or expression body for property/indexer update:
-            if (edit.Kind == EditKind.Update && (edit.OldNode.IsKind(SyntaxKind.PropertyDeclaration) || edit.OldNode.IsKind(SyntaxKind.IndexerDeclaration)))
+            if (oldDeclaration.IsKind(SyntaxKind.PropertyDeclaration, SyntaxKind.IndexerDeclaration))
             {
-                oldBody = SyntaxUtilities.TryGetEffectiveGetterBody(edit.OldNode);
-                newBody = SyntaxUtilities.TryGetEffectiveGetterBody(edit.NewNode);
+                oldBody = SyntaxUtilities.TryGetEffectiveGetterBody(oldDeclaration);
+                newBody = SyntaxUtilities.TryGetEffectiveGetterBody(newDeclaration);
 
                 if (oldBody != null && newBody != null)
                 {
-                    return true;
+                    return;
                 }
             }
 
-            // Second, ignore deletion of a getter body:
-            if (IsGetterToExpressionBodyTransformation(edit.Kind, edit.OldNode ?? edit.NewNode, editMap))
-            {
-                oldBody = newBody = null;
-                return false;
-            }
-
-            return base.TryGetDeclarationBodyEdit(edit, editMap, out oldBody, out newBody);
+            base.GetUpdatedDeclarationBodies(oldDeclaration, newDeclaration, out oldBody, out newBody);
         }
 
         private static bool IsGetterToExpressionBodyTransformation(EditKind editKind, SyntaxNode node, IReadOnlyDictionary<SyntaxNode, EditKind> editMap)
         {
-            if ((editKind == EditKind.Insert || editKind == EditKind.Delete) && node.IsKind(SyntaxKind.GetAccessorDeclaration))
+            if ((editKind is EditKind.Insert or EditKind.Delete) && node.IsKind(SyntaxKind.GetAccessorDeclaration))
             {
                 RoslynDebug.Assert(node.Parent.IsKind(SyntaxKind.AccessorList));
-                RoslynDebug.Assert(node.Parent.Parent.IsKind(SyntaxKind.PropertyDeclaration) || node.Parent.Parent.IsKind(SyntaxKind.IndexerDeclaration));
+                RoslynDebug.Assert(node.Parent.Parent.IsKind(SyntaxKind.PropertyDeclaration, SyntaxKind.IndexerDeclaration));
                 return editMap.TryGetValue(node.Parent, out var parentEdit) && parentEdit == editKind &&
                        editMap.TryGetValue(node.Parent!.Parent, out parentEdit) && parentEdit == EditKind.Update;
             }
@@ -1135,7 +1149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             => node.IsKind(SyntaxKind.LocalFunctionStatement);
 
         internal override bool IsNestedFunction(SyntaxNode node)
-            => node is LambdaExpressionSyntax || node is LocalFunctionStatementSyntax;
+            => node is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax;
 
         internal override bool TryGetLambdaBodies(SyntaxNode node, [NotNullWhen(true)] out SyntaxNode? body1, out SyntaxNode? body2)
             => LambdaUtilities.TryGetLambdaBodies(node, out body1, out body2);
@@ -1364,6 +1378,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.InitAccessorDeclaration:
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                 case SyntaxKind.UnknownAccessorDeclaration:
@@ -1629,7 +1644,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return CSharpFeaturesResources.global_statement;
 
                 case SyntaxKind.ExternAliasDirective:
-                    return CSharpFeaturesResources.using_namespace;
+                    return CSharpFeaturesResources.extern_alias;
 
                 case SyntaxKind.UsingDirective:
                     // Dev12 distinguishes using alias from using namespace and reports different errors for removing alias.
@@ -1675,7 +1690,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return FeaturesResources.operator_;
 
                 case SyntaxKind.ConstructorDeclaration:
-                    return FeaturesResources.constructor;
+                    var ctor = (ConstructorDeclarationSyntax)node;
+                    return ctor.Modifiers.Any(SyntaxKind.StaticKeyword) ? FeaturesResources.static_constructor : FeaturesResources.constructor;
 
                 case SyntaxKind.DestructorDeclaration:
                     return CSharpFeaturesResources.destructor;
@@ -1703,6 +1719,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         return CSharpFeaturesResources.indexer_getter;
                     }
 
+                case SyntaxKind.InitAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
                     if (node.Parent!.Parent!.IsKind(SyntaxKind.PropertyDeclaration))
                     {
@@ -1954,7 +1971,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         return;
 
                     case EditKind.Move:
-                        ClassifyMove();
+                        ClassifyMove(_newNode!);
                         return;
 
                     case EditKind.Insert:
@@ -1972,9 +1989,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             #region Move and Reorder
 
-            private void ClassifyMove()
+            private void ClassifyMove(SyntaxNode newNode)
             {
-                if (_newNode.IsKind(SyntaxKind.LocalFunctionStatement))
+                if (newNode.IsKind(SyntaxKind.LocalFunctionStatement))
                 {
                     return;
                 }
@@ -2016,6 +2033,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     case SyntaxKind.EventDeclaration:
                     case SyntaxKind.GetAccessorDeclaration:
                     case SyntaxKind.SetAccessorDeclaration:
+                    case SyntaxKind.InitAccessorDeclaration:
                     case SyntaxKind.AddAccessorDeclaration:
                     case SyntaxKind.RemoveAccessorDeclaration:
                     case SyntaxKind.TypeParameterConstraintClause:
@@ -2064,89 +2082,35 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     case SyntaxKind.ExternAliasDirective:
                     case SyntaxKind.UsingDirective:
                     case SyntaxKind.NamespaceDeclaration:
-                    case SyntaxKind.DestructorDeclaration:
                         ReportError(RudeEditKind.Insert);
                         return;
 
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.StructDeclaration:
-                        var typeDeclaration = (TypeDeclarationSyntax)node;
-                        ClassifyTypeWithPossibleExternMembersInsert(typeDeclaration);
-                        return;
-
                     case SyntaxKind.InterfaceDeclaration:
                     case SyntaxKind.EnumDeclaration:
                     case SyntaxKind.DelegateDeclaration:
-                        return;
-
                     case SyntaxKind.PropertyDeclaration:
-                        var propertyDeclaration = (PropertyDeclarationSyntax)node;
-                        ClassifyModifiedMemberInsert(propertyDeclaration, propertyDeclaration.Modifiers);
-                        return;
-
                     case SyntaxKind.EventDeclaration:
-                        var eventDeclaration = (EventDeclarationSyntax)node;
-                        ClassifyModifiedMemberInsert(eventDeclaration, eventDeclaration.Modifiers);
-                        return;
-
                     case SyntaxKind.IndexerDeclaration:
-                        var indexerDeclaration = (IndexerDeclarationSyntax)node;
-                        ClassifyModifiedMemberInsert(indexerDeclaration, indexerDeclaration.Modifiers);
-                        return;
-
+                    case SyntaxKind.DestructorDeclaration:
                     case SyntaxKind.ConversionOperatorDeclaration:
                     case SyntaxKind.OperatorDeclaration:
-                        ReportError(RudeEditKind.InsertOperator);
-                        return;
-
                     case SyntaxKind.MethodDeclaration:
-                        ClassifyMethodInsert((MethodDeclarationSyntax)node);
-                        return;
-
                     case SyntaxKind.ConstructorDeclaration:
-                        // Allow adding parameterless constructor.
-                        // Semantic analysis will determine if it's an actual addition or 
-                        // just an update of an existing implicit constructor.
-                        var method = (BaseMethodDeclarationSyntax)node;
-                        if (SyntaxUtilities.IsParameterlessConstructor(method))
-                        {
-                            // Disallow adding an extern constructor
-                            if (method.Modifiers.Any(SyntaxKind.ExternKeyword))
-                            {
-                                ReportError(RudeEditKind.InsertExtern);
-                            }
-
-                            return;
-                        }
-
-                        ClassifyModifiedMemberInsert(method, method.Modifiers);
-                        return;
-
                     case SyntaxKind.GetAccessorDeclaration:
                     case SyntaxKind.SetAccessorDeclaration:
+                    case SyntaxKind.InitAccessorDeclaration:
                     case SyntaxKind.AddAccessorDeclaration:
                     case SyntaxKind.RemoveAccessorDeclaration:
-                        ClassifyAccessorInsert((AccessorDeclarationSyntax)node);
-                        return;
-
-                    case SyntaxKind.AccessorList:
-                        // an error will be reported for each accessor
-                        return;
-
                     case SyntaxKind.FieldDeclaration:
                     case SyntaxKind.EventFieldDeclaration:
-                        // allowed: private fields in classes
-                        ClassifyFieldInsert((BaseFieldDeclarationSyntax)node);
-                        return;
-
+                    case SyntaxKind.AccessorList:
                     case SyntaxKind.VariableDeclarator:
-                        // allowed: private fields in classes
-                        ClassifyFieldInsert((VariableDeclaratorSyntax)node);
-                        return;
-
                     case SyntaxKind.VariableDeclaration:
-                        // allowed: private fields in classes
-                        ClassifyFieldInsert((VariableDeclarationSyntax)node);
+                        // Adding these members is not allowed or there are limitations on them that needs to be checked.
+                        // However, any of these members can be moved to a different file or partial type declaration, so 
+                        // we need to defer reporting rude edits till semantic analysis.
                         return;
 
                     case SyntaxKind.Parameter when !_classifyStatementSyntax:
@@ -2171,100 +2135,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 }
             }
 
-            private bool ClassifyModifiedMemberInsert(MemberDeclarationSyntax declaration, SyntaxTokenList modifiers)
-            {
-                if (modifiers.Any(SyntaxKind.ExternKeyword))
-                {
-                    ReportError(RudeEditKind.InsertExtern);
-                    return false;
-                }
-
-                var isExplicitlyVirtual = modifiers.Any(SyntaxKind.VirtualKeyword) || modifiers.Any(SyntaxKind.AbstractKeyword) || modifiers.Any(SyntaxKind.OverrideKeyword);
-
-                var isInterfaceVirtual =
-                    declaration.Parent.IsKind(SyntaxKind.InterfaceDeclaration) &&
-                    !declaration.IsKind(SyntaxKind.EventFieldDeclaration) &&
-                    !declaration.IsKind(SyntaxKind.FieldDeclaration) &&
-                    !modifiers.Any(SyntaxKind.SealedKeyword) &&
-                    !modifiers.Any(SyntaxKind.StaticKeyword);
-
-                if (isExplicitlyVirtual || isInterfaceVirtual)
-                {
-                    ReportError(RudeEditKind.InsertVirtual);
-                    return false;
-                }
-
-                // TODO: Adding a non-virtual member to an interface also fails at runtime
-                // https://github.com/dotnet/roslyn/issues/37128
-                if (declaration.Parent.IsKind(SyntaxKind.InterfaceDeclaration))
-                {
-                    ReportError(RudeEditKind.InsertIntoInterface);
-                    return false;
-                }
-
-                return true;
-            }
-
-            private void ClassifyTypeWithPossibleExternMembersInsert(TypeDeclarationSyntax type)
-            {
-                // extern members are not allowed, even in a new type
-                foreach (var member in type.Members)
-                {
-                    var modifiers = default(SyntaxTokenList);
-
-                    switch (member.Kind())
-                    {
-                        case SyntaxKind.PropertyDeclaration:
-                        case SyntaxKind.IndexerDeclaration:
-                        case SyntaxKind.EventDeclaration:
-                            modifiers = ((BasePropertyDeclarationSyntax)member).Modifiers;
-                            break;
-
-                        case SyntaxKind.ConversionOperatorDeclaration:
-                        case SyntaxKind.OperatorDeclaration:
-                        case SyntaxKind.MethodDeclaration:
-                        case SyntaxKind.ConstructorDeclaration:
-                            modifiers = ((BaseMethodDeclarationSyntax)member).Modifiers;
-                            break;
-                    }
-
-                    if (modifiers.Any(SyntaxKind.ExternKeyword))
-                    {
-                        ReportError(RudeEditKind.InsertExtern, member, member);
-                    }
-                }
-            }
-
-            private void ClassifyMethodInsert(MethodDeclarationSyntax method)
-            {
-                ClassifyModifiedMemberInsert(method, method.Modifiers);
-
-                if (method.Arity > 0)
-                {
-                    ReportError(RudeEditKind.InsertGenericMethod);
-                }
-
-                if (method.ExplicitInterfaceSpecifier != null)
-                {
-                    ReportError(RudeEditKind.InsertMethodWithExplicitInterfaceSpecifier);
-                }
-            }
-
-            private void ClassifyAccessorInsert(AccessorDeclarationSyntax accessor)
-            {
-                var baseProperty = (BasePropertyDeclarationSyntax)accessor.Parent!.Parent!;
-                ClassifyModifiedMemberInsert(baseProperty, baseProperty.Modifiers);
-            }
-
-            private void ClassifyFieldInsert(BaseFieldDeclarationSyntax field)
-                => ClassifyModifiedMemberInsert(field, field.Modifiers);
-
-            private void ClassifyFieldInsert(VariableDeclaratorSyntax fieldVariable)
-                => ClassifyFieldInsert((VariableDeclarationSyntax)fieldVariable.Parent!);
-
-            private void ClassifyFieldInsert(VariableDeclarationSyntax fieldVariable)
-                => ClassifyFieldInsert((BaseFieldDeclarationSyntax)fieldVariable.Parent!);
-
             #endregion
 
             #region Delete
@@ -2281,15 +2151,18 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     case SyntaxKind.ExternAliasDirective:
                     case SyntaxKind.UsingDirective:
                     case SyntaxKind.NamespaceDeclaration:
+                        // To allow removal of declarations we would need to update method bodies that 
+                        // were previously binding to them but now are binding to another symbol that was previously hidden.
+                        ReportError(RudeEditKind.Delete);
+                        return;
+
+                    case SyntaxKind.DestructorDeclaration:
+                    case SyntaxKind.ConversionOperatorDeclaration:
+                    case SyntaxKind.OperatorDeclaration:
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.StructDeclaration:
                     case SyntaxKind.InterfaceDeclaration:
-                    case SyntaxKind.EnumDeclaration:
-                    case SyntaxKind.DelegateDeclaration:
                     case SyntaxKind.MethodDeclaration:
-                    case SyntaxKind.ConversionOperatorDeclaration:
-                    case SyntaxKind.OperatorDeclaration:
-                    case SyntaxKind.DestructorDeclaration:
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.IndexerDeclaration:
                     case SyntaxKind.EventDeclaration:
@@ -2297,46 +2170,21 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     case SyntaxKind.EventFieldDeclaration:
                     case SyntaxKind.VariableDeclarator:
                     case SyntaxKind.VariableDeclaration:
-                        // To allow removal of declarations we would need to update method bodies that 
-                        // were previously binding to them but now are binding to another symbol that was previously hidden.
-                        ReportError(RudeEditKind.Delete);
-                        return;
-
+                    case SyntaxKind.EnumDeclaration:
+                    case SyntaxKind.DelegateDeclaration:
                     case SyntaxKind.ConstructorDeclaration:
-                        // Allow deletion of a parameterless constructor.
-                        // Semantic analysis reports an error if the parameterless ctor isn't replaced by a default ctor.
-                        if (!SyntaxUtilities.IsParameterlessConstructor(oldNode))
-                        {
-                            ReportError(RudeEditKind.Delete);
-                        }
-
+                        // We do not report member delete here since the member might be moving to a different part of a partial type declaration.
+                        // If that is not the case the semantic analysis reports the rude edit.
                         return;
 
                     case SyntaxKind.GetAccessorDeclaration:
                     case SyntaxKind.SetAccessorDeclaration:
+                    case SyntaxKind.InitAccessorDeclaration:
                     case SyntaxKind.AddAccessorDeclaration:
                     case SyntaxKind.RemoveAccessorDeclaration:
-                        // An accessor can be removed. Accessors are not hiding other symbols.
-                        // If the new compilation still uses the removed accessor a semantic error will be reported.
-                        // For simplicity though we disallow deletion of accessors for now. 
-                        // The compiler would need to remember that the accessor has been deleted,
-                        // so that its addition back is interpreted as an update. 
-                        // Additional issues might involve changing accessibility of the accessor.
-                        ReportError(RudeEditKind.Delete);
-                        return;
-
+                    case SyntaxKind.EnumMemberDeclaration:
                     case SyntaxKind.AccessorList:
-                        Debug.Assert(
-                            oldNode.Parent.IsKind(SyntaxKind.PropertyDeclaration) ||
-                            oldNode.Parent.IsKind(SyntaxKind.IndexerDeclaration));
-
-                        var accessorList = (AccessorListSyntax)oldNode;
-                        var setter = accessorList.Accessors.FirstOrDefault(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
-                        if (setter != null)
-                        {
-                            ReportError(RudeEditKind.Delete, accessorList.Parent, setter);
-                        }
-
+                        // We do not report error here since it will be reported in semantic analysis.
                         return;
 
                     case SyntaxKind.AttributeList:
@@ -2344,12 +2192,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         // To allow removal of attributes we would need to check if the removed attribute
                         // is a pseudo-custom attribute that CLR allows us to change, or if it is a compiler well-know attribute
                         // that affects the generated IL.
-                        ReportError(RudeEditKind.Delete);
-                        return;
-
-                    case SyntaxKind.EnumMemberDeclaration:
-                        // We could allow removing enum member if it didn't affect the values of other enum members.
-                        // If the updated compilation binds without errors it means that the enum value wasn't used.
                         ReportError(RudeEditKind.Delete);
                         return;
 
@@ -2465,6 +2307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                     case SyntaxKind.GetAccessorDeclaration:
                     case SyntaxKind.SetAccessorDeclaration:
+                    case SyntaxKind.InitAccessorDeclaration:
                     case SyntaxKind.AddAccessorDeclaration:
                     case SyntaxKind.RemoveAccessorDeclaration:
                         ClassifyUpdate((AccessorDeclarationSyntax)oldNode, (AccessorDeclarationSyntax)newNode);
@@ -2522,7 +2365,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                if (!SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers))
+                // Allow partial keyword to be added or removed.
+                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.PartialKeyword))
                 {
                     ReportError(RudeEditKind.ModifiersUpdate);
                     return;
@@ -2534,8 +2378,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                Debug.Assert(!SyntaxFactory.AreEquivalent(oldNode.BaseList, newNode.BaseList));
-                ReportError(RudeEditKind.BaseTypeOrInterfaceUpdate);
+                if (!SyntaxFactory.AreEquivalent(oldNode.BaseList, newNode.BaseList))
+                {
+                    ReportError(RudeEditKind.BaseTypeOrInterfaceUpdate);
+                }
             }
 
             private void ClassifyUpdate(EnumDeclarationSyntax oldNode, EnumDeclarationSyntax newNode)
@@ -2614,7 +2460,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 // If the argument lists are mismatched the field must have mismatched "fixed" modifier, 
                 // which is reported by the field declaration.
-                if ((oldNode.ArgumentList == null) == (newNode.ArgumentList == null))
+                if (oldNode.ArgumentList is null == newNode.ArgumentList is null)
                 {
                     if (!SyntaxFactory.AreEquivalent(oldNode.ArgumentList, newNode.ArgumentList))
                     {
@@ -2649,7 +2495,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                if (!ClassifyMethodModifierUpdate(oldNode.Modifiers, newNode.Modifiers))
+                // Ignore async keyword when matching modifiers. Async checks are done in ComputeBodyMatch.
+                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.AsyncKeyword))
                 {
                     ReportError(RudeEditKind.ModifiersUpdate);
                     return;
@@ -2672,27 +2519,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     (SyntaxNode?)newNode.Body ?? newNode.ExpressionBody?.Expression,
                     containingMethod: newNode,
                     containingType: (TypeDeclarationSyntax?)newNode.Parent);
-            }
-
-            private static bool ClassifyMethodModifierUpdate(SyntaxTokenList oldModifiers, SyntaxTokenList newModifiers)
-            {
-                // Ignore async keyword when matching modifiers.
-                // async checks are done in ComputeBodyMatch.
-
-                var oldAsyncIndex = oldModifiers.IndexOf(SyntaxKind.AsyncKeyword);
-                var newAsyncIndex = newModifiers.IndexOf(SyntaxKind.AsyncKeyword);
-
-                if (oldAsyncIndex >= 0)
-                {
-                    oldModifiers = oldModifiers.RemoveAt(oldAsyncIndex);
-                }
-
-                if (newAsyncIndex >= 0)
-                {
-                    newModifiers = newModifiers.RemoveAt(newAsyncIndex);
-                }
-
-                return SyntaxFactory.AreEquivalent(oldModifiers, newModifiers);
             }
 
             private void ClassifyUpdate(ConversionOperatorDeclarationSyntax oldNode, ConversionOperatorDeclarationSyntax newNode)
@@ -2960,6 +2786,24 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 // changes in attribute separators are not interesting:
             }
 
+            private static bool AreModifiersEquivalent(SyntaxTokenList oldModifiers, SyntaxTokenList newModifiers, SyntaxKind ignore)
+            {
+                var oldIgnoredModifierIndex = oldModifiers.IndexOf(ignore);
+                var newIgnoredModifierIndex = newModifiers.IndexOf(ignore);
+
+                if (oldIgnoredModifierIndex >= 0)
+                {
+                    oldModifiers = oldModifiers.RemoveAt(oldIgnoredModifierIndex);
+                }
+
+                if (newIgnoredModifierIndex >= 0)
+                {
+                    newModifiers = newModifiers.RemoveAt(newIgnoredModifierIndex);
+                }
+
+                return SyntaxFactory.AreEquivalent(oldModifiers, newModifiers);
+            }
+
             private void ClassifyMethodBodyRudeUpdate(
                 SyntaxNode? oldBody,
                 SyntaxNode? newBody,
@@ -3062,9 +2906,94 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         #region Semantic Rude Edits
 
-        internal override void ReportInsertedMemberSymbolRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol newSymbol)
+        internal override void ReportInsertedMemberSymbolRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol newSymbol, SyntaxNode newNode, bool insertingIntoExistingContainingType)
         {
-            // We rejected all exported methods during syntax analysis, so no additional work is needed here.
+            var rudeEditKind = newSymbol switch
+            {
+                // Inserting extern member into a new or existing type is not allowed.
+                { IsExtern: true }
+                    => RudeEditKind.InsertExtern,
+
+                // All rude edits below only apply when inserting into an existing type (not when the type itself is inserted):
+                _ when !insertingIntoExistingContainingType => RudeEditKind.None,
+
+                // Inserting a member into an existing generic type is not allowed.
+                { ContainingType: { Arity: > 0 } } and not INamedTypeSymbol
+                    => RudeEditKind.InsertIntoGenericType,
+
+                // Inserting virtual or interface member into an existing type is not allowed.
+                { IsVirtual: true } or { IsOverride: true } or { IsAbstract: true } and not INamedTypeSymbol
+                    => RudeEditKind.InsertVirtual,
+
+                // Inserting generic method into an existing type is not allowed.
+                IMethodSymbol { Arity: > 0 }
+                    => RudeEditKind.InsertGenericMethod,
+
+                // Inserting destructor to an existing type is not allowed.
+                IMethodSymbol { MethodKind: MethodKind.Destructor }
+                    => RudeEditKind.Insert,
+
+                // Inserting operator to an existing type is not allowed.
+                IMethodSymbol { MethodKind: MethodKind.Conversion or MethodKind.UserDefinedOperator }
+                    => RudeEditKind.InsertOperator,
+
+                // Inserting a method that explictly implements an interface method into an existing type is not allowed.
+                IMethodSymbol { ExplicitInterfaceImplementations: { IsEmpty: false } }
+                    => RudeEditKind.InsertMethodWithExplicitInterfaceSpecifier,
+
+                // TODO: Inserting non-virtual member to an interface (https://github.com/dotnet/roslyn/issues/37128)
+                { ContainingType: { TypeKind: TypeKind.Interface } } and not INamedTypeSymbol
+                    => RudeEditKind.InsertIntoInterface,
+
+                _ => RudeEditKind.None
+            };
+
+            if (rudeEditKind != RudeEditKind.None)
+            {
+                diagnostics.Add(new RudeEditDiagnostic(
+                    rudeEditKind,
+                    GetDiagnosticSpan(newNode, EditKind.Insert),
+                    newNode,
+                    arguments: new[] { GetDisplayName(newNode, EditKind.Insert) }));
+            }
+        }
+
+        internal override void ReportTypeDeclarationInsertDeleteRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, INamedTypeSymbol oldType, INamedTypeSymbol newType, SyntaxNode newDeclaration, CancellationToken cancellationToken)
+        {
+            using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var oldNodes);
+            using var _2 = ArrayBuilder<SyntaxNode>.GetInstance(out var newNodes);
+
+            // Consider: better error messages
+            Report((b, t) => AddNodes(b, t.AttributeLists), RudeEditKind.Update);
+            Report((b, t) => AddNodes(b, t.TypeParameterList?.Parameters), RudeEditKind.Update);
+            Report((b, t) => AddNodes(b, t.ConstraintClauses), RudeEditKind.Update);
+            Report((b, t) => AddNodes(b, t.BaseList?.Types), RudeEditKind.BaseTypeOrInterfaceUpdate);
+
+            void Report(Action<ArrayBuilder<SyntaxNode>, TypeDeclarationSyntax> addNodes, RudeEditKind rudeEditKind)
+            {
+                foreach (var syntaxRef in oldType.DeclaringSyntaxReferences)
+                {
+                    addNodes(oldNodes, (TypeDeclarationSyntax)syntaxRef.GetSyntax(cancellationToken));
+                }
+
+                foreach (var syntaxRef in newType.DeclaringSyntaxReferences)
+                {
+                    addNodes(newNodes, (TypeDeclarationSyntax)syntaxRef.GetSyntax(cancellationToken));
+                }
+
+                if (oldNodes.Count != newNodes.Count ||
+                    oldNodes.Zip(newNodes, (oldNode, newNode) => SyntaxFactory.AreEquivalent(oldNode, newNode)).Any(isEquivalent => !isEquivalent))
+                {
+                    diagnostics.Add(new RudeEditDiagnostic(
+                        rudeEditKind,
+                        GetDiagnosticSpan(newDeclaration, EditKind.Update),
+                        newDeclaration,
+                        arguments: new[] { GetDisplayName(newDeclaration, EditKind.Update) }));
+                }
+
+                oldNodes.Clear();
+                newNodes.Clear();
+            }
         }
 
         #endregion

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -485,6 +485,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.InitAccessorDeclaration:
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                     isLeaf = true;
@@ -815,6 +816,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.DestructorDeclaration:
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.InitAccessorDeclaration:
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                     // When comparing method bodies we need to NOT ignore VariableDeclaration and VariableDeclarator children,
@@ -1545,6 +1547,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.InitAccessorDeclaration:
                     return null;
 
                 case SyntaxKind.TypeParameterConstraintClause:

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     break;
 
                 case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.InitAccessorDeclaration:
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                 case SyntaxKind.GetAccessorDeclaration:

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -222,6 +222,11 @@
         <target state="translated">asynchronní deklarace using</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;lambda výraz&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">příkaz global</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">using namespace</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -222,6 +222,11 @@
         <target state="translated">asynchrone using-Deklaration</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;Lambdaausdruck&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">global – Anweisung</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">Using-Namespace</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -222,6 +222,11 @@
         <target state="translated">declaración using asincrónica</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;expresión lambda&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">declaración global</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">uso de espacio de nombres</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -222,6 +222,11 @@
         <target state="translated">déclaration using asynchrone</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;expression lambda&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">instruction global</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">espace de noms using</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -222,6 +222,11 @@
         <target state="translated">dichiarazione using asincrona</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;espressione lambda&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">istruzione global</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">spazio dei nomi using</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -222,6 +222,11 @@
         <target state="translated">非同期の using 宣言</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;ラムダ式&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">global ステートメント</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">using namespace</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -222,6 +222,11 @@
         <target state="translated">비동기 using 선언</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;람다 식&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">global 문</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">using 네임스페이스</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -222,6 +222,11 @@
         <target state="translated">asynchroniczna deklaracja using</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;wyrażenie lambda&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">instrukcja global</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">przestrzeń nazw using</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -222,6 +222,11 @@
         <target state="translated">declaração using assíncrona</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;expressão lambda&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">instrução global</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">usando o namespace</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -222,6 +222,11 @@
         <target state="translated">асинхронное объявление using</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;лямбда-выражение&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">инструкция global</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">пространство имен using</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -222,6 +222,11 @@
         <target state="translated">zaman uyumsuz using bildirimi</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt; lambda ifadesi &gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">global deyimi</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">using namespace</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -222,6 +222,11 @@
         <target state="translated">异步 using 声明</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;lambda 表达式&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">global 语句</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">using 命名空间</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -222,6 +222,11 @@
         <target state="translated">非同步 using 宣告</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="extern_alias">
+        <source>extern alias</source>
+        <target state="new">extern alias</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lambda_expression">
         <source>&lt;lambda expression&gt;</source>
         <target state="translated">&lt;Lambda 運算式&gt;</target>
@@ -586,11 +591,6 @@
         <source>global statement</source>
         <target state="translated">global 陳述式</target>
         <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="using_namespace">
-        <source>using namespace</source>
-        <target state="translated">using 命名空間</target>
-        <note />
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -900,8 +900,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         {
             Debug.Assert(!newActiveStatementSpans.IsDefault);
             Debug.Assert(newActiveStatementSpans.IsEmpty || oldActiveStatements.Length == newActiveStatementSpans.Length);
-            Debug.Assert(oldActiveStatements.Length == newActiveStatements.Count);
-            Debug.Assert(oldActiveStatements.Length == newExceptionRegions.Count);
+            Debug.Assert(oldActiveStatements.IsEmpty || oldActiveStatements.Length == newActiveStatements.Count);
+            Debug.Assert(newActiveStatements.Count == newExceptionRegions.Count);
 
             syntaxMap = null;
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             AddRudeEdit(RudeEditKind.InsertAroundActiveStatement, nameof(FeaturesResources.Adding_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.DeleteAroundActiveStatement, nameof(FeaturesResources.Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing));
-            AddRudeEdit(RudeEditKind.DeleteActiveStatement, nameof(FeaturesResources.An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session));
+            AddRudeEdit(RudeEditKind.DeleteActiveStatement, nameof(FeaturesResources.Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.UpdateAroundActiveStatement, nameof(FeaturesResources.Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.UpdateExceptionHandlerOfActiveTry, nameof(FeaturesResources.Modifying_a_catch_finally_handler_with_an_active_statement_in_the_try_block_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.UpdateTryOrCatchWithActiveFinally, nameof(FeaturesResources.Modifying_a_try_catch_finally_statement_when_the_finally_block_is_active_will_prevent_the_debug_session_from_continuing));
@@ -104,13 +104,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.GenericTypeUpdate, nameof(FeaturesResources.Modifying_a_method_inside_the_context_of_a_generic_type_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.GenericTypeTriviaUpdate, nameof(FeaturesResources.Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.GenericTypeInitializerUpdate, nameof(FeaturesResources.Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing));
-            AddRudeEdit(RudeEditKind.PartialTypeInitializerUpdate, nameof(FeaturesResources.Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, nameof(FeaturesResources.Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.RenamingCapturedVariable, nameof(FeaturesResources.Renaming_a_captured_variable_from_0_to_1_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.StackAllocUpdate, nameof(FeaturesResources.Modifying_0_which_contains_the_stackalloc_operator_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.ExperimentalFeaturesEnabled, nameof(FeaturesResources.Modifying_source_with_experimental_language_features_enabled_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.AwaitStatementUpdate, nameof(FeaturesResources.Updating_a_complex_statement_containing_an_await_expression_will_prevent_the_debug_session_from_continuing));
-            AddRudeEdit(RudeEditKind.ChangingConstructorVisibility, nameof(FeaturesResources.Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing));
+            AddRudeEdit(RudeEditKind.ChangingVisibility, nameof(FeaturesResources.Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.CapturingVariable, nameof(FeaturesResources.Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.NotCapturingVariable, nameof(FeaturesResources.Ceasing_to_capture_variable_0_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.DeletingCapturedVariable, nameof(FeaturesResources.Deleting_captured_variable_0_will_prevent_the_debug_session_from_continuing));
@@ -127,7 +126,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.ActiveStatementLambdaRemoved, nameof(FeaturesResources.Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing));
             // TODO: change the error message to better explain what's going on
             AddRudeEdit(RudeEditKind.PartiallyExecutedActiveStatementUpdate, nameof(FeaturesResources.Updating_an_active_statement_will_prevent_the_debug_session_from_continuing));
-            AddRudeEdit(RudeEditKind.PartiallyExecutedActiveStatementDelete, nameof(FeaturesResources.An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session));
+            AddRudeEdit(RudeEditKind.PartiallyExecutedActiveStatementDelete, nameof(FeaturesResources.Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.InsertFile, nameof(FeaturesResources.Adding_a_new_file_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, nameof(FeaturesResources.Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, nameof(FeaturesResources.Attribute_0_is_missing_Updating_an_async_method_or_an_iterator_will_prevent_the_debug_session_from_continuing));
@@ -144,6 +143,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.MemberBodyInternalError, nameof(FeaturesResources.Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_due_to_internal_error));
             AddRudeEdit(RudeEditKind.MemberBodyTooBig, nameof(FeaturesResources.Modifying_body_of_member_will_prevent_the_debug_session_from_continuing_because_the_body_has_too_many_statements));
             AddRudeEdit(RudeEditKind.SourceFileTooBig, nameof(FeaturesResources.Modifying_source_file_will_prevent_the_debug_session_from_continuing_because_the_file_is_too_big));
+            AddRudeEdit(RudeEditKind.InsertIntoGenericType, nameof(FeaturesResources.Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing));
 
             // VB specific
             AddRudeEdit(RudeEditKind.HandlesClauseUpdate, nameof(FeaturesResources.Updating_the_Handles_clause_of_0_will_prevent_the_debug_session_from_continuing));

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         GenericTypeUpdate = 38,
         GenericTypeTriviaUpdate = 39,
         GenericTypeInitializerUpdate = 40,
-        PartialTypeInitializerUpdate = 41,
+        // PartialTypeInitializerUpdate = 41,
         // AsyncMethodUpdate = 42,
         // AsyncMethodTriviaUpdate = 43,
         StackAllocUpdate = 44,
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ExperimentalFeaturesEnabled = 45,
 
         AwaitStatementUpdate = 46,
-        ChangingConstructorVisibility = 47,
+        ChangingVisibility = 47,
 
         CapturingVariable = 48,
         NotCapturingVariable = 49,
@@ -116,5 +116,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         MemberBodyInternalError = 88,
         SourceFileTooBig = 89,
         MemberBodyTooBig = 90,
+        InsertIntoGenericType = 91,
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/SemanticEditInfo.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SemanticEditInfo.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue
+{
+    internal readonly struct SemanticEditInfo
+    {
+        /// <summary>
+        /// <see cref="SemanticEditKind.Insert"/> or <see cref="SemanticEditKind.Update"/>.
+        /// </summary>
+        public SemanticEditKind Kind { get; }
+
+        /// <summary>
+        /// If <see cref="Kind"/> is <see cref="SemanticEditKind.Insert"/> represents the inserted symbol in the new compilation.
+        /// If <see cref="Kind"/> is <see cref="SemanticEditKind.Update"/> represents the updated symbol in both compilations.
+        /// 
+        /// We use <see cref="SymbolKey"/> to represent the symbol rather then <see cref="ISymbol"/>,
+        /// since different semantic edits might hav ebeen calculated against different solution snapshot and thus symbols are not directly comparable.
+        /// When the edits are processed we map the <see cref="SymbolKey"/> to the current compilation.
+        /// </summary>
+        public SymbolKey Symbol { get; }
+
+        public Func<SyntaxNode, SyntaxNode?>? SyntaxMap { get; }
+
+        /// <summary>
+        /// Specified if the edit needs to be merged with other edits of the same <see cref="PartialType"/>.
+        /// <see langword="null"/> for edits of non-partial types or their members and of a member of a partial type that do not require merging.
+        /// 
+        /// If specified, the <see cref="SyntaxMap"/> is incomplete: it only provides mapping of the changed members of a single partial type declaration.
+        /// </summary>
+        public SymbolKey? PartialType { get; }
+
+        public SemanticEditInfo(
+            SemanticEditKind kind,
+            SymbolKey symbol,
+            Func<SyntaxNode, SyntaxNode?>? syntaxMap,
+            SymbolKey? partialType)
+        {
+            Kind = kind;
+            Symbol = symbol;
+            SyntaxMap = syntaxMap;
+            PartialType = partialType;
+        }
+    }
+}

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -363,8 +363,8 @@
   <data name="Updating_a_complex_statement_containing_an_await_expression_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Updating a complex statement containing an await expression will prevent the debug session from continuing.</value>
   </data>
-  <data name="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
-    <value>Changing visibility of a constructor will prevent the debug session from continuing.</value>
+  <data name="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Changing visibility of {0} will prevent the debug session from continuing.</value>
   </data>
   <data name="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</value>
@@ -407,6 +407,9 @@
   </data>
   <data name="Adding_0_into_an_interface_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Adding '{0}' into an interface will prevent the debug session from continuing.</value>
+  </data>
+  <data name="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Adding '{0}' into a generic type will prevent the debug session from continuing.</value>
   </data>
   <data name="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Adding '{0}' into an interface method will prevent the debug session from continuing.</value>
@@ -496,7 +499,7 @@
     <value>Moving '{0}' will prevent the debug session from continuing.</value>
   </data>
   <data name="Deleting_0_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
-    <value>Deleting '{0}' will prevent the debug session from continuing.</value>
+    <value>Deleting {0} will prevent the debug session from continuing.</value>
   </data>
   <data name="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Deleting '{0}' around an active statement will prevent the debug session from continuing.</value>
@@ -535,9 +538,6 @@
   <data name="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</value>
   </data>
-  <data name="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
-    <value>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</value>
-  </data>
   <data name="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Adding a constructor to a type with a field or property initializer that contains an anonymous function will prevent the debug session from continuing.</value>
   </data>
@@ -572,7 +572,7 @@
     <value>Updating an active statement will prevent the debug session from continuing.</value>
   </data>
   <data name="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
-    <value>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</value>
+    <value>Removing {0} that contains an active statement will prevent the debug session from continuing.</value>
   </data>
   <data name="Adding_a_new_file_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Adding a new file will prevent the debug session from continuing.</value>
@@ -790,6 +790,9 @@ Do you want to continue?</value>
   </data>
   <data name="constructor" xml:space="preserve">
     <value>constructor</value>
+  </data>
+  <data name="static_constructor" xml:space="preserve">
+    <value>static constructor</value>
   </data>
   <data name="auto_property" xml:space="preserve">
     <value>auto-property</value>
@@ -2804,6 +2807,13 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   </data>
   <data name="_0_dash_1" xml:space="preserve">
     <value>{0} - {1}</value>
+  </data>
+  <data name="member_kind_and_name" xml:space="preserve">
+    <value>{0} '{1}'</value>
+    <comment>e.g. "method 'M'"</comment>
+  </data>
+  <data name="code" xml:space="preserve">
+    <value>code</value>
   </data>
   <data name="Convert_to_record" xml:space="preserve">
     <value>Convert to record</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -90,6 +90,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Přidat název elementu řazené kolekce členů {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Přidání prvku {0} do metody rozhraní zabrání v pokračování relace ladění.</target>
@@ -124,6 +129,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Podmínky alternativního výrazu nezachytávají a nejde je pojmenovat.</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Pokud se změní {0} na {1}, relace ladění nebude moct pokračovat, protože dojde ke změně tvaru stavového počítače.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ Pokud se specifikátor formátu H použije bez dalších specifikátorů vlastn�
         <target state="translated">Specifikátor vlastního formátu HH reprezentuje hodinu jako číslo od 00 do 23. To znamená, že hodina je reprezentována ve 24hodinovém formátu, který začíná na nule a počítá hodiny od půlnoci. Hodina s jednou číslicí se formátuje s nulou na začátku.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">oddělovač data</target>
@@ -2491,6 +2511,11 @@ Specifikátor standardního formátu f představuje kombinaci vzorů dlouhého d
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">Specifikátor standardního formátu T představuje řetězec vlastního formátu data a času, který se definuje pomocí vlastnosti DateTimeFormatInfo.LongTimePattern konkrétní jazykové verze. Například řetězec vlastního formátu pro invariantní jazykovou verzi je HH:mm:ss.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ Pokud se specifikátor formátu g použije bez dalších specifikátorů vlastn�
         <target state="translated">Aktualizace komplexního příkazu, který obsahuje výraz await, znemožní relaci ladění pokračovat.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Změna viditelnosti konstruktoru znemožní relaci ladění pokračovat.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">Zachycení proměnné {0}, která se nezachytila dřív, zabrání v pokračování relace ladění.</target>
@@ -3155,8 +3175,8 @@ Pokud se specifikátor formátu g použije bez dalších specifikátorů vlastn�
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">Odstranění prvku {0} zabrání v pokračování relace ladění.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Odstranění prvku {0} zabrání v pokračování relace ladění.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ Pokud se specifikátor formátu g použije bez dalších specifikátorů vlastn�
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Odstranění těla metody zabrání v pokračování relace ladění.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Aktivní příkaz je odstraněný z jeho původní metody. Pro pokračování musíte vzít zpátky změny nebo restartovat ladicí relaci.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ Pokud se specifikátor formátu g použije bez dalších specifikátorů vlastn�
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Modifikace inicializátoru pro {0} v obecném typu zabrání v pokračování relace ladění.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Modifikace inicializátoru pro {0} v částečném typu zabrání v pokračování relace ladění.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ Pokud se specifikátor formátu g použije bez dalších specifikátorů vlastn�
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Odebrání prvku {0}, který obsahuje aktivní příkaz, zabrání v pokračování relace ladění.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Odebrání prvku {0}, který obsahuje aktivní příkaz, zabrání v pokračování relace ladění.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 Účelem specifikátoru formátu s je vytvořit výsledné řetězce, které budou konzistentně seřazené vzestupně nebo sestupně podle hodnot data a času. Z toho důvodu operace formátování neupraví hodnotu formátovaného objektu data a času tak, aby odrážela vlastnost DateTime.Kind nebo její vlastnost DateTimeOffset.Offset, i když specifikátor standardního formátu s představuje hodnotu data a času v konzistentním formátu. Například výsledné řetězce vytvořené formátováním hodnot data a času 2014-11-15T18:32:17+00:00 a 2014-11-15T18:32:17+08:00 jsou totožné.
 
 Když se tento specifikátor standardního formátu použije, operace formátování nebo parsování vždy použije invariantní jazykovou verzi.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -90,6 +90,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Tupelelementnamen "{0}" hinzufügen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Das Hinzufügen von "{0}" zu einer Schnittstellenmethode verhindert das Fortsetzen der Debugsitzung.</target>
@@ -124,6 +129,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Wechselbedingungen werden nicht erfasst und können nicht benannt werden.</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Die Änderung von "{0}" in "{1}" verhindert, dass die Debugsitzung fortgesetzt wird, weil sich dadurch die Form des Zustandsautomaten verändert.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ Bei Verwendung des Formatbezeichners "H" ohne weitere benutzerdefinierte Formatb
         <target state="translated">Der benutzerdefinierte Formatbezeichner "HH" (plus beliebig viele zusätzliche H-Bezeichner) repräsentiert die Stunde als eine Zahl zwischen 00 und 23, d. h., die Stunde wird in einem nullbasierten 24-Stunden-Format dargestellt, bei dem die Stunden seit Mitternacht gezählt werden. Ein einstelliger Stundenwert wird mit einer führenden Null formatiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">Datumstrennzeichen</target>
@@ -2491,6 +2511,11 @@ Der Standardformatbezeichner "f" repräsentiert eine Kombination aus den Mustern
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">Der Standardformatbezeichner "T" repräsentiert eine benutzerdefinierte Datums- und Uhrzeitformatzeichenfolge, die durch die DateTimeFormatInfo.LongTimePattern-Eigenschaft einer bestimmten Kultur definiert ist. Die benutzerdefinierte Formatzeichenfolge für die invariante Kultur lautet beispielsweise "HH:mm:ss".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ Bei Verwendung des Formatbezeichners "g" ohne weitere benutzerdefinierte Formatb
         <target state="translated">Beim Ändern von komplexen Anweisungen, die einen "await"-Ausdruck enthalten, wird die Debuggingsitzung unterbrochen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Bei Änderungen an der Sichtbarkeit von Konstruktoren wird die Debuggingsitzung unterbrochen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">Nach dem Erfassen der zuvor noch nicht erfassten Variable "{0}" kann die Debugsitzung nicht mehr fortgesetzt werden.</target>
@@ -3155,8 +3175,8 @@ Bei Verwendung des Formatbezeichners "g" ohne weitere benutzerdefinierte Formatb
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">Durch Löschen von "{0}" wird verhindert, dass die Debuggingsitzung fortgesetzt wird.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Durch Löschen von "{0}" wird verhindert, dass die Debuggingsitzung fortgesetzt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ Bei Verwendung des Formatbezeichners "g" ohne weitere benutzerdefinierte Formatb
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Durch Löschen eines Methodenkörpers wird verhindert, dass eine Debuggingsitzung fortgesetzt wird.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Eine aktive Anweisung wurde aus der ursprünglichen Methode entfernt. Sie müssen Ihre Änderungen rückgängig machen, um die Debuggingsitzung fortzusetzen oder neu zu starten.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ Bei Verwendung des Formatbezeichners "g" ohne weitere benutzerdefinierte Formatb
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Durch Ändern des Initialisierers von "{0}" in einem generischen Typen wird verhindert, dass die Debuggingsitzung fortgesetzt wird.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Durch Ändern des Initialisierers von "{0}" in einem partiellen Typ wird verhindert, dass die Debuggingsitzung fortgesetzt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ Bei Verwendung des Formatbezeichners "g" ohne weitere benutzerdefinierte Formatb
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Durch Entfernen von "{0}", das eine aktive Anweisung enthält, wird verhindert, dass die Debuggingsitzung fortgesetzt wird.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Durch Entfernen von "{0}", das eine aktive Anweisung enthält, wird verhindert, dass die Debuggingsitzung fortgesetzt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 Der Zweck des Formatbezeichners "s" besteht darin, Ergebniszeichenfolgen zu erzeugen, die basierend auf Datums- und Uhrzeitwerten konsistent in aufsteigender oder absteigender Reihenfolge sortiert werden. Obwohl der Standardformatbezeichner "s" einen Datums- und Uhrzeitwert in einem konsistenten Format repräsentiert, wird der Wert des zu formatierenden Objekts für Datum und Uhrzeit bei der Formatierung nicht geändert, um die zugehörige DateTime.Kind-Eigenschaft oder den zugehörigen DateTimeOffset.Offset-Wert widerzuspiegeln. Beispielsweise sind die Ergebniszeichenfolgen, die bei Formatierung der Datums- und Uhrzeitwerte 2014-11-15T18:32:17+00:00 und 2014-11-15T18:32:17+08:00 generiert werden, identisch.
 
 Bei Verwendung dieses Standardformatbezeichners wird zur Formatierung oder Analyse immer die invariante Kultur verwendet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -90,6 +90,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Agregar el nombre del elemento de tupla "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Agregar "{0}" a un método de interfaz impedirá que continúe la sesión de depuración.</target>
@@ -124,6 +129,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Las condiciones de alternancia no se captan y se les puede poner un nombre</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Si se cambia "{0}" a "{1}", la sesión de depuración no podrá continuar porque cambia la forma de la máquina de estados.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ Si el especificador de formato "H" se usa sin otros especificadores de formato p
         <target state="translated">El especificador de formato personalizado "HH" (más cualquier número de especificadores "H" adicionales) representa la hora como un número de 00 a 23, es decir, mediante un reloj de 24 horas de base cero que cuenta las horas desde la medianoche. El formato de una hora de un solo dígito es con un cero inicial.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">separador de fecha</target>
@@ -2491,6 +2511,11 @@ El especificador de formato estándar "f" representa una combinación de los pat
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">El especificador de formato estándar "T" representa una cadena de formato de fecha y hora personalizado que está definida por la propiedad DateTimeFormatInfo.LongTimePattern de una referencia cultural específica. Por ejemplo, la cadena de formato personalizado para la referencia cultural invariable es "HH:mm:ss".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ Si el especificador de formato "g" se usa sin otros especificadores de formato p
         <target state="translated">Si se actualiza una instrucción compleja que contiene una expresión await, la sesión de depuración no podrá continuar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Si se cambia la visibilidad de un constructor, la sesión de depuración no podrá continuar.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">La captura de una variable "{0}" que no se había capturado antes impedirá que continúe la sesión de depuración.</target>
@@ -3155,8 +3175,8 @@ Si el especificador de formato "g" se usa sin otros especificadores de formato p
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">Eliminar '{0}' impedirá que continúe la sesión de depuración.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Eliminar '{0}' impedirá que continúe la sesión de depuración.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ Si el especificador de formato "g" se usa sin otros especificadores de formato p
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Eliminar un cuerpo de método impedirá que continúe la sesión de depuración.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Se quitó una instrucción activa de su método original. Debe revertir los cambios para continuar o reiniciar la sesión de depuración.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ Si el especificador de formato "g" se usa sin otros especificadores de formato p
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Modificar el inicializador de '{0}' en un tipo genérico impedirá que continúe la sesión de depuración.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Modificar el inicializador de '{0}' en un tipo parcial impedirá que continúe la sesión de depuración.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ Si el especificador de formato "g" se usa sin otros especificadores de formato p
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Quitar '{0}' que contiene una instrucción activa impedirá que continúe la sesión de depuración.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Quitar '{0}' que contiene una instrucción activa impedirá que continúe la sesión de depuración.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 La finalidad del especificador de formato "s" es producir cadenas de resultados que se ordenen coherentemente de forma ascendente o descendente según los valores de fecha y hora. Como resultado, aunque el especificador de formato estándar "s" representa un valor de fecha y hora en un formato coherente, la operación de formato no modifica el valor del objeto de fecha y hora al que se está dando formato para reflejar su propiedad DateTime.Kind o DateTimeOffset.Offset. Por ejemplo, las cadenas de resultados generadas por el formato de los valores de fecha y hora 2014-11-15T18:32:17+00:00 y 2014-11-15T18:32:17+08:00 son idénticas.
 
 Cuando se usa este especificador de formato estándar, la operación de formato o análisis utiliza siempre la referencia cultural invariable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -90,6 +90,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Ajouter le nom d'élément tuple '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">L'ajout de '{0}' à une méthode d'interface empêche la session de débogage de se poursuivre.</target>
@@ -124,6 +129,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Les conditions d'alternance n'effectuent pas de capture et ne peuvent pas être nommées</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Le remplacement de '{0}' par '{1}' va empêcher la session de débogage de se poursuivre, car cela change la forme de la machine à états.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ Si le spécificateur de format "H" est utilisé sans autres spécificateurs de f
         <target state="translated">Le spécificateur de format personnalisé "HH" (plus n'importe quel nombre de spécificateurs "H" supplémentaires) représente les heures sous la forme d'un nombre compris entre 00 et 23. En d'autres termes, les heures sont représentées par une horloge de 24 heures de base zéro, qui compte les heures écoulées depuis minuit. Une heure à un chiffre est présentée dans un format qui comporte un zéro de début.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">séparateur de date</target>
@@ -2491,6 +2511,11 @@ Le spécificateur de format standard "f" représente une combinaison des modèle
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">Le spécificateur de format standard "T" représente une chaîne de format de date et d'heure personnalisée, qui est définie par la propriété DateTimeFormatInfo.LongTimePattern d'une culture spécifique. Par exemple, la chaîne de format personnalisée pour la culture invariante est "HH:mm:ss".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ Si le spécificateur de format "g" est utilisé sans autres spécificateurs de f
         <target state="translated">La mise à jour d'une instruction complexe contenant une expression await empêche la session de débogage de se poursuivre.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Le changement de visibilité d'un constructeur empêche la session de débogage de se poursuivre.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">La capture de la variable '{0}' qui n'a pas déjà été capturée empêche la session de débogage de se poursuivre.</target>
@@ -3155,8 +3175,8 @@ Si le spécificateur de format "g" est utilisé sans autres spécificateurs de f
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">La suppression de '{0}' empêche la session de débogage de se poursuivre.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">La suppression de '{0}' empêche la session de débogage de se poursuivre.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ Si le spécificateur de format "g" est utilisé sans autres spécificateurs de f
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">La suppression d'un corps de méthode empêche la session de débogage de se poursuivre.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Une instruction active a été supprimée de sa méthode d'origine. Annulez vos modifications si vous voulez continuer ou redémarrez la session de débogage.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ Si le spécificateur de format "g" est utilisé sans autres spécificateurs de f
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">La modification de l'initialiseur de '{0}' dans un type générique empêche la session de débogage de se poursuivre.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">La modification de l'initialiseur de '{0}' dans un type partiel empêche la session de débogage de se poursuivre.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ Si le spécificateur de format "g" est utilisé sans autres spécificateurs de f
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">La suppression de '{0}' contenant une instruction active empêche la session de débogage de se poursuivre.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">La suppression de '{0}' contenant une instruction active empêche la session de débogage de se poursuivre.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 Le spécificateur de format "s" a pour but de produire des chaînes triées de manière cohérente dans l'ordre croissant ou décroissant en fonction des valeurs de date et d'heure. Ainsi, bien que le spécificateur de format standard "s" représente une valeur de date et d'heure dans un format cohérent, l'opération qui consiste à appliquer un format ne modifie pas la valeur de l'objet de date et d'heure visé pour refléter sa propriété DateTime.Kind ou sa valeur DateTimeOffset.Offset. Par exemple, les chaînes qui résultent de l'application du format souhaité aux valeurs de date et d'heure 2014-11-15T18:32:17+00:00 et 2014-11-15T18:32:17+08:00 sont identiques.
 
 Quand ce spécificateur de format standard est utilisé, l'opération qui consiste à appliquer un format ou à exécuter une analyse utilise toujours la culture invariante.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -90,6 +90,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Aggiungi il nome dell'elemento tupla '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Se si aggiunge '{0}' in un metodo di interfaccia, la sessione di debug non potrà continuare.</target>
@@ -124,6 +129,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Le condizioni di alternanza non consentono l'acquisizione e non possono essere denominate</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Se si modifica '{0}' in '{1}', la sessione di debug non potrà continuare perché modifica la forma della macchina a stati.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ Se l'identificatore di formato "H" viene usato senza altri identificatori di for
         <target state="translated">L'identificatore di formato personalizzato "HH" (più qualsiasi numero di identificatori "H" aggiuntivi) rappresenta l'ora come numero compreso tra 00 e 23, ovvero l'ora rappresentata nell'orario in formato 24 ore a base zero in base al quale il conteggio riparte da mezzanotte. Un'ora costituita da una singola cifra viene formattata con uno zero iniziale.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">Separatore di data</target>
@@ -2491,6 +2511,11 @@ L'identificatore di formato standard "f" rappresenta una combinazione degli sche
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">L'identificatore di formato standard "T" rappresenta una stringa di formato di data e ora personalizzata definita dalla proprietà DateTimeFormatInfo.LongTimePattern di impostazioni cultura specifiche. Ad esempio, la stringa di formato personalizzata per le impostazioni cultura inglese non dipendenti da paese/area geografica è "HH:mm:ss".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ Se l'identificatore di formato "g" viene usato senza altri identificatori di for
         <target state="translated">Se si aggiorna un'istruzione complessa contenente un'espressione await, la sessione di debug non potrà continuare.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Se si modifica la visibilità di un costruttore, la sessione di debug non potrà continuare.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">Se si acquisisce la variabile '{0}' che non è stata ancora acquisita, la sessione di debug non potrà continuare.</target>
@@ -3155,8 +3175,8 @@ Se l'identificatore di formato "g" viene usato senza altri identificatori di for
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">Se si elimina '{0}', la sessione di debug non potrà continuare.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Se si elimina '{0}', la sessione di debug non potrà continuare.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ Se l'identificatore di formato "g" viene usato senza altri identificatori di for
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Se si elimina un corpo del metodo, la sessione di debug non potrà continuare.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Un'istruzione attiva è stata rimossa dal metodo originale. Annullare le modifiche per continuare oppure riavviare la sessione di debug.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ Se l'identificatore di formato "g" viene usato senza altri identificatori di for
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Se si modifica l'inizializzatore di '{0}' in un tipo generico, la sessione di debug non potrà continuare.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Se si modifica l'inizializzatore di '{0}' in un tipo parziale, la sessione di debug non potrà continuare.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ Se l'identificatore di formato "g" viene usato senza altri identificatori di for
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Se si rimuove '{0}', che contiene un'istruzione attiva, la sessione di debug non potrà continuare.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Se si rimuove '{0}', che contiene un'istruzione attiva, la sessione di debug non potrà continuare.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 L'identificatore di formato "s" ha lo scopo di produrre stringhe di risultati organizzate coerentemente in ordine crescente o decrescente, in base ai valori di data e ora. Di conseguenza, anche se l'identificatore di formato standard "s" rappresenta un valore di data e ora in un formato coerente, l'operazione di formattazione non modifica il valore dell'oggetto data e ora che viene formattato per rispecchiare la proprietà DateTime.Kind o il valore DateTimeOffset.Offset corrispondente. Ad esempio, le stringhe di risultati generate dalla formattazione dei valori di data e ora 2014-11-15T18:32:17+00:00 e 2014-11-15T18:32:17+08:00 sono identiche.
 
 Quando si usa questo identificatore di formato standard, la formattazione o l'operazione di analisi usa sempre le impostazioni cultura inglese non dipendenti da paese/area geografica.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -90,6 +90,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">タプル要素名 '{0}' を追加します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">'{0}' をインターフェイス メソッドに追加すると、デバッグ セッションは続行されません。</target>
@@ -124,6 +129,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">選択条件が捕捉されないため、名前を指定できません</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">'{0}' から '{1}' に変更すると、ステート マシンの形状が変わるため、デバッグ セッションは続行されません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ If the "H" format specifier is used without other custom format specifiers, it's
         <target state="translated">"HH" カスタム書式指定子 (任意の数の "H" 指定子を追加できます) は、時を 00 から 23 の数字で表します。つまり、午前 0 時からの時間をカウントする、ゼロから始まる 24 時間制で時が表されます。1 桁の時は、先行ゼロ付きで書式設定されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">日付の区切り記号</target>
@@ -2491,6 +2511,11 @@ The "f" standard format specifier represents a combination of the long date ("D"
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">"T" 標準書式指定子は、特定のカルチャの DateTimeFormatInfo.LongTimePattern プロパティで定義されているカスタム日時書式指定文字列を表します。たとえば、インバリアント カルチャのカスタム書式指定文字列は "HH:mm:ss" です。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <target state="translated">Await 式を含む複雑なステートメントを更新すると、デバッグ セッションを続行できなくなります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">コンストラクターの表示範囲を変更すると、デバッグ セッションを続行できなくなります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">以前にキャプチャされたことのない変数 '{0}' をキャプチャすると、デバッグ セッションは続行されません。</target>
@@ -3155,8 +3175,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">'{0}' を削除すると、デバッグ セッションは続行されません。</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">'{0}' を削除すると、デバッグ セッションは続行されません。</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">メソッド本体を削除すると、デバッグ セッションは続行されません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">アクティブ ステートメントは元のメソッドから削除されました。変更を元に戻して続行するか、またはデバッグ セッションを再開してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">ジェネリック型の '{0}' の初期化子を変更すると、デバッグ セッションは続行されません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">部分型の '{0}' の初期化子を変更すると、デバッグ セッションは続行されません。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">アクティブ ステートメンを含む '{0}' を削除すると、デバッグ セッションは続行されません。</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">アクティブ ステートメンを含む '{0}' を削除すると、デバッグ セッションは続行されません。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 "s" 書式指定子の目的は、書式設定後の文字列が、日付と時刻の値に基づいて、一貫して昇順または降順に並べ替えられるようにすることです。そのため、"s" 標準書式指定子は、一貫性のある形式で日付と時刻の値を表しますが、書式設定操作によって、書式設定の対象となる日付と時刻のオブジェクトの値が、DateTime.Kind プロパティまたは DateTimeOffset.Offset プロパティを反映するために変更されることはありません。たとえば、2014-11-15T18:32:17+00:00 日時値と 2014-11-15T18:32:17+08:00 日時値を書式設定すると、同じ文字列が生成されます。
 
 この標準書式指定子が使用されている場合、書式設定操作または解析操作では常にインバリアント カルチャが使用されます。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -90,6 +90,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">튜플 요소 이름 '{0}' 추가</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">인터페이스 메서드에 '{0}'을(를) 추가하면 디버그 세션을 계속할 수 없습니다.</target>
@@ -124,6 +129,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">교체 조건은 캡처하지 않고 이름을 지정할 수 없습니다.</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">'{0}'을(를) '{1}'(으)로 변경하면 상태 시스템의 셰이프가 변경되므로 디버그 세션을 계속할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ If the "H" format specifier is used without other custom format specifiers, it's
         <target state="translated">"HH" 사용자 지정 형식 지정자(및 임의 개수의 추가 "H" 지정자)는 시간을 00부터 23까지의 숫자로 나타냅니다. 즉, 시간은 자정부터 경과한 시간을 계산하는 0 기반 24시간제로 표현됩니다. 한 자릿수 시간은 앞에 0이 있는 형식으로 지정됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">날짜 구분 기호</target>
@@ -2491,6 +2511,11 @@ The "f" standard format specifier represents a combination of the long date ("D"
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">"T" 표준 형식 지정자는 특정 문화권의 DateTimeFormatInfo.LongTimePattern 속성으로 정의되는 사용자 지정 날짜 및 시간 형식 문자열을 나타냅니다. 예를 들어, 고정 문화권의 사용자 지정 형식 문자열은 "HH:mm:ss"입니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <target state="translated">await 식이 포함된 복합 문을 업데이트하면 디버그 세션을 계속할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">생성자 표시 여부를 변경하면 디버그 세션을 계속할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">이전에 캡처되지 않았던 '{0}' 변수를 캡처하면 디버그 세션을 계속할 수 없습니다.</target>
@@ -3155,8 +3175,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">'{0}'을(를) 삭제하면 디버그 세션을 계속할 수 없습니다.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">'{0}'을(를) 삭제하면 디버그 세션을 계속할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">메서드 본문을 삭제하면 디버그 세션을 계속할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">원래 메서드에서 활성 문이 제거되었습니다. 변경 내용을 취소하고 계속하거나 디버깅 세션을 다시 시작해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">제네릭 형식에서 '{0}'의 이니셜라이저를 수정하면 디버그 세션을 계속할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">부분 형식에서 '{0}'의 이니셜라이저를 수정하면 디버그 세션을 계속할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">활성 문이 포함된 '{0}'을(를) 제거하면 디버그 세션을 계속할 수 없습니다.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">활성 문이 포함된 '{0}'을(를) 제거하면 디버그 세션을 계속할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 "s" 형식 지정자의 목표는 날짜 및 시간 값을 기준으로 일관성 있게 오름차순 또는 내림차순으로 정렬되는 결과 문자열을 생성하는 것입니다. 그 결과 "s" 표준 형식 지정자는 일관성 있는 형식으로 날짜 및 시간 값을 나타내긴 하지만 형식 지정 연산은 형식 지정 대상인 날짜 및 시간 개체가 그 DateTime.Kind 속성 또는 DateTimeOffset.Offset 값을 반영하도록 수정하지 않습니다. 예를 들어, 날짜 및 시간 값 2014-11-15T18:32:17+00:00과 2014-11-15T18:32:17+08:00의 형식을 지정하여 생성되는 결과 문자열은 동일합니다.
 
 이 표준 형식 지정자를 사용하면 형식 지정 또는 구문 분석 연산에서 항상 고정 문화권이 사용됩니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -90,6 +90,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Dodaj nazwę elementu krotki „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Dodanie elementu „{0}” do metody interfejsu uniemożliwi kontynuowanie sesji debugowania.</target>
@@ -124,6 +129,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Warunki alternatywne nie przechwytują i nie mogą być nazywane</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Zmiana elementu „{0}” na „{1}” uniemożliwi kontynuowanie sesji debugowania, ponieważ powoduje zmianę kształtu automatu stanów.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ Jeśli specyfikator formatu „H” zostanie użyty bez innych indywidualnych sp
         <target state="translated">Indywidualny specyfikator formatu „HH” (wraz z dowolną liczbą dodatkowych specyfikatorów „H”) reprezentuje godzinę jako liczbę z zakresu od 00 do 23; tzn. godzina jest reprezentowana przez 24-godzinny zegar zaczynający się od zera i liczący godziny od północy. Godzina 1-cyfrowa jest wyświetlana w formacie z wiodącym zerem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">separator daty</target>
@@ -2491,6 +2511,11 @@ Standardowy specyfikator formatu „f” reprezentuje połączenie wzorców dłu
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">Standardowy specyfikator formatu „T” reprezentuje niestandardowy ciąg formatu daty i godziny zdefiniowany przez właściwość DateTimeFormatInfo.LongTimePattern konkretnej kultury. Na przykład niestandardowy ciąg formatu dla kultury niezmiennej to „HH:mm:ss”.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ Jeśli specyfikator formatu „g” jest używany bez innych niestandardowych sp
         <target state="translated">Zaktualizowanie instrukcji złożonej zawierającej wyrażenie await uniemożliwi kontynuowanie sesji debugowania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Zmiana widoczności konstruktora uniemożliwi kontynuowanie sesji debugowania.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">Przechwycenie zmiennej „{0}”, która nie została przechwycona wcześniej, uniemożliwi kontynuowanie sesji debugowania.</target>
@@ -3155,8 +3175,8 @@ Jeśli specyfikator formatu „g” jest używany bez innych niestandardowych sp
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">Usunięcie elementu „{0}” uniemożliwi kontynuowanie sesji debugowania.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Usunięcie elementu „{0}” uniemożliwi kontynuowanie sesji debugowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ Jeśli specyfikator formatu „g” jest używany bez innych niestandardowych sp
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Usunięcie treści metody uniemożliwi kontynuowanie sesji debugowania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Aktywna instrukcja została usunięta ze swojej oryginalnej metody. Musisz cofnąć zmiany, aby kontynuować, lub uruchomić ponownie sesję debugowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ Jeśli specyfikator formatu „g” jest używany bez innych niestandardowych sp
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Modyfikacja inicjatora elementu „{0}” w typie ogólnym uniemożliwi kontynuowanie sesji debugowania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Modyfikacja inicjatora elementu „{0}” w typie częściowym uniemożliwi kontynuowanie sesji debugowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ Jeśli specyfikator formatu „g” jest używany bez innych niestandardowych sp
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Usunięcie elementu „{0}” zawierającego aktywną instrukcję uniemożliwi kontynuowanie sesji debugowania.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Usunięcie elementu „{0}” zawierającego aktywną instrukcję uniemożliwi kontynuowanie sesji debugowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 Specyfikator formatu „s” jest przeznaczony do tworzenia ciągów wyniku, które można spójnie sortować w kolejności rosnącej lub malejącej na podstawie wartości daty i godziny. Dlatego mimo że standardowy specyfikator formatu „s” reprezentuje wartość daty i godziny w spójnym formacie, operacja formatowania nie modyfikuje wartości formatowanego obiektu daty i godziny w celu odzwierciedlenia jego właściwości DateTime.Kind lub wartości DateTimeOffset.Offset. Na przykład ciągi wyniku generowane przez formatowanie wartości daty i godziny 2014-11-15T18:32:17+00:00 oraz 2014-11-15T18:32:17+08:00 są identyczne.
 
 Gdy jest używany ten standardowy specyfikator formatu, operacja formatowania lub analizowania zawsze używa kultury niezmiennej.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -90,6 +90,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Adicionar o nome do elemento de tupla '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Adicionar '{0}' a um método de interface impedirá que a sessão de depuração continue.</target>
@@ -124,6 +129,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Condições de alternância não capturam e não podem ser nomeadas</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Alterar '{0}' para '{1}' impedirá a continuação da sessão de depuração porque altera a forma da máquina de estado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ Se o especificador de formato "H" for usado sem outros especificadores de format
         <target state="translated">O especificador de formato personalizado "HH" (mais qualquer número de especificadores "H" adicionais) representa a hora como um número de 00 a 23. Ou seja, a hora é representada por um relógio de 24 horas com base em zero que conta as horas desde a meia-noite. Uma hora de dígito único é formatada com um zero à esquerda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">separador de data</target>
@@ -2491,6 +2511,11 @@ O especificador de formato padrão "f" representa uma combinação de padrões d
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">O especificador de formato padrão "T" representa uma cadeia de caracteres de formato personalizado de data e hora que é definida pela propriedade DateTimeFormatInfo.LongTimePattern de uma cultura específica. Por exemplo, a cadeia de caracteres de formato personalizado para a cultura invariável é "HH:mm:ss".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ Se o especificador de formato "g" for usado sem outros especificadores de format
         <target state="translated">Atualizar uma instrução complexa contendo uma expressão aguardar impedirá que a sessão de depuração continue.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Alteração da visibilidade de um construtor impedirá a sessão de depuração de continuar.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">A captura da variável '{0}' que não havia sido capturada antes impedirá a sessão de depuração de continuar.</target>
@@ -3155,8 +3175,8 @@ Se o especificador de formato "g" for usado sem outros especificadores de format
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">Excluir "{0}" impedirá que a sessão de depuração continue.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Excluir "{0}" impedirá que a sessão de depuração continue.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ Se o especificador de formato "g" for usado sem outros especificadores de format
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Excluir um corpo de método impedirá que a sessão de depuração continue.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Uma instrução ativa foi removida de seu método original. Você deve reverter as alterações para continuar ou reiniciar a sessão de depuração.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ Se o especificador de formato "g" for usado sem outros especificadores de format
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Modificar o inicializador de "{0}" em um tipo genérico impedirá que a sessão de depuração continue.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Modificar o inicializador de "{0}" em um tipo parcial impedirá que a sessão de depuração continue.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ Se o especificador de formato "g" for usado sem outros especificadores de format
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Remover "{0}" que contém uma instrução ativa impedirá que a sessão de depuração continue.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Remover "{0}" que contém uma instrução ativa impedirá que a sessão de depuração continue.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 O objetivo do especificador de formato "s" é produzir cadeias de caracteres de resultado que são classificadas consistentemente em ordem crescente ou decrescente com base nos valores de data e hora. Como resultado, embora o especificador de formato padrão "s" represente um valor de data e hora em um formato consistente, a operação de formatação não modifica o valor do objeto de data e hora que está sendo formatado para refletir sua propriedade DateTime.Kind ou seu valor DateTimeOffset.Offset. Por exemplo, as cadeias de caracteres de resultado produzidas pela formatação dos valores de data e hora 2014-11-15T18:32:17+00:00 e 2014-11-15T18:32:17+08:00 são idênticas.
 
 Quando esse especificador de formato padrão é usado, a operação de análise ou formatação sempre usa a cultura invariável.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -90,6 +90,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Добавить имя элемента кортежа "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Добавление "{0}" в метод интерфейса сделает продолжение сеанса отладки невозможным.</target>
@@ -124,6 +129,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Условия чередования не выполняют запись, и им невозможно присвоить имя</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">Изменение "{0}" на "{1}" сделает продолжение сеанса отладки невозможным, так как меняет форму конечной машины.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ If the "H" format specifier is used without other custom format specifiers, it's
         <target state="translated">Описатель пользовательского формата "HH" (плюс любое число дополнительных описателей "H") представляет час в виде числа от 00 до 23, то есть час представлен в начинающемся с нуля 24-часовом формате, отсчитывающем часы с полуночи. Значение часа из одной цифры форматируется с начальным нулем.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">разделитель компонентов даты</target>
@@ -2491,6 +2511,11 @@ The "f" standard format specifier represents a combination of the long date ("D"
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">Описатель стандартного формата "T" представляет строку пользовательского формата даты и времени, определяемую свойством DateTimeFormatInfo.LongTimePattern конкретных языка и региональных параметров. Например, строка пользовательского формата для инвариантных языка и региональных параметров имеет вид "HH:mm:ss".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <target state="translated">Обновление комплексной инструкции с выражением Await помешает продолжению сеанса отладки.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Изменение видимости конструктора помешает продолжению сеанса отладки.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">Запись переменной "{0}", которая не была записана прежде, помешает продолжению сеанса отладки.</target>
@@ -3155,8 +3175,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">Удаление "{0}" сделает продолжение сеанса отладки невозможным.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Удаление "{0}" сделает продолжение сеанса отладки невозможным.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Удаление тела метода сделает продолжение сеанса отладки невозможным.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Активный оператор был удален из исходного метода. Чтобы продолжить выполнение сеанса отладки, необходимо отменить изменения или перезапустить сеанс.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Изменение инициализатора объекта "{0}" в универсальном типе сделает продолжение сеанса отладки невозможным.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Изменение инициализатора объекта "{0}" в разделяемом типе сделает продолжение сеанса отладки невозможным.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Удаление "{0}", содержащего активный оператор, сделает продолжение сеанса отладки невозможным.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Удаление "{0}", содержащего активный оператор, сделает продолжение сеанса отладки невозможным.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 Описатель формата "s" предназначен для получения результирующих строк, которые согласованным образом сортируются по возрастанию или убыванию на основе значений даты и времени. В результате, хотя описатель стандартного формата "s" представляет значение даты и времени в согласованном формате, операция форматирования не изменяет значение объекта даты и времени, которое форматируется, чтобы отразить его свойство DateTime.Kind или его значение DateTimeOffset.Offset. Например, результирующие строки, полученные при форматировании значений даты и времени 2014-11-15T18:32:17+00:00 и 2014-11-15T18:32:17+08:00, идентичны.
 
 Когда используется этот описатель стандартного формата, операция форматирования или анализа всегда использует инвариантные язык и региональные параметры.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -90,6 +90,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">'{0}' demet öğesi adını ekle</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">Arabirim yöntemine '{0}' eklenmesi, hata ayıklama oturumunun devam etmesini engeller.</target>
@@ -124,6 +129,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">Değişim koşulları yakalamak değil ve adlandırılamaz</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">'{0}' öğesini '{1}' olarak değiştirmek, durum makinesinin şeklini değiştirdiğinden hata ayıklama oturumunun devam etmesini engeller.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ If the "H" format specifier is used without other custom format specifiers, it's
         <target state="translated">"HH" özel biçim belirticisi (ve herhangi bir sayıda ek "H" belirticisi) saati 00 ile 23 arasında bir sayı ile temsil eder; yani saat, gece yarısından bu yana geçen saat sayısını belirten sıfır tabanlı 24 saatlik bir düzen ile temsil edilir. Tek haneli bir saat, başına sıfır eklenerek biçimlendirilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">tarih ayırıcısı</target>
@@ -2491,6 +2511,11 @@ The "f" standard format specifier represents a combination of the long date ("D"
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">"T" standart biçim belirticisi, belirli bir kültürün DateTimeFormatInfo.LongTimePattern özelliği tarafından tanımlanan bir özel tarih ve saat biçimi dizesini temsil eder. Örneğin, sabit kültür için özel biçim dizesi "HH:mm:ss" şeklindedir.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <target state="translated">Await ifadesi içeren bir karmaşık deyimin güncelleştirilmesi, hata ayıklama işleminin devam etmesini engeller.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">Bir oluşturucunun görünürlüğünü değiştirmek, hata ayıklama oturumunun devam etmesini engeller.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">Daha önce yakalanmayan '{0}' değişkeninin yakalanması hata ayıklama oturumunun devam etmesini engeller.</target>
@@ -3155,8 +3175,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">'{0}' öğesini silme, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">'{0}' öğesini silme, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">Bir yöntem gövdesi silme, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">Etkin bir deyim özgün yönteminden kaldırılmış. Devam etmek için değişikliklerinizi geri almalısınız veya hata ayıklama oturumunu yeniden başlatmalısınız.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">Genel bir tür içindeki '{0}' öğesinin başlatıcısını değiştirme, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">Kısmi bir tür içindeki '{0}' öğesinin başlatıcısını değiştirme, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Etkin bir deyim içeren '{0}' öğesini kaldırma, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">Etkin bir deyim içeren '{0}' öğesini kaldırma, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 "s" biçim belirticisinin amacı, tarih ve saat değerlerine göre tutarlı olarak artan veya azalan düzende sıralanan sonuç dizeleri üretmelidir. Bu nedenle "s" standart biçim belirticisi bir tarih ve saat değerini tutarlı bir biçimde temsil etse de biçimlendirme işlemi biçimlendirilmekte olan tarih ve saat nesnesinin değerini nesnenin DateTime.Kind özelliğini veya DateTimeOffset.Offset değerini yansıtacak şekilde değiştirmez. Örneğin, 2014-11-15T18:32:17+00:00 ve 2014-11-15T18:32:17+08:00 tarih ve saat değerleri biçimlendirilerek oluşturulan sonuç dizeleri aynıdır.
 
 Bu standart biçim belirticisi kullanıldığında, biçimlendirme veya ayrıştırma işlemi her zaman sabit kültürü kullanır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -90,6 +90,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">添加元组元素名称 "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">将 "{0}" 添加进接口方法将阻止调试会话继续。</target>
@@ -124,6 +129,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">替换条件不捕获且不能命名</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">将“{0}”更改为“{1}”会阻止调试会话继续执行，因为它会更改状态机的形状。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ If the "H" format specifier is used without other custom format specifiers, it's
         <target state="translated">"HH" 自定义格式说明符(另加任意数量的 "H" 说明符)将小时表示为从 00 至 23 的数字，即通过从零开始的 24 小时制表示小时，自午夜开始对小时计数。一位数字的小时数设置为带前导零的格式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">日期分隔符</target>
@@ -2491,6 +2511,11 @@ The "f" standard format specifier represents a combination of the long date ("D"
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">"T" 标准格式说明符表示由特定区域性的 DateTimeFormatInfo.LongTimePattern 属性定义的自定义日期和时间格式字符串。例如，固定区域性的自定义格式字符串为 "HH:mm:ss"。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <target state="translated">更新包含 Await 表达式的复杂语句将中止调试会话。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">更改构造函数的可见性将会中止调试会话。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">捕获之前尚未捕获过的变量“{0}”将阻止调试会话继续执行。</target>
@@ -3155,8 +3175,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">删除“{0}”将阻止调试会话继续。</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">删除“{0}”将阻止调试会话继续。</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">删除方法主体将阻止调试会话继续。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">活动语句已从其初始方法中删除。必须还原更改才能继续或重新启动调试会话。</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">修改泛型类型中的“{0}”的初始值设定项将阻止调试会话继续。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">修改分部类型中“{0}”的初始值设定项将阻止调试会话继续。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">删除含活动语句的“{0}”将阻止调试会话继续。</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">删除含活动语句的“{0}”将阻止调试会话继续。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 "s" 格式说明符的用途是生成结果字符串，该字符串根据日期和时间值以升序或降序顺序进行排序。因此，尽管 "s" 标准格式说明符以一致的格式表示日期和时间值，但该格式设置操作不会修改设置为反映其 DateTime.Kind 属性或其 DateTimeOffset.Offset 值的 date 和 time 对象的值。例如，通过设置日期和时间值(2014-11-15T18:32:17+00:00 和 2014-11-15T18:32:17+08:00)的格式生成的结果字符串是相同的。
 
 使用此标准格式说明符时，格式设置或分析操作始终使用固定区域性。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -90,6 +90,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">新增元組元素名稱 ‘{0}’</target>
         <note />
       </trans-unit>
+      <trans-unit id="Adding_0_into_a_generic_type_will_prevent_the_debug_session_from_continuing">
+        <source>Adding '{0}' into a generic type will prevent the debug session from continuing.</source>
+        <target state="new">Adding '{0}' into a generic type will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing">
         <source>Adding '{0}' into an interface method will prevent the debug session from continuing.</source>
         <target state="translated">將 '{0}' 新增至介面方法，會造成偵錯工作階段無法繼續。</target>
@@ -124,6 +129,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <source>Alternation conditions do not capture and cannot be named</source>
         <target state="translated">替代條件不會擷取，也無法命名</target>
         <note>This is an error message shown to the user when they write an invalid Regular Expression. Example: (?(?'x'))</note>
+      </trans-unit>
+      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
+        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
+        <target state="new">An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</target>
+        <note />
       </trans-unit>
       <trans-unit id="Awaited_task_returns_0">
         <source>Awaited task returns '{0}'</source>
@@ -203,6 +213,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
         <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
         <target state="translated">將 '{0}' 變更為 '{1}' 會變更狀態機器的圖形，進而使偵錯工作階段無法繼續。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing">
+        <source>Changing visibility of {0} will prevent the debug session from continuing.</source>
+        <target state="new">Changing visibility of {0} will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
       <trans-unit id="Configure_0_code_style">
@@ -2336,6 +2351,11 @@ If the "H" format specifier is used without other custom format specifiers, it's
         <target state="translated">"HH" 自訂格式規範 (加上任意數目的其他 "H" 規範) 代表小時，以數字 00 到 23 表示; 換句話說，小時即為自午夜起所經過的時數，是以零開始的 24 小時制。單一數字的小時格式，開頭不會出現零。</target>
         <note />
       </trans-unit>
+      <trans-unit id="code">
+        <source>code</source>
+        <target state="new">code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="date_separator">
         <source>date separator</source>
         <target state="translated">日期分隔符號</target>
@@ -2491,6 +2511,11 @@ The "f" standard format specifier represents a combination of the long date ("D"
         <source>The "T" standard format specifier represents a custom date and time format string that is defined by a specific culture's DateTimeFormatInfo.LongTimePattern property. For example, the custom format string for the invariant culture is "HH:mm:ss".</source>
         <target state="translated">"T" 標準格式規範代表由特定文化特性的 DateTimeFormatInfo.LongTimePattern 屬性所定義的自訂日期與時間格式字串。例如，不因文化特性而異的自訂格式字串為 "HH:mm:ss"。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="member_kind_and_name">
+        <source>{0} '{1}'</source>
+        <target state="new">{0} '{1}'</target>
+        <note>e.g. "method 'M'"</note>
       </trans-unit>
       <trans-unit id="minute_1_2_digits">
         <source>minute (1-2 digits)</source>
@@ -2944,11 +2969,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <target state="translated">更新包含 await 運算式的複雜陳述式會阻礙偵錯工作階段繼續進行。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_visibility_of_a_constructor_will_prevent_the_debug_session_from_continuing">
-        <source>Changing visibility of a constructor will prevent the debug session from continuing.</source>
-        <target state="translated">變更建構函式的可見度會阻礙偵錯工作階段繼續進行。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing">
         <source>Capturing variable '{0}' that hasn't been captured before will prevent the debug session from continuing.</source>
         <target state="translated">擷取先前從未擷取過的變數 '{0}'，會讓偵錯工作階段無法繼續。</target>
@@ -3155,8 +3175,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_will_prevent_the_debug_session_from_continuing">
-        <source>Deleting '{0}' will prevent the debug session from continuing.</source>
-        <target state="translated">刪除 '{0}' 會造成偵錯工作階段無法繼續。</target>
+        <source>Deleting {0} will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">刪除 '{0}' 會造成偵錯工作階段無法繼續。</target>
         <note />
       </trans-unit>
       <trans-unit id="Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3172,11 +3192,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Deleting_a_method_body_will_prevent_the_debug_session_from_continuing">
         <source>Deleting a method body will prevent the debug session from continuing.</source>
         <target state="translated">刪除方法主體，會造成偵錯工作階段無法繼續。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
-        <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
-        <target state="translated">現用陳述式已從其原始方法中移除。您必須還原您的變更才能繼續，或是重新啟動偵錯工作階段。</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
@@ -3207,11 +3222,6 @@ If the "g" format specifier is used without other custom format specifiers, it's
       <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_will_prevent_the_debug_session_from_continuing">
         <source>Modifying the initializer of '{0}' in a generic type will prevent the debug session from continuing.</source>
         <target state="translated">修改泛型類別中 '{0}' 的初始設定式，會造成偵錯工作階段無法繼續。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_partial_type_will_prevent_the_debug_session_from_continuing">
-        <source>Modifying the initializer of '{0}' in a partial type will prevent the debug session from continuing.</source>
-        <target state="translated">修改部分類型之 '{0}' 的初始設定式，會造成偵錯工作階段無法繼續。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_will_prevent_the_debug_session_from_continuing">
@@ -3265,8 +3275,8 @@ If the "g" format specifier is used without other custom format specifiers, it's
         <note />
       </trans-unit>
       <trans-unit id="Removing_0_that_contains_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Removing '{0}' that contains an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">移除包含現用陳述式的 '{0}'，會造成偵錯工作階段無法繼續。</target>
+        <source>Removing {0} that contains an active statement will prevent the debug session from continuing.</source>
+        <target state="needs-review-translation">移除包含現用陳述式的 '{0}'，會造成偵錯工作階段無法繼續。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_new_file_will_prevent_the_debug_session_from_continuing">
@@ -3658,6 +3668,11 @@ When this standard format specifier is used, the formatting or parsing operation
 "s" 格式規範的用途為產生依日期和時間值一致地遞增或遞減排序的結果字串。因此，儘管 "s" 標準格式規範以一致的格式表示日期和時間值，但格式化作業並不會修改要格式化的日期和時間物件值，以反映其 DateTime.Kind 屬性或其 DateTimeOffset.Offset 值。例如，將日期和時間值 2014-11-15T18:32:17+00:00 和 2014-11-15T18:32:17+08:00 格式化所產生的結果字串會完全相同。
 
 使用此標準格式規範時，格式化或剖析作業永遠不因文化特性而異。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="static_constructor">
+        <source>static constructor</source>
+        <target state="new">static constructor</target>
         <note />
       </trans-unit>
       <trans-unit id="symbol_cannot_be_a_namespace">

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -42,8 +42,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         ''' <returns>
         ''' <see cref="MethodBlockBaseSyntax"/> for methods, constructors, operators and accessors.
         ''' <see cref="PropertyStatementSyntax"/> for auto-properties.
-        ''' <see cref="VariableDeclaratorSyntax"/> for fields with simple initialization "Dim a = 1", or "Dim a As New C"
-        ''' <see cref="ModifiedIdentifierSyntax"/> for fields with shared AsNew initialization "Dim a, b As New C" or array initializer "Dim a(n), b(n)".
+        ''' <see cref="VariableDeclaratorSyntax"/> for fields with single identifier in the declaration.
+        ''' <see cref="ModifiedIdentifierSyntax"/> for fields with multiple identifiers in the declaration.
         ''' A null reference otherwise.
         ''' </returns>
         Friend Overrides Function FindMemberDeclaration(rootOpt As SyntaxNode, node As SyntaxNode) As SyntaxNode
@@ -61,31 +61,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return node
 
                     Case SyntaxKind.PropertyStatement
-                        ' Property [|a As Integer = 1|]
-                        ' Property [|a As New C()|]
+                        ' Property a As Integer = 1
+                        ' Property a As New T
                         If Not node.Parent.IsKind(SyntaxKind.PropertyBlock) Then
                             Return node
                         End If
 
                     Case SyntaxKind.VariableDeclarator
-                        If node.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
-                            ' Dim [|a = 0|]
-                            ' Dim [|a = 0|], [|b = 0|]
-                            ' Dim [|b as Integer = 0|]
-                            ' Dim [|v1 As New C|]
-                            ' Dim v1, v2 As New C(Sub [|Goo()|])
+                        ' Dim a = 0
+                        ' Dim a(n) = 0
+                        ' Dim a = 0, b = 0
+                        ' Dim b as Integer = 0
+                        ' Dim b(n) as Integer = 0
+                        ' Dim a As New T
+                        If IsFieldDeclaration(CType(node, VariableDeclaratorSyntax)) Then
                             Return node
                         End If
 
                     Case SyntaxKind.ModifiedIdentifier
-                        ' Dim [|a(n)|], [|b(n)|] As Integer
-                        ' Dim [|v1|], [|v2|] As New C
-                        If Not node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
-                            Exit Select
-                        End If
-
-                        If DirectCast(node, ModifiedIdentifierSyntax).ArrayBounds IsNot Nothing OrElse
-                           DirectCast(node.Parent, VariableDeclaratorSyntax).Names.Count > 1 Then
+                        ' Dim a, b As T
+                        ' Dim a(n), b(n) As T
+                        ' Dim a, b As New T
+                        If IsFieldDeclaration(CType(node, ModifiedIdentifierSyntax)) Then
                             Return node
                         End If
                 End Select
@@ -96,14 +93,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return Nothing
         End Function
 
+        ''' <summary>
+        ''' Returns true if the <see cref="ModifiedIdentifierSyntax"/> node represents a field declaration.
+        ''' </summary>
+        Private Shared Function IsFieldDeclaration(node As ModifiedIdentifierSyntax) As Boolean
+            Return node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) AndAlso DirectCast(node.Parent, VariableDeclaratorSyntax).Names.Count > 1
+        End Function
+
+        ''' <summary>
+        ''' Returns true if the <see cref="VariableDeclaratorSyntax"/> node represents a field declaration.
+        ''' </summary>
+        Private Shared Function IsFieldDeclaration(node As VariableDeclaratorSyntax) As Boolean
+            Return node.Parent.IsKind(SyntaxKind.FieldDeclaration) AndAlso node.Names.Count = 1
+        End Function
+
         ''' <returns>
-        ''' Given a node representing a declaration (<paramref name="isMember"/> = true) or a top-level edit node (<paramref name="isMember"/> = false) returns:
+        ''' Given a node representing a declaration or a top-level edit node returns:
         ''' - <see cref="MethodBlockBaseSyntax"/> for methods, constructors, operators and accessors.
         ''' - <see cref="ExpressionSyntax"/> for auto-properties and fields with initializer or AsNew clause.
         ''' - <see cref="ArgumentListSyntax"/> for fields with array initializer, e.g. "Dim a(1) As Integer".
         ''' A null reference otherwise.
         ''' </returns>
-        Friend Overrides Function TryGetDeclarationBody(node As SyntaxNode, isMember As Boolean) As SyntaxNode
+        Friend Overrides Function TryGetDeclarationBody(node As SyntaxNode) As SyntaxNode
             Select Case node.Kind
                 Case SyntaxKind.SubBlock,
                      SyntaxKind.FunctionBlock,
@@ -136,43 +147,55 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return Nothing
                     End If
 
-                    ' Dim a = initializer
                     Dim variableDeclarator = DirectCast(node, VariableDeclaratorSyntax)
+
+                    Dim body As SyntaxNode = Nothing
+
                     If variableDeclarator.Initializer IsNot Nothing Then
-                        Return variableDeclarator.Initializer.Value
+                        ' Dim a = initializer
+                        body = variableDeclarator.Initializer.Value
+                    ElseIf HasAsNewClause(variableDeclarator) Then
+                        ' Dim a As New T
+                        ' Dim a,b As New T
+                        body = DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression
                     End If
 
-                    If HasAsNewClause(variableDeclarator) Then
-                        ' Dim a As New C()
-                        ' Dim a, b As New C(), but only if the specified node isn't already a member declaration representative.
-                        ' -- This is to handle an edit in AsNew clause because such an edit doesn't affect the modified identifier that would otherwise represent the member.
-                        If variableDeclarator.Names.Count = 1 OrElse Not isMember Then
-                            Return DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression
+                    ' Dim a(n) As T
+                    If variableDeclarator.Names.Count = 1 Then
+                        Dim name = variableDeclarator.Names(0)
+
+                        If name.ArrayBounds IsNot Nothing Then
+                            ' Initializer and AsNew clause can't be syntactically specified at the same time, but array bounds can be (it's a semantic error).
+                            ' Guard against such case to maintain consistency and set body to Nothing in that case.
+                            body = If(body Is Nothing, name.ArrayBounds, Nothing)
                         End If
                     End If
 
-                    Return Nothing
+                    Return body
 
                 Case SyntaxKind.ModifiedIdentifier
                     If Not node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
                         Return Nothing
                     End If
 
+                    Dim modifiedIdentifier = CType(node, ModifiedIdentifierSyntax)
+                    Dim body As SyntaxNode = Nothing
+
                     ' Dim a, b As New C()
                     Dim variableDeclarator = DirectCast(node.Parent, VariableDeclaratorSyntax)
-                    If HasMultiAsNewInitializer(variableDeclarator) Then
-                        Return DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression
+                    If HasAsNewClause(variableDeclarator) Then
+                        body = DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression
                     End If
 
-                    ' Dim a(n)
+                    ' Dim a(n) As Integer
                     ' Dim a(n), b(n) As Integer
-                    ' Dim a(n1, n2, n3) As Integer
-                    Dim modifiedIdentifier = DirectCast(node, ModifiedIdentifierSyntax)
                     If modifiedIdentifier.ArrayBounds IsNot Nothing Then
-                        Return modifiedIdentifier.ArrayBounds
+                        ' AsNew clause can be syntactically specified at the same time as array bounds can be  (it's a semantic error).
+                        ' Guard against such case to maintain consistency and set body to Nothing in that case.
+                        body = If(body Is Nothing, modifiedIdentifier.ArrayBounds, Nothing)
                     End If
 
-                    Return Nothing
+                    Return body
 
                 Case Else
                     ' Note: A method without body is represented by a SubStatement.
@@ -245,14 +268,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                    Select node
         End Function
 
-        Private Shared Function HasSimpleAsNewInitializer(variableDeclarator As VariableDeclaratorSyntax) As Boolean
-            Return variableDeclarator.Names.Count = 1 AndAlso HasAsNewClause(variableDeclarator)
-        End Function
-
-        Private Shared Function HasMultiAsNewInitializer(variableDeclarator As VariableDeclaratorSyntax) As Boolean
-            Return variableDeclarator.Names.Count > 1 AndAlso HasAsNewClause(variableDeclarator)
-        End Function
-
         Private Shared Function HasAsNewClause(variableDeclarator As VariableDeclaratorSyntax) As Boolean
             Return variableDeclarator.AsClause IsNot Nothing AndAlso variableDeclarator.AsClause.IsKind(SyntaxKind.AsNewClause)
         End Function
@@ -300,7 +315,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return Nothing
 
                 Case SyntaxKind.VariableDeclarator
-                    If Not node.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
+                    Dim variableDeclarator = DirectCast(node, VariableDeclaratorSyntax)
+                    If Not IsFieldDeclaration(variableDeclarator) Then
                         Return Nothing
                     End If
 
@@ -311,32 +327,36 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
 
                     ' Dim a = initializer
-                    Dim variableDeclarator = DirectCast(node, VariableDeclaratorSyntax)
                     If variableDeclarator.Initializer IsNot Nothing Then
                         Return variableDeclarator.DescendantTokens()
                     End If
 
                     ' Dim a As New C()
-                    If HasSimpleAsNewInitializer(variableDeclarator) Then
+                    If HasAsNewClause(variableDeclarator) Then
+                        Return variableDeclarator.DescendantTokens()
+                    End If
+
+                    ' Dim a(n) As Integer
+                    Dim modifiedIdentifier = variableDeclarator.Names.Single()
+                    If modifiedIdentifier.ArrayBounds IsNot Nothing Then
                         Return variableDeclarator.DescendantTokens()
                     End If
 
                     Return Nothing
 
                 Case SyntaxKind.ModifiedIdentifier
-                    If Not node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
+                    Dim modifiedIdentifier = DirectCast(node, ModifiedIdentifierSyntax)
+                    If Not IsFieldDeclaration(modifiedIdentifier) Then
                         Return Nothing
                     End If
 
                     ' Dim a, b As New C()
                     Dim variableDeclarator = DirectCast(node.Parent, VariableDeclaratorSyntax)
-                    If HasMultiAsNewInitializer(variableDeclarator) Then
+                    If HasAsNewClause(variableDeclarator) Then
                         Return node.DescendantTokens().Concat(DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression.DescendantTokens())
                     End If
 
-                    ' Dim a(n)
                     ' Dim a(n), b(n) As Integer
-                    Dim modifiedIdentifier = DirectCast(node, ModifiedIdentifierSyntax)
                     If modifiedIdentifier.ArrayBounds IsNot Nothing Then
                         Return node.DescendantTokens()
                     End If
@@ -522,7 +542,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Debug.Assert(leftSymbol IsNot Nothing)
 
                 Dim rightProperty = rightType.GetMembers(leftSymbol.Name).Single()
-                Dim rightDeclaration = DirectCast(GetSymbolSyntax(rightProperty, cancellationToken), PropertyStatementSyntax)
+                Dim rightDeclaration = DirectCast(rightProperty.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken), PropertyStatementSyntax)
 
                 rightInitializer = rightDeclaration.Initializer
             ElseIf leftInitializer.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
@@ -533,7 +553,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Debug.Assert(leftSymbol IsNot Nothing)
 
                 Dim rightSymbol = rightType.GetMembers(leftSymbol.Name).Single()
-                Dim rightDeclarator = DirectCast(GetSymbolSyntax(rightSymbol, cancellationToken).Parent, VariableDeclaratorSyntax)
+                Dim rightDeclarator = DirectCast(rightSymbol.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken).Parent, VariableDeclaratorSyntax)
 
                 rightInitializer = If(leftInitializer.IsKind(SyntaxKind.EqualsValue), rightDeclarator.Initializer, DirectCast(rightDeclarator.AsClause, SyntaxNode))
             Else
@@ -548,7 +568,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Debug.Assert(leftSymbol IsNot Nothing)
 
                 Dim rightSymbol = rightType.GetMembers(leftSymbol.Name).Single()
-                Dim rightIdentifier = DirectCast(GetSymbolSyntax(rightSymbol, cancellationToken), ModifiedIdentifierSyntax)
+                Dim rightIdentifier = DirectCast(rightSymbol.DeclaringSyntaxReferences.Single().GetSyntax(cancellationToken), ModifiedIdentifierSyntax)
 
                 rightInitializer = rightIdentifier.ArrayBounds.Arguments(argumentIndex)
             End If
@@ -601,6 +621,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Protected Overrides Function ComputeTopLevelMatch(oldCompilationUnit As SyntaxNode, newCompilationUnit As SyntaxNode) As Match(Of SyntaxNode)
             Return TopSyntaxComparer.Instance.ComputeMatch(oldCompilationUnit, newCompilationUnit)
+        End Function
+
+        Protected Overrides Function ComputeTopLevelDeclarationMatch(oldDeclaration As SyntaxNode, newDeclaration As SyntaxNode) As Match(Of SyntaxNode)
+            Contract.ThrowIfNull(oldDeclaration.Parent)
+            Contract.ThrowIfNull(newDeclaration.Parent)
+
+            ' Allow matching field declarations represented by a identitifer and the whole variable declarator
+            ' even when their node kinds do not match.
+            If oldDeclaration.IsKind(SyntaxKind.ModifiedIdentifier) AndAlso newDeclaration.IsKind(SyntaxKind.VariableDeclarator) Then
+                oldDeclaration = oldDeclaration.Parent
+            ElseIf oldDeclaration.IsKind(SyntaxKind.VariableDeclarator) AndAlso newDeclaration.IsKind(SyntaxKind.ModifiedIdentifier) Then
+                newDeclaration = newDeclaration.Parent
+            End If
+
+            Dim comparer = New TopSyntaxComparer(oldDeclaration.Parent, newDeclaration.Parent, {oldDeclaration}, {newDeclaration})
+            Return comparer.ComputeMatch(oldDeclaration.Parent, newDeclaration.Parent)
         End Function
 
         Protected Overrides Function ComputeBodyMatch(oldBody As SyntaxNode, newBody As SyntaxNode, knownMatches As IEnumerable(Of KeyValuePair(Of SyntaxNode, SyntaxNode))) As Match(Of SyntaxNode)
@@ -911,7 +947,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         End Function
 
         Friend Overrides Function TryGetContainingTypeDeclaration(node As SyntaxNode) As SyntaxNode
-            Return node.Parent.FirstAncestorOrSelf(Of TypeBlockSyntax)()
+            Return node.Parent.FirstAncestorOrSelf(Of TypeBlockSyntax)() ' TODO: EnbumBlock?
+        End Function
+
+        Friend Overrides Function TryGetAssociatedMemberDeclaration(node As SyntaxNode) As SyntaxNode
+            Return If(node.IsParentKind(SyntaxKind.PropertyBlock, SyntaxKind.EventBlock), node.Parent, Nothing)
         End Function
 
         Friend Overrides Function HasBackingField(propertyDeclaration As SyntaxNode) As Boolean
@@ -957,6 +997,95 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End If
 
             Return Nothing
+        End Function
+
+        ''' <summary>
+        ''' VB symbols return references that represent the declaration statement.
+        ''' The node that represenets the whole declaration (the block) is the parent node if it exists.
+        ''' For example, a method with a body is represented by a SubBlock/FunctionBlock while a method without a body
+        ''' is represented by its declaration statement.
+        ''' </summary>
+        Protected Overrides Function GetSymbolDeclarationSyntax(reference As SyntaxReference, cancellationToken As CancellationToken) As SyntaxNode
+            Dim syntax = reference.GetSyntax(cancellationToken)
+            Dim parent = syntax.Parent
+
+            Select Case syntax.Kind
+                ' declarations that always have block
+
+                Case SyntaxKind.NamespaceStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.NamespaceBlock)
+                    Return parent
+
+                Case SyntaxKind.ClassStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.ClassBlock)
+                    Return parent
+
+                Case SyntaxKind.StructureStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.StructureBlock)
+                    Return parent
+
+                Case SyntaxKind.InterfaceStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.InterfaceBlock)
+                    Return parent
+
+                Case SyntaxKind.ModuleStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.ModuleBlock)
+                    Return parent
+
+                Case SyntaxKind.EnumStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.EnumBlock)
+                    Return parent
+
+                Case SyntaxKind.SubNewStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.ConstructorBlock)
+                    Return parent
+
+                Case SyntaxKind.OperatorStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.OperatorBlock)
+                    Return parent
+
+                Case SyntaxKind.GetAccessorStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.GetAccessorBlock)
+                    Return parent
+
+                Case SyntaxKind.SetAccessorStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.SetAccessorBlock)
+                    Return parent
+
+                Case SyntaxKind.AddHandlerAccessorStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.AddHandlerAccessorBlock)
+                    Return parent
+
+                Case SyntaxKind.RemoveHandlerAccessorStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.RemoveHandlerAccessorBlock)
+                    Return parent
+
+                Case SyntaxKind.RaiseEventAccessorStatement
+                    Debug.Assert(parent.Kind = SyntaxKind.RaiseEventAccessorBlock)
+                    Return parent
+
+                ' declarations that may or may not have block
+
+                Case SyntaxKind.SubStatement
+                    Return If(parent.Kind = SyntaxKind.SubBlock, parent, syntax)
+
+                Case SyntaxKind.FunctionStatement
+                    Return If(parent.Kind = SyntaxKind.FunctionBlock, parent, syntax)
+
+                ' declarations that never have a block
+
+                Case SyntaxKind.ModifiedIdentifier
+                    Contract.ThrowIfFalse(parent.Parent.IsKind(SyntaxKind.FieldDeclaration))
+                    Dim variableDeclaration = CType(parent, VariableDeclaratorSyntax)
+                    Return If(variableDeclaration.Names.Count = 1, parent, syntax)
+
+                Case SyntaxKind.VariableDeclarator
+                    ' fields are represented by ModifiedIdentifier:
+                    Throw ExceptionUtilities.UnexpectedValue(syntax.Kind)
+
+                Case Else
+                    Return syntax
+            End Select
         End Function
 
         Friend Overrides Function IsConstructorWithMemberInitializers(declaration As SyntaxNode) As Boolean
@@ -1007,7 +1136,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                    DirectCast(syntaxRefs.Single().GetSyntax(), TypeStatementSyntax).Modifiers.Any(SyntaxKind.PartialKeyword)
         End Function
 
-        Protected Overrides Function GetSymbolForEdit(model As SemanticModel, node As SyntaxNode, editKind As EditKind, editMap As IReadOnlyDictionary(Of SyntaxNode, EditKind), cancellationToken As CancellationToken) As ISymbol
+        Protected Overrides Function GetSymbolForEdit(model As SemanticModel,
+                                                      node As SyntaxNode,
+                                                      editKind As EditKind,
+                                                      editMap As IReadOnlyDictionary(Of SyntaxNode, EditKind),
+                                                      <Out> ByRef isAmbiguous As Boolean,
+                                                      cancellationToken As CancellationToken) As ISymbol
+
+            isAmbiguous = False
+
             ' Avoid duplicate semantic edits - don't return symbols for statements within blocks.
             Select Case node.Kind()
                 Case SyntaxKind.OperatorStatement,
@@ -1017,8 +1154,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                      SyntaxKind.AddHandlerAccessorStatement,
                      SyntaxKind.RemoveHandlerAccessorStatement,
                      SyntaxKind.RaiseEventAccessorStatement,
-                     SyntaxKind.DeclareSubStatement,
-                     SyntaxKind.DeclareFunctionStatement,
                      SyntaxKind.ClassStatement,
                      SyntaxKind.StructureStatement,
                      SyntaxKind.InterfaceStatement,
@@ -1047,27 +1182,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return Nothing
                     End If
 
-                Case SyntaxKind.Parameter
+                Case SyntaxKind.Parameter,
+                     SyntaxKind.TypeParameter,
+                     SyntaxKind.ImportsStatement,
+                     SyntaxKind.NamespaceBlock
                     Return Nothing
 
                 Case SyntaxKind.ModifiedIdentifier
-                    If node.Parent.IsKind(SyntaxKind.Parameter) Then
+                    If Not node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
                         Return Nothing
                     End If
 
                 Case SyntaxKind.VariableDeclarator
-                    ' An update to a field variable declarator might either be
-                    ' 1) variable declarator update (an initializer is changes)
-                    ' 2) modified identifier update (an array bound changes)
-                    ' Handle the first one here. 
-                    If editKind = editKind.Update AndAlso node.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
-                        ' If multiple fields are defined by this declaration pick the first one.
-                        ' We want to analyze the associated initializer just once. Any of the fields is good.
-                        node = DirectCast(node, VariableDeclaratorSyntax).Names.First()
+                    If Not node.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
+                        Return Nothing
                     End If
+
+                    Dim variableDeclarator = CType(node, VariableDeclaratorSyntax)
+                    isAmbiguous = variableDeclarator.Names.Count > 1
+                    node = variableDeclarator.Names.First
             End Select
 
-            Return model.GetDeclaredSymbol(node, cancellationToken)
+            Dim symbol = model.GetDeclaredSymbol(node, cancellationToken)
+
+            ' Ignore partial method definition parts.
+            ' Partial method that does not have implementation part is not emitted to metadata.
+            ' Partial method without a definition part is a compilation error.
+            If symbol IsNot Nothing AndAlso symbol.Kind = SymbolKind.Method AndAlso CType(symbol, IMethodSymbol).IsPartialDefinition Then
+                Return Nothing
+            End If
+
+            Return symbol
         End Function
 
         Friend Overrides Function ContainsLambda(declaration As SyntaxNode) As Boolean
@@ -1226,13 +1371,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                      SyntaxKind.FunctionBlock,
                      SyntaxKind.OperatorBlock,
                      SyntaxKind.ConstructorBlock,
-                     SyntaxKind.EventBlock,
                      SyntaxKind.SetAccessorBlock,
                      SyntaxKind.GetAccessorBlock,
                      SyntaxKind.AddHandlerAccessorBlock,
                      SyntaxKind.RemoveHandlerAccessorBlock,
                      SyntaxKind.RaiseEventAccessorBlock
                     Return GetDiagnosticSpan(DirectCast(node, MethodBlockBaseSyntax).BlockStatement)
+
+                Case SyntaxKind.EventBlock
+                    Return GetDiagnosticSpan(DirectCast(node, EventBlockSyntax).EventStatement)
 
                 Case SyntaxKind.SubStatement,
                      SyntaxKind.FunctionStatement,
@@ -1598,9 +1745,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                      SyntaxKind.OperatorStatement
                     Return FeaturesResources.operator_
 
-                Case SyntaxKind.ConstructorBlock,
-                     SyntaxKind.SubNewStatement
-                    Return FeaturesResources.constructor
+                Case SyntaxKind.ConstructorBlock
+                    Return If(CType(node, ConstructorBlockSyntax).SubNewStatement.Modifiers.Any(SyntaxKind.SharedKeyword), VBFeaturesResources.shared_constructor, FeaturesResources.constructor)
+
+                Case SyntaxKind.SubNewStatement
+                    Return If(CType(node, SubNewStatementSyntax).Modifiers.Any(SyntaxKind.SharedKeyword), VBFeaturesResources.Shared_constructor, FeaturesResources.constructor)
 
                 Case SyntaxKind.PropertyBlock
 
@@ -1824,7 +1973,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case EditKind.Move
-                        ReportError(RudeEditKind.Move)
+                        ClassifyMove(_newNode)
                         Return
 
                     Case EditKind.Insert
@@ -1841,6 +1990,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End Sub
 
 #Region "Move and Reorder"
+            Private Sub ClassifyMove(newNode As SyntaxNode)
+                Select Case newNode.Kind
+                    Case SyntaxKind.ModifiedIdentifier,
+                         SyntaxKind.VariableDeclarator
+                        ' Identifier can be moved within the same type declaration.
+                        ' Determine validity of such change in semantic analysis.
+                        Return
+
+                    Case Else
+                        ReportError(RudeEditKind.Move)
+                End Select
+            End Sub
+
             Private Sub ClassifyReorder(oldNode As SyntaxNode, newNode As SyntaxNode)
                 Select Case newNode.Kind
                     Case SyntaxKind.OptionStatement,
@@ -1885,8 +2047,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                     Case SyntaxKind.PropertyStatement,
                          SyntaxKind.FieldDeclaration,
-                         SyntaxKind.EventStatement,
-                         SyntaxKind.VariableDeclarator
+                         SyntaxKind.EventStatement
                         ' Maybe we could allow changing order of field declarations unless the containing type layout is sequential,
                         ' and it's not a COM interface.
                         ReportError(RudeEditKind.Move)
@@ -1903,11 +2064,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         ReportError(RudeEditKind.Move)
                         Return
 
-                    Case SyntaxKind.ModifiedIdentifier
-                        ' Identifier can only moved from one VariableDeclarator to another if both are part of 
-                        ' the same declaration. We could allow these moves if the order and types of variables 
-                        ' didn't change.
-                        ReportError(RudeEditKind.Move)
+                    Case SyntaxKind.ModifiedIdentifier,
+                         SyntaxKind.VariableDeclarator
+                        ' Identifier can be moved within the same type declaration.
+                        ' Determine validity of such change in semantic analysis.
                         Return
 
                     Case Else
@@ -1927,91 +2087,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case SyntaxKind.ClassBlock,
-                         SyntaxKind.StructureBlock
-                        ClassifyTypeWithPossibleExternMembersInsert(DirectCast(node, TypeBlockSyntax))
-                        Return
-
-                    Case SyntaxKind.InterfaceBlock
-                        ClassifyTypeInsert(DirectCast(node, TypeBlockSyntax).BlockStatement.Modifiers)
-                        Return
-
-                    Case SyntaxKind.EnumBlock
-                        ClassifyTypeInsert(DirectCast(node, EnumBlockSyntax).EnumStatement.Modifiers)
-                        Return
-
-                    Case SyntaxKind.ModuleBlock
-                        ' Modules can't be nested or private
-                        ReportError(RudeEditKind.Insert)
-                        Return
-
-                    Case SyntaxKind.DelegateSubStatement,
-                         SyntaxKind.DelegateFunctionStatement
-                        ClassifyTypeInsert(DirectCast(node, DelegateStatementSyntax).Modifiers)
-                        Return
-
-                    Case SyntaxKind.SubStatement,               ' interface method
-                         SyntaxKind.FunctionStatement           ' interface method
-                        ReportError(RudeEditKind.Insert)
-                        Return
-
-                    Case SyntaxKind.PropertyBlock
-                        ClassifyModifiedMemberInsert(DirectCast(node, PropertyBlockSyntax).PropertyStatement.Modifiers)
-                        Return
-
-                    Case SyntaxKind.PropertyStatement           ' autoprop or interface property
-                        ' We don't need to check whether the container is an interface, since we disallow 
-                        ' adding public methods And all methods in interface declarations are public.
-                        ClassifyModifiedMemberInsert(DirectCast(node, PropertyStatementSyntax).Modifiers)
-                        Return
-
-                    Case SyntaxKind.EventBlock
-                        ClassifyModifiedMemberInsert(DirectCast(node, EventBlockSyntax).EventStatement.Modifiers)
-                        Return
-
-                    Case SyntaxKind.EventStatement
-                        ClassifyModifiedMemberInsert(DirectCast(node, EventStatementSyntax).Modifiers)
-                        Return
-
-                    Case SyntaxKind.OperatorBlock
-                        ReportError(RudeEditKind.InsertOperator)
-                        Return
-
-                    Case SyntaxKind.SubBlock,
-                         SyntaxKind.FunctionBlock
-                        ClassifyMethodInsert(DirectCast(node, MethodBlockSyntax).SubOrFunctionStatement)
-                        Return
-
-                    Case SyntaxKind.DeclareSubStatement,
-                         SyntaxKind.DeclareFunctionStatement
-                        ' CLR doesn't support adding P/Invokes
-                        ReportError(RudeEditKind.Insert)
-                        Return
-
-                    Case SyntaxKind.ConstructorBlock
-                        If SyntaxUtilities.IsParameterlessConstructor(node) Then
-                            Return
-                        End If
-
-                        ClassifyModifiedMemberInsert(DirectCast(node, MethodBlockBaseSyntax).BlockStatement.Modifiers)
-                        Return
-
-                    Case SyntaxKind.GetAccessorBlock,
+                         SyntaxKind.StructureBlock,
+                         SyntaxKind.InterfaceBlock,
+                         SyntaxKind.EnumBlock,
+                         SyntaxKind.ModuleBlock,
+                         SyntaxKind.DelegateSubStatement,
+                         SyntaxKind.DelegateFunctionStatement,
+                         SyntaxKind.SubStatement,                 ' interface method
+                         SyntaxKind.FunctionStatement,           ' interface method
+                         SyntaxKind.PropertyBlock,
+                         SyntaxKind.PropertyStatement,           ' autoprop or interface property
+                         SyntaxKind.EventBlock,
+                         SyntaxKind.EventStatement,
+                         SyntaxKind.OperatorBlock,
+                         SyntaxKind.SubBlock,
+                         SyntaxKind.FunctionBlock,
+                         SyntaxKind.DeclareSubStatement,
+                         SyntaxKind.DeclareFunctionStatement,
+                         SyntaxKind.ConstructorBlock,
+                         SyntaxKind.GetAccessorBlock,
                          SyntaxKind.SetAccessorBlock,
                          SyntaxKind.AddHandlerAccessorBlock,
                          SyntaxKind.RemoveHandlerAccessorBlock,
-                         SyntaxKind.RaiseEventAccessorBlock
-                        Return
-
-                    Case SyntaxKind.FieldDeclaration
-                        ClassifyFieldInsert(DirectCast(node, FieldDeclarationSyntax))
+                         SyntaxKind.RaiseEventAccessorBlock,
+                         SyntaxKind.FieldDeclaration,
+                         SyntaxKind.ModifiedIdentifier
                         Return
 
                     Case SyntaxKind.VariableDeclarator
                         ' Ignore, errors will be reported for children (ModifiedIdentifier, AsClause)
-                        Return
-
-                    Case SyntaxKind.ModifiedIdentifier
-                        ClassifyFieldInsert(DirectCast(node, ModifiedIdentifierSyntax))
                         Return
 
                     Case SyntaxKind.EnumMemberDeclaration,
@@ -2041,80 +2145,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 End Select
             End Sub
 
-            Private Function ClassifyModifiedMemberInsert(modifiers As SyntaxTokenList) As Boolean
-                If modifiers.Any(SyntaxKind.OverridableKeyword) OrElse
-                   modifiers.Any(SyntaxKind.MustOverrideKeyword) OrElse
-                   modifiers.Any(SyntaxKind.OverridesKeyword) Then
-
-                    ReportError(RudeEditKind.InsertVirtual)
-                    Return False
-                End If
-
-                Return True
-            End Function
-
-            Private Function ClassifyTypeInsert(modifiers As SyntaxTokenList) As Boolean
-                Return ClassifyModifiedMemberInsert(modifiers)
-            End Function
-
-            Private Sub ClassifyTypeWithPossibleExternMembersInsert(type As TypeBlockSyntax)
-                If Not ClassifyTypeInsert(type.BlockStatement.Modifiers) Then
-                    Return
-                End If
-
-                For Each member In type.Members
-                    Dim modifiers As SyntaxTokenList
-
-                    Select Case member.Kind
-                        Case SyntaxKind.DeclareFunctionStatement,
-                             SyntaxKind.DeclareSubStatement
-                            ReportError(RudeEditKind.Insert, member, member)
-
-                        Case SyntaxKind.PropertyStatement
-                            modifiers = DirectCast(member, PropertyStatementSyntax).Modifiers
-
-                        Case SyntaxKind.SubBlock,
-                             SyntaxKind.FunctionBlock
-                            modifiers = DirectCast(member, MethodBlockBaseSyntax).BlockStatement.Modifiers
-                    End Select
-
-                    ' TODO: DllImport/Declare?
-                    'If (modifiers.Any(SyntaxKind.MustOverrideKeyword)) Then
-                    '    ReportError(RudeEditKind.InsertMustOverride, member, member)
-                    'End If
-                Next
-            End Sub
-
-            Private Sub ClassifyMethodInsert(method As MethodStatementSyntax)
-                If method.TypeParameterList IsNot Nothing Then
-                    ReportError(RudeEditKind.InsertGenericMethod)
-                End If
-
-                If method.HandlesClause IsNot Nothing Then
-                    ReportError(RudeEditKind.InsertHandlesClause)
-                End If
-
-                ClassifyModifiedMemberInsert(method.Modifiers)
-            End Sub
-
-            Private Sub ClassifyFieldInsert(field As FieldDeclarationSyntax)
-                ' Can't insert WithEvents field since it is effectively a virtual property.
-                If field.Modifiers.Any(SyntaxKind.WithEventsKeyword) Then
-                    ReportError(RudeEditKind.Insert)
-                    Return
-                End If
-
-                Dim containingType = field.Parent
-                If containingType.IsKind(SyntaxKind.ModuleBlock) Then
-                    ReportError(RudeEditKind.Insert)
-                    Return
-                End If
-            End Sub
-
-            Private Sub ClassifyFieldInsert(fieldVariableName As ModifiedIdentifierSyntax)
-                ClassifyFieldInsert(DirectCast(fieldVariableName.Parent.Parent, FieldDeclarationSyntax))
-            End Sub
-
             Private Sub ClassifyParameterInsert(parameterList As ParameterListSyntax)
                 ' Sub M -> Sub M() is ok
                 If parameterList.Parameters.Count = 0 Then
@@ -2131,9 +2161,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Select Case oldNode.Kind
                     Case SyntaxKind.OptionStatement,
                          SyntaxKind.ImportsStatement,
-                         SyntaxKind.AttributesStatement,
                          SyntaxKind.NamespaceBlock,
-                         SyntaxKind.ClassBlock,
+                         SyntaxKind.AttributesStatement
+                        ReportError(RudeEditKind.Delete)
+                        Return
+
+                    Case SyntaxKind.ClassBlock,
                          SyntaxKind.StructureBlock,
                          SyntaxKind.InterfaceBlock,
                          SyntaxKind.ModuleBlock,
@@ -2152,30 +2185,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                          SyntaxKind.EventBlock,
                          SyntaxKind.EventStatement,
                          SyntaxKind.DeclareSubStatement,
-                         SyntaxKind.DeclareFunctionStatement
-                        ' To allow removal of declarations we would need to update method bodies that 
-                        ' were previously binding to them but now are binding to another symbol that was previously hidden.
-                        ReportError(RudeEditKind.Delete)
-                        Return
-
-                    Case SyntaxKind.ConstructorBlock
-                        ' Allow deletion of a parameterless constructor.
-                        ' Semantic analysis reports an error if the parameterless ctor isn't replaced by a default ctor.
-                        If Not SyntaxUtilities.IsParameterlessConstructor(oldNode) Then
-                            ReportError(RudeEditKind.Delete)
-                        End If
-
+                         SyntaxKind.DeclareFunctionStatement,
+                         SyntaxKind.ConstructorBlock
+                        ' We do not report member delete here since the member might be moving to a different part of a partial type declaration.
+                        ' If that is not the case the semantic analysis reports the rude edit.
                         Return
 
                     Case SyntaxKind.GetAccessorBlock,
                          SyntaxKind.SetAccessorBlock,
                          SyntaxKind.AddHandlerAccessorBlock,
                          SyntaxKind.RemoveHandlerAccessorBlock,
-                         SyntaxKind.RaiseEventAccessorBlock
-                        ' An accessor can be removed. Accessors are not hiding other symbols.
-                        ' If the new compilation still uses the removed accessor a semantic error will be reported.
-                        ' For simplicity though we disallow deletion of accessors for now.
-                        ReportError(RudeEditKind.Delete)
+                         SyntaxKind.RaiseEventAccessorBlock,
+                         SyntaxKind.EnumMemberDeclaration
+                        ' We do not report error here since it will be reported in semantic analysis.
                         Return
 
                     Case SyntaxKind.AttributeList,
@@ -2183,12 +2205,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         ' To allow removal of attributes we would need to check if the removed attribute
                         ' is a pseudo-custom attribute that CLR allows us to change, or if it is a compiler well-know attribute
                         ' that affects the generated IL.
-                        ReportError(RudeEditKind.Delete)
-                        Return
-
-                    Case SyntaxKind.EnumMemberDeclaration
-                        ' We could allow removing enum member if it didn't affect the values of other enum members.
-                        ' If the updated compilation binds without errors it means that the enum value wasn't used.
                         ReportError(RudeEditKind.Delete)
                         Return
 
@@ -2400,13 +2416,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return
                 End If
 
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
+                If Not AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore:=SyntaxKind.PartialKeyword) Then
                     ReportError(RudeEditKind.ModifiersUpdate)
                     Return
                 End If
 
-                Debug.Assert(Not SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier))
-                ReportError(RudeEditKind.Renamed)
+                If Not SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier) Then
+                    ReportError(RudeEditKind.Renamed)
+                End If
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As TypeBlockSyntax, newNode As TypeBlockSyntax)
@@ -2776,6 +2793,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 ClassifyUpdate(oldNode.Identifier, newNode.Identifier)
             End Sub
 
+            Private Shared Function AreModifiersEquivalent(oldModifiers As SyntaxTokenList, newModifiers As SyntaxTokenList, ignore As SyntaxKind) As Boolean
+                Dim oldIgnoredModifierIndex = oldModifiers.IndexOf(ignore)
+                Dim newIgnoredModifierIndex = newModifiers.IndexOf(ignore)
+
+                If oldIgnoredModifierIndex >= 0 Then
+                    oldModifiers = oldModifiers.RemoveAt(oldIgnoredModifierIndex)
+                End If
+
+                If newIgnoredModifierIndex >= 0 Then
+                    newModifiers = newModifiers.RemoveAt(newIgnoredModifierIndex)
+                End If
+
+                Return SyntaxFactory.AreEquivalent(oldModifiers, newModifiers)
+            End Function
+
             Private Sub ClassifyMethodBodyRudeUpdate(oldBody As MethodBlockBaseSyntax,
                                                      newBody As MethodBlockBaseSyntax,
                                                      containingMethod As MethodBlockSyntax,
@@ -2832,10 +2864,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 #End Region
         End Structure
 
-        Friend Overrides Sub ReportTopLevelSyntacticRudeEdits(diagnostics As ArrayBuilder(Of RudeEditDiagnostic),
-                                                      match As Match(Of SyntaxNode),
-                                                      edit As Edit(Of SyntaxNode),
-                                                      editMap As Dictionary(Of SyntaxNode, EditKind))
+        Friend Overrides Sub ReportTopLevelSyntacticRudeEdits(
+            diagnostics As ArrayBuilder(Of RudeEditDiagnostic),
+            match As Match(Of SyntaxNode),
+            edit As Edit(Of SyntaxNode),
+            editMap As Dictionary(Of SyntaxNode, EditKind))
 
             ' For most nodes we ignore Insert and Delete edits if their parent was also inserted or deleted, respectively.
             ' For ModifiedIdentifiers though we check the grandparent instead because variables can move across 
@@ -2880,27 +2913,146 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 #End Region
 
 #Region "Semantic Rude Edits"
-        Friend Overrides Sub ReportInsertedMemberSymbolRudeEdits(diagnostics As ArrayBuilder(Of RudeEditDiagnostic), newSymbol As ISymbol)
-            ' CLR doesn't support adding P/Invokes.
+        Friend Overrides Sub ReportInsertedMemberSymbolRudeEdits(diagnostics As ArrayBuilder(Of RudeEditDiagnostic), newSymbol As ISymbol, newNode As SyntaxNode, insertingIntoExistingContainingType As Boolean)
+            Dim kind = GetInsertedMemberSymbolRudeEditKind(newSymbol, insertingIntoExistingContainingType)
 
-            ' VB needs to check if the type doesn't contain methods with DllImport attribute.
-            If newSymbol.IsKind(SymbolKind.NamedType) Then
-                For Each member In DirectCast(newSymbol, INamedTypeSymbol).GetMembers()
-                    ReportDllImportInsertRudeEdit(diagnostics, member)
-                Next
-            Else
-                ReportDllImportInsertRudeEdit(diagnostics, newSymbol)
+            If kind <> RudeEditKind.None Then
+                diagnostics.Add(New RudeEditDiagnostic(
+                    kind,
+                    GetDiagnosticSpan(newNode, EditKind.Insert),
+                    newNode,
+                    arguments:={GetDisplayName(newNode, EditKind.Insert)}))
             End If
         End Sub
 
-        Private Shared Sub ReportDllImportInsertRudeEdit(diagnostics As ArrayBuilder(Of RudeEditDiagnostic), member As ISymbol)
-            If member.IsKind(SymbolKind.Method) AndAlso
-               DirectCast(member, IMethodSymbol).GetDllImportData() IsNot Nothing Then
+        Private Shared Function GetInsertedMemberSymbolRudeEditKind(newSymbol As ISymbol, insertingIntoExistingContainingType As Boolean) As RudeEditKind
+            Select Case newSymbol.Kind
+                Case SymbolKind.Method
+                    Dim method = DirectCast(newSymbol, IMethodSymbol)
 
-                diagnostics.Add(New RudeEditDiagnostic(RudeEditKind.InsertDllImport,
-                                                       member.Locations.First().SourceSpan))
+                    ' Inserting P/Invoke into a new or existing type is not allowed.
+                    If method.GetDllImportData() IsNot Nothing Then
+                        Return RudeEditKind.InsertDllImport
+                    End If
+
+                    ' Inserting method with handles clause into a new or existing type is not allowed.
+                    If Not method.HandledEvents.IsEmpty Then
+                        Return RudeEditKind.InsertHandlesClause
+                    End If
+
+                Case SymbolKind.NamedType
+                    Dim type = CType(newSymbol, INamedTypeSymbol)
+
+                    ' Inserting module is not allowed.
+                    If type.TypeKind = TypeKind.Module Then
+                        Return RudeEditKind.Insert
+                    End If
+            End Select
+
+            ' All rude edits below only apply when inserting into an existing type (not when the type itself is inserted):
+            If Not insertingIntoExistingContainingType Then
+                Return RudeEditKind.None
             End If
+
+            If newSymbol.ContainingType.Arity > 0 AndAlso newSymbol.Kind <> SymbolKind.NamedType Then
+                Return RudeEditKind.InsertIntoGenericType
+            End If
+
+            ' Inserting virtual or interface member is not allowed.
+            If (newSymbol.IsVirtual Or newSymbol.IsOverride Or newSymbol.IsAbstract) AndAlso newSymbol.Kind <> SymbolKind.NamedType Then
+                Return RudeEditKind.InsertVirtual
+            End If
+
+            Select Case newSymbol.Kind
+                Case SymbolKind.Method
+                    Dim method = DirectCast(newSymbol, IMethodSymbol)
+
+                    ' Inserting generic method into an existing type is not allowed.
+                    If method.Arity > 0 Then
+                        Return RudeEditKind.InsertGenericMethod
+                    End If
+
+                    ' Inserting operator to an existing type is not allowed.
+                    If method.MethodKind = MethodKind.Conversion OrElse method.MethodKind = MethodKind.UserDefinedOperator Then
+                        Return RudeEditKind.InsertOperator
+                    End If
+
+                    Return RudeEditKind.None
+
+                Case SymbolKind.Field
+                    'Dim field = DirectCast(newSymbol, IFieldSymbol)
+                    ' TODO:
+                    ' Can't insert WithEvents field since it is effectively a virtual property.
+                    ' WithEvents X As C
+                    'If field.Modifiers.Any(SyntaxKind.WithEventsKeyword) Then
+                    '    ReportError(RudeEditKind.Insert)
+                    '    Return
+                    'End If
+
+                    'Dim containingType = field.Parent
+                    'If containingType.IsKind(SyntaxKind.ModuleBlock) Then
+                    '    ReportError(RudeEditKind.Insert)
+                    '    Return
+                    'End If
+                    Return RudeEditKind.None
+            End Select
+
+            Return RudeEditKind.None
+        End Function
+
+        Friend Overrides Sub ReportTypeDeclarationInsertDeleteRudeEdits(diagnostics As ArrayBuilder(Of RudeEditDiagnostic), oldType As INamedTypeSymbol, newType As INamedTypeSymbol, newDeclaration As SyntaxNode, cancellationToken As CancellationToken)
+            Dim oldNodes = ArrayBuilder(Of SyntaxNode).GetInstance()
+            Dim newNodes = ArrayBuilder(Of SyntaxNode).GetInstance()
+
+            Dim report =
+                Sub(addNodes As Action(Of ArrayBuilder(Of SyntaxNode), TypeBlockSyntax), rudeEditKind As RudeEditKind)
+
+                    For Each syntaxRef In oldType.DeclaringSyntaxReferences
+                        addNodes(oldNodes, CType(GetSymbolDeclarationSyntax(syntaxRef, cancellationToken), TypeBlockSyntax))
+                    Next
+
+                    For Each syntaxRef In newType.DeclaringSyntaxReferences
+                        addNodes(newNodes, CType(GetSymbolDeclarationSyntax(syntaxRef, cancellationToken), TypeBlockSyntax))
+                    Next
+
+                    If oldNodes.Count <> newNodes.Count OrElse
+                                oldNodes.Zip(newNodes, Function(oldNode, newNode) SyntaxFactory.AreEquivalent(oldNode, newNode)).Any(Function(isEquivalent) Not isEquivalent) Then
+
+                        diagnostics.Add(New RudeEditDiagnostic(
+                                    rudeEditKind,
+                                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
+                                    newDeclaration,
+                                    arguments:={GetDisplayName(newDeclaration, EditKind.Update)}))
+                    End If
+
+                    oldNodes.Clear()
+                    newNodes.Clear()
+                End Sub
+
+            ' Consider better error messages
+            report(Sub(b, t) AddNodes(b, t.BlockStatement.AttributeLists), RudeEditKind.Update)
+            report(Sub(b, t) AddNodes(b, t.BlockStatement.TypeParameterList?.Parameters), RudeEditKind.Update)
+
+            report(Sub(b, t)
+                       For Each inherit In t.Inherits
+                           For Each baseType In inherit.Types
+                               b.Add(baseType)
+                           Next
+                       Next
+                   End Sub, RudeEditKind.BaseTypeOrInterfaceUpdate)
+
+            report(Sub(b, t)
+                       For Each impl In t.Implements
+                           For Each baseInterface In impl.Types
+                               b.Add(baseInterface)
+                           Next
+                       Next
+                   End Sub, RudeEditKind.BaseTypeOrInterfaceUpdate)
+
+            oldNodes.Free()
+            newNodes.Free()
         End Sub
+
 #End Region
 
 #Region "Exception Handling Rude Edits"

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
@@ -1252,4 +1252,7 @@ Sub(&lt;parameterList&gt;) &lt;statement&gt;</value>
   <data name="_0_Events" xml:space="preserve">
     <value>({0} Events)</value>
   </data>
+  <data name="Shared_constructor" xml:space="preserve">
+    <value>Shared constructor</value>
+  </data>
 </root>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.cs.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.cs.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Odebrat klíčové slovo Shared ze členu modulu</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Sem vložte název, kterým deklarujete novou položku.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.de.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.de.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Schlüsselwort "Shared" aus Modulmember entfernen</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Geben Sie hier einen Namen ein, um ein neues Feld zu deklarieren.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.es.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.es.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Quitar la palabra clave "Shared" del miembro del módulo</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Escriba aquí un nombre para declarar un nuevo campo.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.fr.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.fr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Supprimer le mot clé 'Shared' du membre de module</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Tapez un nom ici pour déclarer un nouveau champ.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.it.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.it.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Rimuovi la parola chiave 'Shared' dal membro Module</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Digitare qui un nome per dichiarare un nuovo campo.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ja.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ja.xlf
@@ -102,6 +102,11 @@
         <target state="translated">モジュール メンバーから 'Shared' キーワードを削除</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">新しいフィールドを宣言するには、ここに名前を入力します。</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ko.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ko.xlf
@@ -102,6 +102,11 @@
         <target state="translated">모듈 멤버에서 'Shared' 키워드 제거</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">여기에 이름을 입력하여 새 필드를 선언하세요.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pl.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pl.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Usuń słowo kluczowe "Shared" ze składowej modułu</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Wpisz tutaj nazwę, aby utworzyć deklarację nowego pola.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pt-BR.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Remover a palavra-chave 'Shared' do membro do Módulo</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Digite um nome aqui para declarar um novo campo.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ru.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.ru.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Удалить ключевое слово "Shared" из элемента модуля</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Введите здесь имя для объявления нового поля.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.tr.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.tr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Modül üyesinden 'Shared' anahtar sözcüğünü kaldır</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">Yeni bir alan bildirmek için buraya bir ad yazın.</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hans.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="translated">从模块成员中删除 "Shared" 关键字</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">请在此处键入名称以声明新字段。</target>

--- a/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hant.xlf
+++ b/src/Features/VisualBasic/Portable/xlf/VBFeaturesResources.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="translated">從模組成員移除 'Shared' 關鍵字</target>
         <note>{Locked="Shared"} "Shared" is a VB keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="Shared_constructor">
+        <source>Shared constructor</source>
+        <target state="new">Shared constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Type_a_name_here_to_declare_a_new_field">
         <source>Type a name here to declare a new field.</source>
         <target state="translated">於此輸入名稱以宣告新的欄位。</target>

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -210,17 +210,30 @@ namespace Microsoft.CodeAnalysis.Differencing
                         // consider avoiding matching them to all other nodes of the same label.
                         // Rather we should only match them with their siblings that share the same parent.
 
-                        var ancestor1 = _comparer.GetAncestor(node1, tiedToAncestor);
-                        var ancestor2 = _comparer.GetAncestor(node2, tiedToAncestor);
+                        // Check if nodes that are configured to be tied to their ancestor have the respective ancestor matching.
+                        // In cases when we compare substrees rooted below both of these ancestors we assume the ancestors are
+                        // matching since the roots of the subtrees must match and therefore their ancestors must match as well.
+                        // If one node's ancestor is present in the subtree and the other isn't then we are not in the scenario
+                        // of comparing subtrees with matching roots and thus we consider the nodes not matching.
 
-                        // Since CategorizeNodesByLabels added nodes to the s1/s2 lists in depth-first prefix order,
-                        // we can also accept equality in the following condition. That's because we find the partner 
-                        // of the parent node before we get to finding it for the child node of the same kind.
-                        Debug.Assert(_comparer.GetLabel(ancestor1) <= _comparer.GetLabel(node1));
-
-                        if (!Contains(ancestor1, ancestor2))
+                        var hasAncestor1 = _comparer.TryGetAncestor(node1, tiedToAncestor, out var ancestor1);
+                        var hasAncestor2 = _comparer.TryGetAncestor(node2, tiedToAncestor, out var ancestor2);
+                        if (hasAncestor1 != hasAncestor2)
                         {
                             continue;
+                        }
+
+                        if (hasAncestor1)
+                        {
+                            // Since CategorizeNodesByLabels added nodes to the s1/s2 lists in depth-first prefix order,
+                            // we can also accept equality in the following condition. That's because we find the partner 
+                            // of the parent node before we get to finding it for the child node of the same kind.
+                            Debug.Assert(_comparer.GetLabel(ancestor1) <= _comparer.GetLabel(node1));
+
+                            if (!Contains(ancestor1, ancestor2))
+                            {
+                                continue;
+                            }
                         }
                     }
 

--- a/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
+++ b/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
@@ -100,15 +100,25 @@ namespace Microsoft.CodeAnalysis.Differencing
             return parent!;
         }
 
-        internal TNode GetAncestor(TNode node, int level)
+        internal bool TryGetAncestor(TNode node, int level, [MaybeNullWhen(false)] out TNode ancestor)
         {
             while (level > 0)
             {
-                node = GetParent(node);
+                if (TryGetParent(node, out var parent))
+                {
+                    node = parent;
+                }
+                else
+                {
+                    ancestor = default;
+                    return false;
+                }
+
                 level--;
             }
 
-            return node;
+            ancestor = node;
+            return true;
         }
 
         /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledHashSet.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledHashSet.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Roslyn.Utilities;
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
-    internal partial class PooledHashSet<T> : IPooled
+    internal partial class PooledHashSet<T> : IPooled, IReadOnlySet<T>
     {
         public static PooledDisposer<PooledHashSet<T>> GetInstance(out PooledHashSet<T> instance)
         {


### PR DESCRIPTION
Adds support for editing partial types, moving members across files (in between different parts of a partial type declaration), adding a file to a compilation, or moving whole type declaration to another file.

The core of the change is in inverting the approach to the analysis. Previously we had two separate passes: syntactic (top-level and statement level) and semantic. If a rude edit was found during the first one we did not run the second one. The whole analysis was entirely based on the document content except for constructor semantic analysis, which could use semantic information from other documents. The new approach performs top-level only syntactic analysis and then feeds the top-level edits directly into semantic analysis. The semantic analysis translates the syntactic edits to symbol edits and if performs statement level syntactic and semantic analysis for members with updated bodies. This allows us to compare member bodies across documents - since we can run the body analysis not only on bodies located in the document being analyzed but also bodies retrieved from the syntax references of symbols.

The new approach requires the semantic and member body analysis to be more robust and handle semantically incorrect code since we no can no longer discover many of the rude edits in the first phase (top-level) and bail. E.g. the first phase can't distinguish between a deleted member declaration and a member declaration moved to another file.

Some edits in partial classes require additional post-processing. E.g. if field initializers of a partial type located in different documents are updated the resulting semantic edit should be a single edit of each of the constructors that emits these initializers. Since we still perform and store the results of the analysis per document (for each changed document) we'll end up with the constructor updates recorded for each document. The final results must merge these results before passing it to the compiler when emitting deltas.

Fixes:
https://github.com/dotnet/roslyn/issues/50016
https://github.com/dotnet/roslyn/issues/32494
https://github.com/dotnet/roslyn/issues/51177
https://github.com/dotnet/roslyn/issues/50876

Follow-ups/potential improvements:
- [ ] It is possible to emit invalid delta if semantic info is inferred from documents that are not up to date (https://github.com/dotnet/roslyn/issues/51261)
- [ ] member moves across partial definitions might be classified as renamed and not handled correctly (https://github.com/dotnet/roslyn/issues/51011)
- [ ] Support moving member containing an active statement to a different file (https://github.com/dotnet/roslyn/issues/51177)
- [ ] Adding a constructor to a type with field/property initializers that contain lambdas (https://github.com/dotnet/roslyn/issues/2504)