### PR TITLE
Cover the 'end' cases in AutomaticLineEnderTests

### DIFF
--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -1145,7 +1145,7 @@ public class Bar
 {
     public int P
     {
-        ge$$t
+        ge$$t$$
     }
 }";
 
@@ -1226,7 +1226,7 @@ public class Bar
 {
     public int this[int i]
     {
-        ge$$t
+        ge$$t$$
     }
 }");
         }
@@ -1346,7 +1346,7 @@ public class Bar
     public int this[int i]
     {
         get;
-        se$$t
+        se$$t$$
     }
 }");
         }
@@ -1401,7 +1401,7 @@ public class Bar
 {
     public event EventHandler e
     {
-        ad$$d
+        ad$$d$$
         remove
     }
 }");
@@ -1460,7 +1460,7 @@ public class Bar
     public event EventHandler e
     {
         add
-        remo$$ve
+        remo$$ve$$
     }
 }");
         }
@@ -2966,7 +2966,7 @@ public class Bar
         catch (System.Exception)
         {
         }
-        fin$$ally
+        fin$$ally$$
         {
         }
     }


### PR DESCRIPTION
As Cyrus points out, when the caret is placed at the end, we should ensure everything still work