### PR TITLE
Optimize storage for segment information

### DIFF
--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis.Collections.Internal
 {
@@ -15,6 +17,52 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         internal const int IntrosortSizeThreshold = 16;
 
         /// <summary>
+        /// A combination of <see cref="MethodImplOptions.AggressiveInlining"/> and
+        /// <see cref="F:System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization"/>.
+        /// </summary>
+        [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The field is not supported in all compilation targets.")]
+        internal const MethodImplOptions FastPathMethodImplOptions = MethodImplOptions.AggressiveInlining | (MethodImplOptions)512;
+
+        [MethodImpl(FastPathMethodImplOptions)]
+        internal static int GetSegmentSize<T>()
+        {
+            if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
+            {
+                return ReferenceTypeSegmentHelper.SegmentSize;
+            }
+            else
+            {
+                return ValueTypeSegmentHelper<T>.SegmentSize;
+            }
+        }
+
+        [MethodImpl(FastPathMethodImplOptions)]
+        internal static int GetSegmentShift<T>()
+        {
+            if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
+            {
+                return ReferenceTypeSegmentHelper.SegmentShift;
+            }
+            else
+            {
+                return ValueTypeSegmentHelper<T>.SegmentShift;
+            }
+        }
+
+        [MethodImpl(FastPathMethodImplOptions)]
+        internal static int GetOffsetMask<T>()
+        {
+            if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
+            {
+                return ReferenceTypeSegmentHelper.OffsetMask;
+            }
+            else
+            {
+                return ValueTypeSegmentHelper<T>.OffsetMask;
+            }
+        }
+
+        /// <summary>
         /// Calculates the maximum number of elements of size <paramref name="elementSize"/> which can fit into an array
         /// which has the following characteristics:
         /// <list type="bullet">
@@ -24,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         /// </summary>
         /// <param name="elementSize">The size of the elements in the array.</param>
         /// <returns>The segment size to use for small object heap segmented arrays.</returns>
-        internal static int CalculateSegmentSize(int elementSize)
+        private static int CalculateSegmentSize(int elementSize)
         {
             // Default Large Object Heap size threshold
             // https://github.com/dotnet/runtime/blob/c9d69e38d0e54bea5d188593ef6c3b30139f3ab1/src/coreclr/src/gc/gc.h#L111
@@ -50,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         /// </summary>
         /// <param name="segmentSize">The number of elements in each page of the segmented array. Must be a power of 2.</param>
         /// <returns>The shift to apply to the absolute index to get the page index within a segmented array.</returns>
-        internal static int CalculateSegmentShift(int segmentSize)
+        private static int CalculateSegmentShift(int segmentSize)
         {
             var segmentShift = 0;
             while (0 != (segmentSize >>= 1))
@@ -67,10 +115,36 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         /// </summary>
         /// <param name="segmentSize">The number of elements in each page of the segmented array. Must be a power of 2.</param>
         /// <returns>The bit mask to obtain the index within a page from an absolute index within a segmented array.</returns>
-        internal static int CalculateOffsetMask(int segmentSize)
+        private static int CalculateOffsetMask(int segmentSize)
         {
             Debug.Assert(segmentSize == 1 || (segmentSize & (segmentSize - 1)) == 0, "Expected size of 1, or a power of 2");
             return segmentSize - 1;
+        }
+
+        internal static class TestAccessor
+        {
+            public static int CalculateSegmentSize(int elementSize)
+                => SegmentedArrayHelper.CalculateSegmentSize(elementSize);
+
+            public static int CalculateSegmentShift(int elementSize)
+                => SegmentedArrayHelper.CalculateSegmentShift(elementSize);
+
+            public static int CalculateOffsetMask(int elementSize)
+                => SegmentedArrayHelper.CalculateOffsetMask(elementSize);
+        }
+
+        private static class ReferenceTypeSegmentHelper
+        {
+            public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<object>());
+            public static readonly int SegmentShift = CalculateSegmentShift(SegmentSize);
+            public static readonly int OffsetMask = CalculateOffsetMask(SegmentSize);
+        }
+
+        private static class ValueTypeSegmentHelper<T>
+        {
+            public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<T>());
+            public static readonly int SegmentShift = CalculateSegmentShift(SegmentSize);
+            public static readonly int OffsetMask = CalculateOffsetMask(SegmentSize);
         }
     }
 }

