### PR TITLE
Do not show and/or after an incomplete pattern.

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/AndKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AndKeywordRecommenderTests.cs
@@ -534,5 +534,24 @@ x = e switch
 {
     global::$$"));
         }
+
+        [WorkItem(51431, "https://github.com/dotnet/roslyn/issues/51431")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAtIncompleteSwitchPattern()
+        {
+            await VerifyAbsenceAsync(
+@"
+var goo = Goo.First;
+switch (goo)
+{
+    case Goo.$$
+}
+
+public enum Goo
+{
+    First,
+    Second
+}");
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1485,7 +1485,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             static bool IsAtEndOfSwitchStatementPattern(SyntaxToken leftToken)
             {
-                SyntaxNode node = leftToken.Parent as ExpressionSyntax;
+                SyntaxNode? node = leftToken.Parent as ExpressionSyntax;
                 if (node == null)
                     return false;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1489,7 +1489,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 if (node == null)
                     return false;
 
-                // Walk up the expression that precedes us, as long as it is complete.
+                // Walk up the right edge of all complete expressions.
                 while (node is ExpressionSyntax && node.GetLastToken(includeZeroWidth: true) == leftToken)
                     node = node.GetRequiredParent();
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -1489,16 +1490,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     return false;
 
                 // Walking up the tree for expressions such as 'case (((N.C.P $$'
-                if (node.IsParentKind(SyntaxKind.SimpleMemberAccessExpression))
+                if (CSharpSyntaxFacts.Instance.IsNameOfAnyMemberAccessExpression(node))
                     node = node.GetRequiredParent();
+
+                if (node is MemberAccessExpressionSyntax memberAccess && memberAccess.Name.Identifier != leftToken)
+                    return false;
 
                 // Getting rid of the extra parentheses to deal with cases such as 'case (((1 $$'
                 while (node.IsParentKind(SyntaxKind.ParenthesizedExpression))
                     node = node.GetRequiredParent();
-
-                // Only after a pattern if the pattern is complete on the left of us.
-                if (node.GetLastToken(includeZeroWidth: true) != leftToken)
-                    return false;
 
                 // case (1 $$
                 if (node.IsParentKind(SyntaxKind.CaseSwitchLabel) && node.Parent.IsParentKind(SyntaxKind.SwitchSection))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1485,24 +1485,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             static bool IsAtEndOfSwitchStatementPattern(SyntaxToken leftToken)
             {
                 var node = leftToken.Parent;
+                if (node == null)
+                    return false;
 
                 // Walking up the tree for expressions such as 'case (((N.C.P $$'
-                while (node.IsParentKind(SyntaxKind.SimpleMemberAccessExpression))
-                {
-                    node = node.Parent;
-                }
+                if (node.IsParentKind(SyntaxKind.SimpleMemberAccessExpression))
+                    node = node.GetRequiredParent();
 
                 // Getting rid of the extra parentheses to deal with cases such as 'case (((1 $$'
                 while (node.IsParentKind(SyntaxKind.ParenthesizedExpression))
-                {
-                    node = node.Parent;
-                }
+                    node = node.GetRequiredParent();
+
+                // Only after a pattern if the pattern is complete on the left of us.
+                if (node.GetLastToken(includeZeroWidth: true) != leftToken)
+                    return false;
 
                 // case (1 $$
                 if (node.IsParentKind(SyntaxKind.CaseSwitchLabel) && node.Parent.IsParentKind(SyntaxKind.SwitchSection))
-                {
                     return true;
-                }
 
                 return false;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51431