### PR TITLE
Add support for finding explicit conversion operators that are directly callled

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ExplicitConversionSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ExplicitConversionSymbols.vb
@@ -1,0 +1,305 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.Remote.Testing
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
+    Partial Public Class FindReferencesTests
+#Region "C#"
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionPredefinedType_CSharp(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+
+struct Goo
+{
+    public static explicit operator {|Definition:$$int|}(Goo value) => default;
+
+    static void M()
+    {
+        _ = [|(|]int)new Goo();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionNamedType1_CSharp(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+
+struct Goo
+{
+    public static explicit operator {|Definition:$$Int32|}(Goo value) => default;
+
+    static void M()
+    {
+        _ = [|(|]int)new Goo();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionNamedType2_CSharp(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+
+struct Goo
+{
+    public static explicit operator {|Definition:$$int|}(Goo value) => default;
+
+    static void M()
+    {
+        _ = [|(|]Int32)new Goo();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionQualifiedNamedType1_CSharp(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+
+struct Goo
+{
+    public static explicit operator {|Definition:$$System.Int32|}(Goo value) => default;
+
+    static void M()
+    {
+        _ = [|(|]int)new Goo();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionQualifiedNamedType2_CSharp(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+
+struct Goo
+{
+    public static explicit operator {|Definition:$$int|}(Goo value) => default;
+
+    static void M()
+    {
+        _ = [|(|]System.Int32)new Goo();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionArrayType_CSharp(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+
+struct Goo
+{
+    public static explicit operator {|Definition:$$int[]|}(Goo value) => default;
+
+    static void M()
+    {
+        _ = [|(|]int[])new Goo();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+#End Region
+
+#Region "Visual Basic"
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionPredefinedType_VisualBasic(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+imports system
+
+structure Goo
+    Public Shared Narrowing Operator {|Definition:$$CType|}(value as goo) as integer
+        return nothing
+    end operator
+
+    sub M()
+        dim y = [|ctype|](new Goo(), integer)
+    end sub
+end structure
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionNamedType1_VisualBasic(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+imports system
+
+structure Goo
+    Public Shared Narrowing Operator {|Definition:$$CType|}(value as goo) as int32
+        return nothing
+    end operator
+
+    sub M()
+        dim y = [|ctype|](new Goo(), integer)
+    end sub
+end structure
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionNamedType2_VisualBasic(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+imports system
+
+structure Goo
+    Public Shared Narrowing Operator {|Definition:$$CType|}(value as goo) as integer)
+        return nothing
+    end operator
+
+    sub M()
+        dim y = [|ctype|](new Goo(), int32)
+    end sub
+end structure
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionQualifiedNamedType1_VisualBasic(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+imports system
+
+structure Goo
+    Public Shared Narrowing Operator {|Definition:$$CType|}(value as goo) as system.int32
+        return nothing
+    end operator
+
+    sub M()
+        dim y = [|ctype|](new Goo(), integer)
+    end sub
+end structure
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionQualifiedNamedType2_VisualBasic(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+imports system
+
+structure Goo
+    Public Shared Narrowing Operator {|Definition:$$CType|}(value as goo) as integer
+        return nothing
+    end operator
+
+    sub M()
+        dim y = [|ctype|](new Goo(), system.int32)
+    end sub
+end structure
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(50850, "https://github.com/dotnet/roslyn/issues/50850")>
+        Public Async Function TestExplicitConversionArrayType_VisualBasic(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+imports system
+
+structure Goo
+    Public Shared Narrowing Operator {|Definition:$$CType|}(value as goo) as integer()
+        return nothing
+    end operator
+
+    sub M()
+        dim y = [|ctype|](new Goo(), integer())
+    end sub
+end structure
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+#End Region
+    End Class
+End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.UnderlyingNamedTypeVisitor.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.UnderlyingNamedTypeVisitor.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.FindSymbols.Finders
+{
+    internal partial class ExplicitConversionSymbolReferenceFinder
+    {
+        private class UnderlyingNamedTypeVisitor : SymbolVisitor<INamedTypeSymbol?>
+        {
+            public static readonly UnderlyingNamedTypeVisitor Instance = new UnderlyingNamedTypeVisitor();
+
+            private UnderlyingNamedTypeVisitor()
+            {
+            }
+
+            public override INamedTypeSymbol? VisitArrayType(IArrayTypeSymbol symbol)
+                => Visit(symbol.ElementType);
+
+            public override INamedTypeSymbol? VisitDynamicType(IDynamicTypeSymbol symbol)
+                => null;
+
+            public override INamedTypeSymbol? VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
+                => null;
+
+            public override INamedTypeSymbol? VisitPointerType(IPointerTypeSymbol symbol)
+                => Visit(symbol.PointedAtType);
+
+            public override INamedTypeSymbol? VisitTypeParameter(ITypeParameterSymbol symbol)
+                => null;
+
+            public override INamedTypeSymbol? VisitNamedType(INamedTypeSymbol symbol)
+                => symbol;
+
+            public override INamedTypeSymbol? DefaultVisit(ISymbol symbol)
+            {
+                Debug.Fail($"Symbol case not handled: {symbol.Kind}");
+                return base.DefaultVisit(symbol);
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FindSymbols.Finders
+{
+    internal partial class ExplicitConversionSymbolReferenceFinder : AbstractReferenceFinder<IMethodSymbol>
+    {
+        protected override bool CanFind(IMethodSymbol symbol)
+            => symbol is { MethodKind: MethodKind.Conversion, Name: WellKnownMemberNames.ExplicitConversionName } &&
+               GetUnderlyingNamedType(symbol.ReturnType) is not null;
+
+        private static INamedTypeSymbol? GetUnderlyingNamedType(ITypeSymbol symbol)
+            => UnderlyingNamedTypeVisitor.Instance.Visit(symbol);
+
+        protected override async Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+            IMethodSymbol symbol,
+            Project project,
+            IImmutableSet<Document>? documents,
+            FindReferencesSearchOptions options,
+            CancellationToken cancellationToken)
+        {
+            // Look for documents that both contain an explicit cast in them as well as a reference to the type in the
+            // explicit conversion.  i.e. if we have `public static explicit operator Goo(Bar b);` we want to find files
+            // both with `Goo` `and `(...)` in them as we're looking for cases of `(Goo)...`.
+            //
+            // Note that explicit conversions may be to complex types (like arrays).  For example:
+            //
+            //      public static explicit operator Goo[](Bar b);
+            //
+            // So we need to find the underlying named type `Goo` (if there is one) to find references.
+
+            var underlyingNamedType = GetUnderlyingNamedType(symbol.ReturnType);
+            Contract.ThrowIfNull(underlyingNamedType);
+            var documentsWithName = await FindDocumentsAsync(project, documents, findInGlobalSuppressions: false, cancellationToken, underlyingNamedType.Name).ConfigureAwait(false);
+            var documentsWithType = await FindDocumentsAsync(project, documents, underlyingNamedType.SpecialType.ToPredefinedType(), cancellationToken).ConfigureAwait(false);
+
+            using var _ = ArrayBuilder<Document>.GetInstance(out var result);
+
+            // Ignore any documents that don't also have an explicit cast in them.
+            foreach (var document in documentsWithName.Concat(documentsWithType).Distinct())
+            {
+                var index = await SyntaxTreeIndex.GetIndexAsync(document, cancellationToken).ConfigureAwait(false);
+                if (index.ContainsConversion)
+                    result.Add(document);
+            }
+
+            return result.ToImmutable();
+        }
+
+        protected override ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(
+            IMethodSymbol symbol,
+            Document document,
+            SemanticModel semanticModel,
+            FindReferencesSearchOptions options,
+            CancellationToken cancellationToken)
+        {
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+
+            return FindReferencesInDocumentAsync(
+                symbol, document, semanticModel,
+                t => IsPotentialReference(syntaxFacts, t),
+                cancellationToken);
+        }
+
+        private static bool IsPotentialReference(
+            ISyntaxFactsService syntaxFacts,
+            SyntaxToken token)
+        {
+            var node = token.GetRequiredParent();
+            return node.GetFirstToken() == token && syntaxFacts.IsConversionExpression(node);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ReferenceFinders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ReferenceFinders.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         public static readonly IReferenceFinder Constructor = ConstructorSymbolReferenceFinder.Instance;
         public static readonly IReferenceFinder ConstructorInitializer = new ConstructorInitializerSymbolReferenceFinder();
         public static readonly IReferenceFinder Destructor = new DestructorSymbolReferenceFinder();
+        public static readonly IReferenceFinder ExplicitConversion = new ExplicitConversionSymbolReferenceFinder();
         public static readonly IReferenceFinder ExplicitInterfaceMethod = new ExplicitInterfaceMethodReferenceFinder();
         public static readonly IReferenceFinder Event = new EventSymbolReferenceFinder();
         public static readonly IReferenceFinder Field = new FieldSymbolReferenceFinder();
@@ -42,6 +43,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 Constructor,
                 Destructor,
                 Event,
+                ExplicitConversion,
                 ExplicitInterfaceMethod,
                 Field,
                 Label,

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Roslyn.Utilities;
@@ -33,7 +31,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsAwait,
                 bool containsTupleExpressionOrTupleType,
                 bool containsImplicitObjectCreation,
-                bool containsGlobalAttributes)
+                bool containsGlobalAttributes,
+                bool containsConversion)
                 : this(predefinedTypes, predefinedOperators,
                        ConvertToContainingNodeFlag(
                          containsForEachStatement,
@@ -48,7 +47,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                          containsAwait,
                          containsTupleExpressionOrTupleType,
                          containsImplicitObjectCreation,
-                         containsGlobalAttributes))
+                         containsGlobalAttributes,
+                         containsConversion))
             {
             }
 
@@ -72,7 +72,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsAwait,
                 bool containsTupleExpressionOrTupleType,
                 bool containsImplicitObjectCreation,
-                bool containsGlobalAttributes)
+                bool containsGlobalAttributes,
+                bool containsConversion)
             {
                 var containingNodes = ContainingNodes.None;
 
@@ -89,6 +90,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 containingNodes |= containsTupleExpressionOrTupleType ? ContainingNodes.ContainsTupleExpressionOrTupleType : 0;
                 containingNodes |= containsImplicitObjectCreation ? ContainingNodes.ContainsImplicitObjectCreation : 0;
                 containingNodes |= containsGlobalAttributes ? ContainingNodes.ContainsGlobalAttributes : 0;
+                containingNodes |= containsConversion ? ContainingNodes.ContainsConversion : 0;
 
                 return containingNodes;
             }
@@ -138,6 +140,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             public bool ContainsGlobalAttributes
                 => (_containingNodes & ContainingNodes.ContainsGlobalAttributes) == ContainingNodes.ContainsGlobalAttributes;
 
+            public bool ContainsConversion
+                => (_containingNodes & ContainingNodes.ContainsConversion) == ContainingNodes.ContainsConversion;
+
             public void WriteTo(ObjectWriter writer)
             {
                 writer.WriteInt32(_predefinedTypes);
@@ -179,6 +184,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ContainsTupleExpressionOrTupleType = 1 << 10,
                 ContainsImplicitObjectCreation = 1 << 11,
                 ContainsGlobalAttributes = 1 << 12,
+                ContainsConversion = 1 << 13,
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -91,6 +91,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var containsTupleExpressionOrTupleType = false;
                 var containsImplicitObjectCreation = false;
                 var containsGlobalAttributes = false;
+                var containsConversion = false;
 
                 var predefinedTypes = (int)PredefinedType.None;
                 var predefinedOperators = (int)PredefinedOperator.None;
@@ -121,6 +122,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                                 syntaxFacts.IsTupleExpression(node) || syntaxFacts.IsTupleType(node);
                             containsImplicitObjectCreation = containsImplicitObjectCreation || syntaxFacts.IsImplicitObjectCreationExpression(node);
                             containsGlobalAttributes = containsGlobalAttributes || syntaxFacts.IsGlobalAttribute(node);
+                            containsConversion = containsConversion || syntaxFacts.IsConversionExpression(node);
 
                             if (syntaxFacts.IsUsingAliasDirective(node) && infoFactory.TryGetAliasesFromUsingDirective(node, out var aliases))
                             {
@@ -269,7 +271,8 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                             containsAwait,
                             containsTupleExpressionOrTupleType,
                             containsImplicitObjectCreation,
-                            containsGlobalAttributes),
+                            containsGlobalAttributes,
+                            containsConversion),
                     new DeclarationInfo(
                             declaredSymbolInfos.ToImmutable()),
                     new ExtensionMethodInfo(

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -41,6 +39,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public bool ContainsIndexerMemberCref => _contextInfo.ContainsIndexerMemberCref;
         public bool ContainsTupleExpressionOrTupleType => _contextInfo.ContainsTupleExpressionOrTupleType;
         public bool ContainsGlobalAttributes => _contextInfo.ContainsGlobalAttributes;
+        public bool ContainsConversion => _contextInfo.ContainsConversion;
 
         /// <summary>
         /// Same as <see cref="DeclaredSymbolInfos"/>, just stored as a set for easy containment checks.

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class SyntaxTreeIndex : IObjectWritable
     {
         private const string PersistenceName = "<SyntaxTreeIndex>";
-        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("21");
+        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("22");
 
         public readonly Checksum Checksum;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
@@ -58,13 +58,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var ancestor in token.GetAncestors<SyntaxNode>())
             {
                 var symbol = semanticModel.GetDeclaredSymbol(ancestor, cancellationToken);
-
                 if (symbol != null)
                 {
-                    if (symbol.Locations.Contains(location))
-                    {
+                    // The token may be part of a larger name (for example, `int` in `public static operator int[](Goo g);`.
+                    // So check if the symbol's location encompasses the span of the token we're asking about.
+                    if (symbol.Locations.Any(loc => loc.SourceTree == location.SourceTree && loc.SourceSpan.Contains(location.SourceSpan)))
                         return symbol;
-                    }
 
                     // We found some symbol, but it defined something else. We're not going to have a higher node defining _another_ symbol with this token, so we can stop now.
                     return null;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1726,6 +1726,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
                 return ImmutableArray<SyntaxNode>.Empty;
         }
 
+        public bool IsConversionExpression([NotNullWhen(true)] SyntaxNode? node)
+            => node is CastExpressionSyntax;
+
         public bool IsCastExpression([NotNullWhen(true)] SyntaxNode? node)
             => node is CastExpressionSyntax;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/IMethodSymbolExtensions.cs
@@ -46,61 +46,32 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static PredefinedOperator GetPredefinedOperator(this IMethodSymbol symbol)
-        {
-            switch (symbol.Name)
+            => symbol.Name switch
             {
-                case "op_Addition":
-                case "op_UnaryPlus":
-                    return PredefinedOperator.Addition;
-                case "op_BitwiseAnd":
-                    return PredefinedOperator.BitwiseAnd;
-                case "op_BitwiseOr":
-                    return PredefinedOperator.BitwiseOr;
-                case "op_Concatenate":
-                    return PredefinedOperator.Concatenate;
-                case "op_Decrement":
-                    return PredefinedOperator.Decrement;
-                case "op_Division":
-                    return PredefinedOperator.Division;
-                case "op_Equality":
-                    return PredefinedOperator.Equality;
-                case "op_ExclusiveOr":
-                    return PredefinedOperator.ExclusiveOr;
-                case "op_Exponent":
-                    return PredefinedOperator.Exponent;
-                case "op_GreaterThan":
-                    return PredefinedOperator.GreaterThan;
-                case "op_GreaterThanOrEqual":
-                    return PredefinedOperator.GreaterThanOrEqual;
-                case "op_Increment":
-                    return PredefinedOperator.Increment;
-                case "op_Inequality":
-                    return PredefinedOperator.Inequality;
-                case "op_IntegerDivision":
-                    return PredefinedOperator.IntegerDivision;
-                case "op_LeftShift":
-                    return PredefinedOperator.LeftShift;
-                case "op_LessThan":
-                    return PredefinedOperator.LessThan;
-                case "op_LessThanOrEqual":
-                    return PredefinedOperator.LessThanOrEqual;
-                case "op_Like":
-                    return PredefinedOperator.Like;
-                case "op_LogicalNot":
-                case "op_OnesComplement":
-                    return PredefinedOperator.Complement;
-                case "op_Modulus":
-                    return PredefinedOperator.Modulus;
-                case "op_Multiply":
-                    return PredefinedOperator.Multiplication;
-                case "op_RightShift":
-                    return PredefinedOperator.RightShift;
-                case "op_Subtraction":
-                case "op_UnaryNegation":
-                    return PredefinedOperator.Subtraction;
-                default:
-                    return PredefinedOperator.None;
-            }
-        }
+                "op_Addition" or "op_UnaryPlus" => PredefinedOperator.Addition,
+                "op_BitwiseAnd" => PredefinedOperator.BitwiseAnd,
+                "op_BitwiseOr" => PredefinedOperator.BitwiseOr,
+                "op_Concatenate" => PredefinedOperator.Concatenate,
+                "op_Decrement" => PredefinedOperator.Decrement,
+                "op_Division" => PredefinedOperator.Division,
+                "op_Equality" => PredefinedOperator.Equality,
+                "op_ExclusiveOr" => PredefinedOperator.ExclusiveOr,
+                "op_Exponent" => PredefinedOperator.Exponent,
+                "op_GreaterThan" => PredefinedOperator.GreaterThan,
+                "op_GreaterThanOrEqual" => PredefinedOperator.GreaterThanOrEqual,
+                "op_Increment" => PredefinedOperator.Increment,
+                "op_Inequality" => PredefinedOperator.Inequality,
+                "op_IntegerDivision" => PredefinedOperator.IntegerDivision,
+                "op_LeftShift" => PredefinedOperator.LeftShift,
+                "op_LessThan" => PredefinedOperator.LessThan,
+                "op_LessThanOrEqual" => PredefinedOperator.LessThanOrEqual,
+                "op_Like" => PredefinedOperator.Like,
+                "op_LogicalNot" or "op_OnesComplement" => PredefinedOperator.Complement,
+                "op_Modulus" => PredefinedOperator.Modulus,
+                "op_Multiply" => PredefinedOperator.Multiplication,
+                "op_RightShift" => PredefinedOperator.RightShift,
+                "op_Subtraction" or "op_UnaryNegation" => PredefinedOperator.Subtraction,
+                _ => PredefinedOperator.None,
+            };
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -130,6 +130,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         void GetPartsOfConditionalExpression(SyntaxNode node, out SyntaxNode condition, out SyntaxNode whenTrue, out SyntaxNode whenFalse);
 
+        bool IsConversionExpression([NotNullWhen(true)] SyntaxNode? node);
         bool IsCastExpression([NotNullWhen(true)] SyntaxNode? node);
         void GetPartsOfCastExpression(SyntaxNode node, out SyntaxNode type, out SyntaxNode expression);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1857,6 +1857,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return MyBase.GetNodeWithoutLeadingBlankLines(node)
         End Function
 
+        Public Function IsConversionExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsConversionExpression
+            Return node.Kind = SyntaxKind.CTypeExpression
+        End Function
+
         Public Function IsCastExpression(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsCastExpression
             Return node.Kind = SyntaxKind.DirectCastExpression
         End Function


### PR DESCRIPTION
Improves experience somewhat for https://github.com/dotnet/roslyn/issues/50850