--- a/src/Dependencies/Collections/SegmentedArray`1.cs
+++ b/src/Dependencies/Collections/SegmentedArray`1.cs
@@ -30,17 +30,38 @@ namespace Microsoft.CodeAnalysis.Collections
         /// including any padding the implementation chooses to add. Specifically, array elements lie <c>sizeof</c>
         /// bytes apart.</para>
         /// </remarks>
-        private static readonly int s_segmentSize = SegmentedArrayHelper.CalculateSegmentSize(Unsafe.SizeOf<T>());
+        private static int SegmentSize
+        {
+            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
+            get
+            {
+                return SegmentedArrayHelper.GetSegmentSize<T>();
+            }
+        }
 
         /// <summary>
         /// The bit shift to apply to an array index to get the page index within <see cref="_items"/>.
         /// </summary>
-        private static readonly int s_segmentShift = SegmentedArrayHelper.CalculateSegmentShift(s_segmentSize);
+        private static int SegmentShift
+        {
+            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
+            get
+            {
+                return SegmentedArrayHelper.GetSegmentShift<T>();
+            }
+        }
 
         /// <summary>
         /// The bit mask to apply to an array index to get the index within a page of <see cref="_items"/>.
         /// </summary>
-        private static readonly int s_offsetMask = SegmentedArrayHelper.CalculateOffsetMask(s_segmentSize);
+        private static int OffsetMask
+        {
+            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
+            get
+            {
+                return SegmentedArrayHelper.GetOffsetMask<T>();
+            }
+        }
 
         private readonly int _length;
         private readonly T[][] _items;
@@ -59,17 +80,17 @@ namespace Microsoft.CodeAnalysis.Collections
             }
             else
             {
-                _items = new T[(length + s_segmentSize - 1) >> s_segmentShift][];
+                _items = new T[(length + SegmentSize - 1) >> SegmentShift][];
                 for (var i = 0; i < _items.Length - 1; i++)
                 {
-                    _items[i] = new T[s_segmentSize];
+                    _items[i] = new T[SegmentSize];
                 }
 
                 // Make sure the last page only contains the number of elements required for the desired length. This
                 // collection is not resizeable so any additional padding would be a waste of space.
                 //
                 // Avoid using (length & s_offsetMask) because it doesn't handle a last page size of s_segmentSize.
-                var lastPageSize = length - ((_items.Length - 1) << s_segmentShift);
+                var lastPageSize = length - ((_items.Length - 1) << SegmentShift);
 
                 _items[_items.Length - 1] = new T[lastPageSize];
                 _length = length;
@@ -94,9 +115,10 @@ namespace Microsoft.CodeAnalysis.Collections
 
         public ref T this[int index]
         {
+            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
             get
             {
-                return ref _items[index >> s_segmentShift][index & s_offsetMask];
+                return ref _items[index >> SegmentShift][index & OffsetMask];
             }
         }
 
@@ -135,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Collections
         {
             for (var i = 0; i < _items.Length; i++)
             {
-                _items[i].CopyTo(array, index + (i * s_segmentSize));
+                _items[i].CopyTo(array, index + (i * SegmentSize));
             }
         }
 
@@ -144,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Collections
             for (var i = 0; i < _items.Length; i++)
             {
                 ICollection<T> collection = _items[i];
-                collection.CopyTo(array, arrayIndex + (i * s_segmentSize));
+                collection.CopyTo(array, arrayIndex + (i * SegmentSize));
             }
         }
 
@@ -207,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 var index = list.IndexOf(value);
                 if (index >= 0)
                 {
-                    return index + i * s_segmentSize;
+                    return index + i * SegmentSize;
                 }
             }
 
@@ -222,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 var index = list.IndexOf(value);
                 if (index >= 0)
                 {
-                    return index + i * s_segmentSize;
+                    return index + i * SegmentSize;
                 }
             }
 
@@ -393,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 _array = array;
             }
 
