### PR TITLE
Add SolutionFilter support to MSBuildWorkspace

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -225,6 +225,7 @@
     <SystemSecurityPrincipalVersion>4.3.0</SystemSecurityPrincipalVersion>
     <SystemTextEncodingCodePagesVersion>4.5.1</SystemTextEncodingCodePagesVersion>
     <SystemTextEncodingExtensionsVersion>4.3.0</SystemTextEncodingExtensionsVersion>
+    <SystemTextJsonVersion>5.0.0</SystemTextJsonVersion>
     <SystemThreadingTasksDataflowVersion>5.0.0</SystemThreadingTasksDataflowVersion>
     <!-- We need System.ValueTuple assembly version at least 4.0.3.0 on net47 to make F5 work against Dev15 - see https://github.com/dotnet/roslyn/issues/29705 -->
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.SolutionFilterReader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.SolutionFilterReader.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Text.Json;
+
+namespace Microsoft.CodeAnalysis.MSBuild
+{
+    public partial class MSBuildProjectLoader
+    {
+        private static class SolutionFilterReader
+        {
+            public static bool IsSolutionFilterFilename(string filename)
+            {
+                return Path.GetExtension(filename) == ".slnf";
+            }
+
+            public static bool TryRead(string filterFilename, PathResolver pathResolver, out string solutionFilename, out ImmutableHashSet<string> projectFilter)
+            {
+                try
+                {
+                    using var document = JsonDocument.Parse(File.ReadAllText(filterFilename));
+                    var solution = document.RootElement.GetProperty("solution");
+                    var solutionPath = solution.GetProperty("path").GetString();
+
+                    if (!pathResolver.TryGetAbsoluteSolutionPath(solutionPath, baseDirectory: Path.GetDirectoryName(filterFilename), DiagnosticReportingMode.Throw, out solutionFilename))
+                    {
+                        // TryGetAbsoluteSolutionPath should throw before we get here.
+                        solutionFilename = string.Empty;
+                        projectFilter = ImmutableHashSet<string>.Empty;
+                        return false;
+                    }
+
+                    if (!File.Exists(solutionFilename))
+                    {
+                        projectFilter = ImmutableHashSet<string>.Empty;
+                        return false;
+                    }
+
+                    var filterProjects = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var project in solution.GetProperty("projects").EnumerateArray())
+                    {
+                        var projectPath = project.GetString();
+                        if (projectPath is null)
+                        {
+                            continue;
+                        }
+
+                        filterProjects.Add(projectPath);
+                    }
+
+                    projectFilter = filterProjects.ToImmutable();
+                    return true;
+                }
+                catch
+                {
+                    solutionFilename = string.Empty;
+                    projectFilter = ImmutableHashSet<string>.Empty;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.SolutionFilterReader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.SolutionFilterReader.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             public static bool IsSolutionFilterFilename(string filename)
             {
-                return Path.GetExtension(filename) == ".slnf";
+                return Path.GetExtension(filename).Equals(".slnf", StringComparison.OrdinalIgnoreCase);
             }
 
             public static bool TryRead(string filterFilename, PathResolver pathResolver, out string solutionFilename, out ImmutableHashSet<string> projectFilter)

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
@@ -194,13 +194,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
                     continue;
                 }
 
-                // Do not load project if we have a project filter and the project path isn't present.
-                if (projectfilter?.Contains(project.RelativePath) == false)
+                // Load project if we have an empty project filter and the project path is present.
+                if (projectfilter.IsEmpty ||
+                    projectfilter.Contains(project.RelativePath))
                 {
-                    continue;
+                    projectPaths.Add(project.RelativePath);
                 }
-
-                projectPaths.Add(project.RelativePath);
             }
 
             var buildManager = new ProjectBuildManager(_properties, msbuildLogger);

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
@@ -80,13 +80,13 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
         /// <summary>
         /// Determines if unrecognized projects are skipped when solutions or projects are opened.
-        /// 
-        /// A project is unrecognized if it either has 
-        ///   a) an invalid file path, 
+        ///
+        /// A project is unrecognized if it either has
+        ///   a) an invalid file path,
         ///   b) a non-existent project file,
-        ///   c) has an unrecognized file extension or 
+        ///   c) has an unrecognized file extension or
         ///   d) a file extension associated with an unsupported language.
-        /// 
+        ///
         /// If unrecognized projects cannot be skipped a corresponding exception is thrown.
         /// </summary>
         public bool SkipUnrecognizedProjects { get; set; } = true;
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 : DiagnosticReportingMode.Throw;
 
         /// <summary>
-        /// Loads the <see cref="SolutionInfo"/> for the specified solution file, including all projects referenced by the solution file and 
+        /// Loads the <see cref="SolutionInfo"/> for the specified solution file, including all projects referenced by the solution file and
         /// all the projects referenced by the project files.
         /// </summary>
         /// <param name="solutionFilePath">The path to the solution file to be loaded. This may be an absolute path or a path relative to the
@@ -163,13 +163,19 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 return null!;
             }
 
+            var projectfilter = ImmutableHashSet<string>.Empty;
+            if (SolutionFilterReader.IsSolutionFilterFilename(absoluteSolutionPath) &&
+                !SolutionFilterReader.TryRead(absoluteSolutionPath, _pathResolver, out absoluteSolutionPath, out projectfilter))
+            {
+                throw new Exception(string.Format(WorkspaceMSBuildResources.Failed_to_load_solution_filter_0, solutionFilePath));
+            }
+
             using (_dataGuard.DisposableWait(cancellationToken))
             {
                 this.SetSolutionProperties(absoluteSolutionPath);
             }
 
             var solutionFile = MSB.Construction.SolutionFile.Parse(absoluteSolutionPath);
-
             var reportingMode = GetReportingModeForUnrecognizedProjects();
 
             var reportingOptions = new DiagnosticReportingOptions(
@@ -183,10 +189,18 @@ namespace Microsoft.CodeAnalysis.MSBuild
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (project.ProjectType != MSB.Construction.SolutionProjectType.SolutionFolder)
+                if (project.ProjectType == MSB.Construction.SolutionProjectType.SolutionFolder)
                 {
-                    projectPaths.Add(project.RelativePath);
+                    continue;
                 }
+
+                // Do not load project if we have a project filter and the project path isn't present.
+                if (projectfilter?.Contains(project.RelativePath) == false)
+                {
+                    continue;
+                }
+
+                projectPaths.Add(project.RelativePath);
             }
 
             var buildManager = new ProjectBuildManager(_properties, msbuildLogger);

--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.resx
+++ b/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.resx
@@ -120,6 +120,9 @@
   <data name="Duplicate_project_discovered_and_skipped_0" xml:space="preserve">
     <value>Duplicate project discovered and skipped: {0}</value>
   </data>
+  <data name="Failed_to_load_solution_filter_0" xml:space="preserve">
+    <value>Failed to load solution filter: '{0}'</value>
+  </data>
   <data name="Found_project_reference_without_a_matching_metadata_reference_0" xml:space="preserve">
     <value>Found project reference without a matching metadata reference: {0}</value>
   </data>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.cs.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Našel se odkaz na projekt bez odpovídajícího odkazu na metadata: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.de.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Projektverweis ohne passenden Metadatenverweis gefunden: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.es.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Se ha encontrado referencia de proyecto sin una referencia de metadatos coincidentes: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.fr.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Référence de projet sans référence de métadonnées correspondante : {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.it.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">È stato trovato un riferimento al progetto senza un riferimento corrispondente ai metadati: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ja.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">一致するメタデータ参照が含まれないプロジェクト参照が見つかりました: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ko.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">일치하는 메타데이터 참조가 없는 프로젝트 참조를 찾음: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pl.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Znaleziono odwołanie projektu bez zgodnego odwołania metadanych: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pt-BR.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Referência de projeto encontrada sem uma referência de metadados correspondentes: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ru.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Обнаружена ссылка на проект без соответствующей ссылки на метаданные: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.tr.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">Proje başvurusu eşleşen meta veriler başvuru olmadan bulundu: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">找到了项目引用但没有匹配的元数据引用: {0}</target>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Failed_to_load_solution_filter_0">
+        <source>Failed to load solution filter: '{0}'</source>
+        <target state="new">Failed to load solution filter: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
         <source>Found project reference without a matching metadata reference: {0}</source>
         <target state="translated">發現沒有相符中繼資料參考的專案參考: {0}</target>

--- a/src/Workspaces/MSBuildTest/Resources/SolutionFilters/CSharpSolutionFilter.slnf
+++ b/src/Workspaces/MSBuildTest/Resources/SolutionFilters/CSharpSolutionFilter.slnf
@@ -1,0 +1,8 @@
+﻿{
+  "solution": {
+    "path": "TestSolution.sln",
+    "projects": [
+      "CSharpProject\\CSharpProject.csproj"
+    ]
+  }
+}

--- a/src/Workspaces/MSBuildTest/Resources/SolutionFilters/InvalidSolutionFilter.slnf
+++ b/src/Workspaces/MSBuildTest/Resources/SolutionFilters/InvalidSolutionFilter.slnf
@@ -1,0 +1,8 @@
+﻿{
+  "solution": {
+    "path": "TestSolution.sln",
+    "projects": [
+      { "name": "CSharpProject", "path": "CSharpProject\\CSharpProject.csproj" }
+    ]
+  }
+}

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -76,6 +76,12 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
         public static byte[] Key_snk => GetBytes("key.snk");
         public static string NuGet_Config => GetText("NuGet.Config");
 
+        public static class SolutionFilters
+        {
+            public static string Invalid => GetText("SolutionFilters.InvalidSolutionFilter.slnf");
+            public static string CSharp => GetText("SolutionFilters.CSharpSolutionFilter.slnf");
+        }
+
         public static class SolutionFiles
         {
             public static string AnalyzerReference => GetText("SolutionFiles.AnalyzerReference.sln");


### PR DESCRIPTION
Even if MSBuild provided us a way to get the filtered list of projects from the loaded SolutionFile, Filter support would then be tied to having a sufficiently recent MSBuild. Reading the filter file separately allows these changes to work even with versions of MSBuild that did not contain support.

Based on the changes in https://github.com/dotnet/msbuild/pull/4899