### PR TITLE
Share NavigableSymbols folder between Mac and Windows

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
+++ b/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="..\Core.Wpf\ExternalAccess\VSTypeScript\**\*.cs" LinkBase="ExternalAccess\VSTypeScript" />
     <Compile Include="..\Core.Wpf\InlineRename\**\*.cs" Exclude="..\Core.Wpf\InlineRename\Dashboard\**\*.cs" LinkBase="InlineRename" />
+    <Compile Include="..\Core.Wpf\NavigableSymbols\**\*.cs" LinkBase="NavigableSymbols" />
     <Compile Include="..\Core.Wpf\SignatureHelp\**\*.cs" LinkBase="SignatureHelp" />
     <Compile Include="..\Core.Wpf\IDebuggerTextView2.cs" Link="IDebuggerTextView2.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes [AB#1282486](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1282486)

Tested locally on my macbook. This doesn't need to be inserted into 16.9 VS Windows, but the insertion needs to be created to publish packages for VS Mac to consume at least.