### PR TITLE
Handle multi-targeted projects in UnusedReferencesRemover

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/RemoveUnusedReferencesDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/RemoveUnusedReferencesDialog.xaml.cs
@@ -31,13 +31,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             InitializeComponent();
         }
 
-        public bool? ShowModal(Project project, ImmutableArray<ReferenceUpdate> referenceUpdates)
+        public bool? ShowModal(Solution solution, string projectFilePath, ImmutableArray<ReferenceUpdate> referenceUpdates)
         {
             bool? result = null;
 
             try
             {
-                _tableProvider.AddTableData(project, referenceUpdates);
+                _tableProvider.AddTableData(solution, projectFilePath, referenceUpdates);
 
                 using var tableControl = _tableProvider.CreateTableControl();
                 TablePanel.Child = tableControl.Control;

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.DataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.DataSource.cs
@@ -30,9 +30,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
                 return new SinkManager(this, sink);
             }
 
-            public void AddTableData(Project project, ImmutableArray<ReferenceUpdate> referenceUpdates)
+            public void AddTableData(Solution solution, string projectFilePath, ImmutableArray<ReferenceUpdate> referenceUpdates)
             {
-                var solutionName = Path.GetFileName(project.Solution.FilePath);
+                var solutionName = Path.GetFileName(solution.FilePath);
+                var project = solution.Projects.First(project => projectFilePath.Equals(project.FilePath, StringComparison.OrdinalIgnoreCase));
                 var entries = referenceUpdates
                     .Select(update => new UnusedReferencesEntry(solutionName, project.Name, project.Language, update))
                     .ToImmutableArray();

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.cs
@@ -59,9 +59,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             }
         }
 
-        public void AddTableData(Project project, ImmutableArray<ReferenceUpdate> referenceUpdates)
+        public void AddTableData(Solution solution, string projectFilePath, ImmutableArray<ReferenceUpdate> referenceUpdates)
         {
-            _dataSource.AddTableData(project, referenceUpdates);
+            _dataSource.AddTableData(solution, projectFilePath, referenceUpdates);
         }
 
         public void ClearTableData()

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.cs
@@ -52,10 +52,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             {
                 return ImmutableArray.Create(
                     new ColumnState2(UnusedReferencesColumnDefinitions.SolutionName, isVisible: false, width: 200, sortPriority: 0, descendingSort: false, groupingPriority: 1),
-                    new ColumnState2(UnusedReferencesColumnDefinitions.ProjectName, isVisible: false, width: 200, sortPriority: 0, descendingSort: false, groupingPriority: 2),
-                    new ColumnState2(UnusedReferencesColumnDefinitions.ReferenceType, isVisible: false, width: 200, sortPriority: 0, descendingSort: false, groupingPriority: 3),
-                    new ColumnState(UnusedReferencesColumnDefinitions.ReferenceName, isVisible: true, width: 300, sortPriority: 0, descendingSort: false),
-                    new ColumnState(UnusedReferencesColumnDefinitions.UpdateAction, isVisible: true, width: 100, sortPriority: 0, descendingSort: false));
+                    new ColumnState2(UnusedReferencesColumnDefinitions.ProjectName, isVisible: false, width: 200, sortPriority: 1, descendingSort: false, groupingPriority: 2),
+                    new ColumnState2(UnusedReferencesColumnDefinitions.ReferenceType, isVisible: false, width: 200, sortPriority: 2, descendingSort: false, groupingPriority: 3),
+                    new ColumnState(UnusedReferencesColumnDefinitions.ReferenceName, isVisible: true, width: 300, sortPriority: 3, descendingSort: false),
+                    new ColumnState(UnusedReferencesColumnDefinitions.UpdateAction, isVisible: true, width: 100, sortPriority: 4, descendingSort: false));
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsReader.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsReader.cs
@@ -100,11 +100,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
 
             var packagesPath = projectAssets.Project?.Restore?.PackagesPath ?? string.Empty;
 
