### PR TITLE
Fix links

### DIFF
--- a/docs/contributing/Nullable Annotations.md
+++ b/docs/contributing/Nullable Annotations.md
@@ -2,7 +2,7 @@
 
 This document describes how nullable annotations should be approached in the 
 Roslyn code base. The default is to simply follow [the same guidance](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/api-guidelines/nullability.md)
-as the [dotnet/runtime](github.com/dotnet/runtime) repository. This document
+as the [dotnet/runtime](https://github.com/dotnet/runtime) repository. This document
 serves to detail the places where the guidance differs for Roslyn and 
 re-emphasize rules that come up frequently.
 

--- a/docs/wiki/C#-Interactive-Walkthrough.md
+++ b/docs/wiki/C#-Interactive-Walkthrough.md
@@ -1,4 +1,4 @@
-This walkthrough is a beginner's guide to learning basic interactive concepts and how to navigate the C# Interactive Window. To learn more about the Interactive window, watch [this video](channel9.msdn.com/Events/Visual-Studio/Connect-event-2015/103) or check out [our documentation](https://github.com/dotnet/roslyn/blob/main/docs/wiki/Interactive-Window.md).
+This walkthrough is a beginner's guide to learning basic interactive concepts and how to navigate the C# Interactive Window. To learn more about the Interactive window, watch [this video](https://channel9.msdn.com/Events/Visual-Studio/Connect-event-2015/103) or check out [our documentation](https://github.com/dotnet/roslyn/blob/main/docs/wiki/Interactive-Window.md).
 
 *Note*: This walkthrough is adapted from [Bill Chiles](https://github.com/billchi-ms)' original. Thanks, Bill!
 


### PR DESCRIPTION
Without https, it's considered a relative path and redirects to invalid link: `https://github.com/dotnet/roslyn/blob/main/docs/wiki/channel9.msdn.com/Events/Visual-Studio/Connect-event-2015/103`