### PR TITLE
Remove unnecessary apikey for nuget publishing

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -26,16 +26,11 @@ variables:
     - group: DotNet-GitHub-Versions-Repo-Write
     - name: _DevDivDropAccessToken
       value: $(System.AccessToken)
-  # For publishing from devdiv pipeline to devdiv feed, the API key can 
-  # be any non-empty string as authentication is done in the pipeline. 
-    - name: _DevDivNugetFeedAccessToken
-      value: "AzureArtifacts"
   # If the pipeline is running in dnceng:
   # Get access token with $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw from DotNet-VSTS-Infra-Access
   # Get $dotnetfeed-storage-access-key-1 from DotNet-Blob-Feed
   # Get $microsoft-symbol-server-pat and $symweb-symbol-server-pat from DotNet-Symbol-Server-Pats
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
-  # Get $dn-bot-devdiv-packaging-rw from DotNet-DevDiv-Insertion-Workflow-Variables
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - group: DotNet-Blob-Feed
     - group: DotNet-Symbol-Server-Pats
@@ -44,8 +39,6 @@ variables:
     - group: DotNet-DevDiv-Insertion-Workflow-Variables
     - name: _DevDivDropAccessToken
       value: $(dn-bot-devdiv-drop-rw-code-rw)
-    - name: _DevDivNugetFeedAccessToken
-      value: $(dn-bot-devdiv-packaging-rw)
 
 stages:
 - stage: build
@@ -192,7 +185,7 @@ stages:
       displayName: Publish Assets
       inputs:
         filePath: 'eng\publish-assets.ps1'
-        arguments: '-configuration $(BuildConfiguration) -branchName "$(SourceBranchName)" -gitHubUserName $(Roslyn.GitHubUserName) -gitHubToken $(AccessToken-dotnet-build-bot-public-repo) -gitHubEmail $(Roslyn.GitHubEmail) -devdivApiKey $(_DevDivNugetFeedAccessToken)'
+        arguments: '-configuration $(BuildConfiguration) -branchName "$(SourceBranchName)" -gitHubUserName $(Roslyn.GitHubUserName) -gitHubToken $(AccessToken-dotnet-build-bot-public-repo) -gitHubEmail $(Roslyn.GitHubEmail)'
       condition: and(succeeded(), eq(variables['PRNumber'], 'default'))
 
     # Publish OptProf configuration files

--- a/eng/publish-assets.ps1
+++ b/eng/publish-assets.ps1
@@ -18,8 +18,7 @@ Param(
   [string]$gitHubUserName = "",
   [string]$gitHubToken = "",
   [string]$gitHubEmail = "",
-  [string]$nugetApiKey = "",
-  [string]$devdivApiKey = ""
+  [string]$nugetApiKey = ""
 )
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
@@ -29,7 +28,8 @@ function Get-PublishKey([string]$uploadUrl) {
   $url = New-Object Uri $uploadUrl
   switch ($url.Host) {
     "api.nuget.org" { return $nugetApiKey }
-    "pkgs.dev.azure.com" { return $devdivApiKey}
+    # For publishing to azure, the API key can be any non-empty string as authentication is done in the pipeline.
+    "pkgs.dev.azure.com" { return "AzureArtifacts"}
     default { throw "Cannot determine publish key for $uploadUrl" }
   }
 }


### PR DESCRIPTION
Passing api key doesn't work, the original problem with authentication was actually caused by misconfigured service connection in dnceng for publishing to azure-public feeds, which is fixed now. 