### PR TITLE
Optimize option lookup allocations

### DIFF
--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigDocumentOptionsProviderFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigDocumentOptionsProviderFactory.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Options.EditorConfig
 
                 public bool TryGetDocumentOption(OptionKey option, out object? value)
                 {
-                    var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
+                    var editorConfigPersistence = (IEditorConfigStorageLocation?)option.Option.StorageLocations.SingleOrDefault(static location => location is IEditorConfigStorageLocation);
                     if (editorConfigPersistence == null)
                     {
                         value = null;

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -20,55 +20,62 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         private ImmutableDictionary<string, AnalyzerConfigOptions> _lazyAnalyzerConfigOptions = s_emptyAnalyzerConfigOptions;
 
+        private readonly Func<OptionKey, object?> _getOptionCore;
+
+        public OptionSet()
+        {
+            _getOptionCore = GetOptionCore;
+        }
+
         private protected abstract object? GetOptionCore(OptionKey optionKey);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         public object? GetOption(OptionKey optionKey)
-            => OptionsHelpers.GetPublicOption(optionKey, GetOptionCore);
+            => OptionsHelpers.GetPublicOption(optionKey, _getOptionCore);
 
         /// <summary>
         /// Gets the value of the option cast to type <typeparamref name="T"/>, or the default value if not otherwise set.
         /// </summary>
         public T GetOption<T>(OptionKey optionKey)
-            => OptionsHelpers.GetOption<T>(optionKey, GetOptionCore);
+            => OptionsHelpers.GetOption<T>(optionKey, _getOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         internal object? GetOption(OptionKey2 optionKey)
-            => OptionsHelpers.GetOption<object?>(optionKey, GetOptionCore);
+            => OptionsHelpers.GetOption<object?>(optionKey, _getOptionCore);
 
         /// <summary>
         /// Gets the value of the option cast to type <typeparamref name="T"/>, or the default value if not otherwise set.
         /// </summary>
         internal T GetOption<T>(OptionKey2 optionKey)
-            => OptionsHelpers.GetOption<T>(optionKey, GetOptionCore);
+            => OptionsHelpers.GetOption<T>(optionKey, _getOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         public T GetOption<T>(Option<T> option)
-            => OptionsHelpers.GetOption(option, GetOptionCore);
+            => OptionsHelpers.GetOption(option, _getOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         internal T GetOption<T>(Option2<T> option)
-            => OptionsHelpers.GetOption(option, GetOptionCore);
+            => OptionsHelpers.GetOption(option, _getOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         public T GetOption<T>(PerLanguageOption<T> option, string? language)
-            => OptionsHelpers.GetOption(option, language, GetOptionCore);
+            => OptionsHelpers.GetOption(option, language, _getOptionCore);
 
         /// <summary>
         /// Gets the value of the option, or the default value if not otherwise set.
         /// </summary>
         internal T GetOption<T>(PerLanguageOption2<T> option, string? language)
-            => OptionsHelpers.GetOption(option, language, GetOptionCore);
+            => OptionsHelpers.GetOption(option, language, _getOptionCore);
 
         /// <summary>
         /// Creates a new <see cref="OptionSet" /> that contains the changed value.


### PR DESCRIPTION
Reduces allocations in FormattingAnalyzer by 775MB (7.6%) on Roslyn.sln.