### PR TITLE
Add a delegate compatibility check in GetMethodGroupDelegateConversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -58,6 +58,38 @@ namespace Microsoft.CodeAnalysis.CSharp
             var conversion = (resolution.IsEmpty || resolution.HasAnyErrors) ?
                 Conversion.NoConversion :
                 ToConversion(resolution.OverloadResolutionResult, resolution.MethodGroup, ((NamedTypeSymbol)destination).DelegateInvokeMethod.ParameterCount);
+
+            var dParams = destination.DelegateParameters();
+            if (conversion.Exists && dParams.Length > 0)
+            {
+                // Check the delegate compatibility (section 15.2).
+                //  * Every value parameter (no-ref or non-out) from the delegate type has an identity conversion or an implicit reference conversion to the corresponding parameter
+                //  * Every ref or out parameter from the delegate type has an identity conversion to the corresponding parameter
+                // On this `conversion`, the function applicability has been checked, but the delegate compatibility has not.
+
+                var mParams = conversion.MethodSymbol.Parameters;
+                var hasThis = resolution.IsExtensionMethodGroup ? 1 : 0;
+
+                for (var i = 0; i < dParams.Length; ++i)
+                {
+                    var dParam = dParams[i];
+
+                    // From the function applicability, the ref or out parameter has the same modifier and has an identity conversion to the corresponding parameter.
+                    if (dParam.RefKind == RefKind.Ref || dParam.RefKind == RefKind.Out)
+                    {
+                        continue;
+                    }
+
+                    var dType = dParam.Type;
+                    var mType = (Symbols.PublicModel.TypeSymbol)mParams[i + hasThis].Type;
+                    if (!HasIdentityOrImplicitReferenceConversion(dType, mType.UnderlyingTypeSymbol, ref useSiteInfo))
+                    {
+                        conversion = Conversion.NoConversion;
+                        break;
+                    }
+                }
+            }
+
             resolution.Free();
             return conversion;
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MethodBodyModelTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MethodBodyModelTests.cs
@@ -433,13 +433,13 @@ public class Program1
 
     void T()
     {
-        D(Y); // wrong parameter type
+        D(Y); // resolved to D(MyAction<long>)
     }
 }
 ";
             var tree = Parse(text);
             var comp = CreateCompilation(tree);
-            Assert.Equal(1, comp.GetDiagnostics().Count());
+            comp.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -11411,5 +11411,26 @@ class Program
                 Assert.Equal("event D<A, B> Base<A, B>.E", symbol.ToTestDisplayString());
             }
         }
+
+        [WorkItem(51232, "https://github.com/dotnet/roslyn/issues/51232")]
+        [Fact]
+        public void DelegateTypeParameterOverload()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static void F(Action<byte> a) { Console.Write(1); }
+    static void F(Action<int> a) { Console.Write(2); }
+    static void A(int n) { }
+
+    static void Main()
+    {
+        F(A);
+    }
+}";
+
+            CompileAndVerify(source, expectedOutput: @"2");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -3451,8 +3451,8 @@ class C
     }
 }";
             CreateCompilation(text).VerifyDiagnostics(
-                // (10,16): error CS0123: No overload for 'C.far<int>(int)' matches delegate 'boo'
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "far<int>").WithArguments("C.far<int>(int)", "boo"));
+                // (10,16): error CS0123: No overload for 'far' matches delegate 'boo'
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "far<int>").WithArguments("far", "boo"));
         }
 
         [WorkItem(539909, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539909")]
@@ -3482,8 +3482,8 @@ class D
     }
 }";
             CreateCompilation(text).VerifyDiagnostics(
-                // (15,24): error CS0123: No overload for 'C<long>.far(long)' matches delegate 'boo'
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "C<long>.far").WithArguments("C<long>.far(long)", "boo").WithLocation(15, 24),
+                // (15,32): error CS0123: No overload for 'far' matches delegate 'boo'
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "far").WithArguments("far", "boo").WithLocation(15, 32),
                 // (16,32): error CS0123: No overload for 'par' matches delegate 'boo'
                 //         C<long>.goo += C<long>.par<byte>;
                 Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "par<byte>").WithArguments("par", "boo").WithLocation(16, 32),


### PR DESCRIPTION
fixes: #51232

## Summary

Add a delegate compatibility check after getting a method group to delegate conversion in the method `GetMethodGroupDelegateConversion`.

## Test modification:

### MethodBodyModelTests.MethodGroupToDelegate04
This is that I want to fix.

### OverloadResolutionTests.DelegateTypeParameterOverload
Test case from #51232.

### SemanticErrorTests.CS0123ERR_MethDelegateMismatch_01, 02
MInor changes in error messages.