### PR TITLE
Remove dependency on internal VS utility apis.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
@@ -17,7 +17,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.BraceCompletion;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
-using Microsoft.VisualStudio.Utilities.Internal;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/AddParameterDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/AddParameterDialogViewModel.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
-using Microsoft.VisualStudio.Utilities.Internal;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
@@ -141,13 +140,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 return false;
             }
 
-            if (IsCallsiteRegularValue && CallSiteValue.IsNullOrWhiteSpace())
+            if (IsCallsiteRegularValue && string.IsNullOrWhiteSpace(CallSiteValue))
             {
                 message = ServicesVSResources.Enter_a_call_site_value_or_choose_a_different_value_injection_kind;
                 return false;
             }
 
-            if (IsOptional && DefaultValue.IsNullOrWhiteSpace())
+            if (IsOptional && string.IsNullOrWhiteSpace(DefaultValue))
             {
                 message = ServicesVSResources.Optional_parameters_must_provide_a_default_value;
                 return false;
@@ -177,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         {
             VerbatimTypeName = typeName;
 
-            if (typeName.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(typeName))
             {
                 TypeIsEmptyImage = Visibility.Visible;
                 TypeDoesNotParseImage = Visibility.Collapsed;

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.Utilities.Internal;
 using Roslyn.Utilities;
 using StreamJsonRpc;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -558,7 +557,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 {
                     // There were diagnostics from other documents, but none from the current document.
                     // If we're tracking the current document, we can stop.
-                    _publishedFileToDiagnostics.GetOrDefault(fileUri)?.Remove(document.Id);
+                    ((IReadOnlyDictionary<Uri, Dictionary<DocumentId, ImmutableArray<LanguageServer.Protocol.Diagnostic>>>)_publishedFileToDiagnostics).GetValueOrDefault(fileUri)?.Remove(document.Id);
                     _documentsToPublishedUris.MultiRemove(document.Id, fileUri);
                 }
             }
@@ -645,7 +644,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         // In this case, unless we have a null client name, we don't want to publish the diagnostic
         // (since a null client name represents the C#/VB language server).
         private bool IncludeDiagnostic(DiagnosticData diagnostic) =>
-            diagnostic.Properties.GetOrDefault(nameof(DocumentPropertiesService.DiagnosticsLspClientName)) == _clientName;
+            ((IReadOnlyDictionary<string, string?>)diagnostic.Properties).GetValueOrDefault(nameof(DocumentPropertiesService.DiagnosticsLspClientName)) == _clientName;
 
         private static LSP.Range GetDiagnosticRange(DiagnosticDataLocation diagnosticDataLocation, SourceText text)
         {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -557,8 +557,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 {
                     // There were diagnostics from other documents, but none from the current document.
                     // If we're tracking the current document, we can stop.
-                    ((IReadOnlyDictionary<Uri, Dictionary<DocumentId, ImmutableArray<LanguageServer.Protocol.Diagnostic>>>)_publishedFileToDiagnostics).GetValueOrDefault(fileUri)?.Remove(document.Id);
-                    _documentsToPublishedUris.MultiRemove(document.Id, fileUri);
+                    IReadOnlyDictionaryExtensions.GetValueOrDefault(_publishedFileToDiagnostics, fileUri)?.Remove(document.Id);
                 }
             }
         }
@@ -643,8 +642,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         // if we were working with a non-C#/VB file, then the property should have been populated.
         // In this case, unless we have a null client name, we don't want to publish the diagnostic
         // (since a null client name represents the C#/VB language server).
-        private bool IncludeDiagnostic(DiagnosticData diagnostic) =>
-            ((IReadOnlyDictionary<string, string?>)diagnostic.Properties).GetValueOrDefault(nameof(DocumentPropertiesService.DiagnosticsLspClientName)) == _clientName;
+        private bool IncludeDiagnostic(DiagnosticData diagnostic)
+            => IReadOnlyDictionaryExtensions.GetValueOrDefault(diagnostic.Properties, nameof(DocumentPropertiesService.DiagnosticsLspClientName)) == _clientName;
 
         private static LSP.Range GetDiagnosticRange(DiagnosticDataLocation diagnosticDataLocation, SourceText text)
         {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -558,6 +558,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                     // There were diagnostics from other documents, but none from the current document.
                     // If we're tracking the current document, we can stop.
                     IReadOnlyDictionaryExtensions.GetValueOrDefault(_publishedFileToDiagnostics, fileUri)?.Remove(document.Id);
+                    _documentsToPublishedUris.MultiRemove(document.Id, fileUri);
                 }
             }
         }


### PR DESCRIPTION
These appear to all have been added accidentally.  The APIs are also removed in later VS package releases.  