### PR TITLE
Use frozen-partial semantics when producing semantic classifications

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Threading;
+using Microsoft.CodeAnalysis.Editor.Tagging;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
+{
+    /// <summary>
+    /// Tagger event that fires once the compilation is ready for a particular project.  Used to trigger a
+    /// reclassification pass as classification may show either cached classifications (from a previous session), or
+    /// incomplete classifications due to frozen-partial compilations being used.
+    /// </summary>
+    internal class CompilationAvailableTaggerEventSource : ITaggerEventSource
+    {
+        private readonly object _gate = new();
+        private readonly ITextBuffer _subjectBuffer;
+        private readonly TaggerDelay _delay;
+        private readonly IAsynchronousOperationListener _asyncListener;
+
+        /// <summary>
+        /// Other event sources we're composing over.  If they fire, we should reclassify.  However, after they fire, we
+        /// should also refire an event once we get the next full compilation ready.
+        /// </summary>
+        private readonly ITaggerEventSource[] _eventSources;
+
+        private bool _disconnected;
+
+        private readonly AsynchronousSerialWorkQueue _workQueue;
+        /// <summary>
+        /// Outstanding task we issue when we get an even 
+        /// </summary>
+        private Task<Compilation?> _getCompilationTask = Task.FromResult<Compilation?>(null);
+        private CancellationTokenSource _tokenSource = new();
+
+        public CompilationAvailableTaggerEventSource(
+            ITextBuffer subjectBuffer,
+            TaggerDelay delay,
+            IAsynchronousOperationListener asyncListener,
+            params ITaggerEventSource[] eventSources)
+        {
+            _subjectBuffer = subjectBuffer;
+            _delay = delay;
+            _asyncListener = asyncListener;
+            _eventSources = eventSources;
+        }
+
+        public event EventHandler<TaggerEventArgs>? Changed;
+
+        public void Connect()
+        {
+            _eventSources.Do(p =>
+            {
+                p.Connect();
+                p.Changed += OnEventSourceChanged;
+            });
+        }
+
+        public void Disconnect()
+        {
+            _disconnected = true;
+            _tokenSource.Cancel();
+            _tokenSource.Dispose();
+            _eventSources.Do(p =>
+            {
+                p.Changed -= OnEventSourceChanged;
+                p.Disconnect();
+            });
+        }
+
+        public event EventHandler UIUpdatesPaused
+        {
+            add { _eventSources.Do(p => p.UIUpdatesPaused += value); }
+            remove { _eventSources.Do(p => p.UIUpdatesPaused -= value); }
+        }
+
+        public event EventHandler UIUpdatesResumed
+        {
+            add { _eventSources.Do(p => p.UIUpdatesResumed += value); }
+            remove { _eventSources.Do(p => p.UIUpdatesResumed -= value); }
+        }
+
+        private void OnEventSourceChanged(object? sender, TaggerEventArgs args)
+        {
+            // First, notify anyone listening to us that something definitely changed.
+            this.Changed?.Invoke(this, args);
+
+            if (_disconnected)
+                return;
+
+            var document = _subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+            if (document == null)
+                return;
+
+            if (!document.SupportsSemanticModel)
+                return;
+
+            // Now, attempt to cancel any existing work to get the compilation for this project, and kick off a new
+            // piece of work in the future to do so.
+            lock (_gate)
+            {
+                _tokenSource.Cancel();
+                _tokenSource.Dispose();
+                _tokenSource = new CancellationTokenSource();
+                var cancellationToken = _tokenSource.Token;
+
+                // Keep track that we're doing async work in tests.
+                var asyncToken = _asyncListener.BeginAsyncOperation(nameof(OnEventSourceChanged));
+                _getCompilationTask = _getCompilationTask.ContinueWithAfterDelay(
+                    _ => GetCompilationAndFireChangedEventAsync(document, asyncToken, cancellationToken),
+                    cancellationToken,
+                    500,
+                    // Ensure we run the callback outside of the lock.
+                    TaskContinuationOptions.RunContinuationsAsynchronously,
+                    TaskScheduler.Default).Unwrap();
+            }
+        }
+
+        private async Task<Compilation?> GetCompilationAndFireChangedEventAsync(
+            Document document, IAsyncToken asyncToken, CancellationToken cancellationToken)
+        {
+            using (asyncToken)
+            {
+                // Wait for the actual compilation to be available.
+                var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+                // And then fire an event so we know to reclassify.
+                this.Changed?.Invoke(this, new TaggerEventArgs(_delay));
+                return compilation;
+            }|
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
@@ -46,7 +46,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 _subjectBuffer = subjectBuffer;
 
                 const TaggerDelay Delay = TaggerDelay.Short;
-                _eventSource = TaggerEventSources.Compose(
+
+                // Note: because we use frozen-partial documents for semantic classification, we may end up with incomplete
+                // semantics (esp. during solution load).  Because of this, we also register to hear when the full
+                // compilation is available so that reclassify and bring ourselves up to date.
+                _eventSource = new CompilationAvailableTaggerEventSource(
+                    subjectBuffer, Delay,
+                    owner.ThreadingContext,
+                    asyncListener,
                     TaggerEventSources.OnWorkspaceChanged(subjectBuffer, Delay, asyncListener),
                     TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay));
 

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -67,10 +67,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             // 
             // Note: when the user scrolls, we will try to reclassify as soon as possible.  That way
             // we appear semantically unclassified for a very short amount of time.
-            return TaggerEventSources.Compose(
+            return new CompilationAvailableTaggerEventSource(
+                subjectBuffer, Delay,
                 TaggerEventSources.OnViewSpanChanged(ThreadingContext, textView, textChangeDelay: Delay, scrollChangeDelay: TaggerDelay.NearImmediate),
                 TaggerEventSources.OnWorkspaceChanged(subjectBuffer, Delay, this.AsyncListener),
-                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay));
+                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay)));
         }
 
         protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -62,16 +62,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             this.AssertIsForeground();
             const TaggerDelay Delay = TaggerDelay.Short;
 
