### PR TITLE
Add a missing check for AccessorDeclaration

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -748,6 +748,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
         // event EventHandler Bar {add; remove;}
         private static bool ShouldRemoveBraceForAccessorDeclaration(AccessorDeclarationSyntax accessorDeclarationNode, int caretPosition)
             => accessorDeclarationNode.Body != null
+               && accessorDeclarationNode.Body.Statements.IsEmpty()
                && accessorDeclarationNode.ExpressionBody == null
                && accessorDeclarationNode.Parent != null
                && accessorDeclarationNode.Parent.IsParentKind(SyntaxKind.PropertyDeclaration)

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -1259,6 +1259,74 @@ public class Bar
         }
 
         [WpfFact]
+        public void TestNonEmptyGetAccessor()
+        {
+            Test(@"
+public Class Bar
+{
+    public int P
+    {
+        get
+        {
+            if (true)
+            $$
+            {
+                return 1;
+            }
+        }
+    }   
+}",
+                @"
+public Class Bar
+{
+    public int P
+    {
+        get
+        {
+            i$$f ($$true$$)$$
+            {
+                return 1;
+            }
+        }
+    }   
+}");
+        }
+
+        [WpfFact]
+        public void TestNonEmptySetAccessor()
+        {
+            Test(@"
+public Class Bar
+{
+    public int P
+    {
+        get;
+        set
+        {
+            if (true)
+            $$
+            {
+            }
+        }
+    }   
+}",
+                @"
+public Class Bar
+{
+    public int P
+    {
+        get;
+        set
+        {
+            i$$f (t$$rue)$$
+            {
+            }
+        }
+    }   
+}");
+        }
+
+        [WpfFact]
         public void TestSetAccessorOfIndexer()
         {
             Test(@"
@@ -1471,6 +1539,27 @@ public class Bar
         }
 
         [WpfFact]
+        public void TestNonEmptyProperty()
+        {
+            Test(@"
+public class Bar
+{
+    public int Foo
+    {
+        get { }
+        $$
+    }
+}", @"
+public class Bar
+{
+    public int Foo
+    {
+        $$get$$ { }$$
+    }
+}");
+        }
+
+        [WpfFact]
         public void TestMulitpleFields()
         {
             Test(@"
@@ -1529,6 +1618,29 @@ public class Bar
 }";
             Test(firstResult, initialMarkup);
             Test(secondResult, firstResult);
+        }
+
+        [WpfFact]
+        public void TestNonEmptyEvent()
+        {
+            Test(@"
+using System;
+public class Bar
+{
+    public event EventHandler Foo
+    {
+        add { }
+        $$
+    }
+}", @"
+using System;
+public class Bar
+{
+    public event EventHandler Foo
+    {
+        $$add$$ {$$ }$$
+    }
+}");
         }
 
         [WpfFact]
@@ -1806,6 +1918,40 @@ public class Foo
 
             Test(firstResult, initialMarkup);
             Test(secondResult, firstResult);
+        }
+
+        [WpfFact]
+        public void TestObjectCreationExpressionWithNonEmptyInitializer()
+        {
+            Test(
+                @"
+public class Bar
+{
+    public void M()
+    {
+        var a = new Foo() { HH = 1, PP = 2 };
+        $$
+    }
+}
+public class Foo
+{
+    public int HH { get; set; }
+    public int PP { get; set; }
+}",
+                @"
+public class Bar
+{
+    public void M()
+    {
+        var a = n$$ew Fo$$o($$) {$$ HH = 1$$, PP = 2 $$};
+    }
+}
+public class Foo
+{
+    public int HH { get; set; }
+    public int PP { get; set; }
+}");
+
         }
 
         [WpfFact]


### PR DESCRIPTION
Fix the bug found by Sam and it is caused because a missing check.
Also, add a few tests around the braces removal scenarios.

Tracking: https://github.com/dotnet/roslyn/issues/51404