### PR TITLE
[LSP] Disable text sync for C# in 16.9

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
@@ -26,6 +26,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 
         public Task<object?> HandleRequestAsync(LSP.DidCloseTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
         {
+            // GetTextDocumentIdentifier returns null to avoid creating the solution, so the queue is not able to log the uri.
+            context.TraceInformation($"didClose for {request.TextDocument.Uri}");
+
             context.StopTracking(request.TextDocument.Uri);
 
             return SpecializedTasks.Default<object>();

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -27,6 +27,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 
         public Task<object?> HandleRequestAsync(LSP.DidOpenTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
         {
+            // GetTextDocumentIdentifier returns null to avoid creating the solution, so the queue is not able to log the uri.
+            context.TraceInformation($"didOpen for {request.TextDocument.Uri}");
+
             // Add the document and ensure the text we have matches whats on the client
             var sourceText = SourceText.From(request.TextDocument.Text, System.Text.Encoding.UTF8);
 

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
@@ -71,21 +71,21 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             public void StartTracking(Uri documentUri, SourceText initialText)
             {
-                Contract.ThrowIfTrue(_trackedDocuments.ContainsKey(documentUri), "didOpen received for an already open document.");
+                Contract.ThrowIfTrue(_trackedDocuments.ContainsKey(documentUri), $"didOpen received for {documentUri} which is already open.");
 
                 _trackedDocuments.Add(documentUri, initialText);
             }
 
             public void UpdateTrackedDocument(Uri documentUri, SourceText text)
             {
-                Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(documentUri), "didChange received for a document that isn't open.");
+                Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(documentUri), $"didChange received for {documentUri} which is not open.");
 
                 _trackedDocuments[documentUri] = text;
             }
 
             public void StopTracking(Uri documentUri)
             {
-                Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(documentUri), "didClose received for a document that isn't open.");
+                Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(documentUri), $"didClose received for {documentUri} which is not open.");
 
                 _trackedDocuments.Remove(documentUri);
             }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Options;
@@ -47,17 +48,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             => ServicesVSResources.CSharp_Visual_Basic_Language_Server_Client;
 
         protected internal override VSServerCapabilities GetCapabilities()
-            => new VSServerCapabilities
+        {
+            var experimentationService = Workspace.Services.GetRequiredService<IExperimentationService>();
+            var isTextSyncEnabled = experimentationService.IsExperimentEnabled(WellKnownExperimentNames.LspTextSyncEnabled);
+
+            return new VSServerCapabilities
             {
                 TextDocumentSync = new TextDocumentSyncOptions
                 {
-                    Change = TextDocumentSyncKind.None,
-                    OpenClose = false,
+                    Change = isTextSyncEnabled ? TextDocumentSyncKind.Incremental : TextDocumentSyncKind.None,
+                    OpenClose = isTextSyncEnabled,
                 },
                 SupportsDiagnosticRequests = this.Workspace.IsPullDiagnostics(InternalDiagnosticsOptions.NormalDiagnosticMode),
                 // This flag ensures that ctrl+, search locally uses the old editor APIs so that only ctrl+Q search is powered via LSP.
                 DisableGoToWorkspaceSymbols = true,
                 WorkspaceSymbolProvider = true,
             };
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
@@ -51,8 +51,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             {
                 TextDocumentSync = new TextDocumentSyncOptions
                 {
-                    Change = TextDocumentSyncKind.Incremental,
-                    OpenClose = true,
+                    Change = TextDocumentSyncKind.None,
+                    OpenClose = false,
                 },
                 SupportsDiagnosticRequests = this.Workspace.IsPullDiagnostics(InternalDiagnosticsOptions.NormalDiagnosticMode),
                 // This flag ensures that ctrl+, search locally uses the old editor APIs so that only ctrl+Q search is powered via LSP.

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -34,5 +34,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string TriggerCompletionInArgumentLists = "Roslyn.TriggerCompletionInArgumentLists";
         public const string OOPServerGC = "Roslyn.OOPServerGC";
         public const string ImportsOnPasteDefaultEnabled = "Roslyn.ImportsOnPasteDefaultEnabled";
+        public const string LspTextSyncEnabled = "Roslyn.LspTextSyncEnabled";
     }
 }


### PR DESCRIPTION
Disables text sync for C# in 16.9 due to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1287570
The current known issues are on the LSP client but the fixes are in their refactoring.  
We disable text sync for C# for the following reasons
1.  We don't need text sync for C# right now (it is only for cntrl+Q search which can use the workspace text).
2.  There are very likely other underlying text sync issues, so if we don't throw and restart we may end up with invalid documents or encounter other issues which would lead to wrong cntrl+Q search results (e.g. we get an open and then drop all change requests).  It is best to just use the workspace text which we know to be correct.
3.  There's not much more we can learn from 16.9 by leaving it on.  There is more LSP client logging in 16.10 (and on our side), we've improved our text sync handling, and the LSP client refactor will fix a ton of race conditions.  Additionally, there are bugs in 16.9 with attaching loghub logs to feedback, so we don't even always get logs.  We'd be doing more harm than good by leaving it on.
4. Wholesale disabling text sync is a small change that is easy to verify.

We leave it enabled for razor for a couple reasons.
1.  LSP for razor is non-sensical without text sync.  Diagnostics will be mismatched, completion will be wrong, etc.
2.  LSP for razor is experimental and under a feature flag and not rolled out completely
3.  Text buffers for razor are in-memory and not actual files and are protected by client name.  We think it is less likely that changes to these buffers (e.g. during git checkout / project reload) will randomly become text files.  We don't have feedback issues around txt files causing the razor c# server to restart (though there are other known text sync issues, e.g. https://github.com/dotnet/aspnetcore/issues/30002)


f846b17 should be reverted in 16.10 as we've somewhat mitigated the restarting issue and there are additional LSP client logs to help diagnose issues.  Will followup with PR as soon as this merges to main.

6bc956f adds extra logging for text sync to 16.9 so for scenarios where it is enabled (razor) we have logs to show the issue.

FYI @jinujoseph 