### PR TITLE
Fix bug where parenthesized lambdas were being classified as top level

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -10214,6 +10214,62 @@ class C
                 Diagnostic(RudeEditKind.NotCapturingVariable, "a", "a"));
         }
 
+        [Fact, WorkItem(51297, "https://github.com/dotnet/roslyn/issues/51297")]
+        public void IndexerWithExpressionBody_Update_LiftedParameter_3()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    int this[int a] => new Func<int>(() => { return a + 1; })();
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    int this[int a] => new Func<int>(() => { return 2; })();   // not capturing a anymore
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [int this[int a] => new Func<int>(() => { return a + 1; })();]@35 -> [int this[int a] => new Func<int>(() => { return 2; })();]@35");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.NotCapturingVariable, "a", "a"));
+        }
+
+        [Fact, WorkItem(51297, "https://github.com/dotnet/roslyn/issues/51297")]
+        public void IndexerWithExpressionBody_Update_LiftedParameter_4()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    int this[int a] => new Func<int>(delegate { return a + 1; })();
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    int this[int a] => new Func<int>(delegate { return 2; })();   // not capturing a anymore
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [int this[int a] => new Func<int>(delegate { return a + 1; })();]@35 -> [int this[int a] => new Func<int>(delegate { return 2; })();]@35");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.NotCapturingVariable, "a", "a"));
+        }
+
         [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
         public void Indexer_ExpressionBodyToBlockBody()
         {

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -647,9 +647,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return Label.FinallyClause;
 
                 case SyntaxKind.LocalFunctionStatement:
-                case SyntaxKind.ParenthesizedLambdaExpression:
                 case SyntaxKind.AnonymousMethodExpression:
-                    // Note: Simple lambda expression is only labeled for statements, so it is below
+                    // Note: Lambda expression is only labeled for statements, see below
                     return Label.NestedFunction;
 
                 case SyntaxKind.FromClause:
@@ -742,6 +741,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 // Statement syntax
                 switch (kind)
                 {
+                    case SyntaxKind.ParenthesizedLambdaExpression:
                     case SyntaxKind.SimpleLambdaExpression:
                         return Label.NestedFunction;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51297

Missed one type of lambda when combining the two syntax comparers.