### PR TITLE
Correctly handle lambda expressions in the nullable walker when they are passed as arguments to a bad expression

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -4991,7 +4991,7 @@ namespace System
             AssertEx.Equal("(System.String a, System.String b)", model.GetTypeInfo(tupleLiteral).Type.ToTestDisplayString(includeNonNullable: false));
         }
 
-        [Fact]
+        [Fact, WorkItem(51461, "https://github.com/dotnet/roslyn/issues/51461")]
         public void LambdaInBadExpression()
         {
             var comp = CreateCompilation(@"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -4990,5 +4990,57 @@ namespace System
             var tupleLiteral = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>().Single();
             AssertEx.Equal("(System.String a, System.String b)", model.GetTypeInfo(tupleLiteral).Type.ToTestDisplayString(includeNonNullable: false));
         }
+
+        [Fact]
+        public void LambdaInBadExpression()
+        {
+            var comp = CreateCompilation(@"
+public class C
+{
+    public C(int i) {}
+
+    static void M1()
+    {
+        string s = null;
+        C c = new C(() =>
+        { 
+            M2();
+            _ = s;
+            s = """";
+            _ = s;
+        });
+    }
+
+    static void M2() {}
+}
+", options: WithNullableEnable());
+
+            comp.VerifyDiagnostics(
+                // (8,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         string s = null;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(8, 20),
+                // (9,21): error CS1660: Cannot convert lambda expression to type 'int' because it is not a delegate type
+                //         C c = new C(() =>
+                Diagnostic(ErrorCode.ERR_AnonMethToNonDel, @"() =>
+        { 
+            M2();
+            _ = s;
+            s = """";
+            _ = s;
+        }").WithArguments("lambda expression", "int").WithLocation(9, 21)
+            );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var constructor = tree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().Single();
+            AssertEx.Equal("C..ctor(System.Int32 i)", model.GetSymbolInfo(constructor).CandidateSymbols[0].ToTestDisplayString());
+
+            var assignmentsInLambda = constructor.DescendantNodes().OfType<AssignmentExpressionSyntax>().ToArray();
+            AssertEx.Equal("_ = s", assignmentsInLambda[0].ToString());
+            AssertEx.Equal("_ = s", assignmentsInLambda[2].ToString());
+            AssertEx.Equal("System.String?", model.GetTypeInfo(assignmentsInLambda[0].Right).Type.ToTestDisplayString(includeNonNullable: true));
+            AssertEx.Equal("System.String!", model.GetTypeInfo(assignmentsInLambda[2].Right).Type.ToTestDisplayString(includeNonNullable: true));
+        }
     }
 }


### PR DESCRIPTION
We weren't handling this case correctly, when a lambda appears as a direct argument to a bad expression such as a bad constructor call. We have similar issues for initializers documented at https://github.com/dotnet/roslyn/issues/35042, but those are both more complicated to solve and easier to work around in the verifier, so I took the option of actually fixing the bug. This will cause us to report new warnings for bad code: the warnings in `Lambda_21` and `Lambda_22` were not present prior to this change because we skipped visiting the lambda body entirely. As it's always invalid code, this should be fine.

Fixes https://github.com/dotnet/roslyn/issues/51461. @dotnet/roslyn-compiler @RikkiGibson for review.