### PR TITLE
Don't log or report operation cancelled exceptions

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -228,10 +228,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     }
                 }
             }
-            catch (OperationCanceledException e) when (e.CancellationToken == _cancelSource.Token)
+            catch (OperationCanceledException)
             {
-                // If the queue is asked to shut down between the start of the while loop, and the Dequeue call
-                // we could end up here, but we don't want to report an error. The Shutdown call will take care of things.
+                // If we're being cancelled then we shut down but logging it as an exception is misleading in the logs
+                // If we have shut ourselves down then calling Shutdown() here is redundant, but there is no issue calling
+                // it multiple times so better safe than sorry.
+                Shutdown();
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))
             {


### PR DESCRIPTION
From what I can tell, I missed changing this when refactoring the error handling a while ago. When unloading a solution we were getting cancelled, but logging and reporting via watson, which is unnecessary.

The LSP logging was also attributing the cancellation to the previous LSP message, eg didClose for the document, which is misleading as far as investigating issues goes.