### PR TITLE
Null coalescing in definite assignment

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2471,7 +2471,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     BoundConditionalAccess ca => ca,
                     // PROTOTYPE(improved-definite-assignment): consider when to handle conversion nodes which contain conditional accesses
-                    BoundConversion { ExplicitCastInCode: false, HasErrors: false } => throw ExceptionUtilities.Unreachable,
+                    BoundConversion { ExplicitCastInCode: false, HasErrors: false, Operand: BoundConditionalAccess } => throw ExceptionUtilities.Unreachable,
                     _ => null
                 };
                 if (access is not null)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2435,16 +2435,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                TLocalState savedState;
-                if (VisitPossibleConditionalAccess(node.LeftOperand, out var stateWhenNotNull))
-                {
-                    savedState = stateWhenNotNull;
-                }
-                else
-                {
-                    Unsplit();
-                    savedState = State.Clone();
-                }
+                TLocalState savedState = VisitPossibleConditionalAccess(node.LeftOperand, out var stateWhenNotNull)
+                    ? stateWhenNotNull
+                    : State.Clone();
 
                 if (node.LeftOperand.ConstantValue != null)
                 {
@@ -2468,6 +2461,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             EnterRegionIfNeeded(node);
             var hasStateWhenNotNull = visit(out stateWhenNotNull);
+            Debug.Assert(!IsConditionalState);
             LeaveRegionIfNeeded(node);
             return hasStateWhenNotNull;
 
@@ -2488,6 +2482,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     stateWhenNotNull = default;
                     VisitWithStackGuard(node);
+                    Unsplit();
                     return false;
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2457,6 +2457,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        /// <summary>
+        /// Unconditionally visits an expression.
+        /// If the expression has "state when not null" after visiting,
+        /// the method returns 'true' and writes the state to <paramref name="stateWhenNotNull" />.
+        /// </summary>
         protected bool VisitPossibleConditionalAccess(BoundExpression node, Conversion conversion, [NotNullWhen(true)] out TLocalState? stateWhenNotNull)
         {
             EnterRegionIfNeeded(node);
@@ -2557,7 +2562,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitConditionalAccess(BoundConditionalAccess node)
         {
-            VisitConditionalAccess(node, out _);
+            VisitConditionalAccess(node, stateWhenNotNull: out _);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2435,7 +2435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                TLocalState savedState = VisitPossibleConditionalAccess(node.LeftOperand, node.LeftConversion, out var stateWhenNotNull)
+                TLocalState savedState = VisitPossibleConditionalAccess(node.LeftOperand, out var stateWhenNotNull)
                     ? stateWhenNotNull
                     : State.Clone();
 
@@ -2462,7 +2462,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// If the expression has "state when not null" after visiting,
         /// the method returns 'true' and writes the state to <paramref name="stateWhenNotNull" />.
         /// </summary>
-        protected bool VisitPossibleConditionalAccess(BoundExpression node, Conversion conversion, [NotNullWhen(true)] out TLocalState? stateWhenNotNull)
+        protected bool VisitPossibleConditionalAccess(BoundExpression node, [NotNullWhen(true)] out TLocalState? stateWhenNotNull)
         {
             EnterRegionIfNeeded(node);
             var hasStateWhenNotNull = visit(out stateWhenNotNull);
@@ -2479,7 +2479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _ => null
                 };
 
-                if (access is not null && isAcceptableConversion(access, conversion))
+                if (access is not null)
                 {
                     return VisitConditionalAccess(access, out stateWhenNotNull);
                 }
@@ -2492,7 +2492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // "State when not nulL" can only propagate out of a conditional access if
+            // "State when not null" can only propagate out of a conditional access if
             // it is not subject to a user-defined conversion whose parameter is not of a non-nullable value type.
             static bool isAcceptableConversion(BoundConditionalAccess operand, Conversion conversion)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2435,7 +2435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                TLocalState savedState = VisitPossibleConditionalAccess(node.LeftOperand, out var stateWhenNotNull)
+                TLocalState savedState = VisitPossibleConditionalAccess(node.LeftOperand, node.LeftConversion, out var stateWhenNotNull)
                     ? stateWhenNotNull
                     : State.Clone();
 
@@ -2457,7 +2457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        protected bool VisitPossibleConditionalAccess(BoundExpression node, [NotNullWhen(true)] out TLocalState? stateWhenNotNull)
+        protected bool VisitPossibleConditionalAccess(BoundExpression node, Conversion conversion, [NotNullWhen(true)] out TLocalState? stateWhenNotNull)
         {
             EnterRegionIfNeeded(node);
             var hasStateWhenNotNull = visit(out stateWhenNotNull);
@@ -2474,7 +2474,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundConversion { ExplicitCastInCode: false, HasErrors: false, Operand: BoundConditionalAccess } => throw ExceptionUtilities.Unreachable,
                     _ => null
                 };
-                if (access is not null)
+
+                if (access is not null && conversion.Kind is not (ConversionKind.ImplicitUserDefined or ConversionKind.ExplicitUserDefined))
                 {
                     return VisitConditionalAccess(access, out stateWhenNotNull);
                 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
@@ -2460,16 +2460,13 @@ class C
     {
         int x;
         _ = (object)c1?.M(x = 0) ?? throw new System.Exception();
-        x.ToString(); // 1
+        x.ToString();
     }
 
     C M(object obj) { return this; }
 }
 ";
-            CreateCompilation(source).VerifyDiagnostics(
-                // (8,9): error CS0165: Use of unassigned local variable 'x'
-                //         x.ToString(); // 1
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(8, 9));
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -2562,7 +2559,7 @@ class C
     B M2(object obj) { return new B(); }
 }
 ";
-            // If the LHS of a `??` is subject to a non-lifted user-defined conversion
+            // If the LHS of a `??` is subject to a user-defined conversion whose parameter is not a non-nullable value type
             // we can't propagate out the "state when not null"
             // because we can't know whether the conditional access itself was non-null.
             CreateCompilation(source).VerifyDiagnostics(
@@ -2584,6 +2581,84 @@ struct C
     {
         int x;
         B b = c1?.M1(x = 0) ?? c1!.Value.M2(x = 0);
+        x.ToString();
+    }
+
+    C M1(object obj) { return this; }
+    B M2(object obj) { return new B(); }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullCoalescing_CondAccess_UserDefinedConv_04()
+        {
+            var source = @"
+struct B { }
+struct C
+{
+    public static implicit operator B?(C c) => null;
+
+    void M1(C? c1)
+    {
+        int x;
+        B? b = c1?.M1(x = 0) ?? c1!.Value.M2(x = 0);
+        x.ToString();
+    }
+
+    C M1(object obj) { return this; }
+    B? M2(object obj) { return new B(); }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullCoalescing_CondAccess_ExplicitUserDefinedConv_01()
+        {
+            var source = @"
+struct S { }
+
+struct C
+{
+    public static explicit operator S(C? c)
+    {
+        return default(S);
+    }
+
+    void M1(C? c1)
+    {
+        int x;
+        S s = (S?)c1?.M2(x = 0) ?? c1.Value.M3(x = 0);
+        x.ToString(); // 1
+    }
+
+    C M2(object obj) { return this; }
+    S M3(object obj) { return (S)this; }
+}
+";
+            // PROTOTYPE(improved-definite-assignment):
+            // Arguably, in this scenario, the RHS of the `??` should be visited in an unreachable state
+            CreateCompilation(source).VerifyDiagnostics(
+                // (15,9): error CS0165: Use of unassigned local variable 'x'
+                //         x.ToString(); // 1
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(15, 9));
+        }
+
+        [Fact]
+        public void NullCoalescing_CondAccess_ExplicitUserDefinedConv_02()
+        {
+            var source = @"
+class B { }
+class C
+{
+    public static explicit operator B(C c) => new B();
+
+    void M1(C c1)
+    {
+        int x;
+        B b = (B)c1?.M1(x = 0) ?? c1!.M2(x = 0);
         x.ToString(); // 1
     }
 
@@ -2591,16 +2666,59 @@ struct C
     B M2(object obj) { return new B(); }
 }
 ";
-            // PROTOTYPE(improved-definite-assignment):
-            // strictly speaking, we know here that if the conversion result is not-null, then the operand was not-null.
-            // However, I don't yet know whether we want to make this work.
-            // 1. I'm concerned about user confusion around when "state when not null" can propagate out of user-defined conversions or not.
-            // 2. If the owner of the operator declaration decides to change the operand type from `C` to `C?`
-            //    they now have to weigh it against the inability to definitely assign variables in obscure cases.
+            // If the LHS of a `??` is subject to a user-defined conversion whose parameter is not a non-nullable value type
+            // we can't propagate out the "state when not null"
+            // because we can't know whether the conditional access itself was non-null.
             CreateCompilation(source).VerifyDiagnostics(
                 // (11,9): error CS0165: Use of unassigned local variable 'x'
                 //         x.ToString(); // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(11, 9));
+        }
+
+        [Fact]
+        public void NullCoalescing_CondAccess_ExplicitUserDefinedConv_03()
+        {
+            var source = @"
+struct B { }
+struct C
+{
+    public static explicit operator B(C c) => new B();
+
+    void M1(C? c1)
+    {
+        int x;
+        B b = (B?)c1?.M1(x = 0) ?? c1!.Value.M2(x = 0);
+        x.ToString();
+    }
+
+    C M1(object obj) { return this; }
+    B M2(object obj) { return new B(); }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullCoalescing_CondAccess_ExplicitUserDefinedConv_04()
+        {
+            var source = @"
+struct B { }
+struct C
+{
+    public static explicit operator B?(C c) => null;
+
+    void M1(C? c1)
+    {
+        int x;
+        B? b = (B?)c1?.M1(x = 0) ?? c1!.Value.M2(x = 0);
+        x.ToString();
+    }
+
+    C M1(object obj) { return this; }
+    B? M2(object obj) { return new B(); }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [WorkItem(529603, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529603")]

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
@@ -2733,6 +2733,27 @@ class C
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(13, 9));
         }
 
+        [Fact]
+        public void NullCoalescing_CondAccess_NullableEnum()
+        {
+            var source = @"
+public enum E { E1 = 1 }
+
+public static class Extensions
+{
+    public static E M1(this E e, object obj) => e;
+
+    static void M2(E? e)
+    {
+        int x;
+        E e2 = e?.M1(x = 0) ?? e.Value.M1(x = 0);
+        x.ToString();
+    }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
         [WorkItem(529603, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529603")]
         [Theory]
         [InlineData("true", "false")]

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
@@ -2467,9 +2467,9 @@ class C
 }
 ";
             CreateCompilation(source).VerifyDiagnostics(
-                // (9,9): error CS0165: Use of unassigned local variable 'x'
+                // (8,9): error CS0165: Use of unassigned local variable 'x'
                 //         x.ToString(); // 1
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(9, 9));
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(8, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
@@ -2239,9 +2239,9 @@ class C
                 // (8,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(8, 15),
-                // (17,15): error CS0165: Use of unassigned local variable 'x'
-                //             : x.ToString(); // 2
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(17, 15));
+                // (17,15): error CS0165: Use of unassigned local variable 'y'
+                //             : y.ToString(); // 2
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(17, 15));
         }
 
         [Fact]
@@ -2397,7 +2397,7 @@ class C
         int x, y;
         _ = (bool?)(b && c1.M(x = y = 0)) ?? false
             ? x.ToString() // 1
-            : y.ToString();
+            : y.ToString(); // 2
     }
 
     bool M(object obj) { return true; }
@@ -2407,7 +2407,10 @@ class C
             CreateCompilation(source).VerifyDiagnostics(
                 // (9,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 1
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(9, 15));
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(9, 15),
+                // (10,15): error CS0165: Use of unassigned local variable 'y'
+                //             : y.ToString(); // 2
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(10, 15));
         }
 
         [WorkItem(529603, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529603")]

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
@@ -2470,44 +2470,6 @@ class C
         }
 
         [Fact]
-        public void NullCoalescing_CondAccess_ImplicitReferenceConv()
-        {
-            var source = @"
-class C
-{
-    void M1(C c1, bool b)
-    {
-        int x;
-        object obj = c1?.M(x = 0) ?? (object)(x = 0);
-        x.ToString();
-    }
-
-    C M(object obj) { return this; }
-}
-";
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void NullCoalescing_CondAccess_BoxingConv()
-        {
-            var source = @"
-class C
-{
-    void M1(C c1)
-    {
-        int x;
-        object obj = c1?.M(x = 0) ?? c1.M(x = 0);
-        x.ToString();
-    }
-
-    bool? M(object obj) { return null; }
-}
-";
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
         public void NullCoalescing_CondAccess_UserDefinedConv_01()
         {
             var source = @"
@@ -2762,7 +2724,7 @@ class C
     }
 
     C M1(object obj) { return this; }
-    B M2(object obj) { return this; }
+    B M2(object obj) { return default; }
 }
 ";
             CreateCompilation(source).VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -2517,6 +2517,35 @@ public class C
             }
         }
 
+        [Fact]
+        public void CondAccess_NullCoalescing_DataFlow()
+        {
+            // This test corresponds to ExtractMethodTests.TestFlowStateNullableParameters3
+            var dataFlowAnalysis = CompileAndAnalyzeDataFlowExpression(@"
+#nullable enable
+class C
+{
+    public string M()
+    {
+        string? a = null;
+        string? b = null;
+        return /*<bind>*/(a + b + a)?.ToString()/*</bind>*/ ?? string.Empty;
+    }
+}
+");
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.AlwaysAssigned));
+            Assert.Equal("a, b", GetSymbolNamesJoined(dataFlowAnalysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.DataFlowsOut));
+            Assert.Equal("a, b", GetSymbolNamesJoined(dataFlowAnalysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.WrittenInside));
+            Assert.Equal("this, a, b", GetSymbolNamesJoined(dataFlowAnalysis.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.CapturedOutside));
+        }
+
         #endregion
 
         #region "Statements"


### PR DESCRIPTION
Related to #51463 

This PR implements the following section of the [spec](https://github.com/dotnet/csharplang/blob/master/proposals/improved-definite-assignment.md#-null-coalescing-expressions-augment):

> ## ?? (null-coalescing expressions) augment
> We augment the section [?? (null coalescing) expressions](https://github.com/dotnet/csharplang/blob/master/spec/variables.md#-null-coalescing-expressions) as follows:
> 
> For an expression *expr* of the form `expr_first ?? expr_second`:
> - ...
> - The definite assignment state of *v* after *expr* is determined by:
>   - ...
>   - If *expr_first* directly contains a null-conditional expression *E*, and *v* is definitely assigned after the non-conditional counterpart *E<sub>0</sub>*, then the definite assignment state of *v* after *expr* is the same as the definite assignment state of *v* after *expr_second*.
> 
> ### Remarks
> The above rule formalizes that for an expression like `a?.M(out x) ?? (x = false)`, either the `a?.M(out x)` was fully evaluated and produced a non-null value, in which case `x` was assigned, or the `x = false` was evaluated, in which case `x` was also assigned. Therefore `x` is always assigned after this expression.
> 
> This also handles the `dict?.TryGetValue(key, out var value) ?? false` scenario, by observing that *v* is definitely assigned after `dict.TryGetValue(key, out var value)`, and *v* is "definitely assigned when true" after `false`, and concluding that *v* must be "definitely assigned when true".
> 
> The more general formulation also allows us to handle some more unusual scenarios, such as:
> - `if (x?.M(out y) ?? (b && z.M(out y))) y.ToString();`
> - `if (x?.M(out y) ?? z?.M(out y) ?? false) y.ToString();`