-            // Note: we don't listen for OnTextChanged.  They'll get reported by the ViewSpan changing 
-            // and also the SemanticChange nodification. 
+            // Note: we don't listen for OnTextChanged.  They'll get reported by the ViewSpan changing and also the
+            // SemanticChange notification. 
             // 
-            // Note: when the user scrolls, we will try to reclassify as soon as possible.  That way
-            // we appear semantically unclassified for a very short amount of time.
+            // Note: when the user scrolls, we will try to reclassify as soon as possible.  That way we appear
+            // semantically unclassified for a very short amount of time.
+            //
+            // Note: because we use frozen-partial documents for semantic classification, we may end up with incomplete
+            // semantics (esp. during solution load).  Because of this, we also register to hear when the full
+            // compilation is available so that reclassify and bring ourselves up to date.
             return new CompilationAvailableTaggerEventSource(
                 subjectBuffer, Delay,
+                ThreadingContext,
+                AsyncListener,
                 TaggerEventSources.OnViewSpanChanged(ThreadingContext, textView, textChangeDelay: Delay, scrollChangeDelay: TaggerDelay.NearImmediate),
                 TaggerEventSources.OnWorkspaceChanged(subjectBuffer, Delay, this.AsyncListener),
-                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay)));
+                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay));
         }
 
         protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textView, ITextBuffer subjectBuffer)


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1284416

Normal semantics may take a very long time to compute for a document.  Particularly during project load, or in multi-lang cases (due to building skeleton assemblies).  This waiting does not help, and actively hinders the classification experience as it means that we have to wait for all bg compilation work to finish for that project before getting semantic classifications. 

With frozen partial semantics though, we snap the state of hte project wherever we are in BG compilation (i.e. however far along we are with parsing files and loading metadata).  This allows us to at least classify what we understand so far, allowing more accurate classifications to be returned gradually as we understand more of the project.

For a multi-lang case, we'd be able to get classifications for all types parsed in that lang, and all normal metadata refs.  Only things like symbols from skeletons would take a little bit longer.