-            public static int SegmentSize => s_segmentSize;
+            public static int SegmentSize => SegmentedArray<T>.SegmentSize;
 
             public T[][] Items => _array._items;
         }

--- a/src/Dependencies/Collections/SegmentedArray`1.cs
+++ b/src/Dependencies/Collections/SegmentedArray`1.cs
@@ -7,7 +7,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Collections.Internal;
 
 namespace Microsoft.CodeAnalysis.Collections
@@ -119,28 +118,7 @@ namespace Microsoft.CodeAnalysis.Collections
             [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
             get
             {
-#if NET
-                if (typeof(T).IsValueType)
-                {
-                    // Direct indexing is faster because it avoids more null checks
-                    return ref _items[index >> SegmentShift][index & OffsetMask];
-                }
-                else
-                {
-                    // Operate on a local copy of the structure since this method uses unsafe operations based on
-                    // validation at the start of the method.
-                    var self = this;
-
-                    // MemoryMarshal.GetArrayDataReference is faster because it avoids array variance checks
-                    if ((uint)index >= (uint)self.Length)
-                        ThrowHelper.ThrowIndexOutOfRangeException();
-
-                    var segment = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(self._items), index >> SegmentShift);
-                    return ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(segment), index & OffsetMask);
-                }
-#else
                 return ref _items[index >> SegmentShift][index & OffsetMask];
-#endif
             }
         }
 

--- a/src/Dependencies/Collections/SegmentedArray`1.cs
+++ b/src/Dependencies/Collections/SegmentedArray`1.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Collections.Internal;
 
 namespace Microsoft.CodeAnalysis.Collections
@@ -118,7 +119,28 @@ namespace Microsoft.CodeAnalysis.Collections
             [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
             get
             {
+#if NET
+                if (typeof(T).IsValueType)
+                {
+                    // Direct indexing is faster because it avoids more null checks
+                    return ref _items[index >> SegmentShift][index & OffsetMask];
+                }
+                else
+                {
+                    // Operate on a local copy of the structure since this method uses unsafe operations based on
+                    // validation at the start of the method.
+                    var self = this;
+
+                    // MemoryMarshal.GetArrayDataReference is faster because it avoids array variance checks
+                    if ((uint)index >= (uint)self.Length)
+                        ThrowHelper.ThrowIndexOutOfRangeException();
+
+                    var segment = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(self._items), index >> SegmentShift);
+                    return ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(segment), index & OffsetMask);
+                }
+#else
                 return ref _items[index >> SegmentShift][index & OffsetMask];
+#endif
             }
         }
 

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -1049,11 +1049,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
             if (_size > 1)
             {
-#if NET
-                _items.AsSpan(0, _size).Sort(comparison);
-#else
                 SegmentedArray.Sort<T>(_items, 0, _size, Comparer<T>.Create(comparison));
-#endif
             }
             _version++;
         }

--- a/src/Dependencies/Collections/SegmentedList`1.cs
+++ b/src/Dependencies/Collections/SegmentedList`1.cs
@@ -1049,7 +1049,11 @@ namespace Microsoft.CodeAnalysis.Collections
 
             if (_size > 1)
             {
+#if NET
+                _items.AsSpan(0, _size).Sort(comparison);
+#else
                 SegmentedArray.Sort<T>(_items, 0, _size, Comparer<T>.Create(comparison));
+#endif
             }
             _version++;
         }

--- a/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
+++ b/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net472</TargetFrameworks>
     <IsShipping>false</IsShipping>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <!-- Automatically generate the necessary assembly binding redirects -->

