### PR TITLE
Perform code-lens 'find' operations serially.

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -51,10 +51,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Await TestStreamingFeature(element, searchSingleFileOnly, uiVisibleOnly, host)
         End Function
 
-        Private Shared Async Function TestStreamingFeature(element As XElement,
-                                                    searchSingleFileOnly As Boolean,
-                                                    uiVisibleOnly As Boolean,
-                                                    host As TestHost) As Task
+        Private Shared Async Function TestStreamingFeature(
+                element As XElement,
+                searchSingleFileOnly As Boolean,
+                uiVisibleOnly As Boolean,
+                host As TestHost) As Task
             ' We don't support testing features that only expect partial results.
             If searchSingleFileOnly OrElse uiVisibleOnly Then
                 Return
@@ -254,7 +255,19 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 Optional uiVisibleOnly As Boolean = False,
                 Optional options As FindReferencesSearchOptions = Nothing) As Task
 
+            Await TestAPI(definition, host, parallel:=False, searchSingleFileOnly, uiVisibleOnly, options)
+            Await TestAPI(definition, host, parallel:=True, searchSingleFileOnly, uiVisibleOnly, options)
+        End Function
+
+        Private Async Function TestAPI(
+                definition As XElement,
+                host As TestHost,
+                parallel As Boolean,
+                searchSingleFileOnly As Boolean,
+                uiVisibleOnly As Boolean,
+                options As FindReferencesSearchOptions) As Task
             options = If(options, FindReferencesSearchOptions.Default)
+            options = options.With(parallel:=parallel)
             Using workspace = TestWorkspace.Create(definition, composition:=s_composition.WithTestHostParts(host))
                 workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
 

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
             //
             // This can save a lot of extra time spent finding callers, especially for methods with
             // high fan-out (like IDisposable.Dispose()).
-            var findRefsOptions = FindReferencesSearchOptions.Default.WithCascade(false);
+            var findRefsOptions = FindReferencesSearchOptions.Default.With(cascade: false);
             var references = await SymbolFinder.FindReferencesAsync(
                 implMember, solution, findRefsOptions, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -26,6 +26,11 @@ namespace Microsoft.CodeAnalysis.CodeLens
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
                 memberOptions: SymbolDisplayMemberOptions.IncludeContainingType);
 
+        // Do not perform the finding operation in parallel.  We're running ephemerally in the BG and do not want to
+        // saturate the system with work that then slows the user down.
+        private static readonly FindReferencesSearchOptions s_nonParallelSearch =
+            FindReferencesSearchOptions.Default.With(parallel: false);
+
         private static async Task<T?> FindAsync<T>(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             Func<CodeLensFindReferencesProgress, Task<T>> onResults, Func<CodeLensFindReferencesProgress, Task<T>> onCapped,
             int searchCap, CancellationToken cancellationToken) where T : struct
@@ -49,8 +54,8 @@ namespace Microsoft.CodeAnalysis.CodeLens
             using var progress = new CodeLensFindReferencesProgress(symbol, syntaxNode, searchCap, cancellationToken);
             try
             {
-                await SymbolFinder.FindReferencesAsync(symbol, solution, progress, null,
-                    progress.CancellationToken).ConfigureAwait(false);
+                await SymbolFinder.FindReferencesAsync(
+                    symbol, solution, progress, documents: null, s_nonParallelSearch, progress.CancellationToken).ConfigureAwait(false);
 
                 return await onResults(progress).ConfigureAwait(false);
             }

--- a/src/Features/Core/Portable/InlineTemporary/AbstractInlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InlineTemporary/AbstractInlineTemporaryCodeRefactoringProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.InlineTemporary
                 // Do not cascade when finding references to this local.  Cascading can cause us to find linked
                 // references as well which can throw things off for us.  For inline variable, we only care about the
                 // direct real references in this project context.