-            foreach (var target in projectAssets.Targets!.Values)
+            RoslynDebug.AssertNotNull(projectAssets.Targets);
+            RoslynDebug.AssertNotNull(projectAssets.Libraries);
+
+            foreach (var target in projectAssets.Targets.Values)
             {
                 var key = target.Keys.FirstOrDefault(library => library.Split('/')[0] == referenceName);
                 if (key is null ||
-                    !projectAssets.Libraries!.TryGetValue(key, out var library))
+                    !projectAssets.Libraries.TryGetValue(key, out var library))
                 {
                     continue;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsReader.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsReader.cs
@@ -21,8 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
 
         public static ImmutableArray<ReferenceInfo> ReadReferences(
             ImmutableArray<ReferenceInfo> projectReferences,
-            string projectAssetsFilePath,
-            string targetFrameworkMoniker)
+            string projectAssetsFilePath)
         {
             if (!File.Exists(projectAssetsFilePath))
             {
@@ -48,7 +47,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             }
 
             if (projectAssets.Targets is null ||
-                !projectAssets.Targets.TryGetValue(targetFrameworkMoniker, out var target))
+                projectAssets.Targets.Count == 0)
+            {
+                return ImmutableArray<ReferenceInfo>.Empty;
+            }
+
+            if (projectAssets.Libraries is null ||
+                projectAssets.Libraries.Count == 0)
             {
                 return ImmutableArray<ReferenceInfo>.Empty;
             }
@@ -60,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             autoReferences ??= ImmutableHashSet<string>.Empty;
 
             var references = projectReferences
-                .Select(projectReference => BuildReference(projectAssets, target, projectReference, autoReferences))
+                .Select(projectReference => BuildReference(projectAssets, projectReference, autoReferences))
                 .WhereNotNull()
                 .ToImmutableArray();
 
@@ -69,7 +74,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
 
         private static ReferenceInfo? BuildReference(
             ProjectAssetsFile projectAssets,
-            Dictionary<string, ProjectAssetsTargetLibrary> target,
             ReferenceInfo referenceInfo,
             ImmutableHashSet<string> autoReferences)
         {
@@ -82,61 +86,62 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
                 return null;
             }
 
