### PR TITLE
Use RTM version of framework ref assemblies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -108,7 +108,7 @@
     <jnm2ReferenceAssembliesnet35Version>1.0.1</jnm2ReferenceAssembliesnet35Version>
     <MicrosoftNETCoreTestHostVersion>1.1.0</MicrosoftNETCoreTestHostVersion>
     <MicrosoftNetFX20Version>1.0.3</MicrosoftNetFX20Version>
-    <MicrosoftNetFrameworkReferenceAssembliesVersion>1.0.0-preview.1</MicrosoftNetFrameworkReferenceAssembliesVersion>
+    <MicrosoftNetFrameworkReferenceAssembliesVersion>1.0.0</MicrosoftNetFrameworkReferenceAssembliesVersion>
     <MicrosoftNetSdkVersion>2.0.0-alpha-20170405-2</MicrosoftNetSdkVersion>
     <MicrosoftNuGetBuildTasksVersion>0.1.0</MicrosoftNuGetBuildTasksVersion>
     <MicrosoftPortableTargetsVersion>0.1.2-dev</MicrosoftPortableTargetsVersion>

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -1214,11 +1214,11 @@ Friend Module CompilationUtils
         Array.Sort(strings)
         Dim builder = PooledStringBuilderPool.Allocate()
         With builder.Builder
-            For Each str In strings
+            For Each item In strings
                 If .Length > 0 Then
                     .AppendLine()
                 End If
-                .Append(str)
+                .Append(item)
             Next
         End With
         Return builder.ToStringAndFree()


### PR DESCRIPTION
This changes our code to use the RTM version of the framework reference
assemblies rather than preview.

The RTM version though forces a reference to Microsoft.VisualBasic.dll
when building VB projects. That caused a compilation error in part of
our code because of the following pattern

```vb
For Each str in strings
```

In VB the identifier in the `For Each` is not necessarily a new
declaration but can also refer to existing identifiers. Hence this name
must go through standard name lookup.

Once the reference to Microsoft.VisualBasic.dll is added the
`Microsoft.VisualBasic.Conversions` module becomes available and the
method `Str` in that module is now a valid top level name. This causes
the above code to stop compiling. Fix is to use a non-conflicting
identifier.

closes #51711