### PR TITLE
Rebuild csc

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,10 @@
       // If you have changed target frameworks, make sure to update the program path.
       "program": "${workspaceFolder}/artifacts/bin/BuildValidator/Debug/netcoreapp3.1/BuildValidator.dll",
       "args": [
-        "--assembliesPath", "./artifacts/obj/csc/Debug/net472",
-        "--referencesPaths", "./artifacts/bin",
+        "--assembliesPath", "./artifacts/obj/csc/Debug/netcoreapp3.1",
+        "--referencesPath", "./artifacts/bin",
+        "--referencesPath", "C:/Program Files/dotnet/packs/Microsoft.AspNetCore.App.Ref",
+        "--referencesPath", "C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref",
         "--debugPath", "./artifacts/BuildValidator",
         "--sourcePath", "."
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       // If you have changed target frameworks, make sure to update the program path.
       "program": "${workspaceFolder}/artifacts/bin/BuildValidator/Debug/netcoreapp3.1/BuildValidator.dll",
       "args": [
-        "--assembliesPath", "./artifacts/obj/RunTests",
+        "--assembliesPath", "./artifacts/obj/csc/Debug/net472",
+        "--referencesPaths", "./artifacts/bin",
         "--debugPath", "./artifacts/BuildValidator",
         "--sourcePath", "."
       ],

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,12 +227,6 @@ jobs:
         filePath: eng/build.ps1
         arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
 
-    - task: PowerShell@2 
-      displayName: Build
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -configuration Debug -prepareMachine -ci -build -bootstrap -publish -binaryLog -skipDocumentation
-
     - powershell: .\eng\test-rebuild.ps1
       displayName: Run BuildValidator
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,7 +227,7 @@ jobs:
         filePath: eng/build.ps1
         arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
 
-    - powershell: .\eng\test-rebuild.ps1
+    - powershell: .\eng\test-rebuild.ps1 -ci
       displayName: Run BuildValidator
 
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,7 +215,8 @@ jobs:
 
 - job: Correctness_Rebuild
   pool:
-    vmImage: windows-2019
+    name: NetCorePublic-Pool
+    queue: BuildPool.Windows.10.Amd64.Open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -232,7 +232,7 @@ jobs:
         filePath: eng/build.ps1
         arguments: -configuration Debug -prepareMachine -ci -build -bootstrap -publish -binaryLog -skipDocumentation
 
-    - script: .\artifacts\bin\BuildValidator\Debug\net472\BuildValidator.exe --assembliesPath .\artifacts\obj\Microsoft.CodeAnalysis --debugPath .\artifacts\BuildValidator --sourcePath .
+    - powershell: .\eng\test-rebuild.ps1
       displayName: Run BuildValidator
 
     - task: PublishBuildArtifacts@1

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,9 +90,8 @@
     <MicrosoftDiaSymReaderNativeVersion>16.9.0-beta1.21055.5</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.5.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftDotNetVersionToolsVersion>3.0.0-preview1-03617-02</MicrosoftDotNetVersionToolsVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingVersion>5.0.0</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>5.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.13.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>15.8.27812-alpha</MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -333,7 +333,7 @@ function Make-BootstrapBuild([switch]$force32 = $false) {
 
   Run-MSBuild $projectPath "/restore /t:Pack /p:RoslynEnforceCodeStyle=false /p:RunAnalyzersDuringBuild=false /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:EnableNgenOptimization=false /p:PublishWindowsPdb=false $force32Flag" -logFileName "Bootstrap" -configuration $bootstrapConfiguration -runAnalyzers
   $packageFile = Get-ChildItem -Path $dir -Filter "$packageName.*.nupkg"
-  Unzip (Join-Path $dir $packageFile) $dir
+  Unzip (Join-Path $dir $packageFile.Name) $dir
 
   Write-Host "Cleaning Bootstrap compiler artifacts"
   Run-MSBuild $projectPath "/t:Clean" -logFileName "BootstrapClean"

--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -34,12 +34,15 @@ try {
     Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -build -bootstrap -ci:$ci -configuration:$configuration -pack -binaryLog }
   }
 
+  $dotnetInstallDir = (InitializeDotNetCli -install:$true)
   $rebuildArgs = ("--verbose" +
-  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis/$configuration/netcoreapp3.1`"" +
+  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis/$configuration`"" +
   " --assembliesPath $ArtifactsDir/obj/csc/$configuration/netcoreapp3.1" +
-  " --debugPath `"$ArtifactsDir\BuildValidator`"" +
+  " --debugPath `"$ArtifactsDir/BuildValidator`"" +
   " --sourcePath `"$RepoRoot`"" +
-  " --referencesPaths `"$ArtifactsDir\bin`"")
+  " --referencesPath `"$ArtifactsDir/bin`"" +
+  " --referencesPath `"$dotnetInstallDir/packs/Microsoft.AspNetCore.App.Ref`"" +
+  " --referencesPath `"$dotnetInstallDir/packs/Microsoft.NETCore.App.Ref`"")
   Exec-Console "$ArtifactsDir/bin/BuildValidator/$configuration/net472/BuildValidator.exe" $rebuildArgs
 
   exit 0

--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -35,7 +35,8 @@ try {
   }
 
   $rebuildArgs = ("--verbose" +
-  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis/netcoreapp3.1`"" +
+  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis`"" +
+  " --assembliesPath $ArtifactsDir/obj/csc/$configuration/netcoreapp3.1" +
   " --debugPath `"$ArtifactsDir\BuildValidator`"" +
   " --sourcePath `"$RepoRoot`"" +
   " --referencesPaths `"$ArtifactsDir\bin`"")

--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -16,7 +16,7 @@ function Print-Usage() {
   Write-Host "Usage: test-rebuild.ps1"
   Write-Host "  -configuration            Build configuration ('Debug' or 'Release')"
   Write-Host "  -ci                       Set when running on CI server"
-  Write-Host "  -noBuild                  If set, skips building before running the rebuild"
+  Write-Host "  -noBuild                  If set, skips running a bootstrap build before running the rebuild"
   Write-Host "  -help                     Print help and exit"
 }
 

--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -6,6 +6,7 @@
 param(
   [string]$configuration = "Debug",
   [switch]$ci = $false,
+  [switch]$noBuild = $false,
   [switch]$help)
 
 Set-StrictMode -version 2.0
@@ -15,6 +16,7 @@ function Print-Usage() {
   Write-Host "Usage: test-rebuild.ps1"
   Write-Host "  -configuration            Build configuration ('Debug' or 'Release')"
   Write-Host "  -ci                       Set when running on CI server"
+  Write-Host "  -noBuild                  If set, skips building before running the rebuild"
   Write-Host "  -help                     Print help and exit"
 }
 
@@ -27,9 +29,17 @@ try {
   . (Join-Path $PSScriptRoot "build-utils.ps1")
   Push-Location $RepoRoot
 
-  Write-Host "Building Roslyn"
-  Exec-Console (Join-Path $PSScriptRoot "build.ps1") "-restore -build -ci:$ci -configuration:$configuration -pack -binaryLog"
-  Exec-Console "artifacts\bin\BuildValidator\$configuration\net472\BuildValidator.exe" "--assembliesPath '$ArtifactsDir/obj/Microsoft.CodeAnalysis'"
+  if (-not $noBuild) {
+    Write-Host "Building Roslyn"
+    Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -ci:$ci -configuration:$configuration -pack -binaryLog }
+  }
+
+  $rebuildArgs = ("--verbose" +
+  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis/netcoreapp3.1`"" +
+  " --debugPath `"$ArtifactsDir\BuildValidator`"" +
+  " --sourcePath `"$RepoRoot`"" +
+  " --referencesPaths `"$ArtifactsDir\bin`"")
+  Exec-Console "$ArtifactsDir/bin/BuildValidator/$configuration/net472/BuildValidator.exe" $rebuildArgs
 
   exit 0
 }

--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -31,11 +31,11 @@ try {
 
   if (-not $noBuild) {
     Write-Host "Building Roslyn"
-    Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -ci:$ci -configuration:$configuration -pack -binaryLog }
+    Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -build -bootstrap -ci:$ci -configuration:$configuration -pack -binaryLog }
   }
 
   $rebuildArgs = ("--verbose" +
-  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis`"" +
+  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis/$configuration/netcoreapp3.1`"" +
   " --assembliesPath $ArtifactsDir/obj/csc/$configuration/netcoreapp3.1" +
   " --debugPath `"$ArtifactsDir\BuildValidator`"" +
   " --sourcePath `"$RepoRoot`"" +

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -12,6 +12,7 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <UseAppHost>false</UseAppHost>
     <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Tools/BuildValidator/BuildValidator.csproj
+++ b/src/Tools/BuildValidator/BuildValidator.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="Microsoft.Metadata.Visualizer" Version="$(MicrosoftMetadataVisualizerVersion)" />
+    <PackageReference Include="Microsoft.DiaSymReader.Converter.Xml" Version="$(MicrosoftDiaSymReaderConverterXmlVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>

--- a/src/Tools/BuildValidator/CompilationDiff.cs
+++ b/src/Tools/BuildValidator/CompilationDiff.cs
@@ -196,7 +196,7 @@ namespace BuildValidator
                                     var rebuildSourceFileInfos = rebuildReader.GetSourceFileInfos(rebuildReader.GetEncoding());
                                     foreach (var info in rebuildSourceFileInfos)
                                     {
-                                        if (info.EmbeddedCompressedHash is {} hash)
+                                        if (info.EmbeddedCompressedHash is { } hash)
                                         {
                                             var hashString = BitConverter.ToString(hash).Replace("-", "");
                                             logger.LogInformation($@"""{info.SourceFilePath}"" - {hashString}");

--- a/src/Tools/BuildValidator/CompilationDiff.cs
+++ b/src/Tools/BuildValidator/CompilationDiff.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.DiaSymReader.Tools;
 using Microsoft.Extensions.Logging;
 using Microsoft.Metadata.Tools;
 
@@ -61,6 +62,13 @@ namespace BuildValidator
                 iconInIcoFormat: null);
 
             var sourceLink = optionsReader.GetSourceLinkUTF8();
+
+            var embeddedTexts = producedCompilation.SyntaxTrees
+                    .Select(st => (path: st.FilePath, text: st.GetText()))
+                    .Where(pair => pair.text.CanBeEmbedded)
+                    .Select(pair => EmbeddedText.FromSource(pair.path, pair.text))
+                    .ToImmutableArray();
+
             var emitResult = producedCompilation.Emit(
                 peStream: rebuildPeStream,
                 pdbStream: null,
@@ -73,10 +81,7 @@ namespace BuildValidator
                 metadataPEStream: null,
                 pdbOptionsBlobReader: optionsReader.GetMetadataCompilationOptionsBlobReader(),
                 sourceLinkStream: sourceLink != null ? new MemoryStream(sourceLink) : null,
-                embeddedTexts: producedCompilation.SyntaxTrees
-                    .Select(st => (path: st.FilePath, text: st.GetText()))
-                    .Where(pair => pair.text.CanBeEmbedded)
-                    .Select(pair => EmbeddedText.FromSource(pair.path, pair.text)),
+                embeddedTexts: embeddedTexts,
                 cancellationToken: CancellationToken.None);
 
             if (!emitResult.Success)
@@ -141,6 +146,26 @@ namespace BuildValidator
                         writeVisualization(originalPeMdvPath, optionsReader.PeReader.GetMetadataReader());
                         writeVisualization(originalPdbMdvPath, optionsReader.PdbReader);
 
+                        var originalPdbXmlPath = Path.Combine(originalPath, assemblyName + ".pdb.xml");
+                        using var originalPdbXml = File.Create(originalPdbXmlPath);
+
+                        var rebuildPdbXmlPath = Path.Combine(rebuildPath, assemblyName + ".pdb.xml");
+
+                        var pdbToXmlOptions = PdbToXmlOptions.ResolveTokens
+                            | PdbToXmlOptions.ThrowOnError
+                            | PdbToXmlOptions.ExcludeScopes
+                            | PdbToXmlOptions.IncludeSourceServerInformation
+                            | PdbToXmlOptions.IncludeEmbeddedSources
+                            | PdbToXmlOptions.IncludeTokens
+                            | PdbToXmlOptions.IncludeMethodSpans;
+
+                        PdbToXmlConverter.ToXml(
+                            new StreamWriter(originalPdbXml),
+                            pdbStream: new UnmanagedMemoryStream(optionsReader.PdbReader.MetadataPointer, optionsReader.PdbReader.MetadataLength),
+                            peStream: new MemoryStream(originalBytes),
+                            options: pdbToXmlOptions,
+                            methodName: null);
+
                         var rebuildPeMdvPath = Path.Combine(rebuildPath, assemblyName + ".pe.mdv");
                         var rebuildPdbMdvPath = Path.Combine(rebuildPath, assemblyName + ".pdb.mdv");
                         fixed (byte* ptr = rebuildBytes)
@@ -156,6 +181,28 @@ namespace BuildValidator
                             {
                                 var rebuildPdbReader = provider.GetMetadataReader(MetadataReaderOptions.Default);
                                 writeVisualization(rebuildPdbMdvPath, rebuildPdbReader);
+
+                                using var rebuildPdbXml = File.Create(rebuildPdbXmlPath);
+                                PdbToXmlConverter.ToXml(
+                                    new StreamWriter(rebuildPdbXml),
+                                    pdbStream: new UnmanagedMemoryStream(rebuildPdbReader.MetadataPointer, rebuildPdbReader.MetadataLength),
+                                    peStream: new MemoryStream(rebuildBytes),
+                                    options: pdbToXmlOptions,
+                                    methodName: null);
+
+                                using (logger.BeginScope("Rebuild Embedded Texts raw SHAs"))
+                                {
+                                    var rebuildReader = new CompilationOptionsReader(logger, rebuildPdbReader, rebuildPeReader);
+                                    var rebuildSourceFileInfos = rebuildReader.GetSourceFileInfos(rebuildReader.GetEncoding());
+                                    foreach (var info in rebuildSourceFileInfos)
+                                    {
+                                        if (info.EmbeddedCompressedHash is {} hash)
+                                        {
+                                            var hashString = BitConverter.ToString(hash).Replace("-", "");
+                                            logger.LogInformation($@"""{info.SourceFilePath}"" - {hashString}");
+                                        }
+                                    }
+                                }
                             }
                         }
 