-            return BuildReference(projectAssets, target, referenceName, referenceInfo.TreatAsUsed);
+            return BuildReference(projectAssets, referenceName, referenceInfo.TreatAsUsed);
         }
 
         private static ReferenceInfo? BuildReference(
             ProjectAssetsFile projectAssets,
-            Dictionary<string, ProjectAssetsTargetLibrary> target,
-            string dependency,
+            string referenceName,
             bool treatAsUsed)
         {
-            var key = target.Keys.FirstOrDefault(library => library.Split('/')[0] == dependency);
-            if (key is null)
-            {
-                return null;
-            }
-
-            return BuildReference(projectAssets, target, dependency, treatAsUsed, key, target[key]);
-        }
-
-        private static ReferenceInfo? BuildReference(
-            ProjectAssetsFile projectAssets,
-            Dictionary<string, ProjectAssetsTargetLibrary> target,
-            string referenceName,
-            bool treatAsUsed,
-            string key,
-            ProjectAssetsTargetLibrary targetLibrary)
-        {
-            if (projectAssets.Libraries is null ||
-                !projectAssets.Libraries.TryGetValue(key, out var library))
-            {
-                return null;
-            }
-
-            var type = targetLibrary.Type switch
-            {
-                "package" => ReferenceType.Package,
-                "project" => ReferenceType.Project,
-                _ => ReferenceType.Assembly
-            };
-
-            var dependencies = targetLibrary.Dependencies != null
-                ? targetLibrary.Dependencies.Keys
-                    .Select(dependency => BuildReference(projectAssets, target, dependency, treatAsUsed: false))
-                    .WhereNotNull()
-                    .ToImmutableArray()
-                : ImmutableArray<ReferenceInfo>.Empty;
+            var dependencyNames = new HashSet<string>();
+            var compilationAssemblies = ImmutableArray.CreateBuilder<string>();
+            var referenceType = ReferenceType.Unknown;
 
             var packagesPath = projectAssets.Project?.Restore?.PackagesPath ?? string.Empty;
-            var compilationAssemblies = targetLibrary.Compile != null
-                ? targetLibrary.Compile.Keys
-                    .Where(assemblyPath => !assemblyPath.EndsWith(NuGetEmptyFileName))
-                    .Select(assemblyPath => Path.GetFullPath(Path.Combine(packagesPath, library.Path, assemblyPath)))
-                    .ToImmutableArray()
-                : ImmutableArray<string>.Empty;
 
-            return new ReferenceInfo(type, referenceName, treatAsUsed, compilationAssemblies, dependencies);
+            foreach (var target in projectAssets.Targets!.Values)
+            {
+                var key = target.Keys.FirstOrDefault(library => library.Split('/')[0] == referenceName);
+                if (key is null ||
+                    !projectAssets.Libraries!.TryGetValue(key, out var library))
+                {
+                    continue;
+                }
+
+                var targetLibrary = target[key];
+
+                referenceType = targetLibrary.Type switch
+                {
+                    "package" => ReferenceType.Package,
+                    "project" => ReferenceType.Project,
+                    _ => ReferenceType.Assembly
+                };
+
+                if (targetLibrary.Dependencies != null)
+                {
+                    dependencyNames.AddRange(targetLibrary.Dependencies.Keys);
+                }
+
+                if (targetLibrary.Compile != null)
+                {
+                    compilationAssemblies.AddRange(targetLibrary.Compile.Keys
+                        .Where(assemblyPath => !assemblyPath.EndsWith(NuGetEmptyFileName))
+                        .Select(assemblyPath => Path.GetFullPath(Path.Combine(packagesPath, library.Path, assemblyPath))));
+                }
+            }
+
+            if (referenceType == ReferenceType.Unknown)
+            {
+                return null;
+            }
+
+            var dependencies = dependencyNames
+                .Select(dependency => BuildReference(projectAssets, dependency, treatAsUsed: false))
+                .WhereNotNull()
+                .ToImmutableArray();
+
+            return new ReferenceInfo(referenceType, referenceName, treatAsUsed, compilationAssemblies.ToImmutable(), dependencies);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/RemoveUnusedReferencesCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/RemoveUnusedReferencesCommandHandler.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
                 }
 
                 if (solution is null ||
-                    projectFilePath is null ||
+                    projectFilePath is not string { Length: > 0 } ||
                     referenceUpdates.IsEmpty)
                 {
                     MessageDialog.Show(ServicesVSResources.Remove_Unused_References, ServicesVSResources.No_unused_references_were_found, MessageDialogCommandSet.Ok);

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/RemoveUnusedReferencesCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/RemoveUnusedReferencesCommandHandler.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.UnusedReferences;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReferences.Dialog;
@@ -107,11 +106,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
         {
             if (VisualStudioCommandHandlerHelpers.TryGetSelectedProjectHierarchy(_serviceProvider, out var hierarchy))
             {
-                Project? project = null;
+                Solution? solution = null;
+                string? projectFilePath = null;
                 ImmutableArray<ReferenceUpdate> referenceUpdates = default;
                 var status = _threadOperationExecutor.Execute(ServicesVSResources.Remove_Unused_References, ServicesVSResources.Analyzing_project_references, allowCancellation: true, showProgress: true, (operationContext) =>
                 {
-                    (project, referenceUpdates) = GetUnusedReferencesForProjectHierarchy(hierarchy, operationContext.UserCancellationToken);
+                    (solution, projectFilePath, referenceUpdates) = GetUnusedReferencesForProjectHierarchy(hierarchy, operationContext.UserCancellationToken);
                 });
 
                 if (status == UIThreadOperationStatus.Canceled)
@@ -119,7 +119,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
                     return;
                 }
 
-                if (project is null ||
+                if (solution is null ||
+                    projectFilePath is null ||
                     referenceUpdates.IsEmpty)
                 {
                     MessageDialog.Show(ServicesVSResources.Remove_Unused_References, ServicesVSResources.No_unused_references_were_found, MessageDialogCommandSet.Ok);
@@ -127,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
                 }
 
                 var dialog = _unusedReferenceDialogProvider.CreateDialog();
-                if (dialog.ShowModal(project, referenceUpdates) == false)
+                if (dialog.ShowModal(solution, projectFilePath, referenceUpdates) == false)
                 {
                     return;
                 }
@@ -153,48 +154,43 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
 
                 _threadOperationExecutor.Execute(ServicesVSResources.Remove_Unused_References, ServicesVSResources.Updating_project_references, allowCancellation: false, showProgress: true, (operationContext) =>
                 {
-                    ApplyUnusedReferenceUpdates(project, referenceChanges, CancellationToken.None);
+                    ApplyUnusedReferenceUpdates(solution, projectFilePath, referenceChanges, CancellationToken.None);
                 });
             }
 
             return;
         }
 
-        private (Project?, ImmutableArray<ReferenceUpdate>) GetUnusedReferencesForProjectHierarchy(IVsHierarchy projectHierarchy, CancellationToken cancellationToken)
+        private (Solution?, string?, ImmutableArray<ReferenceUpdate>) GetUnusedReferencesForProjectHierarchy(
+            IVsHierarchy projectHierarchy,
+            CancellationToken cancellationToken)
         {
-            if (!TryGetPropertyValue(projectHierarchy, ProjectAssetsFilePropertyName, out var projectAssetsFile) ||
-                !projectHierarchy.TryGetTargetFrameworkMoniker((uint)VSConstants.VSITEMID.Root, out var targetFrameworkMoniker))
+            if (!TryGetPropertyValue(projectHierarchy, ProjectAssetsFilePropertyName, out var projectAssetsFile))
             {
-                return (null, ImmutableArray<ReferenceUpdate>.Empty);
+                return (null, null, ImmutableArray<ReferenceUpdate>.Empty);
             }
 
-            var projectMap = _workspace.Services.GetRequiredService<IHierarchyItemToProjectIdMap>();
-            var projectHierarchyItem = _vsHierarchyItemManager.GetHierarchyItem(projectHierarchy, VSConstants.VSITEMID_ROOT);
-
-            if (!projectMap.TryGetProjectId(projectHierarchyItem, targetFrameworkMoniker, out var projectId))
+            var projectFilePath = projectHierarchy.TryGetProjectFilePath();
+            if (string.IsNullOrEmpty(projectFilePath))
             {
-                return (null, ImmutableArray<ReferenceUpdate>.Empty);
+                return (null, null, ImmutableArray<ReferenceUpdate>.Empty);
             }
 
-            var project = _workspace.CurrentSolution.GetProject(projectId);
-            if (project is null)
-            {
-                return (null, ImmutableArray<ReferenceUpdate>.Empty);
-            }
+            var solution = _workspace.CurrentSolution;
 
-            var unusedReferences = GetUnusedReferencesForProject(project, projectAssetsFile, targetFrameworkMoniker, cancellationToken);
+            var unusedReferences = GetUnusedReferencesForProject(solution, projectFilePath!, projectAssetsFile, cancellationToken);
 
-            return (project, unusedReferences);
+            return (solution, projectFilePath, unusedReferences);
         }
 
-        private ImmutableArray<ReferenceUpdate> GetUnusedReferencesForProject(Project project, string projectAssetsFile, string targetFrameworkMoniker, CancellationToken cancellationToken)
+        private ImmutableArray<ReferenceUpdate> GetUnusedReferencesForProject(Solution solution, string projectFilePath, string projectAssetsFile, CancellationToken cancellationToken)
         {
             ImmutableArray<ReferenceInfo> unusedReferences = ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var projectReferences = await _lazyReferenceCleanupService.Value.GetProjectReferencesAsync(project.FilePath!, cancellationToken).ConfigureAwait(true);
-                var references = ProjectAssetsReader.ReadReferences(projectReferences, projectAssetsFile, targetFrameworkMoniker);
+                var projectReferences = await _lazyReferenceCleanupService.Value.GetProjectReferencesAsync(projectFilePath, cancellationToken).ConfigureAwait(true);
+                var references = ProjectAssetsReader.ReadReferences(projectReferences, projectAssetsFile);
 
-                return await UnusedReferencesRemover.GetUnusedReferencesAsync(project, references, cancellationToken).ConfigureAwait(true);
+                return await UnusedReferencesRemover.GetUnusedReferencesAsync(solution, projectFilePath, references, cancellationToken).ConfigureAwait(true);
             });
 
             var referenceUpdates = unusedReferences
@@ -204,10 +200,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             return referenceUpdates;
         }
 
-        private void ApplyUnusedReferenceUpdates(Project project, ImmutableArray<ReferenceUpdate> referenceUpdates, CancellationToken cancellationToken)
+        private void ApplyUnusedReferenceUpdates(Solution solution, string projectFilePath, ImmutableArray<ReferenceUpdate> referenceUpdates, CancellationToken cancellationToken)
         {
             ThreadHelper.JoinableTaskFactory.Run(
-                () => UnusedReferencesRemover.UpdateReferencesAsync(project, referenceUpdates, cancellationToken));
+                () => UnusedReferencesRemover.UpdateReferencesAsync(solution, projectFilePath, referenceUpdates, cancellationToken));
         }
 
         private static bool TryGetPropertyValue(IVsHierarchy hierarchy, string propertyName, [NotNullWhen(returnValue: true)] out string? propertyValue)


### PR DESCRIPTION
When building our list of references, we add the compilation assemblies from each used target. When building our list of used compilation assemblies, we add the used assemblies from all projects with the same path (each target gets their own project instance). When determine if a reference is used, we consider it used if even one targets compilation assembly is used.

implements part of https://github.com/dotnet/roslyn/issues/50054