### PR TITLE
Microsoft.CodeAnalysis.EditorFeatures2.UnitTests should be deterministic again

### DIFF
--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -22,10 +22,7 @@ if ($help) {
 
 # List of binary names that should be skipped because they have a known issue that
 # makes them non-deterministic.  
-$script:skipList = @(
-  # Added to work around https://github.com/dotnet/roslyn/issues/48417
-  "Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll"
-)
+$script:skipList = @()
 function Run-Build([string]$rootDir, [string]$logFileName) {
 
   # Clean out the previous run


### PR DESCRIPTION
#48417 mentioned as the reason for non-determinism has been closed