### PR TITLE
Split imports binder into its own binder.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var methods = ArrayBuilder<MethodSymbol>.GetInstance();
             var binder = scope.Binder;
-            binder.GetCandidateExtensionMethods(scope.SearchUsingsNotNamespace, methods, name, arity, options, this);
+            binder.GetCandidateExtensionMethods(methods, name, arity, options, this);
 
             foreach (var method in methods)
             {
@@ -692,7 +692,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// to search the available members list in binding types that represent types, namespaces, and usings.
         /// </summary>
         internal virtual void GetCandidateExtensionMethods(
-            bool searchUsingsNotNamespace,
             ArrayBuilder<MethodSymbol> methods,
             string name,
             int arity,

--- a/src/Compilers/CSharp/Portable/Binder/ExtensionMethodScope.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExtensionMethodScope.cs
@@ -14,12 +14,10 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal struct ExtensionMethodScope
     {
         public readonly Binder Binder;
-        public readonly bool SearchUsingsNotNamespace;
 
-        public ExtensionMethodScope(Binder binder, bool searchUsingsNotNamespace)
+        public ExtensionMethodScope(Binder binder)
         {
             this.Binder = binder;
-            this.SearchUsingsNotNamespace = searchUsingsNotNamespace;
         }
     }
 
@@ -70,17 +68,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 var binder = _current.Binder;
-                if (!_current.SearchUsingsNotNamespace)
-                {
-                    // Return a scope for the same Binder that was previously exposed
-                    // for the namespace, this time exposed for the usings.
-                    _current = new ExtensionMethodScope(binder, searchUsingsNotNamespace: true);
-                }
-                else
-                {
-                    // Return a scope for the next Binder that supports extension methods.
-                    _current = GetNextScope(binder.Next);
-                }
+                // Return a scope for the next Binder that supports extension methods.
+                _current = GetNextScope(binder.Next);
             }
 
             return (_current.Binder != null);
@@ -92,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (scope.SupportsExtensionMethods)
                 {
-                    return new ExtensionMethodScope(scope, searchUsingsNotNamespace: false);
+                    return new ExtensionMethodScope(scope);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static Imports FromSyntax(
             CSharpSyntaxNode declarationSyntax,
-            InContainerBinder binder,
+            ImportsBinder binder,
             ConsList<TypeSymbol> basesBeingResolved,
             bool inUsing)
         {
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty,
                             externAliases,
                             diagnostics: null);
-                    usingsBinder = new InContainerBinder(binder.Container, binder.Next, imports);
+                    usingsBinder = new InContainerBinder(binder.Container, new ImportsBinder(binder.Container, binder.Next, imports));
                 }
 
                 var uniqueUsings = SpecializedSymbolCollections.GetPooledSymbolHashSetInstance<NamespaceOrTypeSymbol>();
@@ -483,7 +483,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static ImmutableArray<AliasAndExternAliasDirective> BuildExternAliases(
             SyntaxList<ExternAliasDirectiveSyntax> syntaxList,
-            InContainerBinder binder,
+            ImportsBinder binder,
             DiagnosticBag diagnostics)
         {
             CSharpCompilation compilation = binder.Compilation;

--- a/src/Compilers/CSharp/Portable/Binder/ImportsBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ImportsBinder.cs
@@ -200,6 +200,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(result.IsClear);
 
+            if (IsSubmissionClass)
+            {
+                // Submission imports are handled by LookupMembersInternal in InContainerBinder.LookupSymbolsInSingleBinder.
+                return;
+            }
+
             var imports = GetImports(basesBeingResolved);
 
             // Try using aliases or symbols in imported namespaces

--- a/src/Compilers/CSharp/Portable/Binder/ImportsBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ImportsBinder.cs
@@ -1,0 +1,232 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// A binder that represent scope introduced by 'using' directives and deals with looking up names in it.
+    /// </summary>
+    internal sealed class ImportsBinder : Binder
+    {
+        private readonly NamespaceOrTypeSymbol _container;
+        private readonly Func<ConsList<TypeSymbol>, Imports> _computeImports;
+        private Imports _lazyImports;
+        private ImportChain _lazyImportChain;
+        private QuickAttributeChecker _lazyQuickAttributeChecker;
+        private readonly SyntaxList<UsingDirectiveSyntax> _usingsSyntax;
+
+        /// <summary>
+        /// Creates a binder imports (usings and extern aliases) within a <paramref name="container"/> that can be
+        /// retrieved from <paramref name="declarationSyntax"/>.
+        /// </summary>
+        internal ImportsBinder(NamespaceOrTypeSymbol container, Binder next, CSharpSyntaxNode declarationSyntax, bool inUsing)
+            : base(next)
+        {
+            Debug.Assert((object)container != null);
+            Debug.Assert(declarationSyntax != null);
+
+            _container = container;
+            _computeImports = basesBeingResolved => Imports.FromSyntax(declarationSyntax, this, basesBeingResolved, inUsing);
+
+            if (!inUsing)
+            {
+                if (declarationSyntax.Kind() == SyntaxKind.CompilationUnit)
+                {
+                    var compilationUnit = (CompilationUnitSyntax)declarationSyntax;
+                    _usingsSyntax = compilationUnit.Usings;
+                }
+                else if (declarationSyntax.Kind() == SyntaxKind.NamespaceDeclaration)
+                {
+                    var namespaceDecl = (NamespaceDeclarationSyntax)declarationSyntax;
+                    _usingsSyntax = namespaceDecl.Usings;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a binder with given imports.
+        /// </summary>
+        internal ImportsBinder(NamespaceOrTypeSymbol container, Binder next, Imports imports = null)
+            : base(next)
+        {
+            Debug.Assert((object)container != null || imports != null);
+
+            _container = container;
+            _lazyImports = imports ?? Imports.Empty;
+        }
+
+        /// <summary>
+        /// Creates a binder with given import computation function.
+        /// </summary>
+        internal ImportsBinder(Binder next, Func<ConsList<TypeSymbol>, Imports> computeImports)
+            : base(next)
+        {
+            Debug.Assert(computeImports != null);
+
+            _container = null;
+            _computeImports = computeImports;
+        }
+
+        internal NamespaceOrTypeSymbol Container
+        {
+            get
+            {
+                return _container;
+            }
+        }
+
+        private bool IsSubmissionClass
+        {
+            get { return (_container?.Kind == SymbolKind.NamedType) && ((NamedTypeSymbol)_container).IsSubmissionClass; }
+        }
+
+        internal override Imports GetImports(ConsList<TypeSymbol> basesBeingResolved)
+        {
+            Debug.Assert(_lazyImports != null || _computeImports != null, "Have neither imports nor a way to compute them.");
+
+            if (_lazyImports == null)
+            {
+                Interlocked.CompareExchange(ref _lazyImports, _computeImports(basesBeingResolved), null);
+            }
+
+            return _lazyImports;
+        }
+
+        /// <summary>
+        /// Look for a type forwarder for the given type in any referenced assemblies, checking any using namespaces in
+        /// the current imports.
+        /// </summary>
+        /// <param name="name">The metadata name of the (potentially) forwarded type, without qualifiers.</param>
+        /// <param name="qualifierOpt">Will be used to return the namespace of the found forwarder, 
+        /// if any.</param>
+        /// <param name="diagnostics">Will be used to report non-fatal errors during look up.</param>
+        /// <param name="location">Location to report errors on.</param>
+        /// <returns>Returns the Assembly to which the type is forwarded, or null if none is found.</returns>
+        /// <remarks>
+        /// Since this method is intended to be used for error reporting, it stops as soon as it finds
+        /// any type forwarder (or an error to report). It does not check other assemblies for consistency or better results.
+        /// </remarks>
+        protected override AssemblySymbol GetForwardedToAssemblyInUsingNamespaces(string name, ref NamespaceOrTypeSymbol qualifierOpt, BindingDiagnosticBag diagnostics, Location location)
+        {
+            var imports = GetImports(basesBeingResolved: null);
+            foreach (var typeOrNamespace in imports.Usings)
+            {
+                var fullName = typeOrNamespace.NamespaceOrType + "." + name;
+                var result = GetForwardedToAssembly(fullName, diagnostics, location);
+                if (result != null)
+                {
+                    qualifierOpt = typeOrNamespace.NamespaceOrType;
+                    return result;
+                }
+            }
+
+            return base.GetForwardedToAssemblyInUsingNamespaces(name, ref qualifierOpt, diagnostics, location);
+        }
+
+        internal override ImportChain ImportChain
+        {
+            get
+            {
+                if (_lazyImportChain == null)
+                {
+                    ImportChain importChain = this.Next.ImportChain;
+                    if ((object)_container == null || _container.Kind == SymbolKind.Namespace)
+                    {
+                        importChain = new ImportChain(GetImports(basesBeingResolved: null), importChain);
+                    }
+
+                    Interlocked.CompareExchange(ref _lazyImportChain, importChain, null);
+                }
+
+                Debug.Assert(_lazyImportChain != null);
+
+                return _lazyImportChain;
+            }
+        }
+
+        /// <summary>
+        /// Get <see cref="QuickAttributeChecker"/> that can be used to quickly
+        /// check for certain attribute applications in context of this binder.
+        /// </summary>
+        internal override QuickAttributeChecker QuickAttributeChecker
+        {
+            get
+            {
+                if (_lazyQuickAttributeChecker == null)
+                {
+                    QuickAttributeChecker result = this.Next.QuickAttributeChecker;
+
+                    if ((object)_container == null || _container.Kind == SymbolKind.Namespace)
+                    {
+                        result = result.AddAliasesIfAny(_usingsSyntax);
+                    }
+
+                    _lazyQuickAttributeChecker = result;
+                }
+
+                return _lazyQuickAttributeChecker;
+            }
+        }
+
+        internal override bool SupportsExtensionMethods
+        {
+            get { return true; }
+        }
+
+        internal override void GetCandidateExtensionMethods(
+            ArrayBuilder<MethodSymbol> methods,
+            string name,
+            int arity,
+            LookupOptions options,
+            Binder originalBinder)
+        {
+            this.GetImports(basesBeingResolved: null).LookupExtensionMethodsInUsings(methods, name, arity, options, originalBinder);
+        }
+
+        internal override void LookupSymbolsInSingleBinder(
+            LookupResult result, string name, int arity, ConsList<TypeSymbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            Debug.Assert(result.IsClear);
+
+            var imports = GetImports(basesBeingResolved);
+
+            // Try using aliases or symbols in imported namespaces
+            imports.LookupSymbol(originalBinder, result, name, arity, basesBeingResolved, options, diagnose, ref useSiteInfo);
+        }
+
+        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        {
+            // If we are looking only for labels we do not need to search through the imports.
+            // Submission imports are handled by AddMemberLookupSymbolsInfo in InContainerBinder.AddLookupSymbolsInfoInSingleBinder.
+            if (!IsSubmissionClass && ((options & LookupOptions.LabelsOnly) == 0))
+            {
+                var imports = GetImports(basesBeingResolved: null);
+                imports.AddLookupSymbolsInfo(result, options, originalBinder);
+            }
+        }
+
+        protected override SourceLocalSymbol LookupLocal(SyntaxToken nameToken)
+        {
+            return null;
+        }
+
+        protected override LocalFunctionSymbol LookupLocalFunction(SyntaxToken nameToken)
+        {
+            return null;
+        }
+
+        internal override uint LocalScopeDepth => Binder.ExternalScope;
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -16,68 +16,20 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
-    /// A binder that places the members of a symbol in scope.  If there is a container declaration
-    /// with using directives, those are merged when looking up names.
+    /// A binder that places the members of a symbol in scope.
     /// </summary>
     internal sealed class InContainerBinder : Binder
     {
         private readonly NamespaceOrTypeSymbol _container;
-        private readonly Func<ConsList<TypeSymbol>, Imports> _computeImports;
-        private Imports _lazyImports;
-        private ImportChain _lazyImportChain;
-        private QuickAttributeChecker _lazyQuickAttributeChecker;
-        private readonly SyntaxList<UsingDirectiveSyntax> _usingsSyntax;
 
         /// <summary>
-        /// Creates a binder for a container with imports (usings and extern aliases) that can be
-        /// retrieved from <paramref name="declarationSyntax"/>.
+        /// Creates a binder for a container.
         /// </summary>
-        internal InContainerBinder(NamespaceOrTypeSymbol container, Binder next, CSharpSyntaxNode declarationSyntax, bool inUsing)
+        internal InContainerBinder(NamespaceOrTypeSymbol container, Binder next)
             : base(next)
         {
             Debug.Assert((object)container != null);
-            Debug.Assert(declarationSyntax != null);
-
             _container = container;
-            _computeImports = basesBeingResolved => Imports.FromSyntax(declarationSyntax, this, basesBeingResolved, inUsing);
-
-            if (!inUsing)
-            {
-                if (declarationSyntax.Kind() == SyntaxKind.CompilationUnit)
-                {
-                    var compilationUnit = (CompilationUnitSyntax)declarationSyntax;
-                    _usingsSyntax = compilationUnit.Usings;
-                }
-                else if (declarationSyntax.Kind() == SyntaxKind.NamespaceDeclaration)
-                {
-                    var namespaceDecl = (NamespaceDeclarationSyntax)declarationSyntax;
-                    _usingsSyntax = namespaceDecl.Usings;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Creates a binder with given imports.
-        /// </summary>
-        internal InContainerBinder(NamespaceOrTypeSymbol container, Binder next, Imports imports = null)
-            : base(next)
-        {
-            Debug.Assert((object)container != null || imports != null);
-
-            _container = container;
-            _lazyImports = imports ?? Imports.Empty;
-        }
-
-        /// <summary>
-        /// Creates a binder with given import computation function.
-        /// </summary>
-        internal InContainerBinder(Binder next, Func<ConsList<TypeSymbol>, Imports> computeImports)
-            : base(next)
-        {
-            Debug.Assert(computeImports != null);
-
-            _container = null;
-            _computeImports = computeImports;
         }
 
         internal NamespaceOrTypeSymbol Container
@@ -85,94 +37,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 return _container;
-            }
-        }
-
-        internal override Imports GetImports(ConsList<TypeSymbol> basesBeingResolved)
-        {
-            Debug.Assert(_lazyImports != null || _computeImports != null, "Have neither imports nor a way to compute them.");
-
-            if (_lazyImports == null)
-            {
-                Interlocked.CompareExchange(ref _lazyImports, _computeImports(basesBeingResolved), null);
-            }
-
-            return _lazyImports;
-        }
-
-        /// <summary>
-        /// Look for a type forwarder for the given type in any referenced assemblies, checking any using namespaces in
-        /// the current imports.
-        /// </summary>
-        /// <param name="name">The metadata name of the (potentially) forwarded type, without qualifiers.</param>
-        /// <param name="qualifierOpt">Will be used to return the namespace of the found forwarder, 
-        /// if any.</param>
-        /// <param name="diagnostics">Will be used to report non-fatal errors during look up.</param>
-        /// <param name="location">Location to report errors on.</param>
-        /// <returns>Returns the Assembly to which the type is forwarded, or null if none is found.</returns>
-        /// <remarks>
-        /// Since this method is intended to be used for error reporting, it stops as soon as it finds
-        /// any type forwarder (or an error to report). It does not check other assemblies for consistency or better results.
-        /// </remarks>
-        protected override AssemblySymbol GetForwardedToAssemblyInUsingNamespaces(string name, ref NamespaceOrTypeSymbol qualifierOpt, BindingDiagnosticBag diagnostics, Location location)
-        {
-            var imports = GetImports(basesBeingResolved: null);
-            foreach (var typeOrNamespace in imports.Usings)
-            {
-                var fullName = typeOrNamespace.NamespaceOrType + "." + name;
-                var result = GetForwardedToAssembly(fullName, diagnostics, location);
-                if (result != null)
-                {
-                    qualifierOpt = typeOrNamespace.NamespaceOrType;
-                    return result;
-                }
-            }
-
-            return base.GetForwardedToAssemblyInUsingNamespaces(name, ref qualifierOpt, diagnostics, location);
-        }
-
-        internal override ImportChain ImportChain
-        {
-            get
-            {
-                if (_lazyImportChain == null)
-                {
-                    ImportChain importChain = this.Next.ImportChain;
-                    if ((object)_container == null || _container.Kind == SymbolKind.Namespace)
-                    {
-                        importChain = new ImportChain(GetImports(basesBeingResolved: null), importChain);
-                    }
-
-                    Interlocked.CompareExchange(ref _lazyImportChain, importChain, null);
-                }
-
-                Debug.Assert(_lazyImportChain != null);
-
-                return _lazyImportChain;
-            }
-        }
-
-        /// <summary>
-        /// Get <see cref="QuickAttributeChecker"/> that can be used to quickly
-        /// check for certain attribute applications in context of this binder.
-        /// </summary>
-        internal override QuickAttributeChecker QuickAttributeChecker
-        {
-            get
-            {
-                if (_lazyQuickAttributeChecker == null)
-                {
-                    QuickAttributeChecker result = this.Next.QuickAttributeChecker;
-
-                    if ((object)_container == null || _container.Kind == SymbolKind.Namespace)
-                    {
-                        result = result.AddAliasesIfAny(_usingsSyntax);
-                    }
-
-                    _lazyQuickAttributeChecker = result;
-                }
-
-                return _lazyQuickAttributeChecker;
             }
         }
 
@@ -187,12 +51,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool IsSubmissionClass
         {
-            get { return (_container?.Kind == SymbolKind.NamedType) && ((NamedTypeSymbol)_container).IsSubmissionClass; }
+            get { return (_container.Kind == SymbolKind.NamedType) && ((NamedTypeSymbol)_container).IsSubmissionClass; }
         }
 
         private bool IsScriptClass
         {
-            get { return (_container?.Kind == SymbolKind.NamedType) && ((NamedTypeSymbol)_container).IsScriptClass; }
+            get { return (_container.Kind == SymbolKind.NamedType) && ((NamedTypeSymbol)_container).IsScriptClass; }
         }
 
         internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, ConsList<TypeSymbol> basesBeingResolved)
@@ -214,18 +78,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal override void GetCandidateExtensionMethods(
-            bool searchUsingsNotNamespace,
             ArrayBuilder<MethodSymbol> methods,
             string name,
             int arity,
             LookupOptions options,
             Binder originalBinder)
         {
-            if (searchUsingsNotNamespace)
-            {
-                this.GetImports(basesBeingResolved: null).LookupExtensionMethodsInUsings(methods, name, arity, options, originalBinder);
-            }
-            else if (_container?.Kind == SymbolKind.Namespace)
+            if (_container.Kind == SymbolKind.Namespace)
             {
                 ((NamespaceSymbol)_container).GetExtensionMethods(methods, name, arity, options);
             }
@@ -264,45 +123,45 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            var imports = GetImports(basesBeingResolved);
-
             // first lookup members of the namespace
-            if ((options & LookupOptions.NamespaceAliasesOnly) == 0 && _container != null)
+            if ((options & LookupOptions.NamespaceAliasesOnly) == 0)
             {
                 this.LookupMembersInternal(result, _container, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteInfo);
 
                 if (result.IsMultiViable)
                 {
-                    // symbols cannot conflict with using alias names
-                    if (arity == 0 && imports.IsUsingAlias(name, originalBinder.IsSemanticModelBinder))
+                    if (arity == 0 && _container.IsNamespace)
                     {
-                        CSDiagnosticInfo diagInfo = new CSDiagnosticInfo(ErrorCode.ERR_ConflictAliasAndMember, name, _container);
-                        var error = new ExtendedErrorTypeSymbol((NamespaceOrTypeSymbol)null, name, arity, diagInfo, unreported: true);
-                        result.SetFrom(LookupResult.Good(error)); // force lookup to be done w/ error symbol as result
+                        // symbols cannot conflict with using alias names
+                        Binder binder = this;
+
+                        do
+                        {
+                            binder = binder.Next;
+                        }
+                        while (binder is object && !(binder is ImportsBinder));
+
+                        if (binder is ImportsBinder importsBinder && importsBinder.Container == _container)
+                        {
+                            var imports = importsBinder.GetImports(basesBeingResolved);
+
+                            if (imports.IsUsingAlias(name, originalBinder.IsSemanticModelBinder))
+                            {
+                                CSDiagnosticInfo diagInfo = new CSDiagnosticInfo(ErrorCode.ERR_ConflictAliasAndMember, name, _container);
+                                var error = new ExtendedErrorTypeSymbol((NamespaceOrTypeSymbol)null, name, arity, diagInfo, unreported: true);
+                                result.SetFrom(LookupResult.Good(error)); // force lookup to be done w/ error symbol as result
+                            }
+                        }
                     }
 
                     return;
                 }
             }
-
-            // next try using aliases or symbols in imported namespaces
-            imports.LookupSymbol(originalBinder, result, name, arity, basesBeingResolved, options, diagnose, ref useSiteInfo);
         }
 
         protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
-            if (_container != null)
-            {
-                this.AddMemberLookupSymbolsInfo(result, _container, options, originalBinder);
-            }
-
-            // If we are looking only for labels we do not need to search through the imports.
-            // Submission imports are handled by AddMemberLookupSymbolsInfo (above).
-            if (!IsSubmissionClass && ((options & LookupOptions.LabelsOnly) == 0))
-            {
-                var imports = GetImports(basesBeingResolved: null);
-                imports.AddLookupSymbolsInfo(result, options, originalBinder);
-            }
+            this.AddMemberLookupSymbolsInfo(result, _container, options, originalBinder);
         }
 
         protected override SourceLocalSymbol LookupLocal(SyntaxToken nameToken)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4526,8 +4526,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var extensionMethods = ArrayBuilder<MethodSymbol>.GetInstance();
                     var otherBinder = scope.Binder;
-                    otherBinder.GetCandidateExtensionMethods(scope.SearchUsingsNotNamespace,
-                                                             extensionMethods,
+                    otherBinder.GetCandidateExtensionMethods(extensionMethods,
                                                              name,
                                                              arity,
                                                              options,

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Creates a new top-level binder that just contains the global imports for the compilation.
                 // The imports are required if a consumer of the scripting API is using a Task implementation 
                 // that uses extension methods.
-                var binder = new InContainerBinder(
+                Binder binder = new ImportsBinder(
                     container: null,
                     next: new BuckStopsHereBinder(compilation),
                     imports: compilation.GlobalImports);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -195,7 +195,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CSharpCompilation compilation = DeclaringCompilation;
 
             Binder result = new BuckStopsHereBinder(compilation);
-            result = new InContainerBinder(compilation.GlobalNamespace, result, SyntaxNode, inUsing: false);
+            var globalNamespace = compilation.GlobalNamespace;
+            result = new InContainerBinder(globalNamespace, new ImportsBinder(globalNamespace, result, SyntaxNode, inUsing: false));
             result = new InContainerBinder(ContainingType, result);
             result = new InMethodBinder(this, result);
             result = result.WithAdditionalFlags(ignoreAccessibility ? BinderFlags.IgnoreAccessibility : BinderFlags.None);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -746,7 +746,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     currentStringGroup--;
                 }
 
-                binder = new InContainerBinder(@namespace, binder, imports);
+                binder = new InContainerBinder(@namespace, new ImportsBinder(@namespace, binder, imports));
             }
 
             stack.Free();
@@ -958,8 +958,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 // the actual binder chain.
                 binder = new InContainerBinder(
                     binder.Container,
-                    binder,
-                    Imports.FromCustomDebugInfo(binder.Compilation, ImmutableDictionary<string, AliasAndUsingDirective>.Empty, ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, externs));
+                    new ImportsBinder(
+                        binder.Container,
+                        binder,
+                        Imports.FromCustomDebugInfo(binder.Compilation, ImmutableDictionary<string, AliasAndUsingDirective>.Empty, ImmutableArray<NamespaceOrTypeAndUsingDirective>.Empty, externs)));
             }
 
             var usingAliases = ImmutableDictionary.CreateBuilder<string, AliasAndUsingDirective>();


### PR DESCRIPTION
This is a refactoring, no behavior change intended.