### PR TITLE
IOperation Test Leg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,6 +103,15 @@ jobs:
     configuration: Release
     testArguments: -testCoreClr
 
+- template: eng/pipelines/test-windows-job.yml
+  parameters:
+    testRunName: 'Test Windows CoreCLR IOperation Debug'
+    jobName: Test_Windows_CoreClr_IOperation_Debug
+    buildJobName: Build_Windows_Debug
+    testArtifactName: Transport_Artifacts_Windows_Debug
+    configuration: Debug
+    testArguments: -testCoreClr -testIOperation -testCompilerOnly
+
 # Unix Build and Test Jobs
 - template: eng/pipelines/build-unix-job.yml
   parameters:

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -331,16 +331,19 @@ function GetIbcDropName() {
 
 function GetCompilerTestAssembliesIncludePaths() {
   $assemblies = " --include '^Microsoft\.CodeAnalysis\.UnitTests$'"
+  $assemblies += " --include '^Microsoft\.CodeAnalysis\.CompilerServer\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.CSharp\.Syntax\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.CSharp\.Symbol\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.CSharp\.Semantic\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.CSharp\.Emit\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.CSharp\.IOperation\.UnitTests$'"
+  $assemblies += " --include '^Microsoft\.CodeAnalysis\.CSharp\.CommandLine\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.VisualBasic\.Syntax\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.VisualBasic\.Symbol\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.VisualBasic\.Semantic\.UnitTests$'"
   $assemblies += " --include '^Microsoft\.CodeAnalysis\.VisualBasic\.Emit\.UnitTests$'"
   $assemblies += " --include '^Roslyn\.Compilers\.VisualBasic\.IOperation\.UnitTests$'"
+  $assemblies += " --include '^Microsoft\.CodeAnalysis\.VisualBasic\.CommandLine\.UnitTests$'"
   return $assemblies
 }
 

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -158,15 +158,19 @@ namespace RunTests
                 var rehydrateFilename = isUnix ? "rehydrate.sh" : "rehydrate.cmd";
                 var lsCommand = isUnix ? "ls" : "dir";
                 var rehydrateCommand = isUnix ? $"./{rehydrateFilename}" : $@"call .\{rehydrateFilename}";
-                var workItem = @"
-        <HelixWorkItem Include=""" + assemblyInfo.DisplayName + @""">
-            <PayloadDirectory>" + Path.Combine(msbuildTestPayloadRoot, Path.GetDirectoryName(assemblyInfo.AssemblyPath)!) + @"</PayloadDirectory>
+                var setEnvironmentVariables = Environment.GetEnvironmentVariable("ROSLYN_TEST_IOPERATION") is { } iop
+                    ? $"{(isUnix ? "export" : "set")} ROSLYN_TEST_IOPERATION={iop}"
+                    : "";
+                var workItem = $@"
+        <HelixWorkItem Include=""{assemblyInfo.DisplayName}"">
+            <PayloadDirectory>{Path.Combine(msbuildTestPayloadRoot, Path.GetDirectoryName(assemblyInfo.AssemblyPath)!)}</PayloadDirectory>
             <Command>
-                " + lsCommand + @"
-                " + rehydrateCommand + @"
-                " + lsCommand + @"
+                {lsCommand}
+                {rehydrateCommand}
+                {lsCommand}
                 dotnet --version
-                dotnet " + commandLineArguments + @"
+                {setEnvironmentVariables}
+                dotnet {commandLineArguments}
             </Command>
             <Timeout>00:15:00</Timeout>
         </HelixWorkItem>


### PR DESCRIPTION
Adds a test leg that verifies IOperation in CI. Fixes https://github.com/dotnet/roslyn/issues/31450.