@@ -163,11 +210,12 @@ namespace BuildValidator
                         var ildasmRebuildOutputPath = Path.Combine(rebuildPath, assemblyName + ".il");
 
                         // TODO: can we bundle ildasm in with the utility?
-                        Process.Start(@"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\ildasm.exe", $@"{originalBinaryPath.FullName} /out={ildasmOriginalOutputPath}").WaitForExit();
-                        Process.Start(@"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\ildasm.exe", $@"{rebuildAssemblyPath} /out={ildasmRebuildOutputPath}").WaitForExit();
+                        Process.Start(@"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\ildasm.exe", $@"{originalBinaryPath.FullName} /all /out={ildasmOriginalOutputPath}").WaitForExit();
+                        Process.Start(@"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\ildasm.exe", $@"{rebuildAssemblyPath} /all /out={ildasmRebuildOutputPath}").WaitForExit();
 
                         File.WriteAllText(Path.Combine(assemblyDebugPath, "compare-pe.mdv.ps1"), $@"code --diff (Join-Path $PSScriptRoot ""{originalPeMdvPath.Substring(assemblyDebugPath.Length)}"") (Join-Path $PSScriptRoot ""{rebuildPeMdvPath.Substring(assemblyDebugPath.Length)}"")");
                         File.WriteAllText(Path.Combine(assemblyDebugPath, "compare-pdb.mdv.ps1"), $@"code --diff (Join-Path $PSScriptRoot ""{originalPdbMdvPath.Substring(assemblyDebugPath.Length)}"") (Join-Path $PSScriptRoot ""{rebuildPdbMdvPath.Substring(assemblyDebugPath.Length)}"")");
