### PR TITLE
Provide structured information in binlog for the compiler server

### DIFF
--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -462,10 +462,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             ErrorMessages = errorMessages;
         }
 
-        /// <summary>
-        /// AnalyzerInconsistency has no body.
-        /// </summary>
-        /// <param name="writer"></param>
         protected override void AddResponseBody(BinaryWriter writer)
         {
             writer.Write(ErrorMessages.Count);
@@ -499,10 +495,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             Reason = reason;
         }
 
-        /// <summary>
-        /// AnalyzerInconsistency has no body.
-        /// </summary>
-        /// <param name="writer"></param>
         protected override void AddResponseBody(BinaryWriter writer)
         {
             WriteLengthPrefixedString(writer, Reason);

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -370,7 +370,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
     ///  Length             UInteger        4
     ///  ReturnCode         Integer         4
     ///  Output             String          Variable
-    ///  ErrorOutput        String          Variable
     /// 
     /// Strings are encoded via a character count prefix as a 
     /// 32-bit integer, followed by an array of characters.
@@ -381,7 +380,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
         public readonly int ReturnCode;
         public readonly bool Utf8Output;
         public readonly string Output;
-        public readonly string ErrorOutput;
 
         public CompletedBuildResponse(int returnCode,
                                       bool utf8output,
@@ -390,11 +388,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             ReturnCode = returnCode;
             Utf8Output = utf8output;
             Output = output ?? string.Empty;
-
-            // This field existed to support writing to Console.Error.  The compiler doesn't ever write to 
-            // this field or Console.Error.  This field is only kept around in order to maintain the existing
-            // protocol semantics.
-            ErrorOutput = string.Empty;
         }
 
         public override ResponseType Type => ResponseType.Completed;
@@ -404,12 +397,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var returnCode = reader.ReadInt32();
             var utf8Output = reader.ReadBoolean();
             var output = ReadLengthPrefixedString(reader);
-            var errorOutput = ReadLengthPrefixedString(reader);
-            if (!string.IsNullOrEmpty(errorOutput))
-            {
-                throw new InvalidOperationException();
-            }
-
             return new CompletedBuildResponse(returnCode, utf8Output, output);
         }
 
@@ -418,7 +405,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             writer.Write(ReturnCode);
             writer.Write(Utf8Output);
             WriteLengthPrefixedString(writer, Output);
-            WriteLengthPrefixedString(writer, ErrorOutput);
         }
     }
 

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         // Same separators as those used by Process.OutputDataReceived to maintain consistency between csc and VBCSCompiler
         private static readonly string[] s_separators = { "\r\n", "\r", "\n" };
 
-        internal override void LogMessages(string output, MessageImportance messageImportance)
+        private protected override void LogCompilerOutput(string output, MessageImportance messageImportance)
         {
             var lines = output.Split(s_separators, StringSplitOptions.RemoveEmptyEntries);
             foreach (string line in lines)

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -628,7 +628,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 case BuildResponse.ResponseType.Completed:
                     var completedResponse = (CompletedBuildResponse)response;
-                    LogMessages(completedResponse.Output, StandardOutputImportanceToUse);
+                    LogCompilerOutput(completedResponse.Output, StandardOutputImportanceToUse);
                     return completedResponse.ReturnCode;
 
                 case BuildResponse.ResponseType.MismatchedVersion:
@@ -667,27 +667,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
         }
 
-        private void LogErrorMultiline(string output)
-        {
-            string[] lines = output.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (string line in lines)
-            {
-                string trimmedMessage = line.Trim();
-                if (trimmedMessage != "")
-                {
-                    Log.LogError(trimmedMessage);
-                }
-            }
-        }
-
         /// <summary>
-        /// Log each of the messages in the given output with the given importance.
-        /// We assume each line is a message to log.
+        /// Log the compiler output to MSBuild. Each language will override this to parse their output and log it
+        /// in the language specific manner. This often involves parsing the raw output and formatting it as 
+        /// individual messages for MSBuild.
         /// </summary>
