### PR TITLE
Update the Find-References feature to only find inheritance results that could lead to a specific member being used at runtime.

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             await context.SetSearchTitleAsync(string.Format(EditorFeaturesResources._0_references,
                 FindUsagesHelpers.GetDisplayName(symbol))).ConfigureAwait(false);
 
-            var options = FindSymbols.FindReferencesSearchOptions.GetFeatureOptionsForStartingSymbol(symbol);
+            var options = FindReferencesSearchOptions.GetFeatureOptionsForStartingSymbol(symbol);
 
             // Now call into the underlying FAR engine to find reference.  The FAR
             // engine will push results into the 'progress' instance passed into it.

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AccessorSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AccessorSymbols.vb
@@ -495,7 +495,57 @@ class Usages
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpAccessor_FromNameOf_Feature1(host As TestHost) As Task
+        Public Async Function TestCSharpAccessor_FromNameOf1_Api(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface IC
+{
+    int {|Definition:Prop|} { get; set; }
+}
+
+class C : IC
+{
+    public virtual int {|Definition:Prop|} { get; set; }
+}
+
+class D : C
+{
+    public override int {|Definition:Prop|} { get => base.[|Prop|]; set => base.[|Prop|] = value; }
+}
+
+class Usages
+{
+    void M()
+    {
+        IC ic;
+        var n1 = nameof(ic.[|$$Prop|]);
+        var v1 = ic.[|Prop|];
+        ic.[|Prop|] = 1;
+        ic.[|Prop|]++;
+
+        C c;
+        var n2 = nameof(c.[|Prop|]);
+        var v2 = c.[|Prop|];
+        c.[|Prop|] = 1;
+        c.[|Prop|]++;
+
+        D d;
+        var n3 = nameof(d.[|Prop|]);
+        var v3 = d.[|Prop|];
+        d.[|Prop|] = 1;
+        d.[|Prop|]++;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpAccessor_FromNameOf1_Feature(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
@@ -582,7 +582,7 @@ interface I<X>
 class C : I<int>, I<string>
 {
     public void {|Definition:$$Goo|}(int x) { }
-    public void {|Definition:Goo|}(string x) { }
+    public void Goo(string x) { }
 }
 ]]>
         </Document>
@@ -629,7 +629,7 @@ interface I<X>
 
 class C : I<int>, I<string>
 {
-    public void {|Definition:Goo|}(int x) { }
+    public void Goo(int x) { }
     public void {|Definition:$$Goo|}(string x) { }
 }
 ]]>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