+                        File.WriteAllText(Path.Combine(assemblyDebugPath, "compare-pdb.xml.ps1"), $@"code --diff (Join-Path $PSScriptRoot ""{originalPdbXmlPath.Substring(assemblyDebugPath.Length)}"") (Join-Path $PSScriptRoot ""{rebuildPdbXmlPath.Substring(assemblyDebugPath.Length)}"")");
                         File.WriteAllText(Path.Combine(assemblyDebugPath, "compare-il.ps1"), $@"code --diff (Join-Path $PSScriptRoot ""{ildasmOriginalOutputPath.Substring(assemblyDebugPath.Length)}"") (Join-Path $PSScriptRoot ""{ildasmRebuildOutputPath.Substring(assemblyDebugPath.Length)}"")");
                     }
                 }

--- a/src/Tools/BuildValidator/LocalReferenceResolver.cs
+++ b/src/Tools/BuildValidator/LocalReferenceResolver.cs
@@ -30,10 +30,6 @@ namespace BuildValidator
         public LocalReferenceResolver(Options options, ILoggerFactory loggerFactory)
         {
             _logger = loggerFactory.CreateLogger<LocalReferenceResolver>();
-            foreach (var directoryInfo in GetRefAssembliesDirectories())
-            {
-                _indexDirectories.Add(directoryInfo);
-            }
             foreach (var path in options.AssembliesPaths)
             {
                 _indexDirectories.Add(new DirectoryInfo(path));
@@ -60,16 +56,6 @@ namespace BuildValidator
             }
 
             return new DirectoryInfo(nugetPackageDirectory);
-        }
-
-        public static DirectoryInfo[] GetRefAssembliesDirectories()
-        {
-            // TODO: Don't hardcode the paths here. 
-            return new[]
-            {
-                new DirectoryInfo(@"C:\Program Files\dotnet\packs\Microsoft.AspNetCore.App.Ref"),
-                new DirectoryInfo(@"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref")
-            };
         }
 
         public string GetReferencePath(MetadataReferenceInfo referenceInfo)