--- a/src/Tools/IdeCoreBenchmarks/SegmentedArrayBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/SegmentedArrayBenchmarks.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis.Collections;
+
+namespace IdeCoreBenchmarks
+{
+    [DisassemblyDiagnoser]
+    public class SegmentedArrayBenchmarks
+    {
+        private int[] _values = null!;
+        private object?[] _valuesObject = null!;
+
+        private SegmentedArray<int> _segmentedValues;
+        private SegmentedArray<object?> _segmentedValuesObject;
+
+        [Params(100000)]
+        public int Count { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _values = new int[Count];
+            _valuesObject = new object?[Count];
+            _segmentedValues = new SegmentedArray<int>(Count);
+            _segmentedValuesObject = new SegmentedArray<object?>(Count);
+        }
+
+        [Benchmark(Description = "int[]", Baseline = true)]
+        public void ShiftAllArray()
+        {
+            for (var i = 0; i < _values.Length - 1; i++)
+            {
+                _values[i] = _values[i + 1];
+            }
+
+            _values[^1] = 0;
+        }
+
+        [Benchmark(Description = "object[]")]
+        public void ShiftAllArrayObject()
+        {
+            for (var i = 0; i < _valuesObject.Length - 1; i++)
+            {
+                _valuesObject[i] = _valuesObject[i + 1];
+            }
+
+            _valuesObject[^1] = null;
+        }
+
+        [Benchmark(Description = "SegmentedArray<int>")]
+        public void ShiftAllSegmented()
+        {
+            for (var i = 0; i < _segmentedValues.Length - 1; i++)
+            {
+                _segmentedValues[i] = _segmentedValues[i + 1];
+            }
+
+            _segmentedValues[^1] = 0;
+        }
+
+        [Benchmark(Description = "SegmentedArray<object>")]
+        public void ShiftAllSegmentedObject()
+        {
+            for (var i = 0; i < _segmentedValuesObject.Length - 1; i++)
+            {
+                _segmentedValuesObject[i] = _segmentedValuesObject[i + 1];
+            }
+
+            _segmentedValuesObject[^1] = null;
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/Collections/SegmentedArrayHelperTests.cs
+++ b/src/Workspaces/CoreTest/Collections/SegmentedArrayHelperTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 _ => throw ExceptionUtilities.Unreachable,
             };
 
-            Assert.Equal(expected, SegmentedArrayHelper.CalculateSegmentSize(elementSize));
+            Assert.Equal(expected, SegmentedArrayHelper.TestAccessor.CalculateSegmentSize(elementSize));
         }
 
         [Theory]
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 _ => throw ExceptionUtilities.Unreachable,
             };
 
-            Assert.Equal(expected, SegmentedArrayHelper.CalculateSegmentShift(segmentSize));
+            Assert.Equal(expected, SegmentedArrayHelper.TestAccessor.CalculateSegmentShift(segmentSize));
         }
 
         [Theory]
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 _ => throw ExceptionUtilities.Unreachable,
             };
 
-            Assert.Equal(expected, SegmentedArrayHelper.CalculateOffsetMask(segmentSize));
+            Assert.Equal(expected, SegmentedArrayHelper.TestAccessor.CalculateOffsetMask(segmentSize));
         }
     }
 }


### PR DESCRIPTION
* Closes the gap for using `SegmentedArray<int>` (and other unmanaged types) from 2.69x the cost of `int[]` to 1.29x on .NET Framework
* Reduces the penalty for using `SegmentedArray<object>` (and other reference types), particularly on .NET Framework

## Before this change

### net472

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT


```
|                 Method |  Count |        Mean |    Error |   StdDev | Ratio | RatioSD | Code Size |
|----------------------- |------- |------------:|---------:|---------:|------:|--------:|----------:|
|                &#39;int[]&#39; | 100000 |    78.29 μs | 0.133 μs | 0.104 μs |  1.00 |    0.00 |     107 B |
|             &#39;object[]&#39; | 100000 |   180.58 μs | 0.285 μs | 0.238 μs |  2.31 |    0.00 |     113 B |
|    SegmentedArray&lt;int&gt; | 100000 |   358.65 μs | 1.645 μs | 1.458 μs |  4.58 |    0.02 |     144 B |
| SegmentedArray&lt;object&gt; | 100000 | 1,381.35 μs | 7.889 μs | 7.379 μs | 17.62 |    0.08 |     224 B |

### netcoreapp3.1

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET Core SDK=5.0.103
  [Host]     : .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT
  DefaultJob : .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT


```
|                 Method |  Count |     Mean |   Error |  StdDev | Ratio | RatioSD | Code Size |
|----------------------- |------- |---------:|--------:|--------:|------:|--------:|----------:|
|                &#39;int[]&#39; | 100000 | 133.1 μs | 0.75 μs | 0.70 μs |  1.00 |    0.00 |     107 B |
|             &#39;object[]&#39; | 100000 | 155.7 μs | 0.66 μs | 0.62 μs |  1.17 |    0.01 |     113 B |
|    SegmentedArray&lt;int&gt; | 100000 | 221.8 μs | 0.74 μs | 0.69 μs |  1.67 |    0.01 |     219 B |
| SegmentedArray&lt;object&gt; | 100000 | 554.6 μs | 2.43 μs | 2.15 μs |  4.16 |    0.03 |     275 B |

