### PR TITLE
Fix crash for top-level in unused value analyzer

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -744,10 +744,13 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
             {
                 if (useFullSpan || node.Span.Contains(position))
                 {
-                    var kind = node.Kind();
-                    if ((kind != SyntaxKind.GlobalStatement) && (kind != SyntaxKind.IncompleteMember) && (node is MemberDeclarationSyntax))
+                    if (!node.IsKind(SyntaxKind.IncompleteMember) && (node is MemberDeclarationSyntax))
                     {
                         return node;
+                    }
+                    else if (node.IsKind(SyntaxKind.GlobalStatement))
+                    {
+                        return root;
                     }
                 }
 


### PR DESCRIPTION
While this fixes #51737, there are still issues here :confused:
I'll point to them in separate comments