### PR TITLE
Adds benchmark updating a document with a new SourceText.

### DIFF
--- a/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
@@ -24,7 +24,6 @@ namespace IdeCoreBenchmarks
             private Project _hundredProject;
             private Project _thousandsProject;
 
-
             public IterateDocuments()
             {
                 // These fields are initialized in GlobalSetup

--- a/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ProjectOperationBenchmarks.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.CodeAnalysis;
@@ -13,6 +14,8 @@ namespace IdeCoreBenchmarks
 {
     public class ProjectOperationBenchmarks
     {
+        private static readonly SourceText s_newText = SourceText.From("text");
+
         [MemoryDiagnoser]
         public class IterateDocuments
         {
@@ -20,6 +23,7 @@ namespace IdeCoreBenchmarks
             private Project _emptyProject;
             private Project _hundredProject;
             private Project _thousandsProject;
+
 
             public IterateDocuments()
             {
@@ -96,6 +100,17 @@ namespace IdeCoreBenchmarks
                 }
 
                 return count;
+            }
+
+            [Benchmark(Description = "Solution.WithDocumentText")]
+            public void WithDocumentText()
+            {
+                var solution = Project.Solution;
+                var documentId = Project.DocumentIds.FirstOrDefault();
+                if (documentId != null)
+                {
+                    var _ = solution.WithDocumentText(documentId, s_newText);
+                }
             }
         }
     }


### PR DESCRIPTION
Baseline:
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen Threadripper 3960X, 1 CPU, 48 logical and 24 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT

|                    Method | DocumentCount |            Mean |         Error |        StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------- |-------------- |----------------:|--------------:|--------------:|-------:|-------:|------:|----------:|
| Solution.WithDocumentText |             0 |        17.09 ns |      0.158 ns |      0.140 ns |      - |      - |     - |         - |
| Solution.WithDocumentText |           100 |    12,661.10 ns |    252.509 ns |    319.343 ns | 0.8240 | 0.2594 |     - |    5172 B |
| Solution.WithDocumentText |         10000 |    13,574.50 ns |    270.030 ns |    500.518 ns | 0.8545 | 0.2289 |     - |    5425 B |
```