--- a/src/Tools/BuildValidator/LocalReferenceResolver.cs
+++ b/src/Tools/BuildValidator/LocalReferenceResolver.cs
@@ -34,7 +34,10 @@ namespace BuildValidator
             {
                 _indexDirectories.Add(directoryInfo);
             }
-            _indexDirectories.Add(new DirectoryInfo(options.AssembliesPath));
+            foreach (var path in options.AssembliesPaths)
+            {
+                _indexDirectories.Add(new DirectoryInfo(path));
+            }
             _indexDirectories.Add(GetNugetCacheDirectory());
             foreach (var path in options.ReferencesPaths)
             {

--- a/src/Tools/BuildValidator/LocalReferenceResolver.cs
+++ b/src/Tools/BuildValidator/LocalReferenceResolver.cs
@@ -44,7 +44,7 @@ namespace BuildValidator
             using var _ = _logger.BeginScope("Assembly Reference Search Paths");
             foreach (var directory in _indexDirectories)
             {
-                _logger.LogInformation($@"""{directory}""");
+                _logger.LogInformation($@"""{directory.FullName}""");
             }
         }
 

--- a/src/Tools/BuildValidator/Options.cs
+++ b/src/Tools/BuildValidator/Options.cs
@@ -10,7 +10,7 @@ using System.IO;
 namespace BuildValidator
 {
     internal record Options(
-        string AssembliesPath,
+        string[] AssembliesPaths,
         string[] ReferencesPaths,
         string SourcePath,
         bool Verbose,

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -64,8 +64,6 @@ namespace BuildValidator
                     "--debugPath", "Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled."
                 )
             };
