### PR TITLE
Record structs: add properties and primary ctor

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -1142,15 +1142,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new WithParametersBinder(method.Parameters, nextBinder);
                 }
 
-                // PROTOTYPE(record-structs): update for record structs
-                if (memberSyntax is RecordDeclarationSyntax { ParameterList: { ParameterCount: > 0 } } recordDeclSyntax)
+                if (memberSyntax is RecordDeclarationSyntax { ParameterList: { ParameterCount: > 0 } }
+                    or RecordStructDeclarationSyntax { ParameterList: { ParameterCount: > 0 } })
                 {
                     Binder outerBinder = VisitCore(memberSyntax);
-                    SourceNamedTypeSymbol recordType = ((NamespaceOrTypeSymbol)outerBinder.ContainingMemberOrLambda).GetSourceTypeMember(recordDeclSyntax);
+                    SourceNamedTypeSymbol recordType = ((NamespaceOrTypeSymbol)outerBinder.ContainingMemberOrLambda).GetSourceTypeMember((TypeDeclarationSyntax)memberSyntax);
                     var primaryConstructor = recordType.GetMembersUnordered().OfType<SynthesizedRecordConstructor>().SingleOrDefault();
 
-                    if (primaryConstructor.SyntaxRef.SyntaxTree == recordDeclSyntax.SyntaxTree &&
-                        primaryConstructor.GetSyntax() == recordDeclSyntax)
+                    if (primaryConstructor.SyntaxRef.SyntaxTree == memberSyntax.SyntaxTree &&
+                        primaryConstructor.GetSyntax() == memberSyntax)
                     {
                         return new WithParametersBinder(primaryConstructor.Parameters, nextBinder);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -140,8 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal InMethodBinder GetRecordConstructorInMethodBinder(SynthesizedRecordConstructor constructor)
         {
-            // PROTOTYPE(record-structs): update for record structs
-            RecordDeclarationSyntax typeDecl = constructor.GetSyntax();
+            TypeDeclarationSyntax typeDecl = constructor.GetSyntax();
 
             var extraInfo = NodeUsage.ConstructorBodyOrInitializer;
             var key = BinderFactoryVisitor.CreateBinderCacheKey(typeDecl, extraInfo);
@@ -158,8 +157,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (InMethodBinder)resultBinder;
         }
 
-        internal Binder GetInRecordBodyBinder(RecordDeclarationSyntax typeDecl)
+        internal Binder GetInRecordBodyBinder(TypeDeclarationSyntax typeDecl)
         {
+            Debug.Assert(typeDecl.Kind() is SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration);
+
             BinderFactoryVisitor visitor = _binderFactoryVisitorPool.Allocate();
             visitor.Initialize(position: typeDecl.SpanStart, memberDeclarationOpt: null, memberOpt: null);
             Binder resultBinder = visitor.VisitTypeDeclarationCore(typeDecl, NodeUsage.NamedTypeBodyOrTypeParameters);

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal InMethodBinder GetRecordConstructorInMethodBinder(SynthesizedRecordConstructor constructor)
         {
             TypeDeclarationSyntax typeDecl = constructor.GetSyntax();
+            Debug.Assert(typeDecl is RecordDeclarationSyntax);
 
             var extraInfo = NodeUsage.ConstructorBodyOrInitializer;
             var key = BinderFactoryVisitor.CreateBinderCacheKey(typeDecl, extraInfo);
@@ -159,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal Binder GetInRecordBodyBinder(TypeDeclarationSyntax typeDecl)
         {
-            Debug.Assert(typeDecl.Kind() is SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration);
+            Debug.Assert(typeDecl.Kind() is SyntaxKind.RecordDeclaration); // TODO2
 
             BinderFactoryVisitor visitor = _binderFactoryVisitorPool.Allocate();
             visitor.Initialize(position: typeDecl.SpanStart, memberDeclarationOpt: null, memberOpt: null);

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal Binder GetInRecordBodyBinder(TypeDeclarationSyntax typeDecl)
         {
-            Debug.Assert(typeDecl.Kind() is SyntaxKind.RecordDeclaration); // TODO2
+            Debug.Assert(typeDecl.Kind() is SyntaxKind.RecordDeclaration);
 
             BinderFactoryVisitor visitor = _binderFactoryVisitorPool.Allocate();
             visitor.Initialize(position: typeDecl.SpanStart, memberDeclarationOpt: null, memberOpt: null);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3289,9 +3289,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case RecordDeclarationSyntax recordDecl:
                     return BindRecordConstructorBody(recordDecl, diagnostics);
 
-                case RecordStructDeclarationSyntax recordDecl:
-                    return BindRecordStructConstructorBody(recordDecl);
-
                 case BaseMethodDeclarationSyntax method:
                     if (method.Kind() == SyntaxKind.ConstructorDeclaration)
                     {
@@ -3355,17 +3352,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                   bodyBinder.GetDeclaredLocalsForScope(recordDecl),
                                                   initializer,
                                                   blockBody: new BoundBlock(recordDecl, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty).MakeCompilerGenerated(),
-                                                  expressionBody: null);
-        }
-
-        private BoundNode BindRecordStructConstructorBody(RecordStructDeclarationSyntax recordStructDecl)
-        {
-            Debug.Assert(recordStructDecl.ParameterList is object);
-
-            return new BoundConstructorMethodBody(recordStructDecl,
-                                                  locals: ImmutableArray<LocalSymbol>.Empty,
-                                                  initializer: null,
-                                                  blockBody: new BoundBlock(recordStructDecl, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty).MakeCompilerGenerated(),
                                                   expressionBody: null);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3286,9 +3286,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             switch (syntax)
             {
-                // PROTOTYPE(record-structs): update for record structs
                 case RecordDeclarationSyntax recordDecl:
                     return BindRecordConstructorBody(recordDecl, diagnostics);
+
+                case RecordStructDeclarationSyntax recordDecl:
+                    return BindRecordStructConstructorBody(recordDecl);
 
                 case BaseMethodDeclarationSyntax method:
                     if (method.Kind() == SyntaxKind.ConstructorDeclaration)
@@ -3353,6 +3355,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                   bodyBinder.GetDeclaredLocalsForScope(recordDecl),
                                                   initializer,
                                                   blockBody: new BoundBlock(recordDecl, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty).MakeCompilerGenerated(),
+                                                  expressionBody: null);
+        }
+
+        private BoundNode BindRecordStructConstructorBody(RecordStructDeclarationSyntax recordStructDecl)
+        {
+            Debug.Assert(recordStructDecl.ParameterList is object);
+
+            Binder bodyBinder = this.GetBinder(recordStructDecl);
+            Debug.Assert(bodyBinder != null);
+
+            return new BoundConstructorMethodBody(recordStructDecl,
+                                                  bodyBinder.GetDeclaredLocalsForScope(recordStructDecl),
+                                                  initializer: null,
+                                                  blockBody: new BoundBlock(recordStructDecl, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty).MakeCompilerGenerated(),
                                                   expressionBody: null);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3362,11 +3362,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(recordStructDecl.ParameterList is object);
 
-            Binder bodyBinder = this.GetBinder(recordStructDecl);
-            Debug.Assert(bodyBinder != null);
-
             return new BoundConstructorMethodBody(recordStructDecl,
-                                                  bodyBinder.GetDeclaredLocalsForScope(recordStructDecl),
+                                                  locals: ImmutableArray<LocalSymbol>.Empty,
                                                   initializer: null,
                                                   blockBody: new BoundBlock(recordStructDecl, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty).MakeCompilerGenerated(),
                                                   expressionBody: null);

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -54,8 +54,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(node.Parent is ConstructorInitializerSyntax || node.Parent is PrimaryConstructorBaseTypeSyntax);
                     break;
                 case SyntaxKind.RecordDeclaration:
-                    // PROTOTYPE(record-structs): update for record structs
                     Debug.Assert(((RecordDeclarationSyntax)node).ParameterList is object);
+                    break;
+                case SyntaxKind.RecordStructDeclaration:
+                    Debug.Assert(((RecordStructDeclarationSyntax)node).ParameterList is object);
                     break;
                 default:
                     Debug.Assert(node is ExpressionSyntax);
@@ -396,7 +398,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        // PROTOTYPE(record-structs): update for record structs
         public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
         {
             Debug.Assert(node.ParameterList is object);
@@ -405,6 +406,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 VisitNodeToBind(baseWithArguments);
             }
+        }
+
+        public override void VisitRecordStructDeclaration(RecordStructDeclarationSyntax node)
+        {
+            Debug.Assert(node.ParameterList is object);
         }
 
         private void CollectVariablesFromDeconstruction(

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -405,11 +405,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public override void VisitRecordStructDeclaration(RecordStructDeclarationSyntax node)
-        {
-            Debug.Assert(node.ParameterList is object);
-        }
-
         private void CollectVariablesFromDeconstruction(
             ExpressionSyntax possibleTupleDeclaration,
             AssignmentExpressionSyntax deconstruction)

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -56,9 +56,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.RecordDeclaration:
                     Debug.Assert(((RecordDeclarationSyntax)node).ParameterList is object);
                     break;
-                case SyntaxKind.RecordStructDeclaration:
-                    Debug.Assert(((RecordStructDeclarationSyntax)node).ParameterList is object);
-                    break;
                 default:
                     Debug.Assert(node is ExpressionSyntax);
                     break;

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -167,11 +167,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Visit(node.PrimaryConstructorBaseType, enclosing);
         }
 
-        public override void VisitRecordStructDeclaration(RecordStructDeclarationSyntax node)
-        {
-            Debug.Assert(node.ParameterList is object);
-        }
-
         public override void VisitPrimaryConstructorBaseType(PrimaryConstructorBaseTypeSyntax node)
         {
             Binder enclosing = _enclosing.WithAdditionalFlags(BinderFlags.ConstructorInitializer);

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -170,9 +170,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitRecordStructDeclaration(RecordStructDeclarationSyntax node)
         {
             Debug.Assert(node.ParameterList is object);
-
-            Binder enclosing = new ExpressionVariableBinder(node, _enclosing);
-            AddToMap(node, enclosing);
         }
 
         public override void VisitPrimaryConstructorBaseType(PrimaryConstructorBaseTypeSyntax node)

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -158,7 +158,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Visit(node.ExpressionBody, enclosing);
         }
 
-        // PROTOTYPE(record-structs): update for record structs
         public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
         {
             Debug.Assert(node.ParameterList is object);
@@ -166,6 +165,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             Binder enclosing = new ExpressionVariableBinder(node, _enclosing);
             AddToMap(node, enclosing);
             Visit(node.PrimaryConstructorBaseType, enclosing);
+        }
+
+        public override void VisitRecordStructDeclaration(RecordStructDeclarationSyntax node)
+        {
+            Debug.Assert(node.ParameterList is object);
+
+            Binder enclosing = new ExpressionVariableBinder(node, _enclosing);
+            AddToMap(node, enclosing);
         }
 
         public override void VisitPrimaryConstructorBaseType(PrimaryConstructorBaseTypeSyntax node)

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -103,7 +103,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.RemoveAccessorDeclaration:
                 case SyntaxKind.CompilationUnit:
                 case SyntaxKind.RecordDeclaration:
-                case SyntaxKind.RecordStructDeclaration:
                     return binder.BindMethodBody(node, diagnostics);
             }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.RemoveAccessorDeclaration:
                 case SyntaxKind.CompilationUnit:
                 case SyntaxKind.RecordDeclaration:
+                case SyntaxKind.RecordStructDeclaration:
                     return binder.BindMethodBody(node, diagnostics);
             }
 
@@ -270,7 +271,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override bool TryGetSpeculativeSemanticModelCore(SyntaxTreeSemanticModel parentModel, int position, PrimaryConstructorBaseTypeSyntax constructorInitializer, out SemanticModel speculativeModel)
         {
             if (MemberSymbol is SynthesizedRecordConstructor primaryCtor &&
-                Root.FindToken(position).Parent?.AncestorsAndSelf().OfType<PrimaryConstructorBaseTypeSyntax>().FirstOrDefault() == primaryCtor.GetSyntax().PrimaryConstructorBaseType)
+                primaryCtor.GetSyntax() is RecordDeclarationSyntax recordDecl &&
+                Root.FindToken(position).Parent?.AncestorsAndSelf().OfType<PrimaryConstructorBaseTypeSyntax>().FirstOrDefault() == recordDecl.PrimaryConstructorBaseType)
             {
                 var binder = this.GetEnclosingBinder(position);
                 if (binder != null)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1913,7 +1913,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol constructor, BindingDiagnosticBag diagnostics, CSharpCompilation compilation)
         {
             // Note that the base type can be null if we're compiling System.Object in source.
-            NamedTypeSymbol baseType = constructor.ContainingType.BaseTypeNoUseSiteDiagnostics;
+            NamedTypeSymbol containingType = constructor.ContainingType;
+            NamedTypeSymbol baseType = containingType.BaseTypeNoUseSiteDiagnostics;
 
             SourceMemberMethodSymbol sourceConstructor = constructor as SourceMemberMethodSymbol;
             Debug.Assert(sourceConstructor?.SyntaxNode is RecordDeclarationSyntax or RecordStructDeclarationSyntax
@@ -1939,7 +1940,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (constructor is SynthesizedRecordConstructor && constructor.ContainingType.IsStructType())
+            if (containingType.IsStructType() || containingType.IsEnumType())
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1939,7 +1939,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (constructor is SynthesizedRecordCopyCtor copyCtor)
+            if (constructor is SynthesizedRecordConstructor && constructor.ContainingType.IsStructType())
+            {
+                return null;
+            }
+            else if (constructor is SynthesizedRecordCopyCtor copyCtor)
             {
                 return GenerateBaseCopyConstructorInitializer(copyCtor, diagnostics);
             }
@@ -1967,7 +1971,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CSharpSyntaxNode containerNode = constructor.GetNonNullSyntaxNode();
                 BinderFactory binderFactory = compilation.GetBinderFactory(containerNode.SyntaxTree);
 
-                if (containerNode is RecordDeclarationSyntax or RecordStructDeclarationSyntax)
+                if (containerNode is RecordDeclarationSyntax)
                 {
                     outerBinder = binderFactory.GetInRecordBodyBinder((TypeDeclarationSyntax)containerNode);
                 }
@@ -1993,10 +1997,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case RecordDeclarationSyntax recordDecl:
                         outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
-                        break;
-
-                    case RecordStructDeclarationSyntax recordStructDecl:
-                        outerBinder = binderFactory.GetInRecordBodyBinder(recordStructDecl);
                         break;
 
                     default:

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1687,7 +1687,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundBlock body;
 
-            if (method is SourceMemberMethodSymbol sourceMethod)
+            if (method is SynthesizedRecordConstructor recordStructPrimaryCtor && method.ContainingType.IsRecordStruct)
+            {
+                body = BoundBlock.SynthesizedNoLocals(recordStructPrimaryCtor.GetSyntax());
+            }
+            else if (method is SourceMemberMethodSymbol sourceMethod)
             {
                 CSharpSyntaxNode syntaxNode = sourceMethod.SyntaxNode;
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1912,8 +1912,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             NamedTypeSymbol baseType = constructor.ContainingType.BaseTypeNoUseSiteDiagnostics;
 
             SourceMemberMethodSymbol sourceConstructor = constructor as SourceMemberMethodSymbol;
-            // PROTOTYPE(record-structs): update for record structs
-            Debug.Assert(sourceConstructor?.SyntaxNode is RecordDeclarationSyntax || ((ConstructorDeclarationSyntax)sourceConstructor?.SyntaxNode)?.Initializer == null);
+            Debug.Assert(sourceConstructor?.SyntaxNode is RecordDeclarationSyntax or RecordStructDeclarationSyntax
+                || ((ConstructorDeclarationSyntax)sourceConstructor?.SyntaxNode)?.Initializer == null);
 
             // The common case is that the type inherits directly from object.
             // Also, we might be trying to generate a constructor for an entirely compiler-generated class such
@@ -1963,9 +1963,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CSharpSyntaxNode containerNode = constructor.GetNonNullSyntaxNode();
                 BinderFactory binderFactory = compilation.GetBinderFactory(containerNode.SyntaxTree);
 
-                if (containerNode is RecordDeclarationSyntax recordDecl)
+                if (containerNode is RecordDeclarationSyntax or RecordStructDeclarationSyntax)
                 {
-                    outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
+                    outerBinder = binderFactory.GetInRecordBodyBinder((TypeDeclarationSyntax)containerNode);
                 }
                 else
                 {
@@ -1989,6 +1989,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case RecordDeclarationSyntax recordDecl:
                         outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
+                        break;
+
+                    case RecordStructDeclarationSyntax recordStructDecl:
+                        outerBinder = binderFactory.GetInRecordBodyBinder(recordStructDecl);
                         break;
 
                     default:

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -405,10 +405,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             var memberNames = GetNonTypeMemberNames(((Syntax.InternalSyntax.TypeDeclarationSyntax)(node.Green)).Members,
                                                     ref declFlags);
 
-            // PROTOTYPE(record-structs): update for record structs
             // A record with parameters at least has a primary constructor
             if (((declFlags & SingleTypeDeclaration.TypeDeclarationFlags.HasAnyNontypeMembers) == 0) &&
-                node is RecordDeclarationSyntax { ParameterList: { } })
+                node is RecordDeclarationSyntax { ParameterList: { } } or RecordStructDeclarationSyntax { ParameterList: { } })
             {
                 declFlags |= SingleTypeDeclaration.TypeDeclarationFlags.HasAnyNontypeMembers;
             }
@@ -631,7 +630,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.InterfaceDeclaration:
                 case SyntaxKind.EnumDeclaration:
                 case SyntaxKind.RecordDeclaration:
-                    // PROTOTYPE(record-structs): update for record structs
+                case SyntaxKind.RecordStructDeclaration:
                     return (((Syntax.InternalSyntax.BaseTypeDeclarationSyntax)member).AttributeLists).Any();
 
                 case SyntaxKind.DelegateDeclaration:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
@@ -27,7 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(
                 syntax.IsKind(SyntaxKind.ConstructorDeclaration) ||
-                syntax.IsKind(SyntaxKind.RecordDeclaration));
+                syntax.IsKind(SyntaxKind.RecordDeclaration) ||
+                syntax.IsKind(SyntaxKind.RecordStructDeclaration));
         }
 
         protected sealed override void MethodChecks(BindingDiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3435,8 +3435,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(TypeKind == TypeKind.Struct);
 
-            if (builder.RecordDeclarationWithParameters is RecordStructDeclarationSyntax)
+            if (builder.RecordDeclarationWithParameters is not null)
             {
+                Debug.Assert(builder.RecordDeclarationWithParameters is RecordStructDeclarationSyntax { ParameterList: not null });
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1162,8 +1162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                // PROTOTYPE(record-structs): update for record structs
-                return (IsTupleType || IsRecord) ? GetMembers().Select(m => m.Name) : this.declaration.MemberNames;
+                return (IsTupleType || IsRecord || IsRecordStruct) ? GetMembers().Select(m => m.Name) : this.declaration.MemberNames;
             }
         }
 
@@ -1477,7 +1476,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// The purpose of this function is to assert that the <paramref name="member"/> symbol
         /// is actually among the symbols cached by this type symbol in a way that ensures
         /// that any consumer of standard APIs to get to type's members is going to get the same 
-        /// symbol (same instance) for the member rather than an equvalent, but different instance.
+        /// symbol (same instance) for the member rather than an equivalent, but different instance.
         /// </summary>
         [Conditional("DEBUG")]
         internal void AssertMemberExposure(Symbol member, bool forDiagnostics = false)
@@ -2492,7 +2491,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public readonly ArrayBuilder<ArrayBuilder<FieldOrPropertyInitializer>> StaticInitializers = ArrayBuilder<ArrayBuilder<FieldOrPropertyInitializer>>.GetInstance();
             public readonly ArrayBuilder<ArrayBuilder<FieldOrPropertyInitializer>> InstanceInitializers = ArrayBuilder<ArrayBuilder<FieldOrPropertyInitializer>>.GetInstance();
             public bool HaveIndexers;
-            public RecordDeclarationSyntax? RecordDeclarationWithParameters;
+
+            private TypeDeclarationSyntax? _recordDeclarationWithParameters;
+            public TypeDeclarationSyntax? RecordDeclarationWithParameters
+            {
+                get { return _recordDeclarationWithParameters; }
+                set
+                {
+                    Debug.Assert(value is RecordDeclarationSyntax or RecordStructDeclarationSyntax);
+                    _recordDeclarationWithParameters = value;
+                }
+            }
+
             public SynthesizedRecordConstructor? RecordPrimaryConstructor;
             public bool IsNullableEnabledForInstanceConstructorsAndFields;
             public bool IsNullableEnabledForStaticConstructorsAndFields;
@@ -2557,8 +2567,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public readonly ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> StaticInitializers;
             public readonly ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> InstanceInitializers;
             public readonly bool HaveIndexers;
-            // PROTOTYPE(record-structs): update for record structs
-            public readonly RecordDeclarationSyntax? RecordDeclarationWithParameters;
+            public readonly TypeDeclarationSyntax? RecordDeclarationWithParameters;
             public readonly SynthesizedRecordConstructor? RecordPrimaryConstructor;
             public readonly bool IsNullableEnabledForInstanceConstructorsAndFields;
             public readonly bool IsNullableEnabledForStaticConstructorsAndFields;
@@ -2574,7 +2583,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> staticInitializers,
                 ImmutableArray<ImmutableArray<FieldOrPropertyInitializer>> instanceInitializers,
                 bool haveIndexers,
-                RecordDeclarationSyntax? recordDeclarationWithParameters,
+                TypeDeclarationSyntax? recordDeclarationWithParameters,
                 SynthesizedRecordConstructor? recordPrimaryConstructor,
                 bool isNullableEnabledForInstanceConstructorsAndFields,
                 bool isNullableEnabledForStaticConstructorsAndFields,
@@ -2586,6 +2595,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 Debug.Assert(!nonTypeMembers.Any(s => s is TypeSymbol));
                 Debug.Assert(recordDeclarationWithParameters is object == recordPrimaryConstructor is object);
+                Debug.Assert(recordDeclarationWithParameters is null or RecordDeclarationSyntax or RecordStructDeclarationSyntax);
 
                 this.NonTypeMembers = nonTypeMembers;
                 this.StaticInitializers = staticInitializers;
@@ -2948,16 +2958,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.InterfaceDeclaration:
                     case SyntaxKind.StructDeclaration:
-                    case SyntaxKind.RecordStructDeclaration:
-                        // PROTOTYPE(record-structs): update for record structs
                         var typeDecl = (TypeDeclarationSyntax)syntax;
                         AddNonTypeMembers(builder, typeDecl.Members, diagnostics);
                         break;
 
                     case SyntaxKind.RecordDeclaration:
                         var recordDecl = (RecordDeclarationSyntax)syntax;
-                        noteRecordParameters(recordDecl, builder, diagnostics);
+                        noteRecordParameters(recordDecl, recordDecl.ParameterList, builder, diagnostics);
                         AddNonTypeMembers(builder, recordDecl.Members, diagnostics);
+                        break;
+
+                    case SyntaxKind.RecordStructDeclaration:
+                        var recordStructDecl = (RecordStructDeclarationSyntax)syntax;
+                        noteRecordParameters(recordStructDecl, recordStructDecl.ParameterList, builder, diagnostics);
+                        AddNonTypeMembers(builder, recordStructDecl.Members, diagnostics);
                         break;
 
                     default:
@@ -2965,9 +2979,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            void noteRecordParameters(RecordDeclarationSyntax syntax, DeclaredMembersAndInitializersBuilder builder, BindingDiagnosticBag diagnostics)
+            void noteRecordParameters(TypeDeclarationSyntax syntax, ParameterListSyntax? parameterList, DeclaredMembersAndInitializersBuilder builder, BindingDiagnosticBag diagnostics)
             {
-                var parameterList = syntax.ParameterList;
                 if (parameterList is null)
                 {
                     return;
@@ -2980,8 +2993,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     builder.RecordPrimaryConstructor = ctor;
 
                     var compilation = DeclaringCompilation;
-                    builder.UpdateIsNullableEnabledForConstructorsAndFields(ctor.IsStatic, compilation, syntax.ParameterList);
-                    if (syntax.PrimaryConstructorBaseType?.ArgumentList is { } baseParamList)
+                    builder.UpdateIsNullableEnabledForConstructorsAndFields(ctor.IsStatic, compilation, parameterList);
+                    if (syntax is RecordDeclarationSyntax { PrimaryConstructorBaseType: { ArgumentList: { } baseParamList } })
                     {
                         builder.UpdateIsNullableEnabledForConstructorsAndFields(ctor.IsStatic, compilation, baseParamList);
                     }
@@ -3414,6 +3427,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(TypeKind == TypeKind.Struct);
 
+            if (builder.RecordDeclarationWithParameters is RecordStructDeclarationSyntax { ParameterList: { ParameterCount: >= 0 } })
+            {
+                return;
+            }
+
             foreach (var initializers in builder.InstanceInitializers)
             {
                 foreach (FieldOrPropertyInitializer initializer in initializers)
@@ -3426,12 +3444,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void AddSynthesizedRecordMembersIfNecessary(MembersAndInitializersBuilder builder, DeclaredMembersAndInitializers declaredMembersAndInitializers, BindingDiagnosticBag diagnostics)
         {
-            if (declaration.Kind != DeclarationKind.Record)
+            if (declaration.Kind is not (DeclarationKind.Record or DeclarationKind.RecordStruct))
             {
                 return;
             }
 
-            ParameterListSyntax? paramList = declaredMembersAndInitializers.RecordDeclarationWithParameters?.ParameterList;
+            ParameterListSyntax? paramList = declaredMembersAndInitializers.RecordDeclarationWithParameters switch
+            {
+                RecordDeclarationSyntax recordDecl => recordDecl.ParameterList,
+                RecordStructDeclarationSyntax recordStructDecl => recordStructDecl.ParameterList,
+                _ => null
+            };
 
             var memberSignatures = s_duplicateRecordMemberSignatureDictionary.Allocate();
             var membersSoFar = builder.GetNonTypeMembers(declaredMembersAndInitializers);
@@ -3460,12 +3483,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 Debug.Assert(declaredMembersAndInitializers.RecordDeclarationWithParameters is object);
 
+                // primary ctor
                 var ctor = declaredMembersAndInitializers.RecordPrimaryConstructor;
                 Debug.Assert(ctor is object);
                 members.Add(ctor);
 
                 if (ctor.ParameterCount != 0)
                 {
+                    // properties and Deconstruct
                     var existingOrAddedMembers = addProperties(ctor.Parameters);
                     addDeconstruct(ctor, existingOrAddedMembers);
                 }
@@ -3473,24 +3498,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 primaryAndCopyCtorAmbiguity = ctor.ParameterCount == 1 && ctor.Parameters[0].Type.Equals(this, TypeCompareKind.AllIgnoreOptions);
             }
 
-            addCopyCtor(primaryAndCopyCtorAmbiguity);
-            addCloneMethod();
-
-            PropertySymbol equalityContract = addEqualityContract();
-
-            var thisEquals = addThisEquals(equalityContract);
-            addOtherEquals();
-            addObjectEquals(thisEquals);
-            var getHashCode = addGetHashCode(equalityContract);
-            addEqualityOperators();
-
-            if (thisEquals is not SynthesizedRecordEquals && getHashCode is SynthesizedRecordGetHashCode)
+            // PROTOTYPE(record-structs): update for record structs
+            if (declaration.Kind == DeclarationKind.Record)
             {
-                diagnostics.Add(ErrorCode.WRN_RecordEqualsWithoutGetHashCode, thisEquals.Locations[0], declaration.Name);
-            }
+                addCopyCtor(primaryAndCopyCtorAmbiguity);
+                addCloneMethod();
 
-            var printMembers = addPrintMembersMethod();
-            addToStringMethod(printMembers);
+                PropertySymbol equalityContract = addEqualityContract();
+
+                var thisEquals = addThisEquals(equalityContract);
+                addOtherEquals();
+                addObjectEquals(thisEquals);
+                var getHashCode = addGetHashCode(equalityContract);
+                addEqualityOperators();
+
+                if (thisEquals is not SynthesizedRecordEquals && getHashCode is SynthesizedRecordGetHashCode)
+                {
+                    diagnostics.Add(ErrorCode.WRN_RecordEqualsWithoutGetHashCode, thisEquals.Locations[0], declaration.Name);
+                }
+
+                var printMembers = addPrintMembersMethod();
+                addToStringMethod(printMembers);
+            }
 
             memberSignatures.Free();
 
@@ -3938,10 +3967,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     switch (method.MethodKind)
                     {
                         case MethodKind.Constructor:
-                            // PROTOTYPE(record-structs): update for record structs
                             // Ignore the record copy constructor
-                            if (!IsRecord ||
-                                !(SynthesizedRecordCopyCtor.HasCopyConstructorSignature(method) && method is not SynthesizedRecordConstructor))
+                            if (!(IsRecord && SynthesizedRecordCopyCtor.HasCopyConstructorSignature(method) && method is not SynthesizedRecordConstructor))
                             {
                                 hasInstanceConstructor = true;
                                 hasParameterlessInstanceConstructor = hasParameterlessInstanceConstructor || method.ParameterCount == 0;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3980,7 +3980,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         case MethodKind.Constructor:
                             // Ignore the record copy constructor
-                            if (!(IsRecord && SynthesizedRecordCopyCtor.HasCopyConstructorSignature(method) && method is not SynthesizedRecordConstructor))
+                            if (!IsRecord ||
+                                !(SynthesizedRecordCopyCtor.HasCopyConstructorSignature(method) && method is not SynthesizedRecordConstructor))
                             {
                                 hasInstanceConstructor = true;
                                 hasParameterlessInstanceConstructor = hasParameterlessInstanceConstructor || method.ParameterCount == 0;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -57,8 +57,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return (CSharpSyntaxNode)entryPoint.ReturnTypeSyntax;
                 case RecordDeclarationSyntax recordDecl:
                     return recordDecl;
-                case RecordStructDeclarationSyntax recordStructDecl:
-                    return recordStructDecl;
                 default:
                     return null;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -55,9 +55,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return (CSharpSyntaxNode?)localFunction.Body ?? localFunction.ExpressionBody;
                 case CompilationUnitSyntax _ when this is SynthesizedSimpleProgramEntryPointSymbol entryPoint:
                     return (CSharpSyntaxNode)entryPoint.ReturnTypeSyntax;
-                // PROTOTYPE(record-structs): update for record structs
                 case RecordDeclarationSyntax recordDecl:
                     return recordDecl;
+                case RecordStructDeclarationSyntax recordStructDecl:
+                    return recordStructDecl;
                 default:
                     return null;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordConstructor.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -11,9 +12,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         public SynthesizedRecordConstructor(
              SourceMemberContainerTypeSymbol containingType,
-             RecordDeclarationSyntax syntax) :
+             TypeDeclarationSyntax syntax) :
              base(containingType, syntax.Identifier.GetLocation(), syntax, isIterator: false)
         {
+            Debug.Assert(syntax.Kind() is SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration);
+
             this.MakeFlags(
                 MethodKind.Constructor,
                 containingType.IsAbstract ? DeclarationModifiers.Protected : DeclarationModifiers.Public,
@@ -22,17 +25,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 isNullableAnalysisEnabled: false); // IsNullableAnalysisEnabled uses containing type instead.
         }
 
-        internal RecordDeclarationSyntax GetSyntax()
+        internal TypeDeclarationSyntax GetSyntax()
         {
             Debug.Assert(syntaxReferenceOpt != null);
-            return (RecordDeclarationSyntax)syntaxReferenceOpt.GetSyntax();
+            return (TypeDeclarationSyntax)syntaxReferenceOpt.GetSyntax();
         }
 
-        protected override ParameterListSyntax GetParameterList() => GetSyntax().ParameterList!;
+        protected override ParameterListSyntax GetParameterList()
+        {
+            return GetSyntax() switch
+            {
+                RecordDeclarationSyntax record => record.ParameterList!,
+                RecordStructDeclarationSyntax recordStruct => recordStruct.ParameterList!,
+                _ => throw ExceptionUtilities.Unreachable
+            };
+        }
 
         protected override CSharpSyntaxNode? GetInitializer()
         {
-            return GetSyntax().PrimaryConstructorBaseType;
+            return GetSyntax() switch
+            {
+                RecordDeclarationSyntax record => record.PrimaryConstructorBaseType,
+                RecordStructDeclarationSyntax => null,
+                _ => throw ExceptionUtilities.Unreachable
+            };
         }
 
         protected override bool AllowRefOrOut => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordConstructor.cs
@@ -69,6 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override ExecutableCodeBinder TryGetBodyBinder(BinderFactory? binderFactoryOpt = null, bool ignoreAccessibility = false)
         {
             TypeDeclarationSyntax typeDecl = GetSyntax();
+            Debug.Assert(typeDecl is RecordDeclarationSyntax);
             InMethodBinder result = (binderFactoryOpt ?? this.DeclaringCompilation.GetBinderFactory(typeDecl.SyntaxTree)).GetRecordConstructorInMethodBinder(this);
             return new ExecutableCodeBinder(SyntaxNode, this, result.WithAdditionalFlags(ignoreAccessibility ? BinderFlags.IgnoreAccessibility : BinderFlags.None));
         }

--- a/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
@@ -417,6 +417,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.StructDeclaration:
                 case SyntaxKind.RecordDeclaration:
+                case SyntaxKind.RecordStructDeclaration:
                     // With dynamic analysis instrumentation, a type declaration can be the syntax associated
                     // with the analysis payload local of a synthesized constructor.
                     // If the synthesized constructor includes an initializer with a lambda,

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -795,6 +795,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.InterfaceKeyword:
                     return SyntaxKind.InterfaceDeclaration;
                 case SyntaxKind.RecordKeyword:
+                    // PROTOTYPE(record-structs): anything we can do? 
                     return SyntaxKind.RecordDeclaration;
                 default:
                     return SyntaxKind.None;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -81,9 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.PrimaryConstructorBaseType:
                     return true;
 
-                // PROTOTYPE(record-structs): update for record structs
                 case SyntaxKind.RecordDeclaration:
                     return ((RecordDeclarationSyntax)syntax).ParameterList is object;
+
+                case SyntaxKind.RecordStructDeclaration:
+                    return ((RecordStructDeclarationSyntax)syntax).ParameterList is object;
 
                 default:
                     return syntax is StatementSyntax || IsValidScopeDesignator(syntax as ExpressionSyntax);

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ((RecordDeclarationSyntax)syntax).ParameterList is object;
 
                 case SyntaxKind.RecordStructDeclaration:
-                    return ((RecordStructDeclarationSyntax)syntax).ParameterList is object;
+                    return false;
 
                 default:
                     return syntax is StatementSyntax || IsValidScopeDesignator(syntax as ExpressionSyntax);

--- a/src/Compilers/CSharp/Portable/Syntax/TypeDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/TypeDeclarationSyntax.cs
@@ -63,6 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SyntaxKind.InterfaceKeyword;
                 case SyntaxKind.RecordDeclaration:
                     return SyntaxKind.RecordKeyword;
+                // PROTOTYPE(record-structs): update for record structs
                 default:
                     throw ExceptionUtilities.UnexpectedValue(kind);
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -1991,7 +1991,7 @@ record R(int x)
 
             var comp = CreateCompilation(new[] { src, IsExternalInitTypeDefinition }, parseOptions: TestOptions.RegularPreview, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "static ctor");
+            CompileAndVerify(comp, expectedOutput: "static ctor", verify: Verification.Skipped /* init-only */);
         }
 
         [Fact]
@@ -2389,7 +2389,7 @@ record struct R(int O, int P = 1)
                 // record struct R(int O, int P = 1)
                 Diagnostic(ErrorCode.WRN_UnreadRecordParameter, "P").WithArguments("P").WithLocation(5, 28)
                 );
-            var verifier = CompileAndVerify(comp, expectedOutput: "42");
+            var verifier = CompileAndVerify(comp, expectedOutput: "42", verify: Verification.Skipped /* init-only */);
 
             verifier.VerifyIL("R..ctor(int, int)", @"
 {
@@ -2445,7 +2445,7 @@ record struct R(int O, int P = 42)
 ";
             var comp = CreateCompilation(src);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "42");
+            var verifier = CompileAndVerify(comp, expectedOutput: "42", verify: Verification.Skipped /* init-only */);
 
             verifier.VerifyIL("R..ctor(int, int)", @"
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -2053,6 +2053,24 @@ record struct R(int P1) : I
         }
 
         [Fact]
+        public void InterfaceImplementation_NotReadonly_InitOnlyInterface()
+        {
+            var source = @"
+interface I
+{
+    int P1 { get; init; }
+}
+record struct R(int P1) : I;
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,27): error CS8854: 'R' does not implement interface member 'I.P1.init'. 'R.P1.set' cannot implement 'I.P1.init'.
+                // record struct R(int P1) : I;
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberWrongInitOnly, "I").WithArguments("R", "I.P1.init", "R.P1.set").WithLocation(6, 27)
+                );
+        }
+
+        [Fact]
         public void InterfaceImplementation_Readonly()
         {
             var source = @"
@@ -2072,6 +2090,24 @@ readonly record struct R(int P1) : I
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics();
             CompileAndVerify(comp, expectedOutput: "(42, 43)", verify: Verification.Skipped /* init-only */);
+        }
+
+        [Fact]
+        public void InterfaceImplementation_Readonly_SetInterface()
+        {
+            var source = @"
+interface I
+{
+    int P1 { get; set; }
+}
+readonly record struct R(int P1) : I;
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,36): error CS8854: 'R' does not implement interface member 'I.P1.set'. 'R.P1.init' cannot implement 'I.P1.set'.
+                // readonly record struct R(int P1) : I;
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberWrongInitOnly, "I").WithArguments("R", "I.P1.set", "R.P1.init").WithLocation(6, 36)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -796,6 +796,7 @@ partial class C
         [Fact]
         public void PartialRecord_ParametersInScopeOfBothParts()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 var c = new C(2);
 System.Console.Write((c.P1, c.P2));
@@ -836,6 +837,7 @@ public partial record class C
         [Fact]
         public void PartialRecord_DuplicateMemberNames()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 public partial record C(int X)
 {
@@ -875,6 +877,7 @@ public partial record C
         [Fact]
         public void RecordInsideGenericType()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 var c = new C<int>.Nested(2);
 System.Console.Write(c.T);
@@ -892,6 +895,7 @@ public class C<T>
         [Fact]
         public void RecordProperties_01()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 using System;
 record C(int X, int Y)
@@ -928,11 +932,22 @@ record C(int X, int Y)
   IL_001c:  ret
 }
 ");
+
+            var c = verifier.Compilation.GlobalNamespace.GetTypeMember("C");
+            var x = (IPropertySymbol)c.GetMember("X");
+            Assert.Equal("System.Int32 C.X.get", x.GetMethod.ToTestDisplayString());
+            Assert.Equal("void modreq(System.Runtime.CompilerServices.IsExternalInit) C.X.init", x.SetMethod.ToTestDisplayString());
+            Assert.True(x.SetMethod!.IsInitOnly);
+
+            var xBackingField = (IFieldSymbol)c.GetMember("<X>k__BackingField");
+            Assert.Equal("System.Int32 C.<X>k__BackingField", xBackingField.ToTestDisplayString());
+            Assert.True(xBackingField.IsReadOnly);
         }
 
         [Fact]
         public void RecordProperties_02()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 using System;
 record C(int X, int Y)
@@ -967,6 +982,7 @@ record C(int X, int Y)
         [Fact]
         public void RecordProperties_03()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 using System;
 record C(int X, int Y)
@@ -992,6 +1008,7 @@ record C(int X, int Y)
         [Fact]
         public void RecordProperties_04()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 using System;
 record C(int X, int Y)
@@ -1017,6 +1034,7 @@ record C(int X, int Y)
         [Fact, WorkItem(48947, "https://github.com/dotnet/roslyn/issues/48947")]
         public void RecordProperties_05()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record C(int X, int X)
 {
@@ -1121,6 +1139,7 @@ record class C(int X, int X)
         [Fact]
         public void RecordProperties_06()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record C(int X, int Y)
 {
@@ -1173,6 +1192,7 @@ record C(int X, int Y)
         [Fact]
         public void RecordProperties_07()
         {
+            // PROTOTYPE(record-structs): ported
             var comp = CreateCompilation(@"
 record C1(object P, object get_P);
 record C2(object get_P, object P);");
@@ -1189,6 +1209,7 @@ record C2(object get_P, object P);");
         [Fact]
         public void RecordProperties_08()
         {
+            // PROTOTYPE(record-structs): ported
             var comp = CreateCompilation(@"
 record C1(object O1)
 {
@@ -1201,6 +1222,7 @@ record C1(object O1)
         [Fact]
         public void RecordProperties_09()
         {
+            // PROTOTYPE(record-structs): ported
             var src =
 @"record C(object P1, object P2, object P3, object P4)
 {
@@ -1229,6 +1251,7 @@ record C1(object O1)
         [Fact]
         public void RecordProperties_10()
         {
+            // PROTOTYPE(record-structs): ported
             var src =
 @"record C(object P)
 {
@@ -1500,6 +1523,7 @@ public unsafe record C
         [Fact, WorkItem(48584, "https://github.com/dotnet/roslyn/issues/48584")]
         public void RecordProperties_11_UnreadPositionalParameter()
         {
+            // PROTOTYPE(record-structs): ported
             var comp = CreateCompilation(@"
 record C1(object O1, object O2, object O3) // 1, 2
 {
@@ -1549,6 +1573,7 @@ record C5(object O7) : Base((System.Func<object, object>)(_ => (O7 = 42) )) // 4
         [Fact, WorkItem(48584, "https://github.com/dotnet/roslyn/issues/48584")]
         public void RecordProperties_11_UnreadPositionalParameter_InRefOut()
         {
+            // PROTOTYPE(record-structs): ported
             var comp = CreateCompilation(@"
 record C1(object O1, object O2, object O3) // 1
 {
@@ -1734,6 +1759,7 @@ class Program
         [Fact, WorkItem(50170, "https://github.com/dotnet/roslyn/issues/50170")]
         public void StaticCtor()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(int x)
 {
@@ -1755,6 +1781,7 @@ record R(int x)
         [Fact, WorkItem(50170, "https://github.com/dotnet/roslyn/issues/50170")]
         public void StaticCtor_ParameterlessPrimaryCtor()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R()
 {
@@ -1769,6 +1796,7 @@ record R()
         [Fact, WorkItem(50170, "https://github.com/dotnet/roslyn/issues/50170")]
         public void StaticCtor_CopyCtor()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R()
 {
@@ -13731,6 +13759,7 @@ record A(int X)
         [Fact]
         public void Deconstruct_Simple()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 
@@ -13788,6 +13817,7 @@ record B(int X, int Y)
         [Fact]
         public void Deconstruct_PositionalAndNominalProperty()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 
@@ -13821,6 +13851,7 @@ record B(int X)
         [Fact]
         public void Deconstruct_Nested()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 
@@ -13884,6 +13915,7 @@ record C(B B, int Z)
         [Fact]
         public void Deconstruct_PropertyCollision()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 
@@ -13923,6 +13955,7 @@ record B(int X, int Y)
         [Fact]
         public void Deconstruct_MethodCollision_01()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 record B(int X, int Y)
 {
@@ -14078,6 +14111,7 @@ record C(int X, int Y)
         [Fact]
         public void Deconstruct_FieldCollision()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 using System;
 
@@ -14239,6 +14273,7 @@ record C(int X) : B
         [Fact]
         public void Deconstruct_Empty()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 record C
 {
@@ -14557,6 +14592,7 @@ record C(int X, int Y)
         [Fact]
         public void Deconstruct_Conversion_02()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 #nullable enable
 using System;
@@ -14652,6 +14688,7 @@ record C(Derived X, Base Y)
         [Fact]
         public void Deconstruct_Empty_WithParameterList()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 record C()
 {
@@ -14685,6 +14722,7 @@ record C()
         [Fact]
         public void Deconstruct_Empty_WithParameterList_UserDefined_01()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 
@@ -14852,6 +14890,7 @@ record C()
         [Fact]
         public void Deconstruct_UserDefined()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 
@@ -14934,6 +14973,7 @@ record B(int X, int Y)
         [Fact]
         public void Deconstruct_UserDefined_DifferentSignature_02()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 
@@ -15127,6 +15167,7 @@ record B(int X, int Y) : A(X)
         [InlineData("internal protected")]
         public void Deconstruct_UserDefined_Accessibility_07(string accessibility)
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 $@"
 record A(int X)
@@ -24091,6 +24132,7 @@ class A<T>
         [Fact]
         public void InterfaceImplementation()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 interface I
 {
@@ -24119,6 +24161,7 @@ record R(int P1) : I
         [Fact]
         public void Initializers_01()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 using System;
 
@@ -24158,6 +24201,7 @@ record C(int X)
         [Fact]
         public void Initializers_02()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record C(int X)
 {
@@ -24189,6 +24233,7 @@ record C(int X)
         [Fact]
         public void Initializers_03()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record C(int X)
 {
@@ -24220,6 +24265,7 @@ record C(int X)
         [Fact]
         public void Initializers_04()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 using System;
 
@@ -24290,6 +24336,7 @@ record C(int X) : Base(() => 100 + X++)
         [Fact]
         public void SynthesizedRecordPointerProperty()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(int P1, int* P2, delegate*<int> P3);";
 
@@ -24348,6 +24395,7 @@ record R(ref int P1, out int P2) : Base(P2 = 1);
         [Fact, WorkItem(45008, "https://github.com/dotnet/roslyn/issues/45008")]
         public void PositionalMemberModifiers_In()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(in int P1);
 
@@ -24395,6 +24443,7 @@ record R(this int i);
         [Fact, WorkItem(45008, "https://github.com/dotnet/roslyn/issues/45008")]
         public void PositionalMemberModifiers_Params()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(params int[] Array);
 
@@ -24425,6 +24474,7 @@ public class C
         [Fact, WorkItem(45008, "https://github.com/dotnet/roslyn/issues/45008")]
         public void PositionalMemberDefaultValue()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(int P = 42)
 {
@@ -24444,6 +24494,7 @@ record R(int P = 42)
         [Fact, WorkItem(45008, "https://github.com/dotnet/roslyn/issues/45008")]
         public void PositionalMemberDefaultValue_AndPropertyWithInitializer()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(int P = 1)
 {
@@ -24481,6 +24532,7 @@ record R(int P = 1)
         [Fact, WorkItem(45008, "https://github.com/dotnet/roslyn/issues/45008")]
         public void PositionalMemberDefaultValue_AndPropertyWithoutInitializer()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(int P = 42)
 {
@@ -24515,6 +24567,7 @@ record R(int P = 42)
         [Fact, WorkItem(45008, "https://github.com/dotnet/roslyn/issues/45008")]
         public void PositionalMemberDefaultValue_AndPropertyWithInitializer_CopyingParameter()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R(int P = 42)
 {
@@ -25103,6 +25156,7 @@ class C
         [Fact]
         public void RecordWithConstraints_NullableWarning()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 #nullable enable
 record R<T>(T P) where T : class;
@@ -25133,6 +25187,7 @@ public class C
         [Fact]
         public void RecordWithConstraints_ConstraintError()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 record R<T>(T P) where T : class;
 record R2<T>(T P) where T : class { }
@@ -25217,6 +25272,7 @@ abstract record C
         [Fact]
         public void CyclicBases4()
         {
+            // PROTOTYPE(record-structs): ported
             var text =
 @"
 record A<T> : B<A<T>> { }
@@ -25335,6 +25391,7 @@ public partial record C3 : Base<(int a, int b)> { }
         [Fact]
         public void CS0267ERR_PartialMisplaced()
         {
+            // PROTOTYPE(record-structs): ported
             var test = @"
 partial public record C  // CS0267
 {
@@ -25395,6 +25452,7 @@ class C<T, U>
         [Fact]
         public void SealedStaticRecord()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 sealed static record R;
 ";
@@ -25408,6 +25466,7 @@ sealed static record R;
         [Fact]
         public void CS0513ERR_AbstractInConcreteClass02()
         {
+            // PROTOTYPE(record-structs): ported
             var text = @"
 record C
 {
@@ -25479,6 +25538,7 @@ public record D : B {}
         [Fact]
         public void CS0574ERR_BadDestructorName()
         {
+            // PROTOTYPE(record-structs): ported
             var test = @"
 namespace x
 {
@@ -25538,6 +25598,7 @@ public partial record C1
         [Fact]
         public void StaticRecordWithConstructorAndDestructor()
         {
+            // PROTOTYPE(record-structs): ported
             var text = @"
 static record R(int I)
 {
@@ -25556,6 +25617,7 @@ static record R(int I)
         [Fact]
         public void RecordWithPartialMethodExplicitImplementation()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"record R
 {
@@ -27213,6 +27275,7 @@ interface I1 {}
         [WorkItem(46657, "https://github.com/dotnet/roslyn/issues/46657")]
         public void CanDeclareIteratorInRecord()
         {
+            // PROTOTYPE(record-structs): ported
             var source = @"
 using System.Collections.Generic;
 
@@ -27513,6 +27576,7 @@ public sealed class Hamster : Document
         [WorkItem(44571, "https://github.com/dotnet/roslyn/issues/44571")]
         public void XmlDoc()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 /// <summary>Summary</summary>
 /// <param name=""I1"">Description for I1</param>


### PR DESCRIPTION
... and Deconstruct method.

Test plan: https://github.com/dotnet/roslyn/issues/51199
Relevant sections of the [spec](https://github.com/dotnet/csharplang/blob/master/proposals/record-structs.md):

> ## Members of a record struct
> 
> In addition to the members declared in the record struct body, a record struct type has additional synthesized members.
> Members are synthesized unless a member with a "matching" signature is declared in the record struct body or
> an accessible concrete non-virtual member with a "matching" signature is inherited.
> Two members are considered matching if they have the same
> signature or would be considered "hiding" in an inheritance scenario.
> See https://github.com/dotnet/csharplang/blob/master/spec/basic-concepts.md#signatures-and-overloading
> 
> It is an error for a member of a record struct to be named "Clone".
> 
> It is an error for an instance field of a record struct to have an unsafe type.
> 
> A record struct is not permitted to declare a destructor.

...


> ## Positional record struct members
> 
> In addition to the above members, record structs with a parameter list ("positional records") synthesize
> additional members with the same conditions as the members above.
> 
> ### Primary Constructor
> 
> A record struct has a public constructor whose signature corresponds to the value parameters of the
> type declaration. This is called the primary constructor for the type. It is an error to have a primary
> constructor and a constructor with the same signature already present in the struct.
> A record struct is not permitted to declare a parameterless primary constructor.
> 
> Instance field declarations for a record struct are permitted to include variable initializers.
> If there is no primary constructor, the instance initializers execute as part of the parameterless constructor.
> Otherwise, at runtime the primary constructor executes the instance initializers appearing in the record-struct-body.
> 
> If a record struct has a primary constructor, any user-defined constructor must have an
> explicit `this` constructor initializer.
> 
> Parameters of the primary constructor as well as members of the record struct are in scope within initializers of instance fields or properties. 
> Instance members would be an error in these locations (similar to how instance members are in scope in regular constructor initializers
> today, but an error to use), but the parameters of the primary constructor would be in scope and useable and
would shadow members. Static members would also be useable.
> 
> A warning is produced if a parameter of the primary constructor is not read.
> 
> The definite assigment rules for struct instance constructors apply to the primary constructor of record structs. For instance, the following
> is an error:
> 
> ```csharp
> record struct Pos(int X) // definite assignment error in primary constructor
> {
>     private int x;
>     public int X { get { return x; } set { x = value; } } = X;
> }
> ```
> 
> ### Properties
> 
> For each record struct parameter of a record struct declaration there is a corresponding public property
member whose name and type are taken from the value parameter declaration.
> 
> For a record struct:
> 
> * A public `get` and `init` auto-property is created if the record struct has `readonly` modifier, `get` and `set` otherwise.
>   Both kinds of set accessors (`set` and `init`) are considered "matching". So the user may declare an init-only property
>   in place of a synthesized mutable one.
>   An inherited `abstract` property with matching type is overridden.
>   It is an error if the inherited property does not have `public` `get` and `set`/`init` accessors.
>   The auto-property is initialized to the value of the corresponding primary constructor parameter.
>   Attributes can be applied to the synthesized auto-property and its backing field by using `property:` or `field:`
>   targets for attributes syntactically applied to the corresponding record struct parameter.  
>
>
> ### Deconstruct
> 
> A positional record struct with at least one parameter synthesizes a public void-returning instance method called `Deconstruct` with an out 
> parameter declaration for each parameter of the primary constructor declaration. Each parameter
> of the Deconstruct method has the same type as the corresponding parameter of the primary
> constructor declaration. The body of the method assigns each parameter of the Deconstruct method
> to the value from an instance member access to a member of the same name.
> The method can be declared explicitly. It is an error if the explicit declaration does not match
> the expected signature or accessibility, or is static.