### PR TITLE
Use Environment.CurrentManagedThreadId

### DIFF
--- a/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
+++ b/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
-using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
@@ -147,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         {
             if (_loggingStream is object)
             {
-                var threadId = Thread.CurrentThread.ManagedThreadId;
+                var threadId = Environment.CurrentManagedThreadId;
                 var prefix = $"PID={_processId} TID={threadId} Ticks={Environment.TickCount} ";
                 string output = prefix + message + Environment.NewLine;
                 byte[] bytes = Encoding.UTF8.GetBytes(output);

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 ICompilerServerLogger logger,
                 CancellationToken cancellationToken)
             {
-                var originalThreadId = Thread.CurrentThread.ManagedThreadId;
+                var originalThreadId = Environment.CurrentManagedThreadId;
                 var clientDir = buildPaths.ClientDirectory;
                 var timeoutNewProcess = timeoutOverride ?? TimeOutMsNewProcess;
                 var timeoutExistingProcess = timeoutOverride ?? TimeOutMsExistingProcess;
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     }
                     catch (ApplicationException e)
                     {
-                        var releaseThreadId = Thread.CurrentThread.ManagedThreadId;
+                        var releaseThreadId = Environment.CurrentManagedThreadId;
                         var message = $"ReleaseMutex failed. WaitOne Id: {originalThreadId} Release Id: {releaseThreadId}";
                         throw new Exception(message, e);
                     }

--- a/src/Compilers/Test/Core/FX/EnsureEnglishUICulture.cs
+++ b/src/Compilers/Test/Core/FX/EnsureEnglishUICulture.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Threading;
 
 namespace Roslyn.Test.Utilities
 {
@@ -33,7 +32,7 @@ namespace Roslyn.Test.Utilities
 
         public EnsureEnglishUICulture()
         {
-            _threadId = Thread.CurrentThread.ManagedThreadId;
+            _threadId = Environment.CurrentManagedThreadId;
             var preferred = PreferredOrNull;
 
             if (preferred != null)
@@ -47,9 +46,9 @@ namespace Roslyn.Test.Utilities
 
         public void Dispose()
         {
-            Debug.Assert(_threadId == Thread.CurrentThread.ManagedThreadId);
+            Debug.Assert(_threadId == Environment.CurrentManagedThreadId);
 
-            if (_needToRestore && _threadId == Thread.CurrentThread.ManagedThreadId)
+            if (_needToRestore && _threadId == Environment.CurrentManagedThreadId)
             {
                 _needToRestore = false;
                 CultureInfo.CurrentUICulture = _threadUICulture;

--- a/src/Compilers/Test/Core/FX/EnsureInvariantCulture.cs
+++ b/src/Compilers/Test/Core/FX/EnsureInvariantCulture.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Threading;
 
 namespace Roslyn.Test.Utilities
 {
@@ -18,7 +17,7 @@ namespace Roslyn.Test.Utilities
 
         public EnsureInvariantCulture()
         {
-            _threadId = Thread.CurrentThread.ManagedThreadId;
+            _threadId = Environment.CurrentManagedThreadId;
             _threadCulture = CultureInfo.CurrentCulture;
 
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
@@ -26,9 +25,9 @@ namespace Roslyn.Test.Utilities
 
         public void Dispose()
         {
-            Debug.Assert(_threadId == Thread.CurrentThread.ManagedThreadId);
+            Debug.Assert(_threadId == Environment.CurrentManagedThreadId);
 
-            if (_threadId == Thread.CurrentThread.ManagedThreadId)
+            if (_threadId == Environment.CurrentManagedThreadId)
             {
                 CultureInfo.CurrentCulture = _threadCulture;
             }

--- a/src/EditorFeatures/TestUtilities/Threading/StaTaskScheduler.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/StaTaskScheduler.cs
@@ -22,7 +22,7 @@ namespace Roslyn.Test.Utilities
         /// <summary>The STA threads used by the scheduler.</summary>
         public Thread StaThread { get; }
 
-        public bool IsRunningInScheduler => StaThread.ManagedThreadId == Thread.CurrentThread.ManagedThreadId;
+        public bool IsRunningInScheduler => StaThread.ManagedThreadId == Environment.CurrentManagedThreadId;
 
         static StaTaskScheduler()
         {

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Loggers/OutputWindowLogger.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Loggers/OutputWindowLogger.cs
@@ -45,18 +45,18 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         public void Log(FunctionId functionId, LogMessage logMessage)
         {
-            OutputPane.WriteLine(string.Format("[{0}] {1} - {2}", Thread.CurrentThread.ManagedThreadId, functionId.ToString(), logMessage.GetMessage()));
+            OutputPane.WriteLine(string.Format("[{0}] {1} - {2}", Environment.CurrentManagedThreadId, functionId.ToString(), logMessage.GetMessage()));
         }
 
         public void LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
         {
-            OutputPane.WriteLine(string.Format("[{0}] Start({1}) : {2} - {3}", Thread.CurrentThread.ManagedThreadId, uniquePairId, functionId.ToString(), logMessage.GetMessage()));
+            OutputPane.WriteLine(string.Format("[{0}] Start({1}) : {2} - {3}", Environment.CurrentManagedThreadId, uniquePairId, functionId.ToString(), logMessage.GetMessage()));
         }
 
         public void LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
         {
             var functionString = functionId.ToString() + (cancellationToken.IsCancellationRequested ? " Canceled" : string.Empty);
-            OutputPane.WriteLine(string.Format("[{0}] End({1}) : [{2}ms] {3}", Thread.CurrentThread.ManagedThreadId, uniquePairId, delta, functionString));
+            OutputPane.WriteLine(string.Format("[{0}] End({1}) : [{2}ms] {3}", Environment.CurrentManagedThreadId, uniquePairId, delta, functionString));
         }
 
         private class OutputPane

--- a/src/Workspaces/Core/Portable/Log/TraceLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/TraceLogger.cs
@@ -37,15 +37,15 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             => _loggingChecker == null || _loggingChecker(functionId);
 
         public void Log(FunctionId functionId, LogMessage logMessage)
-            => Trace.WriteLine(string.Format("[{0}] {1} - {2}", Thread.CurrentThread.ManagedThreadId, functionId.ToString(), logMessage.GetMessage()));
+            => Trace.WriteLine(string.Format("[{0}] {1} - {2}", Environment.CurrentManagedThreadId, functionId.ToString(), logMessage.GetMessage()));
 
         public void LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
-            => Trace.WriteLine(string.Format("[{0}] Start({1}) : {2} - {3}", Thread.CurrentThread.ManagedThreadId, uniquePairId, functionId.ToString(), logMessage.GetMessage()));
+            => Trace.WriteLine(string.Format("[{0}] Start({1}) : {2} - {3}", Environment.CurrentManagedThreadId, uniquePairId, functionId.ToString(), logMessage.GetMessage()));
 
         public void LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
         {
             var functionString = functionId.ToString() + (cancellationToken.IsCancellationRequested ? " Canceled" : string.Empty);
-            Trace.WriteLine(string.Format("[{0}] End({1}) : [{2}ms] {3}", Thread.CurrentThread.ManagedThreadId, uniquePairId, delta, functionString));
+            Trace.WriteLine(string.Format("[{0}] End({1}) : [{2}ms] {3}", Environment.CurrentManagedThreadId, uniquePairId, delta, functionString));
         }
     }
 }


### PR DESCRIPTION
Use `Environment.CurrentManagedThreadId` instead of `Thread.CurrentThread.ManagedThreadId`.

See dotnet/runtime#43257