-            var res = rootCommand.Parse(args);
-            
             rootCommand.Handler = CommandHandler.Create<string[], string, string[]?, bool, bool, bool, string>(HandleCommand);
             return rootCommand.Invoke(args);
         }
@@ -79,9 +77,8 @@ namespace BuildValidator
 
             var options = new Options(assembliesPath, referencesPath, sourcePath, verbose, quiet, debug, debugPath);
 
-            // TODO: remove the DemoLoggerProvider, update this dependency,
-            // and move to the built in logger.
-            var loggerFactory = LoggerFactory.Create(builder => 
+            // TODO: remove the DemoLoggerProvider or convert it to something more permanent
+            var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder.SetMinimumLevel((options.Verbose, options.Quiet) switch
                 {

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -48,9 +48,9 @@ namespace BuildValidator
                 new Option<string>(
                     "--sourcePath", "Path to sources to use in rebuild"
                 ) { IsRequired = true },
-                new Option<string[]?>(
-                    "--referencesPaths", "Additional paths to referenced assemblies"
-                ),
+                new Option<string>(
+                    "--referencesPath", "Path to referenced assemblies (can be specified zero or more times)"
+                ) { Argument = { Arity = ArgumentArity.ZeroOrMore } },
                 new Option<bool>(
                     "--verbose", "Output verbose log information"
                 ),
@@ -64,18 +64,20 @@ namespace BuildValidator
                     "--debugPath", "Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled."
                 )
             };
+            var res = rootCommand.Parse(args);
+            
             rootCommand.Handler = CommandHandler.Create<string[], string, string[]?, bool, bool, bool, string>(HandleCommand);
             return rootCommand.Invoke(args);
         }
 
