### PR TITLE
Improve performance of lsif generation.

### DIFF
--- a/src/Features/Lsif/Generator/Writing/BatchingLsifJsonWriter.cs
+++ b/src/Features/Lsif/Generator/Writing/BatchingLsifJsonWriter.cs
@@ -57,6 +57,14 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
             }
         }
 
+        public void Write(List<Element> elements)
+        {
+            lock (_elementsGate)
+            {
+                _elements.AddRange(elements);
+            }
+        }
+
         public void FlushToUnderlyingAndEmpty()
         {
             lock (_writingGate)
@@ -69,10 +77,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
                     _elements = new List<Element>();
                 }
 
-                foreach (var element in localElements)
-                {
-                    _underlyingWriter.Write(element);
-                }
+                _underlyingWriter.Write(localElements);
             }
         }
     }

--- a/src/Features/Lsif/Generator/Writing/ILsifJsonWriter.cs
+++ b/src/Features/Lsif/Generator/Writing/ILsifJsonWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph;
 
 namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
@@ -9,5 +10,6 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
     internal interface ILsifJsonWriter
     {
         void Write(Element element);
+        void Write(List<Element> elements);
     }
 }

--- a/src/Features/Lsif/Generator/Writing/JsonModeLsifJsonWriter.cs
+++ b/src/Features/Lsif/Generator/Writing/JsonModeLsifJsonWriter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph;
 using Newtonsoft.Json;
@@ -41,6 +42,15 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
             lock (_writeGate)
             {
                 _jsonSerializer.Serialize(_jsonTextWriter, element);
+            }
+        }
+
+        public void Write(List<Element> elements)
+        {
+            lock (_writeGate)
+            {
+                foreach (var element in elements)
+                    _jsonSerializer.Serialize(_jsonTextWriter, element);
             }
         }
 

--- a/src/Features/Lsif/Generator/Writing/LineModeLsifJsonWriter.cs
+++ b/src/Features/Lsif/Generator/Writing/LineModeLsifJsonWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph;
 using Newtonsoft.Json;
@@ -38,6 +39,19 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
             lock (_writeGate)
             {
                 _outputWriter.WriteLine(line);
+            }
+        }
+
+        public void Write(List<Element> elements)
+        {
+            var lines = new List<string>();
+            foreach (var element in elements)
+                lines.Add(JsonConvert.SerializeObject(element, _settings));
+
+            lock (_writeGate)
+            {
+                foreach (var line in lines)
+                    _outputWriter.WriteLine(line);
             }
         }
     }

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifJsonWriter.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifJsonWriter.vb
@@ -18,6 +18,13 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
         Private ReadOnly _elementsById As Dictionary(Of Id(Of Element), Element) = New Dictionary(Of Id(Of Element), Element)
         Private ReadOnly _edgesByOutVertex As Dictionary(Of Vertex, List(Of Edge)) = New Dictionary(Of Vertex, List(Of Edge))
 
+        Private Sub ILsifJsonWriter_Write(elements As List(Of Element)) Implements ILsifJsonWriter.Write
+            For Each element In elements
+                ILsifJsonWriter_Write(element)
+            Next
+        End Sub
+
+
         Private Sub ILsifJsonWriter_Write(element As Element) Implements ILsifJsonWriter.Write
             SyncLock _gate
                 ' We intentionally use Add so it'll throw if we have a duplicate ID.

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifJsonWriter.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifJsonWriter.vb
@@ -24,7 +24,6 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
             Next
         End Sub
 
-
         Private Sub ILsifJsonWriter_Write(element As Element) Implements ILsifJsonWriter.Write
             SyncLock _gate
                 ' We intentionally use Add so it'll throw if we have a duplicate ID.


### PR DESCRIPTION
We would often write out tens of thousands of elements per file, taking locks for each eleemnt we're writing.  We can just take the lock once and write out the full batch.  

Before time:
```
Total time spent in the generation phase for all projects, including compilation fetch time: 25.02 seconds
```

After time:
```
Total time spent in the generation phase for all projects, including compilation fetch time: 18.67 seconds
```

This is an improvement of 25%.