### PR TITLE
Optimize InsertRange for segmented collections

### DIFF
--- a/src/Dependencies/Collections/SegmentedArray.cs
+++ b/src/Dependencies/Collections/SegmentedArray.cs
@@ -333,10 +333,10 @@ namespace Microsoft.CodeAnalysis.Collections
 #pragma warning disable IDE0051 // Remove unused private members (will be used in follow-up)
         private static AlignedSegmentEnumerable<T> GetSegmentsAligned<T>(SegmentedArray<T> first, int firstOffset, SegmentedArray<T> second, int secondOffset, int length)
             => new(first, firstOffset, second, secondOffset, length);
+#pragma warning restore IDE0051 // Remove unused private members
 
         private static UnalignedSegmentEnumerable<T> GetSegmentsUnaligned<T>(SegmentedArray<T> first, int firstOffset, SegmentedArray<T> second, int secondOffset, int length)
             => new(first, firstOffset, second, secondOffset, length);
-#pragma warning restore IDE0051 // Remove unused private members
 
         private readonly struct AlignedSegmentEnumerable<T>
         {
@@ -498,7 +498,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 var secondSegment = _secondSegments[initialSecondSegment];
                 var remainingInFirstSegment = firstSegment.Length - firstOffset;
                 var remainingInSecondSegment = secondSegment.Length - secondOffset;
-                var currentSegmentLength = Math.Min(Math.Min(remainingInFirstSegment, remainingInSecondSegment), _length);
+                var currentSegmentLength = Math.Min(Math.Min(remainingInFirstSegment, remainingInSecondSegment), _length - _completed);
                 _current = (firstSegment.AsMemory().Slice(firstOffset, currentSegmentLength), secondSegment.AsMemory().Slice(secondOffset, currentSegmentLength));
                 _completed += currentSegmentLength;
                 return true;

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -751,6 +751,14 @@ namespace Microsoft.CodeAnalysis.Collections
                         // Copy last part of _items back to inserted location
                         SegmentedArray.Copy(_items, index + count, _items, index * 2, _size - index);
                     }
+                    else if (c is SegmentedList<T> list)
+                    {
+                        SegmentedArray.Copy(list._items, 0, _items, index, list.Count);
+                    }
+                    else if (c is SegmentedArray<T> array)
+                    {
+                        SegmentedArray.Copy(array, 0, _items, index, array.Length);
+                    }
                     else
                     {
                         var targetIndex = index;


### PR DESCRIPTION
* Avoid enumerator boxing allocations when attempting to insert a segmented collection into another (includes the `AddRange` case).
* Fix a failure to account for the `_completed` count in `UnalignedSegmentEnumerator`.