### PR TITLE
Revert ToggleCompletionMode command name to its canonical name

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,10 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCorePublic-Pool
-    queue: $(queueName)
+    queue: BuildPool.Windows.VS2019.Pre.Scouting.Open
+# One this integration test fix has flowed in to master-vs-deps, we can update the queueName variable, and revert this change.
+# Tracked by https://github.com/dotnet/roslyn/issues/51312
+#    queue: $(queueName)
   strategy:
     maxParallel: 4
     matrix:

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
@@ -17,9 +17,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public const string Edit_ListMembers = "Edit.ListMembers";
         public const string Edit_ParameterInfo = "Edit.ParameterInfo";
         public const string Edit_QuickInfo = "Edit.QuickInfo";
-        // This will need to be reverted when we move to 16.8p3. DevDiv bug:
-        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1193302
-        public const string Edit_ToggleCompletionMode = "Edit.ToggleIntelliSensesuggestioncompletionmode";
+        public const string Edit_ToggleCompletionMode = "Edit.ToggleCompletionMode";
         public const string Edit_Undo = "Edit.Undo";
         public const string Edit_Redo = "Edit.Redo";
         public const string Edit_SelectionCancel = "Edit.SelectionCancel";


### PR DESCRIPTION
[Integration tests are failing in the scouting queue](https://dev.azure.com/dnceng/public/_build/results?buildId=1000536&view=ms.vss-test-web.build-test-results-tab&runId=31286510&resultId=100397&paneView=debug).

In 16.9 Preview 4 the platform has fixed the ToggleCompletionMode command name and we are now failing with this error.
```
System.AggregateException : One or more errors occurred.
---- System.Runtime.InteropServices.COMException : Command "Edit.ToggleIntelliSensesuggestioncompletionmode" is not valid.
```

This PR reverts the WellKnowCommandName back to the canonical name and hardcodes the integration queue to the scouting queue. 

Once this change had flowed into master-vs-deps we can update our pipeline's `queueName` variable and undo the hardcoding. This is tracked in https://github.com/dotnet/roslyn/issues/51312

cc: @RikkiGibson 