-        static int HandleCommand(string[] assembliesPath, string sourcePath, string[]? referencesPaths, bool verbose, bool quiet, bool debug, string? debugPath)
+        static int HandleCommand(string[] assembliesPath, string sourcePath, string[]? referencesPath, bool verbose, bool quiet, bool debug, string? debugPath)
         {
             // If user provided a debug path then assume we should write debug outputs.
             debug |= debugPath is object;
             debugPath ??= Path.Combine(Path.GetTempPath(), $"BuildValidator");
-            referencesPaths ??= Array.Empty<string>();
+            referencesPath ??= Array.Empty<string>();
 
-            var options = new Options(assembliesPath, referencesPaths, sourcePath, verbose, quiet, debug, debugPath);
+            var options = new Options(assembliesPath, referencesPath, sourcePath, verbose, quiet, debug, debugPath);
 
             // TODO: remove the DemoLoggerProvider, update this dependency,
             // and move to the built in logger.

--- a/src/Tools/ManifestGenerator/README.md
+++ b/src/Tools/ManifestGenerator/README.md
@@ -1,4 +1,3 @@
 # dotnet-roslyn-manifest-generator
 
-https://github.com/dotnet/roslyn/blob/efd69176d6ad7f9dbe1d87525201760a6c44e7a0/docs/compilers/terrapin.md#artifacts-manifest-file
-
+[Terrapin doc](../../../docs/compilers/terrapin.md#artifacts-manifest-file)


### PR DESCRIPTION
Modifications to the rebuilder which enable us to build csc in the netcoreapp3.1 target. Additional changes related to copying over the win32 resources are needed to enable us to build the net472 target.
