### PR TITLE
Configure CompilationOutputInfo for projects created using an MSBuildWorkspace

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -397,7 +397,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
                         isSubmission: false,
                         hostObjectType: null)
                         .WithDefaultNamespace(projectFileInfo.DefaultNamespace)
-                        .WithAnalyzerConfigDocuments(analyzerConfigDocuments);
+                        .WithAnalyzerConfigDocuments(analyzerConfigDocuments)
+                        .WithCompilationOutputInfo(new CompilationOutputInfo(projectFileInfo.OutputFilePath));
                 });
             }
 

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -255,6 +255,21 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        public async Task TestCompilationOutputInfo()
+        {
+            CreateFiles(GetMultiProjectSolutionFiles());
+            var solutionFilePath = GetSolutionFileName("TestSolution.sln");
+
+            using var workspace = CreateMSBuildWorkspace();
+            var sol = await workspace.OpenSolutionAsync(solutionFilePath);
+            var p1 = sol.Projects.First(p => p.Language == LanguageNames.CSharp);
+            var p2 = sol.Projects.First(p => p.Language == LanguageNames.VisualBasic);
+
+            Assert.Equal("CSharpProject.dll", Path.GetFileName(p1.CompilationOutputInfo.AssemblyPath));
+            Assert.Equal("VisualBasicProject.dll", Path.GetFileName(p2.CompilationOutputInfo.AssemblyPath));
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         public async Task TestCrossLanguageReferencesUsesInMemoryGeneratedMetadata()
         {
             CreateFiles(GetMultiProjectSolutionFiles());


### PR DESCRIPTION
In an MSBuildWorkspace, we would expect the compilation output path to be the same
as the project output path. Consequently, it seems fairly safe to default this.

There does not appear to be a way to configure this value externally, and this value is used by [EnC](https://github.com/dotnet/roslyn/blob/main/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs#L82-L88).

Fixes https://github.com/dotnet/roslyn/issues/51609