### PR TITLE
Add component debugger support to target files

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -293,5 +293,16 @@
     <MakeDir Condition="'$(CompilerGeneratedFilesOutputPath)' != ''" 
              Directories="$(CompilerGeneratedFilesOutputPath)"  />
   </Target>
-  
+
+  <!--
+    ========================
+    Component Debugger Support
+    ========================
+    
+    Add the specified VS capability if a user indicates this project supports component debugging
+    -->
+  <ItemGroup>
+    <ProjectCapability Include="RoslynComponent" Condition="'$(IsRoslynComponent)' == 'true'"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -714,6 +714,39 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             }
         }
 
+        [Fact]
+        public void ProjectCapabilityIsnotAddedWhenRoslynComponentIsUnSpecified()
+        {
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <Import Project=""Microsoft.Managed.Core.targets"" />
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+
+            var caps = instance.GetItems("ProjectCapability").Select(c => c.EvaluatedInclude);
+            Assert.DoesNotContain("RoslynComponent", caps);
+        }
+
+        [Fact]
+        public void ProjectCapabilityIsAddedWhenRoslynComponentSpecified()
+        {
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <PropertyGroup>
+        <IsRoslynComponent>true</IsRoslynComponent>
+    </PropertyGroup>
+    <Import Project=""Microsoft.Managed.Core.targets"" />
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+
+            var caps = instance.GetItems("ProjectCapability").Select(c => c.EvaluatedInclude);
+            Assert.Contains("RoslynComponent", caps);
+        }
+
         private static ProjectInstance CreateProjectInstance(XmlReader reader)
         {
             Project proj = new Project(reader);

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -715,7 +715,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
-        public void ProjectCapabilityIsnotAddedWhenRoslynComponentIsUnSpecified()
+        public void ProjectCapabilityIsNotAddedWhenRoslynComponentIsUnspecified()
         {
             XmlReader xmlReader = XmlReader.Create(new StringReader($@"
 <Project>


### PR DESCRIPTION
Adds support to the roslyn targets to let users specify `<IsRoslynComponent>true</IsRoslynComponent>` in their project file to enable the component debugger UI option in Visual Studio.