### PR TITLE
Remove rebuilds that don't work in master-vs-deps

### DIFF
--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -56,12 +56,10 @@ try {
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.CSharp.Test.Utilities`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.CSharp.Workspaces`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.CSharp`"" +
-  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.EditorFeatures.Cocoa`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.EditorFeatures.Text`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.ExpressionCompiler`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.ExternalAccess.Debugger`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.ExternalAccess.Razor`"" +
-  " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.FunctionResolver`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator`"" +
   " --assembliesPath `"$ArtifactsDir/obj/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub`"" +


### PR DESCRIPTION
See #51565. Merging into here so that we don't diverge between master and master-vs-deps. No idea why these builds pass in master but fail in master-vs-deps. Looking over the debug artifact a bit it seems like the two affected projects are failing for different reasons:

1. Microsoft.CodeAnalysis.EditorFeatures.Cocoa (missing a system.runtime.interopservices.typeidentifierattribute in rebuild)
2. Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote (off by 4 bytes)

also attaching the BuildValidator artifact with these failures so it's easier to track: [BuildValidator_DebugOut.zip](https://github.com/dotnet/roslyn/files/6064144/BuildValidator_DebugOut.zip)

/cc @jaredpar @allisonchou 