-                var options = FindReferencesSearchOptions.Default.WithCascade(cascade: false);
+                var options = FindReferencesSearchOptions.Default.With(cascade: false);
 
                 var findReferencesResult = await SymbolFinder.FindReferencesAsync(
                     local, document.Project.Solution, options, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -52,8 +52,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             _progressTracker = progress.ProgressTracker;
 
-            var pair = new ConcurrentExclusiveSchedulerPair();
-            _scheduler = _options.Parallel ? pair.ConcurrentScheduler : pair.ExclusiveScheduler;
+            // If we're running in parallel, just defer to the threadpool to execute all our work in parallel.  If we're
+            // running serially, then use a ConcurrentExclusiveSchedulerPair as that's the most built-in way in the TPL
+            // to get a sheduler that can execute in that fashion.
+            _scheduler = _options.Parallel ? TaskScheduler.Default : new ConcurrentExclusiveSchedulerPair().ExclusiveScheduler;
         }
 
         public async Task FindReferencesAsync(ISymbol symbol)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 using var _ = ArrayBuilder<Task>.GetInstance(out var tasks);
 
                 foreach (var (project, documentMap) in projectToDocumentMap)
-                    tasks.Add(Task.Factory.StartNew(() => ProcessProjectAsync(project, documentMap), _cancellationToken, TaskCreationOptions.None, _scheduler));
+                    tasks.Add(Task.Factory.StartNew(() => ProcessProjectAsync(project, documentMap), _cancellationToken, TaskCreationOptions.None, _scheduler).Unwrap());
 
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     foreach (var (symbol, finder) in projectQueue)
                     {
                         tasks.Add(Task.Factory.StartNew(() =>
-                            DetermineDocumentsToSearchAsync(project, symbol, finder), _cancellationToken, TaskCreationOptions.None, _scheduler));
+                            DetermineDocumentsToSearchAsync(project, symbol, finder), _cancellationToken, TaskCreationOptions.None, _scheduler).Unwrap());
                     }
                 }
 
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         _cancellationToken.ThrowIfCancellationRequested();
 
                         await Task.WhenAll(symbolTasks).ConfigureAwait(false);
-                    }, _cancellationToken, TaskCreationOptions.None, _scheduler));
+                    }, _cancellationToken, TaskCreationOptions.None, _scheduler).Unwrap());
                 }
 
                 await Task.WhenAll(finderTasks).ConfigureAwait(false);
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     Contract.ThrowIfNull(child);
                     _cancellationToken.ThrowIfCancellationRequested();
                     symbolTasks.Add(Task.Factory.StartNew(
-                        () => DetermineAllSymbolsCoreAsync(child, result), _cancellationToken, TaskCreationOptions.None, _scheduler));
+                        () => DetermineAllSymbolsCoreAsync(child, result), _cancellationToken, TaskCreationOptions.None, _scheduler).Unwrap());
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     foreach (var (document, documentQueue) in documentMap)
                     {
                         if (document.Project == project)
-                            documentTasks.Add(Task.Run(() => ProcessDocumentQueueAsync(document, documentQueue), _cancellationToken));
+                            documentTasks.Add(Task.Factory.StartNew(() => ProcessDocumentQueueAsync(document, documentQueue), _cancellationToken, TaskCreationOptions.None, _scheduler));
                     }
 
                     await Task.WhenAll(documentTasks).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_ProjectProcessing.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     foreach (var (document, documentQueue) in documentMap)
                     {
                         if (document.Project == project)
-                            documentTasks.Add(Task.Factory.StartNew(() => ProcessDocumentQueueAsync(document, documentQueue), _cancellationToken, TaskCreationOptions.None, _scheduler));
+                            documentTasks.Add(Task.Factory.StartNew(() => ProcessDocumentQueueAsync(document, documentQueue), _cancellationToken, TaskCreationOptions.None, _scheduler).Unwrap());
                     }
 
                     await Task.WhenAll(documentTasks).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Features that run automatically should consider setting this to <see langword="false"/> to avoid
         /// unnecessarily impacting the user while they are doing other work.
         /// </remarks>
-        [DataMember(Order = 1)]
+        [DataMember(Order = 2)]
         public bool Parallel { get; }
 
         public FindReferencesSearchOptions(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -15,7 +13,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public static readonly FindReferencesSearchOptions Default =
             new(
                 associatePropertyReferencesWithSpecificAccessor: false,
-                cascade: true);
+                cascade: true,
+                parallel: true);
 
         /// <summary>
         /// When searching for property, associate specific references we find to the relevant
@@ -39,19 +38,45 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         [DataMember(Order = 1)]
         public bool Cascade { get; }
 
