### PR TITLE
Fix NormalizeWhitespace - String Interpolation with e.g. Initializer-expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -926,6 +926,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
             if (node.StringStartToken.Kind() == SyntaxKind.InterpolatedStringStartToken)
             {
+                /*
+                 * Just for non verbatim strings we want to make sure that the formatting of interpolations does not emit line breaks.
+                 * See: https://github.com/dotnet/roslyn/issues/50742
+                 * 
+                 * The flag _inSingleLineInterpolation is set to true while visiting InterpolatedStringExpressionSyntax and checked in LineBreaksAfter
+                 * to suppress adding newlines.
+                 */
                 var old = _inSingleLineInterpolation;
                 _inSingleLineInterpolation = true;
                 try

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -926,13 +926,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
             if (node.StringStartToken.Kind() == SyntaxKind.InterpolatedStringStartToken)
             {
-                /*
-                 * Just for non verbatim strings we want to make sure that the formatting of interpolations does not emit line breaks.
-                 * See: https://github.com/dotnet/roslyn/issues/50742
-                 * 
-                 * The flag _inSingleLineInterpolation is set to true while visiting InterpolatedStringExpressionSyntax and checked in LineBreaksAfter
-                 * to suppress adding newlines.
-                 */
+                //Just for non verbatim strings we want to make sure that the formatting of interpolations does not emit line breaks.
+                //See: https://github.com/dotnet/roslyn/issues/50742
+                //
+                //The flag _inSingleLineInterpolation is set to true while visiting InterpolatedStringExpressionSyntax and checked in LineBreaksAfter
+                //to suppress adding newlines.
                 var old = _inSingleLineInterpolation;
                 _inSingleLineInterpolation = true;
                 try

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private bool _afterLineBreak;
         private bool _afterIndentation;
+        private bool _inSingleLineInterpolation;
 
         // CONSIDER: if we become concerned about space, we shouldn't actually need any 
         // of the values between indentations[0] and indentations[initialDepth] (exclusive).
@@ -177,6 +178,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private int LineBreaksAfter(SyntaxToken currentToken, SyntaxToken nextToken)
         {
+            if (_inSingleLineInterpolation)
+            {
+                return 0;
+            }
+
             if (currentToken.IsKind(SyntaxKind.EndOfDirectiveToken))
             {
                 return 1;
@@ -914,6 +920,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
 
             return 0;
+        }
+
+        public override SyntaxNode? VisitInterpolatedStringExpression(InterpolatedStringExpressionSyntax node)
+        {
+            if (node.StringStartToken.Kind() == SyntaxKind.InterpolatedStringStartToken)
+            {
+                var old = _inSingleLineInterpolation;
+                _inSingleLineInterpolation = true;
+                try
+                {
+                    return base.VisitInterpolatedStringExpression(node);
+                }
+                finally
+                {
+                    _inSingleLineInterpolation = old;
+                }
+            }
+
+            return base.VisitInterpolatedStringExpression(node);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -535,6 +535,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        [WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
+        public void TestLineBreakInterpolations()
+        {
+            var code = @"$""Printed: { new Printer() { TextToPrint = ""Hello world!"" }.PrintedText }""";
+
+            var syntaxNode = SyntaxFactory.ParseExpression(code).NormalizeWhitespace();
+            var aText = syntaxNode.ToFullString();
+
+            Assert.True(!aText.Contains('\n'));
+        }
+
+        [Fact]
         [WorkItem(21231, "https://github.com/dotnet/roslyn/issues/21231")]
         public void TestSpacingOnCoalescing()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -535,18 +535,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        [WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
-        public void TestLineBreakInterpolations()
-        {
-            var code = @"$""Printed: { new Printer() { TextToPrint = ""Hello world!"" }.PrintedText }""";
-
-            var syntaxNode = SyntaxFactory.ParseExpression(code).NormalizeWhitespace();
-            var aText = syntaxNode.ToFullString();
-
-            Assert.True(!aText.Contains('\n'));
-        }
-
-        [Fact]
         [WorkItem(21231, "https://github.com/dotnet/roslyn/issues/21231")]
         public void TestSpacingOnCoalescing()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -19,36 +19,29 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact, WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
         public void TestLineBreakInterpolations()
         {
-            var code = @"$""Printed: { new Printer() { TextToPrint = ""Hello world!"" }.PrintedText }""";
-
-            var syntaxNode = SyntaxFactory.ParseExpression(code).NormalizeWhitespace();
-            var text = syntaxNode.ToFullString();
-
-            //we test only for line breaks because they caused that the produced text couldn't be parsed after NormalizeWhitespace
-            //the concrete formatting (e.g. spaces, tabs) should be ignored here
-            Assert.True(!text.Contains("\n"));
-
-            var parsed = SyntaxFactory.ParseExpression(text);
-            Assert.False(parsed.HasErrors);
+            TestNormalizeExpression(
+                @"$""Printed: {                    new Printer() { TextToPrint = ""Hello world!"" }.PrintedText }""",
+                @"$""Printed: {new Printer(){TextToPrint = ""Hello world!""}.PrintedText}"""
+            );
         }
 
         [Fact]
         [WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
         public void TestVerbatimStringInterpolationWithLineBreaks()
         {
-            var code = @"Console.WriteLine($@""Test with line
+            TestNormalizeStatement(@"Console.WriteLine($@""Test with line
 breaks
 {
                 new[]{
      1, 2, 3
   }[2]
 }
-            "");";
-
-            var syntaxNode = SyntaxFactory.ParseStatement(code).NormalizeWhitespace();
-            var text = syntaxNode.ToFullString();
-            var parsed = SyntaxFactory.ParseStatement(text);
-            Assert.False(parsed.HasErrors);
+            "");",
+            @"Console.WriteLine($@""Test with line
+breaks
+{new[]{1, 2, 3}[2]}
+            "");"
+            );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -25,8 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             );
         }
 
-        [Fact]
-        [WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
+        [Fact, WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
         public void TestVerbatimStringInterpolationWithLineBreaks()
         {
             TestNormalizeStatement(@"Console.WriteLine($@""Test with line

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -27,7 +27,29 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             //we test only for line breaks because they caused that the produced text couldn't be parsed after NormalizeWhitespace
             //the concrete formatting (e.g. spaces, tabs) should be ignored here
-            Assert.True(!text.Contains('\n'));
+            Assert.True(!text.Contains("\n"));
+
+            var parsed = SyntaxFactory.ParseExpression(text);
+            Assert.False(parsed.HasErrors);
+        }
+
+        [Fact]
+        [WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
+        public void TestVerbatimStringInterpolationWithLineBreaks()
+        {
+            var code = @"Console.WriteLine($@""Test with line
+breaks
+{
+                new[]{
+     1, 2, 3
+  }[2]
+}
+            "");";
+
+            var syntaxNode = SyntaxFactory.ParseStatement(code).NormalizeWhitespace();
+            var text = syntaxNode.ToFullString();
+            var parsed = SyntaxFactory.ParseStatement(text);
+            Assert.False(parsed.HasErrors);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -17,6 +17,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class SyntaxNormalizerTests
     {
         [Fact]
+        [WorkItem(50742, "https://github.com/dotnet/roslyn/issues/50742")]
+        public void TestLineBreakInterpolations()
+        {
+            var code = @"$""Printed: { new Printer() { TextToPrint = ""Hello world!"" }.PrintedText }""";
+
+            var syntaxNode = SyntaxFactory.ParseExpression(code).NormalizeWhitespace();
+            var text = syntaxNode.ToFullString();
+
+            //we test only for line breaks because they caused that the produced text couldn't be parsed after NormalizeWhitespace
+            //the concrete formatting (e.g. spaces, tabs) should be ignored here
+            Assert.True(!text.Contains('\n'));
+        }
+
+        [Fact]
         public void TestNormalizeExpression1()
         {
             TestNormalizeExpression("!a", "!a");


### PR DESCRIPTION
NormalizeWhitespace created new lines inside of interpolated strings which caused code to be invalid after re-parsed.
Currently new-line support in interpolated-string expressions is very limited - therefore we can't do "nice printing".

For more info see: https://github.com/dotnet/roslyn/issues/50742