-        /// <remarks>
-        /// Should be "private protected" visibility once it is introduced into C#.
-        /// </remarks>
-        internal abstract void LogMessages(string output, MessageImportance messageImportance);
+        private protected abstract void LogCompilerOutput(string output, MessageImportance messageImportance);
 
         public string GenerateResponseFileContents()
         {

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     HasToolBeenOverridden ||
                     !BuildServerConnection.IsCompilerServerSupported)
                 {
-                    LogCompilationMessage(logger, CompilationKind.Tool, $"using command line tool by design {pathToTool}");
+                    LogCompilationMessage(logger, CompilationKind.Tool, $"using command line tool by design '{pathToTool}'");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 
@@ -520,7 +520,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 var clientDir = Path.GetDirectoryName(PathToManagedTool);
                 if (clientDir is null || tempDir is null)
                 {
-                    LogCompilationMessage(logger, CompilationKind.Tool, $"using command line tool because we can't find client directory {PathToManagedTool}");
+                    LogCompilationMessage(logger, CompilationKind.Tool, $"using command line tool because we could not find client directory '{PathToManagedTool}'");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 
@@ -634,7 +634,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             if (response is null)
             {
-                LogCompilationMessage(logger, CompilationKind.ToolFallback, "Could not launch server");
+                LogCompilationMessage(logger, CompilationKind.ToolFallback, "could not launch server");
                 return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
             }
 
@@ -652,11 +652,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     return completedResponse.ReturnCode;
 
                 case BuildResponse.ResponseType.MismatchedVersion:
-                    LogCompilationMessage(logger, CompilationKind.FatalError, "server reports different protocol version than build task.");
+                    LogCompilationMessage(logger, CompilationKind.FatalError, "server reports different protocol version than build task");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.IncorrectHash:
-                    LogCompilationMessage(logger, CompilationKind.FatalError, "server reports different hash version than build task.");
+                    LogCompilationMessage(logger, CompilationKind.FatalError, "server reports different hash version than build task");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.Rejected:

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         private enum CompilationKind
         {
             /// <summary>
-            /// Commpilation occured using the command line tool by normal processes, typically because 
-            /// the customer opt'd out of the compiler server
+            /// Commpilation occurred using the command line tool by normal processes, typically because 
+            /// the customer opted out of the compiler server
             /// </summary>
             Tool,
 
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             ToolFallback,
 
             /// <summary>
-            /// Compilation occured in the compiler server process
+            /// Compilation occurred in the compiler server process
             /// </summary>
             Server,
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -629,16 +629,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 case BuildResponse.ResponseType.Completed:
                     var completedResponse = (CompletedBuildResponse)response;
                     LogMessages(completedResponse.Output, StandardOutputImportanceToUse);
-
-                    if (LogStandardErrorAsError)
-                    {
-                        LogErrorMultiline(completedResponse.ErrorOutput);
-                    }
-                    else
-                    {
-                        LogMessages(completedResponse.ErrorOutput, StandardErrorImportanceToUse);
-                    }
-
                     return completedResponse.ReturnCode;
 
                 case BuildResponse.ResponseType.MismatchedVersion:

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -648,7 +648,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 case BuildResponse.ResponseType.Completed:
                     var completedResponse = (CompletedBuildResponse)response;
                     LogCompilerOutput(completedResponse.Output, StandardOutputImportanceToUse);
-                    LogCompilationMessage(logger, CompilationKind.Server, "");
+                    LogCompilationMessage(logger, CompilationKind.Server, "server processed compilation");
                     return completedResponse.ReturnCode;
 
                 case BuildResponse.ResponseType.MismatchedVersion:

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         private static readonly string[] s_separator = { Environment.NewLine };
 
-        internal override void LogMessages(string output, MessageImportance messageImportance)
+        private protected override void LogCompilerOutput(string output, MessageImportance messageImportance)
         {
             var lines = output.Split(s_separator, StringSplitOptions.None);
             foreach (string line in lines)
@@ -614,15 +614,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// This method intercepts the lines to be logged coming from STDOUT from VBC.
-        /// Once we see a standard vb warning or error, then we capture it and grab the next 3
-        /// lines so we can transform the string form the form of FileName.vb(line) to FileName.vb(line,column)
-        /// which will allow us to report the line and column to the IDE, and thus filter the error
-        /// in the duplicate case for multi-targeting, or just squiggle the appropriate token 
-        /// instead of the entire line.
+        /// This method is called by MSBuild when running vbc as a separate process, it does not get called
+        /// for normal VBCSCompiler compilations. 
+        /// 
+        /// The vbc process emits multi-line error messages and this method is called for every line of 
+        /// output one at a time. This method must queue up the messages and re-hydrate them back into the 
+        /// original vbc structure such that we can call <see cref="TaskLoggingHelper.LogMessageFromText(string, MessageImportance)" />
+        /// with the complete error message.
         /// </summary>
-        /// <param name="singleLine">A single line from the STDOUT of the vbc compiler</param>
-        /// <param name="messageImportance">High,Low,Normal</param>
         protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
         {
             // We can return immediately if this was not called by the out of proc compiler

--- a/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
+++ b/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
@@ -100,10 +100,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 if (resolvedPathMvid != loadedAssemblyMvid)
                 {
                     var message = $"analyzer assembly '{resolvedPath}' has MVID '{resolvedPathMvid}' but loaded assembly '{loadedAssembly.FullName}' has MVID '{loadedAssemblyMvid}'";
-                    if (errorMessages is null)
-                    {
-                        errorMessages = new List<string>();
-                    }
+                    errorMessages ??= new List<string>();
                     errorMessages.Add(message);
                 }
             }

--- a/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
+++ b/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                 if (resolvedPathMvid != loadedAssemblyMvid)
                 {
-                    var message = $"Analyzer assembly {resolvedPath} has MVID '{resolvedPathMvid}' but loaded assembly '{loadedAssembly.FullName}' has MVID '{loadedAssemblyMvid}'.";
+                    var message = $"analyzer assembly '{resolvedPath}' has MVID '{resolvedPathMvid}' but loaded assembly '{loadedAssembly.FullName}' has MVID '{loadedAssemblyMvid}'";
                     if (errorMessages is null)
                     {
                         errorMessages = new List<string>();

--- a/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
+++ b/src/Compilers/Server/VBCSCompiler/AnalyzerConsistencyChecker.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Reflection;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.CommandLine;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
 {
@@ -19,16 +21,26 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             string baseDirectory,
             IEnumerable<CommandLineAnalyzerReference> analyzerReferences,
             IAnalyzerAssemblyLoader loader,
-            ICompilerServerLogger? logger = null)
+            ICompilerServerLogger? logger = null) => Check(baseDirectory, analyzerReferences, loader, logger, out var _);
+
+        public static bool Check(
+            string baseDirectory,
+            IEnumerable<CommandLineAnalyzerReference> analyzerReferences,
+            IAnalyzerAssemblyLoader loader,
+            ICompilerServerLogger? logger,
+            [NotNullWhen(false)]
+            out List<string>? errorMessages)
         {
             try
             {
                 logger?.Log("Begin Analyzer Consistency Check");
-                return CheckCore(baseDirectory, analyzerReferences, loader, logger);
+                return CheckCore(baseDirectory, analyzerReferences, loader, logger, out errorMessages);
             }
             catch (Exception e)
             {
                 logger?.LogException(e, "Analyzer Consistency Check");
+                errorMessages = new List<string>();
+                errorMessages.Add(e.Message);
                 return false;
             }
             finally
@@ -41,8 +53,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             string baseDirectory,
             IEnumerable<CommandLineAnalyzerReference> analyzerReferences,
             IAnalyzerAssemblyLoader loader,
-            ICompilerServerLogger? logger)
+            ICompilerServerLogger? logger,
+            [NotNullWhen(false)]
+            out List<string>? errorMessages)
         {
+            errorMessages = null;
             var resolvedPaths = new List<string>();
 
             foreach (var analyzerReference in analyzerReferences)
@@ -84,12 +99,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                 if (resolvedPathMvid != loadedAssemblyMvid)
                 {
-                    logger?.LogError($"Analyzer assembly {resolvedPath} has MVID '{resolvedPathMvid}' but loaded assembly '{loadedAssembly.FullName}' has MVID '{loadedAssemblyMvid}'.");
-                    return false;
+                    var message = $"Analyzer assembly {resolvedPath} has MVID '{resolvedPathMvid}' but loaded assembly '{loadedAssembly.FullName}' has MVID '{loadedAssemblyMvid}'.";
+                    if (errorMessages is null)
+                    {
+                        errorMessages = new List<string>();
+                    }
+                    errorMessages.Add(message);
                 }
             }
 
-            return true;
+            return errorMessages == null;
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/BuildProtocolTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildProtocolTest.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             Assert.Equal(42, read.ReturnCode);
             Assert.False(read.Utf8Output);
             Assert.Equal("a string", read.Output);
-            Assert.Equal("", read.ErrorOutput);
         }
 
         [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.IO;
 using System.IO.Pipes;
@@ -390,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             {
                 var compilerServerHost = new TestableCompilerServerHost(delegate
                 {
-                    return new AnalyzerInconsistencyBuildResponse();
+                    return new AnalyzerInconsistencyBuildResponse(new ReadOnlyCollection<string>(Array.Empty<string>()));
                 });
 
                 using var serverData = await ServerUtil.CreateServer(Logger, compilerServerHost: compilerServerHost).ConfigureAwait(false);


### PR DESCRIPTION
This PR has three commits. The first two are refactoring commits that make it much clearer how error messages are handled in the compiler server. The last commit is the one that has functional changes that provide structured information about the server behavior into the BinLog. 

This last adds structured messages to the binlog about the behavior of the compiler server. These messages will help users, our own developers and automation understand the behavior of the compiler server within a build.

Related to https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/451