@@ -545,7 +545,7 @@ class C : I<int>, I<string>
 
         <WorkItem(539883, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539883")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCascadedMembersFromConstructedInterfaces5(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCascadedMembersFromConstructedInterfaces5_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -564,12 +564,36 @@ class C : I<int>, I<string>
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
         End Function
 
         <WorkItem(539883, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539883")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCascadedMembersFromConstructedInterfaces6(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCascadedMembersFromConstructedInterfaces5_FEature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+interface I<X>
+{
+    void {|Definition:Goo|}(X x);
+}
+
+class C : I<int>, I<string>
+{
+    public void {|Definition:$$Goo|}(int x) { }
+    public void {|Definition:Goo|}(string x) { }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WorkItem(539883, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539883")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCascadedMembersFromConstructedInterfaces6_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -588,7 +612,31 @@ class C : I<int>, I<string>
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
+        End Function
+
+        <WorkItem(539883, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539883")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCascadedMembersFromConstructedInterfaces6_Feature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+interface I<X>
+{
+    void {|Definition:Goo|}(X x);
+}
+
+class C : I<int>, I<string>
+{
+    public void {|Definition:Goo|}(int x) { }
+    public void {|Definition:$$Goo|}(string x) { }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -394,7 +394,7 @@ class C
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestOrdinaryMethodOverride_InMetadata(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestOrdinaryMethodOverride_InMetadata_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -411,7 +411,28 @@ class C
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestOrdinaryMethodOverride_InMetadata_Feature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            // Will walk up to Object.ToString
+            public override string {|Definition:To$$String|}() { }
+        }
+        class O
+        {
+            public override string ToString() { }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
@@ -484,7 +505,7 @@ class C
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromReference_Feature(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromReference_Feature(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -496,7 +517,7 @@ class C
 
         class C1 : I1
         {
-            public void {|Definition:Goo|}()
+            public void Goo()
             {
             }
         }
@@ -585,7 +606,7 @@ class C
 
         interface I2 : I1
         {
-            void {|Definition:Goo|}();
+            void Goo();
             void Bar();
         }
 
@@ -1530,9 +1551,9 @@ End Interface
 
     class Derived<U, V> : Base<U>, I<V>
     {
-        public void {|Definition:F|}()
+        public void F()
         {
-            [|F|]();
+            F();
         }
     }
 ]]>
@@ -1589,7 +1610,7 @@ End Interface
 
     class Base<U> : I<U>
     {
-        void I<U>.{|Definition:F|}() { }
+        void I<U>.F() { }
     }
 
     class Derived<U, V> : Base<U>, I<V>
@@ -1653,7 +1674,7 @@ End Interface
 
     class Base<U> : I<U>
     {
-        void I<U>.{|Definition:F|}() { }
+        void I<U>.F() { }
     }
 
     class Derived<U, V> : Base<U>, I<V>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -3607,5 +3607,184 @@ End Class
             Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
         End Function
 
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestFeatureHierarchyCascade1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            void {|Definition:$$Goo|}();
+        }
+
+        interface I2
+        {
+            void Goo();
+        }
+
+        class B : I1
+        {
+            public virtual void {|Definition:Goo|}() {}
+        }
+
+        class D1 : I1, I2
+        {
+            public override void {|Definition:Goo|}() {}
+        }
+
+        class D2 : I1
+        {
+            public override void {|Definition:Goo|}() {}
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestFeatureHierarchyCascade2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            void Goo();
+        }
+
+        interface I2
+        {
+            void {|Definition:$$Goo|}();
+        }
+
+        class B : I1
+        {
+            public virtual void Goo() {}
+        }
+
+        class D1 : I1, I2
+        {
+            public override void {|Definition:Goo|}() {}
+        }
+
+        class D2 : I1
+        {
+            public override void {|Definition:Goo|}() {}
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestFeatureHierarchyCascade3(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            void {|Definition:Goo|}();
+        }
+
+        interface I2
+        {
+            void Goo();
+        }
+
+        class B : I1
+        {
+            public virtual void {|Definition:$$Goo|}() {}
+        }
+
+        class D1 : I1, I2
+        {
+            public override void {|Definition:Goo|}() {}
+        }
+
+        class D2 : I1
+        {
+            public override void {|Definition:Goo|}() {}
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestFeatureHierarchyCascade4(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            void {|Definition:Goo|}();
+        }
+
+        interface I2
+        {
+            void {|Definition:Goo|}();
+        }
+
+        class B : I1
+        {
+            public virtual void {|Definition:Goo|}() {}
+        }
+
+        class D1 : I1, I2
+        {
+            public override void {|Definition:$$Goo|}() {}
+        }
+
+        class D2 : I1
+        {
+            public override void Goo() {}
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestFeatureHierarchyCascade5(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            void {|Definition:Goo|}();
+        }
+
+        interface I2
+        {
+            void Goo();
+        }
+
+        class B : I1
+        {
+            public virtual void {|Definition:Goo|}() {}
+        }
+
+        class D1 : I1, I2
+        {
+            public override void Goo() {}
+        }
+
+        class D2 : I1
+        {
+            public override void {|Definition:$$Goo|}() {}
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -443,7 +443,7 @@ class C
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromReference(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromReference_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -480,11 +480,52 @@ class C
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromDefinition(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromReference_Feature(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            void {|Definition:Goo|}();
+        }
+
+        class C1 : I1
+        {
+            public void {|Definition:Goo|}()
+            {
+            }
+        }
+
+        interface I2 : I1
+        {
+            void {|Definition:Goo|}();
+            void Bar();
+        }
+
+        class C2 : I2
+        {
+            public void Bar()
+            {
+                [|Goo$$|]();
+            }
+
+            public void {|Definition:Goo|}();
+            {
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromDefinition_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -521,7 +562,48 @@ class C
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestOrdinaryMethodInterfaceInheritance_FromDefinition_Feature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            void {|Definition:Go$$o|}();
+        }
+
+        class C1 : I1
+        {
+            public void {|Definition:Goo|}()
+            {
+            }
+        }
+
+        interface I2 : I1
+        {
+            void {|Definition:Goo|}();
+            void Bar();
+        }
+
+        class C2 : I2
+        {
+            public void Bar()
+            {
+                [|Goo|]();
+            }
+
+            public void {|Definition:Goo|}();
+            {
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
@@ -1398,7 +1480,7 @@ End Interface
 
         <WorkItem(539033, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539033")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface2(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface2_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1425,12 +1507,44 @@ End Interface
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
         End Function
 
         <WorkItem(539033, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539033")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface3(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface2_Feature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+    interface I<T>
+    {
+        void {|Definition:F|}();
+    }
+
+    class Base<U> : I<U>
+    {
+        void I<U>.{|Definition:$$F|}() { }
+    }
+
+    class Derived<U, V> : Base<U>, I<V>
+    {
+        public void {|Definition:F|}()
+        {
+            [|F|]();
+        }
+    }
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WorkItem(539033, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539033")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface3_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1457,12 +1571,44 @@ End Interface
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
         End Function
 
         <WorkItem(539033, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539033")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface4(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface3_Feature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+    interface I<T>
+    {
+        void {|Definition:F|}();
+    }
+
+    class Base<U> : I<U>
+    {
+        void I<U>.{|Definition:F|}() { }
+    }
+
+    class Derived<U, V> : Base<U>, I<V>
+    {
+        public void {|Definition:$$F|}()
+        {
+            [|F|]();
+        }
+    }
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WorkItem(539033, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539033")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface4_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1489,7 +1635,39 @@ End Interface
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
+        End Function
+
+        <WorkItem(539033, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539033")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCascadeOrdinaryMethodFromGenericInterface4_Feature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+    interface I<T>
+    {
+        void {|Definition:F|}();
+    }
+
+    class Base<U> : I<U>
+    {
+        void I<U>.{|Definition:F|}() { }
+    }
+
+    class Derived<U, V> : Base<U>, I<V>
+    {
+        public void {|Definition:F|}()
+        {
+            [|$$F|]();
+        }
+    }
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
 
         <WorkItem(539046, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539046")>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -3628,12 +3628,12 @@ End Class
             public virtual void {|Definition:Goo|}() {}
         }
 
-        class D1 : I1, I2
+        class D1 : B, I1, I2
         {
             public override void {|Definition:Goo|}() {}
         }
 
-        class D2 : I1
+        class D2 : B, I1
         {
             public override void {|Definition:Goo|}() {}
         }
@@ -3664,14 +3664,14 @@ End Class
             public virtual void Goo() {}
         }
 
-        class D1 : I1, I2
+        class D1 : B, I1, I2
         {
             public override void {|Definition:Goo|}() {}
         }
 
-        class D2 : I1
+        class D2 : B, I1
         {
-            public override void {|Definition:Goo|}() {}
+            public override void Goo() {}
         }
         </Document>
     </Project>
@@ -3700,12 +3700,12 @@ End Class
             public virtual void {|Definition:$$Goo|}() {}
         }
 
-        class D1 : I1, I2
+        class D1 : B, I1, I2
         {
             public override void {|Definition:Goo|}() {}
         }
 
-        class D2 : I1
+        class D2 : B, I1
         {
             public override void {|Definition:Goo|}() {}
         }
@@ -3736,12 +3736,12 @@ End Class
             public virtual void {|Definition:Goo|}() {}
         }
 
-        class D1 : I1, I2
+        class D1 : B, I1, I2
         {
             public override void {|Definition:$$Goo|}() {}
         }
 
-        class D2 : I1
+        class D2 : B, I1
         {
             public override void Goo() {}
         }
@@ -3772,12 +3772,12 @@ End Class
             public virtual void {|Definition:Goo|}() {}
         }
 
-        class D1 : I1, I2
+        class D1 : B, I1, I2
         {
             public override void Goo() {}
         }
 
-        class D2 : I1
+        class D2 : B, I1
         {
             public override void {|Definition:$$Goo|}() {}
         }

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -334,7 +334,7 @@ public class M<T> : I1<T>, I3<T>
 
         <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharp_PropertyFromGenericInterface1_Streaming(host As TestHost) As Task
+        Public Async Function TestCSharp_PropertyFromGenericInterface1_Feature(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -354,7 +354,7 @@ interface I2
  
 interface I3<T> : I2
 {
-    new T {|Definition:Name|} { get; set; }
+    new T Name { get; set; }
 }
  
 public class M<T> : I1<T>, I3<T>
@@ -445,7 +445,7 @@ public class M<T> : I1<T>, I3<T>
 
         <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharp_PropertyFromGenericInterface3_Streaming(host As TestHost) As Task
+        Public Async Function TestCSharp_PropertyFromGenericInterface3_FEature(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -455,7 +455,7 @@ using System;
  
 interface I1<T>
 {
-    T {|Definition:Name|} { get; set; }
+    T Name { get; set; }
 }
  
 interface I2

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -297,7 +297,7 @@ public class A : DD
 
         <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharp_PropertyFromGenericInterface1(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCSharp_PropertyFromGenericInterface1_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -329,7 +329,44 @@ public class M<T> : I1<T>, I3<T>
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
+        End Function
+
+        <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_PropertyFromGenericInterface1_Streaming(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+using System;
+ 
+interface I1<T>
+{
+    T {|Definition:$$Name|} { get; set; }
+}
+ 
+interface I2
+{
+    int Name { get; set; }
+}
+ 
+interface I3<T> : I2
+{
+    new T {|Definition:Name|} { get; set; }
+}
+ 
+public class M<T> : I1<T>, I3<T>
+{
+    public T {|Definition:Name|} { get; set; }
+    int I2.Name { get; set; }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
 
         <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>
@@ -371,7 +408,7 @@ public class M<T> : I1<T>, I3<T>
 
         <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharp_PropertyFromGenericInterface3(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCSharp_PropertyFromGenericInterface3_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -403,7 +440,44 @@ public class M<T> : I1<T>, I3<T>
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
+        End Function
+
+        <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_PropertyFromGenericInterface3_Streaming(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+using System;
+ 
+interface I1<T>
+{
+    T {|Definition:Name|} { get; set; }
+}
+ 
+interface I2
+{
+    int Name { get; set; }
+}
+ 
+interface I3<T> : I2
+{
+    new T {|Definition:$$Name|} { get; set; }
+}
+ 
+public class M<T> : I1<T>, I3<T>
+{
+    public T {|Definition:Name|} { get; set; }
+    int I2.Name { get; set; }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
 
         <WorkItem(539885, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539885")>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.WinmdSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.WinmdSymbols.vb
@@ -473,7 +473,7 @@ namespace SampleComponent
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestWinmdVBAllIsWellTest(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestWinmdVBAllIsWellTest_Api(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferencesWinRT="true">
@@ -633,7 +633,171 @@ End Class
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, host)
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestWinmdVBAllIsWellTest_Feature(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferencesWinRT="true">
+        <CompilationOptions OutputType="WindowsRuntimeMetadata"/>
+        <Document>
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+Public Interface I
+    Sub Add(ByVal item As Integer)
+End Interface
+
+Public NotInheritable Class Class1
+    Implements I, IList(Of Integer)
+
+    Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
+        Get
+            Throw New NotImplementedException()
+        End Get
+    End Property
+
+    Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Integer).IsReadOnly
+        Get
+            Throw New NotImplementedException()
+        End Get
+    End Property
+
+    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
+        Get
+            Throw New NotImplementedException()
+        End Get
+        Set(value As Integer)
+            Throw New NotImplementedException()
+        End Set
+    End Property
+
+    Public Sub Add(item As Integer) Implements I.Add
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Clear() Implements ICollection(Of Integer).Clear
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub CopyTo(array() As Integer, arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
+        Throw New NotImplementedException()
+    End Sub
+
+    Private Sub ICollection_Add(item As Integer) Implements ICollection(Of Integer).[|Add|]
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
+        Throw New NotImplementedException()
+    End Function
+
+    Public Function GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
+        Throw New NotImplementedException()
+    End Function
+
+    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
+        Throw New NotImplementedException()
+    End Function
+
+    Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
+        Throw New NotImplementedException()
+    End Function
+
+    Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException()
+    End Function
+End Class
+
+Public NotInheritable Class Class2
+    Implements IList(Of Integer)
+
+    Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
+        Get
+            Throw New NotImplementedException()
+        End Get
+    End Property
+
+    Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Integer).IsReadOnly
+        Get
+            Throw New NotImplementedException()
+        End Get
+    End Property
+
+    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
+        Get
+            Throw New NotImplementedException()
+        End Get
+        Set(value As Integer)
+            Throw New NotImplementedException()
+        End Set
+    End Property
+
+    Public Sub {|Definition:Add|}(item As Integer) Implements ICollection(Of Integer).[|Add|]
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Clear() Implements ICollection(Of Integer).Clear
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub CopyTo(array() As Integer, arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
+        Throw New NotImplementedException()
+    End Sub
+
+    Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
+        Throw New NotImplementedException()
+    End Function
+
+    Public Function GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
+        Throw New NotImplementedException()
+    End Function
+
+    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
+        Throw New NotImplementedException()
+    End Function
+
+    Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
+        Throw New NotImplementedException()
+    End Function
+
+    Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+        Throw New NotImplementedException()
+    End Function
+End Class
+
+Public NotInheritable Class Test
+    Public Sub Goo()
+        Dim c1 = DirectCast(New Class1(), IList(Of Integer))
+        Dim c2 As New Class1
+        Dim c3 As New Class2
+        c2.Add(3)
+        c1.[|Add|](3)
+        c3.[|$$Add|](3)
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.WinmdSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.WinmdSymbols.vb
@@ -487,7 +487,7 @@ Public Interface I
 End Interface
 
 Public NotInheritable Class Class1
-    Implements I, IList(Of Integer)
+    Implements I, ICollection(Of Integer)
 
     Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
         Get
@@ -501,15 +501,6 @@ Public NotInheritable Class Class1
         End Get
     End Property
 
-    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
-        Get
-            Throw New NotImplementedException()
-        End Get
-        Set(value As Integer)
-            Throw New NotImplementedException()
-        End Set
-    End Property
-
     Public Sub Add(item As Integer) Implements I.Add
         Throw New NotImplementedException()
     End Sub
@@ -519,14 +510,6 @@ Public NotInheritable Class Class1
     End Sub
 
     Public Sub CopyTo(array() As Integer, arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
-        Throw New NotImplementedException()
-    End Sub
-
-    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
-        Throw New NotImplementedException()
-    End Sub
-
-    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
         Throw New NotImplementedException()
     End Sub
 
@@ -542,10 +525,6 @@ Public NotInheritable Class Class1
         Throw New NotImplementedException()
     End Function
 
-    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
-        Throw New NotImplementedException()
-    End Function
-
     Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
         Throw New NotImplementedException()
     End Function
@@ -556,7 +535,7 @@ Public NotInheritable Class Class1
 End Class
 
 Public NotInheritable Class Class2
-    Implements IList(Of Integer)
+    Implements ICollection(Of Integer)
 
     Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
         Get
@@ -568,15 +547,6 @@ Public NotInheritable Class Class2
         Get
             Throw New NotImplementedException()
         End Get
-    End Property
-
-    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
-        Get
-            Throw New NotImplementedException()
-        End Get
-        Set(value As Integer)
-            Throw New NotImplementedException()
-        End Set
     End Property
 
     Public Sub {|Definition:Add|}(item As Integer) Implements ICollection(Of Integer).[|Add|]
@@ -591,23 +561,11 @@ Public NotInheritable Class Class2
         Throw New NotImplementedException()
     End Sub
 
-    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
-        Throw New NotImplementedException()
-    End Sub
-
-    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
-        Throw New NotImplementedException()
-    End Sub
-
     Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
         Throw New NotImplementedException()
     End Function
 
     Public Function GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
-        Throw New NotImplementedException()
-    End Function
-
-    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
         Throw New NotImplementedException()
     End Function
 
@@ -622,7 +580,7 @@ End Class
 
 Public NotInheritable Class Test
     Public Sub Goo()
-        Dim c1 = DirectCast(New Class1(), IList(Of Integer))
+        Dim c1 = DirectCast(New Class1(), ICollection(Of Integer))
         Dim c2 As New Class1
         Dim c3 As New Class2
         c2.Add(3)
@@ -651,7 +609,7 @@ Public Interface I
 End Interface
 
 Public NotInheritable Class Class1
-    Implements I, IList(Of Integer)
+    Implements I, ICollection(Of Integer)
 
     Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
         Get
@@ -665,15 +623,6 @@ Public NotInheritable Class Class1
         End Get
     End Property
 
-    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
-        Get
-            Throw New NotImplementedException()
-        End Get
-        Set(value As Integer)
-            Throw New NotImplementedException()
-        End Set
-    End Property
-
     Public Sub Add(item As Integer) Implements I.Add
         Throw New NotImplementedException()
     End Sub
@@ -683,14 +632,6 @@ Public NotInheritable Class Class1
     End Sub
 
     Public Sub CopyTo(array() As Integer, arrayIndex As Integer) Implements ICollection(Of Integer).CopyTo
-        Throw New NotImplementedException()
-    End Sub
-
-    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
-        Throw New NotImplementedException()
-    End Sub
-
-    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
         Throw New NotImplementedException()
     End Sub
 
@@ -706,10 +647,6 @@ Public NotInheritable Class Class1
         Throw New NotImplementedException()
     End Function
 
-    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
-        Throw New NotImplementedException()
-    End Function
-
     Public Function Remove(item As Integer) As Boolean Implements ICollection(Of Integer).Remove
         Throw New NotImplementedException()
     End Function
@@ -720,7 +657,7 @@ Public NotInheritable Class Class1
 End Class
 
 Public NotInheritable Class Class2
-    Implements IList(Of Integer)
+    Implements ICollection(Of Integer)
 
     Public ReadOnly Property Count As Integer Implements ICollection(Of Integer).Count
         Get
@@ -732,15 +669,6 @@ Public NotInheritable Class Class2
         Get
             Throw New NotImplementedException()
         End Get
-    End Property
-
-    Default Public Property Item(index As Integer) As Integer Implements IList(Of Integer).Item
-        Get
-            Throw New NotImplementedException()
-        End Get
-        Set(value As Integer)
-            Throw New NotImplementedException()
-        End Set
     End Property
 
     Public Sub {|Definition:Add|}(item As Integer) Implements ICollection(Of Integer).[|Add|]
@@ -755,23 +683,11 @@ Public NotInheritable Class Class2
         Throw New NotImplementedException()
     End Sub
 
-    Public Sub Insert(index As Integer, item As Integer) Implements IList(Of Integer).Insert
-        Throw New NotImplementedException()
-    End Sub
-
-    Public Sub RemoveAt(index As Integer) Implements IList(Of Integer).RemoveAt
-        Throw New NotImplementedException()
-    End Sub
-
     Public Function Contains(item As Integer) As Boolean Implements ICollection(Of Integer).Contains
         Throw New NotImplementedException()
     End Function
 
     Public Function GetEnumerator() As IEnumerator(Of Integer) Implements IEnumerable(Of Integer).GetEnumerator
-        Throw New NotImplementedException()
-    End Function
-
-    Public Function IndexOf(item As Integer) As Integer Implements IList(Of Integer).IndexOf
         Throw New NotImplementedException()
     End Function
 
@@ -786,7 +702,7 @@ End Class
 
 Public NotInheritable Class Test
     Public Sub Goo()
-        Dim c1 = DirectCast(New Class1(), IList(Of Integer))
+        Dim c1 = DirectCast(New Class1(), ICollection(Of Integer))
         Dim c2 As New Class1
         Dim c3 As New Class2
         c2.Add(3)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesCascadeDirection.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesCascadeDirection.cs
@@ -28,6 +28,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal static class FindReferencesCascadeDirectionExtensions
     {
         public static bool HasFlag(this FindReferencesCascadeDirection value, FindReferencesCascadeDirection flag)
-            => (value & flag) != flag;
+            => (value & flag) == flag;
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesCascadeDirection.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesCascadeDirection.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.FindSymbols
+{
+    internal enum FindReferencesCascadeDirection
+    {
+        /// <summary>
+        /// Cascade to all symbols no matter what.  <see cref="All"/> is not the same as <c>Up | Down</c>.  <see
+        /// cref="All"/> implies that cascading should go in both directions for every symbol hit.  <c>Up | Down</c>
+        /// means going both up and down from the initial symbol, but then any cascaded symbols should stick with <see
+        /// cref="Up"/> or <see cref="Down"/> depending on the initial cascading direction.
+        /// </summary>
+        All = 0,
+
+        /// <summary>
+        /// Cascade up the inheritance hierarchy only.
+        /// </summary>
+        Up = 1,
+
+        /// <summary>
+        /// Cascade down the inheritance hierarchy only.
+        /// </summary>
+        Down = 2,
+    }
+}

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesCascadeDirection.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesCascadeDirection.cs
@@ -2,26 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
+    [Flags]
     internal enum FindReferencesCascadeDirection
     {
         /// <summary>
-        /// Cascade to all symbols no matter what.  <see cref="All"/> is not the same as <c>Up | Down</c>.  <see
-        /// cref="All"/> implies that cascading should go in both directions for every symbol hit.  <c>Up | Down</c>
-        /// means going both up and down from the initial symbol, but then any cascaded symbols should stick with <see
-        /// cref="Up"/> or <see cref="Down"/> depending on the initial cascading direction.
-        /// </summary>
-        All = 0,
-
-        /// <summary>
-        /// Cascade up the inheritance hierarchy only.
+        /// Cascade up the inheritance hierarchy.
         /// </summary>
         Up = 1,
 
         /// <summary>
-        /// Cascade down the inheritance hierarchy only.
+        /// Cascade down the inheritance hierarchy.
         /// </summary>
         Down = 2,
+
+        /// <summary>
+        /// Cascade in both directions.
+        /// </summary>
+        UpAndDown = Up | Down,
+    }
+
+    internal static class FindReferencesCascadeDirectionExtensions
+    {
+        public static bool HasFlag(this FindReferencesCascadeDirection value, FindReferencesCascadeDirection flag)
+            => (value & flag) != flag;
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -67,7 +67,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 await using var _ = await _progressTracker.AddSingleItemAsync().ConfigureAwait(false);
 
-                var symbols = await DetermineAllSymbolsAsync(symbol).ConfigureAwait(false);
+                var cascadeDirection = _options.UnidirectionalHierarchyCascade
+                    ? FindReferencesCascadeDirection.Up | FindReferencesCascadeDirection.Down
+                    : FindReferencesCascadeDirection.All;
+
+                var symbols = await DetermineAllSymbolsAsync(symbol, cascadeDirection).ConfigureAwait(false);
 
                 var projectMap = await CreateProjectMapAsync(symbols).ConfigureAwait(false);
                 var projectToDocumentMap = await CreateProjectToDocumentMapAsync(projectMap).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -67,11 +67,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 await using var _ = await _progressTracker.AddSingleItemAsync().ConfigureAwait(false);
 
-                var cascadeDirection = _options.UnidirectionalHierarchyCascade
-                    ? FindReferencesCascadeDirection.Up | FindReferencesCascadeDirection.Down
-                    : FindReferencesCascadeDirection.All;
-
-                var symbols = await DetermineAllSymbolsAsync(symbol, cascadeDirection).ConfigureAwait(false);
+                // For the starting symbol, always cascade up and down the inheritance hierarchy.
+                var symbols = await DetermineAllSymbolsAsync(symbol, FindReferencesCascadeDirection.UpAndDown).ConfigureAwait(false);
 
                 var projectMap = await CreateProjectMapAsync(symbols).ConfigureAwait(false);
                 var projectToDocumentMap = await CreateProjectToDocumentMapAsync(projectMap).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -11,10 +11,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed class FindReferencesSearchOptions
     {
         public static readonly FindReferencesSearchOptions Default =
-            new(
-                associatePropertyReferencesWithSpecificAccessor: false,
+            new(associatePropertyReferencesWithSpecificAccessor: false,
                 cascade: true,
-                @explicit: true);
+                @explicit: true,
+                unidirectionalHierarchyCascade: false);
 
         /// <summary>
         /// When searching for property, associate specific references we find to the relevant

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -113,10 +113,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         /// <summary>
-        /// For IDE features, if the user starts searching on an accessor, then we want to give results associated with
-        /// the specific accessor.  Otherwise, if they search on a property, then associate everything with the
-        /// property.  We also only want to travel an inheritance hierarchy unidirectionally so that we only see potential
-        /// references that could actually reach this particular member.
+        /// Returns the appropriate options for a given symbol for the specific 'Find References' feature.  This should
+        /// not be used for other features (like 'Rename').  For the 'Find References' feature, if the user starts
+        /// searching on an accessor, then we want to give results associated with the specific accessor.  Otherwise, if
+        /// they search on a property, then associate everything with the property.  We also only want to travel an
+        /// inheritance hierarchy unidirectionally so that we only see potential references that could actually reach
+        /// this particular member.
         /// </summary>
         public static FindReferencesSearchOptions GetFeatureOptionsForStartingSymbol(ISymbol symbol)
             => Default.With(associatePropertyReferencesWithSpecificAccessor: symbol.IsPropertyAccessor(),

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -56,6 +56,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// those interface methods.  This is useful for cases where the client only wants references that could lead to
         /// this symbol actually being called into at runtime.
         /// </summary>
+        /// <remarks>
+        /// There are cases where a client will not want this behavior.  An example of that is 'Rename'.  In rename,
+        /// there is a implicit link between members in a hierarchy with the same name (and appropriate signature).  For example, in:
+        ///
+        /// <code>
+        /// interface I { void Goo(); }
+        /// class C1 : I { public void Goo() { } }
+        /// class C2 : I { public void Goo() { } }
+        /// </code>
+        /// 
+        /// If <c>C1.Goo</c> is renamed, this will need to rename <c>C2.Goo</c> as well to keep the code properly
+        /// compiling.  So, by default 'Rename' will cascade to all of these so it can appropriately update them.  This
+        /// option is the more relevant with knowing if a particular reference would actually result in a call to the
+        /// original member, not if it has a relation to the original member.
+        /// </remarks>
         [DataMember(Order = 3)]
         public bool UnidirectionalHierarchyCascade { get; }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -62,38 +62,49 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public FindReferencesSearchOptions(
             bool associatePropertyReferencesWithSpecificAccessor,
             bool cascade,
-            bool @explicit)
+            bool @explicit,
+            bool unidirectionalHierarchyCascade)
         {
             AssociatePropertyReferencesWithSpecificAccessor = associatePropertyReferencesWithSpecificAccessor;
             Cascade = cascade;
             Explicit = @explicit;
+            UnidirectionalHierarchyCascade = unidirectionalHierarchyCascade;
         }
 
         public FindReferencesSearchOptions With(
             Optional<bool> associatePropertyReferencesWithSpecificAccessor = default,
             Optional<bool> cascade = default,
-            Optional<bool> @explicit = default)
+            Optional<bool> @explicit = default,
+            Optional<bool> unidirectionalHierarchyCascade = default)
         {
             var newAssociatePropertyReferencesWithSpecificAccessor = associatePropertyReferencesWithSpecificAccessor.HasValue ? associatePropertyReferencesWithSpecificAccessor.Value : AssociatePropertyReferencesWithSpecificAccessor;
             var newCascade = cascade.HasValue ? cascade.Value : Cascade;
             var newExplicit = @explicit.HasValue ? @explicit.Value : Explicit;
+            var newUnidirectionalHierarchyCascade = unidirectionalHierarchyCascade.HasValue ? unidirectionalHierarchyCascade.Value : Explicit;
 
             if (newAssociatePropertyReferencesWithSpecificAccessor == AssociatePropertyReferencesWithSpecificAccessor &&
                 newCascade == Cascade &&
-                newExplicit == Explicit)
+                newExplicit == Explicit &&
+                newUnidirectionalHierarchyCascade == UnidirectionalHierarchyCascade)
             {
                 return this;
             }
 
-            return new FindReferencesSearchOptions(newAssociatePropertyReferencesWithSpecificAccessor, newCascade, newExplicit);
+            return new FindReferencesSearchOptions(
+                newAssociatePropertyReferencesWithSpecificAccessor,
+                newCascade,
+                newExplicit,
+                newUnidirectionalHierarchyCascade);
         }
 
         /// <summary>
-        /// For IDE features, if the user starts searching on an accessor, then we want to give
-        /// results associated with the specific accessor.  Otherwise, if they search on a property,
-        /// then associate everything with the property.
+        /// For IDE features, if the user starts searching on an accessor, then we want to give results associated with
+        /// the specific accessor.  Otherwise, if they search on a property, then associate everything with the
+        /// property.  We also only want to travel an inheritance hierarchy unidirectionally so that we only see potential
+        /// references that could actually reach this particular member.
         /// </summary>
         public static FindReferencesSearchOptions GetFeatureOptionsForStartingSymbol(ISymbol symbol)
-            => Default.With(associatePropertyReferencesWithSpecificAccessor: symbol.IsPropertyAccessor());
+            => Default.With(associatePropertyReferencesWithSpecificAccessor: symbol.IsPropertyAccessor(),
+                            unidirectionalHierarchyCascade: true);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var newAssociatePropertyReferencesWithSpecificAccessor = associatePropertyReferencesWithSpecificAccessor.HasValue ? associatePropertyReferencesWithSpecificAccessor.Value : AssociatePropertyReferencesWithSpecificAccessor;
             var newCascade = cascade.HasValue ? cascade.Value : Cascade;
             var newExplicit = @explicit.HasValue ? @explicit.Value : Explicit;
-            var newUnidirectionalHierarchyCascade = unidirectionalHierarchyCascade.HasValue ? unidirectionalHierarchyCascade.Value : Explicit;
+            var newUnidirectionalHierarchyCascade = unidirectionalHierarchyCascade.HasValue ? unidirectionalHierarchyCascade.Value : UnidirectionalHierarchyCascade;
 
             if (newAssociatePropertyReferencesWithSpecificAccessor == AssociatePropertyReferencesWithSpecificAccessor &&
                 newCascade == Cascade &&

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -49,6 +49,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         [DataMember(Order = 2)]
         public bool Explicit { get; }
 
+        /// <summary>
+        /// When cascading if we should only travel in a consistent direction away from the starting symbol.  For
+        /// example, starting on a virtual method, this would cascade upwards to implemented interface methods, and
+        /// downwards to overridden methods.  However, it would not then travel back down to other implementations of
+        /// those interface methods.  This is useful for cases where the client only wants references that could lead to
+        /// this symbol actually being called into at runtime.
+        /// </summary>
+        [DataMember(Order = 3)]
+        public bool UnidirectionalHierarchyCascade { get; }
+
         public FindReferencesSearchOptions(
             bool associatePropertyReferencesWithSpecificAccessor,
             bool cascade,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
@@ -18,43 +18,54 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         {
         }
 
-        protected override async Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        protected override async Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             TSymbol symbol,
             Solution solution,
             IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
+            FindReferencesCascadeDirection cascadeDirection,
             CancellationToken cancellationToken)
         {
             // Static methods can't cascade.
-            if (!symbol.IsStatic)
+            if (symbol.IsStatic)
+                return ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>.Empty;
+
+            if (symbol.IsImplementableMember())
             {
-                if (symbol.IsImplementableMember())
-                {
-                    // We have an interface method.  Find all implementations of that method and
-                    // cascade to them.
-                    return await SymbolFinder.FindMemberImplementationsArrayAsync(symbol, solution, projects, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    // We have a normal method.  Find any interface methods that it implicitly or
-                    // explicitly implements and cascade down to those.
-                    var interfaceMembersImplemented = await SymbolFinder.FindImplementedInterfaceMembersArrayAsync(
-                        symbol, solution, projects, cancellationToken).ConfigureAwait(false);
-
-                    // Finally, methods can cascade through virtual/override inheritance.  NOTE(cyrusn):
-                    // We only need to go up or down one level.  Then, when we're finding references on
-                    // those members, we'll end up traversing the entire hierarchy.
-                    var overrides = await SymbolFinder.FindOverridesArrayAsync(
-                        symbol, solution, projects, cancellationToken).ConfigureAwait(false);
-
-                    var overriddenMember = symbol.GetOverriddenMember();
-                    return overriddenMember == null
-                        ? interfaceMembersImplemented.Concat(overrides)
-                        : interfaceMembersImplemented.Concat(overrides).Concat(overriddenMember);
-                }
+                // We have an interface method.  Walk down the inheritance hierarchy and find all implementations of
+                // that method and cascade to them.
+                var result = cascadeDirection.HasFlag(FindReferencesCascadeDirection.Down)
+                    ? await SymbolFinder.FindMemberImplementationsArrayAsync(symbol, solution, projects, cancellationToken).ConfigureAwait(false)
+                    : ImmutableArray<ISymbol>.Empty;
+                return result.SelectAsArray(s => (s, FindReferencesCascadeDirection.Down));
             }
+            else
+            {
+                // We have a normal method.  Find any interface methods up the inheritance hierarchy that it implicitly
+                // or explicitly implements and cascade to those.
+                var interfaceMembersImplemented = cascadeDirection.HasFlag(FindReferencesCascadeDirection.Up)
+                    ? await SymbolFinder.FindImplementedInterfaceMembersArrayAsync(symbol, solution, projects, cancellationToken).ConfigureAwait(false)
+                    : ImmutableArray<ISymbol>.Empty;
 
-            return ImmutableArray<ISymbol>.Empty;
+                // Finally, methods can cascade through virtual/override inheritance.  NOTE(cyrusn):
+                // We only need to go up or down one level.  Then, when we're finding references on
+                // those members, we'll end up traversing the entire hierarchy.
+                var overrides = cascadeDirection.HasFlag(FindReferencesCascadeDirection.Up)
+                    ? await SymbolFinder.FindOverridesArrayAsync(symbol, solution, projects, cancellationToken).ConfigureAwait(false)
+                    : ImmutableArray<ISymbol>.Empty;
+
+                var overriddenMember = cascadeDirection.HasFlag(FindReferencesCascadeDirection.Up)
+                    ? symbol.GetOverriddenMember()
+                    : null;
+
+                var interfaceMembersImplementedWithDirection = interfaceMembersImplemented.SelectAsArray(s => (s, FindReferencesCascadeDirection.Up));
+                var overridesWithDirection = overrides.SelectAsArray(s => (s, FindReferencesCascadeDirection.Down));
+                var overriddenMemberWithDirection = (overriddenMember!, FindReferencesCascadeDirection.Up);
+
+                return overriddenMember == null
+                    ? interfaceMembersImplementedWithDirection.Concat(overridesWithDirection)
+                    : interfaceMembersImplementedWithDirection.Concat(overridesWithDirection).Concat(overriddenMemberWithDirection);
+            }
         }
 
         protected static ImmutableArray<IMethodSymbol> GetReferencedAccessorSymbols(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 // Finally, methods can cascade through virtual/override inheritance.  NOTE(cyrusn):
                 // We only need to go up or down one level.  Then, when we're finding references on
                 // those members, we'll end up traversing the entire hierarchy.
-                var overrides = cascadeDirection.HasFlag(FindReferencesCascadeDirection.Up)
+                var overrides = cascadeDirection.HasFlag(FindReferencesCascadeDirection.Down)
                     ? await SymbolFinder.FindOverridesArrayAsync(symbol, solution, projects, cancellationToken).ConfigureAwait(false)
                     : ImmutableArray<ISymbol>.Empty;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -26,9 +26,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         public const string ContainingTypeInfoPropertyName = "ContainingTypeInfo";
         public const string ContainingMemberInfoPropertyName = "ContainingMemberInfo";
 
-        public abstract Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        public abstract Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
-            FindReferencesSearchOptions options, CancellationToken cancellationToken);
+            FindReferencesSearchOptions options, FindReferencesCascadeDirection cascadeDirection,
+            CancellationToken cancellationToken);
 
         public abstract Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(ISymbol symbol, Solution solution, IImmutableSet<Project>? projects, CancellationToken cancellationToken);
 
@@ -932,20 +933,20 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 : new ValueTask<ImmutableArray<FinderLocation>>(ImmutableArray<FinderLocation>.Empty);
         }
 
-        public override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        public override Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
-            FindReferencesSearchOptions options, CancellationToken cancellationToken)
+            FindReferencesSearchOptions options, FindReferencesCascadeDirection cascadeDirection,
+            CancellationToken cancellationToken)
         {
             if (options.Cascade &&
                 symbol is TSymbol typedSymbol &&
                 CanFind(typedSymbol))
             {
                 return DetermineCascadedSymbolsAsync(
-                    typedSymbol,
-                    solution, projects, options, cancellationToken);
+                    typedSymbol, solution, projects, options, cascadeDirection, cancellationToken);
             }
 
-            return SpecializedTasks.EmptyImmutableArray<ISymbol>();
+            return SpecializedTasks.EmptyImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>();
         }
 
         protected virtual Task<ImmutableArray<Project>> DetermineProjectsToSearchAsync(
@@ -955,11 +956,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 solution, symbol, projects, cancellationToken);
         }
 
-        protected virtual Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        protected virtual Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             TSymbol symbol, Solution solution, IImmutableSet<Project>? projects,
-            FindReferencesSearchOptions options, CancellationToken cancellationToken)
+            FindReferencesSearchOptions options, FindReferencesCascadeDirection cascadeDirection,
+            CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<ISymbol>();
+            return SpecializedTasks.EmptyImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>();
         }
 
         protected static ValueTask<ImmutableArray<FinderLocation>> FindReferencesInDocumentUsingSymbolNameAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/DestructorSymbolReferenceFinder.cs
@@ -14,16 +14,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override bool CanFind(IMethodSymbol symbol)
             => symbol.MethodKind == MethodKind.Destructor;
 
-        protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
-            IMethodSymbol symbol,
-            Solution solution,
-            IImmutableSet<Project>? projects,
-            FindReferencesSearchOptions options,
-            CancellationToken cancellationToken)
-        {
-            return SpecializedTasks.EmptyImmutableArray<ISymbol>();
-        }
-
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             IMethodSymbol symbol,
             Project project,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitInterfaceMethodReferenceFinder.cs
@@ -14,15 +14,20 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override bool CanFind(IMethodSymbol symbol)
             => symbol.MethodKind == MethodKind.ExplicitInterfaceImplementation;
 
-        protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        protected override Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             IMethodSymbol symbol,
             Solution solution,
             IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
+            FindReferencesCascadeDirection cascadeDirection,
             CancellationToken cancellationToken)
         {
-            // An explicit interface method will cascade to all the methods that it implements.
-            return Task.FromResult(ImmutableArray<ISymbol>.CastUp(symbol.ExplicitInterfaceImplementations));
+            if (!cascadeDirection.HasFlag(FindReferencesCascadeDirection.Up))
+                return SpecializedTasks.EmptyImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>();
+
+            // An explicit interface method will cascade to all the methods that it implements in the up direction.
+            return Task.FromResult(
+                symbol.ExplicitInterfaceImplementations.SelectAsArray(m => ((ISymbol)m, FindReferencesCascadeDirection.Up)));
         }
 
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -14,21 +14,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override bool CanFind(IFieldSymbol symbol)
             => true;
 
-        protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        protected override Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             IFieldSymbol symbol,
             Solution solution,
             IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
+            FindReferencesCascadeDirection cascadeDirection,
             CancellationToken cancellationToken)
         {
-            if (symbol.AssociatedSymbol != null)
-            {
-                return Task.FromResult(ImmutableArray.Create(symbol.AssociatedSymbol));
-            }
-            else
-            {
-                return SpecializedTasks.EmptyImmutableArray<ISymbol>();
-            }
+            return symbol.AssociatedSymbol != null
+                ? Task.FromResult(ImmutableArray.Create((symbol.AssociatedSymbol, cascadeDirection)))
+                : SpecializedTasks.EmptyImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>();
         }
 
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ILanguageServiceReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ILanguageServiceReferenceFinder.cs
@@ -17,6 +17,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
     internal interface ILanguageServiceReferenceFinder : ILanguageService
     {
         Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
-            ISymbol symbol, Project project, CancellationToken cancellationToken);
+            ISymbol symbol, Project project, FindReferencesCascadeDirection cascadeDirection, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ILanguageServiceReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ILanguageServiceReferenceFinder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
     /// </summary>
     internal interface ILanguageServiceReferenceFinder : ILanguageService
     {
-        Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             ISymbol symbol, Project project, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/IReferenceFinder.cs
@@ -24,9 +24,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// 
         /// Implementations of this method must be thread-safe.
         /// </summary>
-        Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
-            FindReferencesSearchOptions options, CancellationToken cancellationToken);
+            FindReferencesSearchOptions options, FindReferencesCascadeDirection cascadeDirection,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Called by the find references search engine to determine which projects should be

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/LinkedFileReferenceFinder.cs
@@ -11,13 +11,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 {
     internal class LinkedFileReferenceFinder : IReferenceFinder
     {
-        public Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        public async Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             ISymbol symbol, Solution solution, IImmutableSet<Project>? projects,
-            FindReferencesSearchOptions options, CancellationToken cancellationToken)
+            FindReferencesSearchOptions options, FindReferencesCascadeDirection cascadeDirection,
+            CancellationToken cancellationToken)
         {
-            return options.Cascade
-                ? SymbolFinder.FindLinkedSymbolsAsync(symbol, solution, cancellationToken)
-                : SpecializedTasks.EmptyImmutableArray<ISymbol>();
+            if (!options.Cascade)
+                return ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>.Empty;
+
+            var linkedSymbols = await SymbolFinder.FindLinkedSymbolsAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
+            return linkedSymbols.SelectAsArray(s => (s, cascadeDirection));
+
         }
 
         public Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/MethodTypeParameterSymbolReferenceFinder.cs
@@ -14,11 +14,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         protected override bool CanFind(ITypeParameterSymbol symbol)
             => symbol.TypeParameterKind == TypeParameterKind.Method;
 
-        protected override Task<ImmutableArray<ISymbol>> DetermineCascadedSymbolsAsync(
+        protected override Task<ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>> DetermineCascadedSymbolsAsync(
             ITypeParameterSymbol symbol,
             Solution solution,
             IImmutableSet<Project>? projects,
             FindReferencesSearchOptions options,
+            FindReferencesCascadeDirection cascadeDirection,
             CancellationToken cancellationToken)
         {
             var method = (IMethodSymbol)symbol.ContainingSymbol;
@@ -28,18 +29,18 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             {
                 if (method.PartialDefinitionPart != null && ordinal < method.PartialDefinitionPart.TypeParameters.Length)
                 {
-                    return Task.FromResult(ImmutableArray.Create<ISymbol>(
-                        method.PartialDefinitionPart.TypeParameters[ordinal]));
+                    return Task.FromResult(ImmutableArray.Create(
+                        ((ISymbol)method.PartialDefinitionPart.TypeParameters[ordinal], cascadeDirection)));
                 }
 
                 if (method.PartialImplementationPart != null && ordinal < method.PartialImplementationPart.TypeParameters.Length)
                 {
-                    return Task.FromResult(ImmutableArray.Create<ISymbol>(
-                        method.PartialImplementationPart.TypeParameters[ordinal]));
+                    return Task.FromResult(ImmutableArray.Create(
+                        ((ISymbol)method.PartialImplementationPart.TypeParameters[ordinal], cascadeDirection)));
                 }
             }
 
-            return SpecializedTasks.EmptyImmutableArray<ISymbol>();
+            return SpecializedTasks.EmptyImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>();
         }
 
         protected override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicReferenceFinder.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicReferenceFinder.vb
@@ -19,58 +19,56 @@ Namespace Microsoft.CodeAnalysis.FindSymbols
         Public Sub New()
         End Sub
 
-        Public Function DetermineCascadedSymbolsAsync(symbol As ISymbol,
-                                                      project As Project,
-                                                      cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of ISymbol)) Implements ILanguageServiceReferenceFinder.DetermineCascadedSymbolsAsync
+        Public Function DetermineCascadedSymbolsAsync(
+                symbol As ISymbol,
+                project As Project,
+                cascadeDirection As FindReferencesCascadeDirection,
+                cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of (symbol As ISymbol, cascadeDirection As FindReferencesCascadeDirection))) Implements ILanguageServiceReferenceFinder.DetermineCascadedSymbolsAsync
             If symbol.Kind = SymbolKind.Property Then
-                Return DetermineCascadedSymbolsAsync(
-                    DirectCast(symbol, IPropertySymbol), project, cancellationToken)
+                Return DetermineCascadedSymbolsAsync(DirectCast(symbol, IPropertySymbol), project, cascadeDirection, cancellationToken)
             ElseIf symbol.Kind = SymbolKind.NamedType Then
-                Return DetermineCascadedSymbolsAsync(
-                    DirectCast(symbol, INamedTypeSymbol), project, cancellationToken)
+                Return DetermineCascadedSymbolsAsync(DirectCast(symbol, INamedTypeSymbol), project, cascadeDirection, cancellationToken)
             Else
-                Return SpecializedTasks.EmptyImmutableArray(Of ISymbol)()
+                Return SpecializedTasks.EmptyImmutableArray(Of (symbol As ISymbol, cascadeDirection As FindReferencesCascadeDirection))()
             End If
         End Function
 
         Private Shared Async Function DetermineCascadedSymbolsAsync(
                 [property] As IPropertySymbol,
                 project As Project,
-                cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of ISymbol))
+                cascadeDirection As FindReferencesCascadeDirection,
+                cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of (symbol As ISymbol, cascadeDirection As FindReferencesCascadeDirection)))
 
             Dim compilation = Await project.GetCompilationAsync(cancellationToken).ConfigureAwait(False)
             Dim relatedSymbol = [property].FindRelatedExplicitlyDeclaredSymbol(compilation)
 
             Return If([property].Equals(relatedSymbol),
-                ImmutableArray(Of ISymbol).Empty,
-                ImmutableArray.Create(relatedSymbol))
+                ImmutableArray(Of (symbol As ISymbol, cascadeDirection As FindReferencesCascadeDirection)).Empty,
+                ImmutableArray.Create((relatedSymbol, cascadeDirection)))
         End Function
 
         Private Shared Async Function DetermineCascadedSymbolsAsync(
                 namedType As INamedTypeSymbol,
                 project As Project,
-                cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of ISymbol))
+                cascadeDirection As FindReferencesCascadeDirection,
+                cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of (symbol As ISymbol, cascadeDirection As FindReferencesCascadeDirection)))
 
             Dim compilation = Await project.GetCompilationAsync(cancellationToken).ConfigureAwait(False)
 
             ' If this is a WinForms project, then the VB 'my' feature may have synthesized 
             ' a property that would return an instance of the main Form type for the project.
             ' Search for such properties and cascade to them as well.
-            Return GetMatchingMyPropertySymbols(namedType, compilation, cancellationToken).
-                Distinct().ToImmutableArray()
-        End Function
 
-        Private Shared Function GetMatchingMyPropertySymbols(
-                namedType As INamedTypeSymbol,
-                compilation As Compilation,
-                cancellationToken As CancellationToken) As IEnumerable(Of ISymbol)
-            Return From childNamespace In compilation.RootNamespace.GetNamespaceMembers()
-                   Where childNamespace.IsMyNamespace(compilation)
-                   From type In childNamespace.GetAllTypes(cancellationToken)
-                   Where type.Name = "MyForms"
-                   From childProperty In type.GetMembers().OfType(Of IPropertySymbol)
-                   Where childProperty.IsImplicitlyDeclared AndAlso childProperty.Type.Equals(namedType)
-                   Select DirectCast(childProperty, ISymbol)
+            Dim matchingMyPropertySymbols =
+                From childNamespace In compilation.RootNamespace.GetNamespaceMembers()
+                Where childNamespace.IsMyNamespace(compilation)
+                From type In childNamespace.GetAllTypes(cancellationToken)
+                Where type.Name = "MyForms"
+                From childProperty In type.GetMembers().OfType(Of IPropertySymbol)
+                Where childProperty.IsImplicitlyDeclared AndAlso childProperty.Type.Equals(namedType)
+                Select (DirectCast(childProperty, ISymbol), cascadeDirection)
+
+            Return matchingMyPropertySymbols.Distinct().ToImmutableArray()
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Previously, 'Find References', which has both an programmatic API (FAR-API), and an end user facing feature (FAR-feature) would walk unilaterally through the inheritance hierarchy for a member with a particular.  So, if you had:

```c#
class C { public virtual void Foo() {} }
class D1 : C { public override void Foo() { } }
class D2 : C { public override void Foo() { } }
```

Then doing a Find-References on D1.Foo, would find references to all three Foo methods shown there.  This was non ideal if you consider this sort of case:

```c#
D2 d = new D2();
d.Foo();
```

Here, this call to `Foo` can never, and will never call into `D1.Foo()`.  Any call through it will never reach D1's Foo method.  Contrast this with:

```c#
C c = ...;
c.Foo();
```

Here, `c.Foo()` could call into `D1.Foo` if `c` is an instance of `D1` at runtime.

The reason FAR-feature worked this way, is that it calls FAR-API to get the results.  This FAR-API was designed for needs of consumers like `Rename`.  In `Rename`, if you rename any of these three methods, then all have to be renamed as there is a coupling here between the members in terms of satisfying interface implementations.  That coupling goes beyond what FAR-feature needs, but it caused the suboptimal behavior seen above.

This change introduces a new concept to FAR-API where the client can specify if they want this behavior or not.  Existing clients (like rename, or 3rd parties) will get the same results as before.  However, clients (like FAR-feature, highlight-refs, and CodeLens) can opt into new behavior where we only find references that could actually call into that member at runtime.  

This also has added benefits for performance as things like codelens (and FAR-feature, and highlight-refs) wont' cascade to many symbols that aren't needed when computing these results.