### net5.0

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET Core SDK=5.0.103
  [Host]     : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT
  DefaultJob : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT


```
|                 Method |  Count |     Mean |   Error |  StdDev | Ratio | RatioSD | Code Size |
|----------------------- |------- |---------:|--------:|--------:|------:|--------:|----------:|
|                &#39;int[]&#39; | 100000 | 133.2 μs | 0.62 μs | 0.58 μs |  1.00 |    0.00 |     107 B |
|             &#39;object[]&#39; | 100000 | 155.7 μs | 0.77 μs | 0.65 μs |  1.17 |    0.01 |     113 B |
|    SegmentedArray&lt;int&gt; | 100000 | 202.8 μs | 0.46 μs | 0.41 μs |  1.52 |    0.01 |     213 B |
| SegmentedArray&lt;object&gt; | 100000 | 448.2 μs | 1.89 μs | 1.68 μs |  3.37 |    0.02 |     279 B |

## After this change

### net472

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT


```
|                 Method |  Count |     Mean |   Error |  StdDev | Ratio | Code Size |
|----------------------- |------- |---------:|--------:|--------:|------:|----------:|
|                &#39;int[]&#39; | 100000 | 133.9 μs | 0.25 μs | 0.21 μs |  1.00 |     107 B |
|             &#39;object[]&#39; | 100000 | 157.3 μs | 0.82 μs | 0.73 μs |  1.18 |     113 B |
|    SegmentedArray&lt;int&gt; | 100000 | 172.6 μs | 0.65 μs | 0.61 μs |  1.29 |     205 B |
| SegmentedArray&lt;object&gt; | 100000 | 531.9 μs | 1.88 μs | 1.66 μs |  3.97 |     233 B |

### netcoreapp3.1

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET Core SDK=5.0.103
  [Host]     : .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT
  DefaultJob : .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT


```
|                 Method |  Count |     Mean |   Error |  StdDev | Ratio | RatioSD | Code Size |
|----------------------- |------- |---------:|--------:|--------:|------:|--------:|----------:|
|                &#39;int[]&#39; | 100000 | 133.2 μs | 0.65 μs | 0.61 μs |  1.00 |    0.00 |     107 B |
|             &#39;object[]&#39; | 100000 | 155.7 μs | 1.04 μs | 0.97 μs |  1.17 |    0.01 |     113 B |
|    SegmentedArray&lt;int&gt; | 100000 | 172.3 μs | 0.59 μs | 0.55 μs |  1.29 |    0.01 |     205 B |
| SegmentedArray&lt;object&gt; | 100000 | 486.8 μs | 1.55 μs | 1.37 μs |  3.66 |    0.02 |     233 B |


### net5.0

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET Core SDK=5.0.103
  [Host]     : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT
  DefaultJob : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT


```
|                 Method |  Count |      Mean |    Error |   StdDev | Ratio | RatioSD | Code Size |
|----------------------- |------- |----------:|---------:|---------:|------:|--------:|----------:|
|                &#39;int[]&#39; | 100000 |  77.69 μs | 0.292 μs | 0.273 μs |  1.00 |    0.00 |     107 B |
|             &#39;object[]&#39; | 100000 | 155.04 μs | 0.427 μs | 0.378 μs |  2.00 |    0.01 |     113 B |
|    SegmentedArray&lt;int&gt; | 100000 | 166.89 μs | 0.550 μs | 0.515 μs |  2.15 |    0.01 |     203 B |
| SegmentedArray&lt;object&gt; | 100000 | 434.87 μs | 1.560 μs | 1.459 μs |  5.60 |    0.03 |     232 B |

