### PR TITLE
Do not add 'static' keyword when fully qualifying using alias.

### DIFF
--- a/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
@@ -1487,5 +1487,14 @@ class Class
         Sqrt(1);
     }");
         }
+
+        [WorkItem(51274, "https://github.com/dotnet/roslyn/issues/51274")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        public async Task TestInUsingContext_UsingAlias()
+        {
+            await TestInRegularAndScriptAsync(
+@"using M = [|Math|]",
+@"using M = System.Math");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/FullyQualify/CSharpFullyQualifyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/FullyQualify/CSharpFullyQualifyCodeFixProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -97,11 +95,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FullyQualify
             var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
             // If the name is a type that is part of a using directive, eg. "using Math" then we can go further and
-            // instead of just changing to "using System.Math", we can make it "using static System.Math"
-            // and avoid the CS0138 that would result from the former.
+            // instead of just changing to "using System.Math", we can make it "using static System.Math" and avoid the
+            // CS0138 that would result from the former.  Don't do this for using aliases though as `static` and using
+            // aliases cannot be combined.
             if (resultingSymbolIsType &&
-                node.Parent is UsingDirectiveSyntax usingDirective &&
-                usingDirective.StaticKeyword == default)
+                node.Parent is UsingDirectiveSyntax { Alias: null, StaticKeyword: { RawKind: 0 } } usingDirective)
             {
                 var newUsingDirective = usingDirective
                     .WithStaticKeyword(SyntaxFactory.Token(SyntaxKind.StaticKeyword))


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51274