### PR TITLE
Add IMethodSymbol.IsPartialDefinition

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
@@ -297,6 +297,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             }
         }
 
+        bool IMethodSymbol.IsPartialDefinition => _underlying.IsPartialDefinition();
+
         INamedTypeSymbol IMethodSymbol.AssociatedAnonymousDelegate
         {
             get

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
@@ -2386,5 +2386,134 @@ class C
             var method = compilation.GetMember<MethodSymbol>("C.M");
             Assert.True(method.IsConditional);
         }
+
+        [Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")]
+        public void IsPartialDefinitionOnNonPartial()
+        {
+            var source = @"
+class C
+{
+    void M() {}
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var m = comp.GetMember<MethodSymbol>("C.M").GetPublicSymbol();
+            Assert.False(m.IsPartialDefinition);
+        }
+
+        [Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")]
+        public void IsPartialDefinitionOnPartialDefinitionOnly()
+        {
+            var source = @"
+partial class C
+{
+    partial void M();
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var m = comp.GetMember<MethodSymbol>("C.M").GetPublicSymbol();
+            Assert.True(m.IsPartialDefinition);
+            Assert.Null(m.PartialDefinitionPart);
+            Assert.Null(m.PartialImplementationPart);
+        }
+
+        [Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")]
+        public void IsPartialDefinitionWithPartialImplementation()
+        {
+            var source = @"
+partial class C
+{
+    partial void M();
+    partial void M() {}
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var m = comp.GetMember<MethodSymbol>("C.M").GetPublicSymbol();
+            Assert.True(m.IsPartialDefinition);
+            Assert.Null(m.PartialDefinitionPart);
+            Assert.False(m.PartialImplementationPart.IsPartialDefinition);
+        }
+
+        [Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")]
+        public void IsPartialDefinitionOnPartialImplementation_NonPartialClass()
+        {
+            var source = @"
+class C
+{
+    partial void M();
+    partial void M() {}
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,18): error CS0751: A partial method must be declared within a partial type
+                //     partial void M();
+                Diagnostic(ErrorCode.ERR_PartialMethodOnlyInPartialClass, "M").WithLocation(4, 18),
+                // (5,18): error CS0751: A partial method must be declared within a partial type
+                //     partial void M() {}
+                Diagnostic(ErrorCode.ERR_PartialMethodOnlyInPartialClass, "M").WithLocation(5, 18)
+            );
+            var m = comp.GetMember<MethodSymbol>("C.M").GetPublicSymbol();
+            Assert.True(m.IsPartialDefinition);
+            Assert.Null(m.PartialDefinitionPart);
+            Assert.False(m.PartialImplementationPart.IsPartialDefinition);
+        }
+
+        [Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")]
+        public void IsPartialDefinitionOnPartialImplementationOnly()
+        {
+            var source = @"
+partial class C
+{
+    partial void M() {}
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,18): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M()'
+                //     partial void M() {}
+                Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments("C.M()").WithLocation(4, 18)
+            );
+            var m = comp.GetMember<MethodSymbol>("C.M").GetPublicSymbol();
+            Assert.False(m.IsPartialDefinition);
+            Assert.Null(m.PartialDefinitionPart);
+            Assert.Null(m.PartialImplementationPart);
+        }
+
+        [Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")]
+        public void IsPartialDefinition_ReturnsFalseFromMetadata()
+        {
+            var source = @"
+public partial class C
+{
+    public partial void M();
+    public partial void M() {}
+}
+";
+
+            CompileAndVerify(source,
+                sourceSymbolValidator: module =>
+                {
+                    var m = module.GlobalNamespace.GetTypeMember("C").GetMethod("M").GetPublicSymbol();
+                    Assert.True(m.IsPartialDefinition);
+                    Assert.Null(m.PartialDefinitionPart);
+                    Assert.False(m.PartialImplementationPart.IsPartialDefinition);
+                },
+                symbolValidator: module =>
+                {
+                    var m = module.GlobalNamespace.GetTypeMember("C").GetMethod("M").GetPublicSymbol();
+                    Assert.False(m.IsPartialDefinition);
+                    Assert.Null(m.PartialDefinitionPart);
+                    Assert.Null(m.PartialImplementationPart);
+                });
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
@@ -2515,5 +2515,36 @@ public partial class C
                     Assert.Null(m.PartialImplementationPart);
                 });
         }
+
+        [Fact]
+        public void IsPartialDefinition_OnPartialExtern()
+        {
+            var source = @"
+public partial class C
+{
+    private partial void M();
+    private extern partial void M();
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var syntax = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(syntax);
+
+            var methods = syntax.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().ToArray();
+
+            var partialDef = model.GetDeclaredSymbol(methods[0]);
+            Assert.True(partialDef.IsPartialDefinition);
+
+            var partialImpl = model.GetDeclaredSymbol(methods[1]);
+            Assert.False(partialImpl.IsPartialDefinition);
+
+            Assert.Same(partialDef.PartialImplementationPart, partialImpl);
+            Assert.Same(partialImpl.PartialDefinitionPart, partialDef);
+
+            Assert.Null(partialDef.PartialDefinitionPart);
+            Assert.Null(partialImpl.PartialImplementationPart);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.CodeAnalysis.GeneratorSyntaxContext
 Microsoft.CodeAnalysis.GeneratorSyntaxContext.GeneratorSyntaxContext() -> void
 Microsoft.CodeAnalysis.GeneratorSyntaxContext.Node.get -> Microsoft.CodeAnalysis.SyntaxNode!
 Microsoft.CodeAnalysis.GeneratorSyntaxContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel!
+Microsoft.CodeAnalysis.IMethodSymbol.IsPartialDefinition.get -> bool
 Microsoft.CodeAnalysis.ISyntaxContextReceiver
 Microsoft.CodeAnalysis.ISyntaxContextReceiver.OnVisitSyntaxNode(Microsoft.CodeAnalysis.GeneratorSyntaxContext context) -> void
 Microsoft.CodeAnalysis.GeneratorInitializationContext.RegisterForPostInitialization(System.Action<Microsoft.CodeAnalysis.GeneratorPostInitializationContext>! callback) -> void

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
@@ -264,6 +264,12 @@ namespace Microsoft.CodeAnalysis
         IMethodSymbol? PartialImplementationPart { get; }
 
         /// <summary>
+        /// Return true if this is a partial method definition without a body. If there
+        /// is an implementing body, it can be retrieved with <see cref="PartialImplementationPart"/>.
+        /// </summary>
+        bool IsPartialDefinition { get; }
+
+        /// <summary>
         /// Platform invoke information, or null if the method isn't a P/Invoke.
         /// </summary>
         DllImportData? GetDllImportData();

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -998,6 +998,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IMethodSymbol_IsPartialDefinition As Boolean Implements IMethodSymbol.IsPartialDefinition
+            Get
+                Return If(TryCast(Me, SourceMemberMethodSymbol)?.IsPartialDefinition, False)
+            End Get
+        End Property
+
         Private ReadOnly Property IMethodSymbol_ReturnsVoid As Boolean Implements IMethodSymbol.ReturnsVoid
             Get
                 Return Me.IsSub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MethodTests.vb
@@ -1732,5 +1732,56 @@ BC32065: Type parameters cannot be specified on this declaration.
 ]]></errors>)
         End Sub
 
+        <Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")>
+        Public Sub IsPartialDefinitionOnNonPartial()
+            Dim source = <![CDATA[
+Public Class C
+    Sub M()
+    End Sub
+End Class
+]]>.Value
+
+            Dim comp = CreateCompilation(source)
+            comp.AssertTheseDiagnostics()
+            Dim m As IMethodSymbol = comp.GetMember(Of MethodSymbol)("C.M")
+            Assert.False(m.IsPartialDefinition)
+        End Sub
+
+        <Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")>
+        Public Sub IsPartialDefinitionOnPartialDefinitionOnly()
+            Dim source = <![CDATA[
+Public Class C
+    Private Partial Sub M()
+    End Sub
+End Class
+]]>.Value
+
+            Dim comp = CreateCompilation(source)
+            comp.AssertTheseDiagnostics()
+            Dim m As IMethodSymbol = comp.GetMember(Of MethodSymbol)("C.M")
+            Assert.True(m.IsPartialDefinition)
+            Assert.Null(m.PartialDefinitionPart)
+            Assert.Null(m.PartialImplementationPart)
+        End Sub
+
+        <Fact, WorkItem(51082, "https://github.com/dotnet/roslyn/issues/51082")>
+        Public Sub IsPartialDefinitionWithPartialImplementation()
+            Dim source = <![CDATA[
+Public Class C
+    Private Partial Sub M()
+    End Sub
+
+    Private Sub M()
+    End Sub
+End Class
+]]>.Value
+
+            Dim comp = CreateCompilation(source)
+            comp.AssertTheseDiagnostics()
+            Dim m As IMethodSymbol = comp.GetMember(Of MethodSymbol)("C.M")
+            Assert.True(m.IsPartialDefinition)
+            Assert.Null(m.PartialDefinitionPart)
+            Assert.False(m.PartialImplementationPart.IsPartialDefinition)
+        End Sub
     End Class
 End Namespace

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -69,6 +69,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public IMethodSymbol PartialImplementationPart => _symbol.PartialImplementationPart;
 
+            public bool IsPartialDefinition => _symbol.IsPartialDefinition;
+
             public ITypeSymbol ReceiverType => _symbol.ReceiverType;
 
             public NullableAnnotation ReceiverNullableAnnotation => _symbol.ReceiverNullableAnnotation;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public abstract ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations { get; }
         public abstract IMethodSymbol PartialDefinitionPart { get; }
         public abstract IMethodSymbol PartialImplementationPart { get; }
+        public abstract bool IsPartialDefinition { get; }
 
         public NullableAnnotation ReceiverNullableAnnotation => ReceiverType.NullableAnnotation;
         public NullableAnnotation ReturnNullableAnnotation => ReturnType.NullableAnnotation;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedMethodSymbol.cs
@@ -100,6 +100,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 // TODO(cyrusn): Construct this.
                 _constructedFrom.PartialImplementationPart;
 
+        public override bool IsPartialDefinition => _constructedFrom.IsPartialDefinition;
+
         protected override CodeGenerationSymbol Clone()
             => new CodeGenerationConstructedMethodSymbol(_constructedFrom, _typeArguments);
     }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationMethodSymbol.cs
@@ -112,5 +112,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public override IMethodSymbol PartialImplementationPart => null;
 
         public override IMethodSymbol PartialDefinitionPart => null;
+
+        public override bool IsPartialDefinition => false;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51082. This adds a new method to IMethodSymbol that returns true if the method is a partial method declaration without a body. This info can be determined from syntax APIs today, but requires users to bifurcate code between C# and VB. We already have the info internally, so this just exposes that API.