+        /// <summary>
+        /// Whether or not we should perform the find operation in parallel.  This can produce results more quickly, but
+        /// at the cost of more system resources.
+        /// </summary>
+        /// <remarks>
+        /// Features that run automatically should consider setting this to <see langword="false"/> to avoid
+        /// unnecessarily impacting the user while they are doing other work.
+        /// </remarks>
+        [DataMember(Order = 1)]
+        public bool Parallel { get; }
+
         public FindReferencesSearchOptions(
             bool associatePropertyReferencesWithSpecificAccessor,
-            bool cascade)
+            bool cascade,
+            bool parallel)
         {
             AssociatePropertyReferencesWithSpecificAccessor = associatePropertyReferencesWithSpecificAccessor;
             Cascade = cascade;
+            Parallel = parallel;
         }
 
-        public FindReferencesSearchOptions WithAssociatePropertyReferencesWithSpecificAccessor(bool associatePropertyReferencesWithSpecificAccessor)
-            => new(associatePropertyReferencesWithSpecificAccessor, Cascade);
+        public FindReferencesSearchOptions With(
+            Optional<bool> associatePropertyReferencesWithSpecificAccessor = default,
+            Optional<bool> cascade = default,
+            Optional<bool> parallel = default)
+        {
+            var newAssociatePropertyReferencesWithSpecificAccessor = associatePropertyReferencesWithSpecificAccessor.HasValue ? associatePropertyReferencesWithSpecificAccessor.Value : AssociatePropertyReferencesWithSpecificAccessor;
+            var newCascade = cascade.HasValue ? cascade.Value : Cascade;
+            var newParallel = parallel.HasValue ? parallel.Value : Parallel;
 
-        public FindReferencesSearchOptions WithCascade(bool cascade)
-            => new(AssociatePropertyReferencesWithSpecificAccessor, cascade);
+            if (newAssociatePropertyReferencesWithSpecificAccessor == AssociatePropertyReferencesWithSpecificAccessor &&
+                newCascade == Cascade &&
+                newParallel == Parallel)
+            {
+                return this;
+            }
+
+            return new FindReferencesSearchOptions(newAssociatePropertyReferencesWithSpecificAccessor, newCascade, newParallel);
+        }
 
         /// <summary>
         /// For IDE features, if the user starts searching on an accessor, then we want to give
@@ -59,6 +84,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// then associate everything with the property.
         /// </summary>
         public static FindReferencesSearchOptions GetFeatureOptionsForStartingSymbol(ISymbol symbol)
-            => Default.WithAssociatePropertyReferencesWithSpecificAccessor(symbol.IsPropertyAccessor());
+            => Default.With(associatePropertyReferencesWithSpecificAccessor: symbol.IsPropertyAccessor());
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 // defer to the Property finder to find these docs and combine them with the result.
                 var propertyDocuments = await ReferenceFinders.Property.DetermineDocumentsToSearchAsync(
                     property, project, documents,
-                    options.WithAssociatePropertyReferencesWithSpecificAccessor(false),
+                    options.With(associatePropertyReferencesWithSpecificAccessor: false),
                     cancellationToken).ConfigureAwait(false);
 
                 result = result.AddRange(propertyDocuments);
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             {
                 var propertyReferences = await ReferenceFinders.Property.FindReferencesInDocumentAsync(
                     property, document, semanticModel,
-                    options.WithAssociatePropertyReferencesWithSpecificAccessor(false),
+                    options.With(associatePropertyReferencesWithSpecificAccessor: false),
                     cancellationToken).ConfigureAwait(false);
 
                 var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Legacy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindReferences_Legacy.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 FindReferencesSearchOptions.Default, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<ImmutableArray<ReferencedSymbol>> FindReferencesAsync(
+        internal static async Task<ImmutableArray<ReferencedSymbol>> FindReferencesAsync(
             ISymbol symbol,
             Solution solution,
             IFindReferencesProgress progress,


### PR DESCRIPTION
CodeLens both runs in the background, and and is commonly run on many visible symbosl in a file.  This leads to a lot of find-references work in our OOP process that is currently done in parallel.  This parallel work uses all the cores it can get, and can generally slow down the editing experience in the host VS process as tehre is less CPU available for the jobs it wants to do.

To avoid this problem, this PR adds a new flag to control if we do this sort of work in parallel or not, and updates CodeLens to ask that the work be done serially instead.  Existing, explicitly invoked features (like FindReferences) will still do work in parallel so they can get their results back to the usre as quickly as possible.

Fixes [AB#1280758](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1280758)