### PR TITLE
Workaround loghub using the default trace listener

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -157,6 +157,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             var configuration = await TraceConfiguration.CreateTraceConfigurationInstanceAsync(service, cancellationToken).ConfigureAwait(false);
             var traceSource = await configuration.RegisterLogSourceAsync(logId, new LogHub.LoggerOptions(), cancellationToken).ConfigureAwait(false);
 
+            // Workaround: Loghub gives us a trace source with the default listener which logs to the debug output window.
+            // This causes a huge amount of spam to the debug output window, so we remove it here.
+            traceSource.Listeners.Remove("Default");
+
             traceSource.Switch.Level = SourceLevels.ActivityTracing | SourceLevels.Information;
 
             // Associate this trace source with the jsonrpc conduit.  This ensures that we can associate logs we report


### PR DESCRIPTION
Loghub includes the default trace listener in the trace sources it gives us, which causes logging to the debug output window.  This causes a huge amount of spam to the output window since LSP is chatty. 

Just keeping this as a draft for now.  This should be a fix done on the loghub side as we're not the only ones spamming the output window (just this change will not fix the entire issue).

