### PR TITLE
Don't commend ushort in global context for regular source

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
@@ -754,5 +754,13 @@ class C
 {
     delegate*$$");
         }
+
+        [WorkItem(51487, "https://github.com/dotnet/roslyn/issues/51487")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAtRoot_Regular()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Regular,
+@"$$");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UShortKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UShortKeywordRecommender.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsAnyExpressionContext ||
                 context.IsDefiniteCastTypeContext ||
                 context.IsStatementContext ||
-                context.IsGlobalStatementContext ||
+                (context.IsGlobalStatementContext && syntaxTree.IsScript()) ||
                 context.IsObjectCreationTypeContext ||
                 (context.IsGenericTypeArgumentContext && !context.TargetToken.GetRequiredParent().HasAncestor<XmlCrefAttributeSyntax>()) ||
                 context.IsFunctionPointerTypeArgumentContext ||


### PR DESCRIPTION
Fixes #51487

This is not ready yet to merge. A similar change is needed for all types derived from `AbstractSpecialTypePreselectingKeywordRecommender`. Wanted to get initial feedback before proceeding with the other recommenders.