### PR TITLE
Add 'AddImportsAnnotation'

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -458,9 +458,11 @@ class Program
 }";
 
             var expected =
-@"class Program
+@"using System.Threading.Tasks;
+
+class Program
 {
-    async System.Threading.Tasks.Task<int> TestAsync()
+    async Task<int> TestAsync()
     {
         await Task.Delay(1);
     }
@@ -481,9 +483,11 @@ class Program
 }";
 
             var expected =
-@"class Program
+@"using System.Threading.Tasks;
+
+class Program
 {
-    async System.Threading.Tasks.Task<Program> TestAsync()
+    async Task<Program> TestAsync()
     {
         await Task.Delay(1);
     }
@@ -1199,9 +1203,11 @@ class C
         }
     }
 }",
-@"class C
+@"using System.Threading.Tasks;
+
+class C
 {
-    async System.Threading.Tasks.Task MAsync()
+    async Task MAsync()
     {
         await using (var x = new object())
         {
@@ -1238,9 +1244,11 @@ class C
         }
     }
 }",
-@"class C
+@"using System.Threading.Tasks;
+
+class C
 {
-    async System.Threading.Tasks.Task MAsync()
+    async Task MAsync()
     {
         await foreach (var n in new int[] { })
         {
@@ -1277,9 +1285,11 @@ class C
         }
     }
 }",
-@"class C
+@"using System.Threading.Tasks;
+
+class C
 {
-    async System.Threading.Tasks.Task MAsync()
+    async Task MAsync()
     {
         await foreach (var (a, b) in new(int, int)[] { })
         {

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
@@ -232,17 +232,23 @@ Async Function rtrt() As Task(Of Integer)
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)>
         Public Async Function TestBadAwaitInNonAsyncFunction3() As Task
             Dim initial =
-<ModuleDeclaration>
+<File>
+Module M1
     Function rtrt() As Integer
         [|Await Nothing|]
     End Function
-</ModuleDeclaration>
+End Module
+</File>
             Dim expected =
-<ModuleDeclaration>
-Async Function rtrtAsync() As Threading.Tasks.Task(Of Integer)
-    Await Nothing
+<File>
+Imports System.Threading.Tasks
+
+Module M1
+    Async Function rtrtAsync() As Task(Of Integer)
+        Await Nothing
     End Function
-</ModuleDeclaration>
+End Module
+</File>
             Await TestAsync(initial, expected)
         End Function
 
@@ -302,8 +308,10 @@ End Class
 </File>
             Dim expected =
 <File>
+Imports System.Threading.Tasks
+
 Class Program
-    Async Function rtrtAsync() As System.Threading.Tasks.Task(Of Integer)
+    Async Function rtrtAsync() As Task(Of Integer)
         Await Nothing
     End Function
 End Class
@@ -323,8 +331,10 @@ End Class
 </File>
             Dim expected =
 <File>
+Imports System.Threading.Tasks
+
 Class Program
-    Async Function rtrtAsync() As System.Threading.Tasks.Task(Of Program)
+    Async Function rtrtAsync() As Task(Of Program)
         Await Nothing
     End Function
 End Class

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                 }
             }
 
-            return newReturnType.WithTriviaFrom(returnTypeSyntax);
+            return newReturnType.WithTriviaFrom(returnTypeSyntax).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
 
             static TypeSyntax MakeGenericType(string type, ITypeSymbol typeArgumentFrom)
             {

--- a/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
@@ -7,6 +7,7 @@ Imports System.Composition
 Imports System.Diagnostics.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.MakeMethodAsynchronous
+Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
@@ -78,7 +79,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
 
             If Not IsTaskLike(methodSymbol.ReturnType, knownTypes) Then
                 ' if the current return type is not already task-list, then wrap it in Task(of ...)
-                Dim returnType = knownTypes._taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax()
+                Dim returnType = knownTypes._taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax().WithAdditionalAnnotations(Simplifier.AddImportsAnnotation)
                 newFunctionStatement = newFunctionStatement.WithAsClause(
                 newFunctionStatement.AsClause.WithType(returnType))
             End If


### PR DESCRIPTION
Fixes #51354

NOTE: Tests that contains compile errors after fix weren't affected. (i.e, they still have fully qualified return type). I believe the new testing library wouldn't have allowed such tests.