### PR TITLE
Fix redundant remark part in MetadataReference.CreateFromStream overload

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReference.cs
@@ -146,7 +146,6 @@ namespace Microsoft.CodeAnalysis
         /// deterministically use <see cref="AssemblyMetadata.CreateFromStream(Stream, PEStreamOptions)"/> 
         /// to create an <see cref="IDisposable"/> metadata object and 
         /// <see cref="AssemblyMetadata.GetReference(DocumentationProvider, ImmutableArray{string}, bool, string, string)"/> to get a reference to it.
-        /// to get a reference to it.
         /// </para>
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="peImage"/> is null.</exception>


### PR DESCRIPTION
Hi, this is my first pull-request in a opensource-repo, if i may have done something wrong i would like to know :-).