### PR TITLE
Add EditorFeatures2.UnitTests.dll to exclusions

### DIFF
--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -84,6 +84,7 @@ try {
   " --exclude net472\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.dll" +
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.dll" +
   " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll" +
+  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll" +
   " --exclude net472\Microsoft.CodeAnalysis.ExpressionEvaluator.FunctionResolver.UnitTests.dll" +
   " --exclude net472\Microsoft.CodeAnalysis.ExternalAccess.FSharp.UnitTests.dll" +
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Features.dll" +


### PR DESCRIPTION
It appears main (or at least main-vs-deps) is currently broken because of a rebuild failure with this DLL. e.g. https://dev.azure.com/dnceng/public/_build/results?buildId=1035200&view=results

/cc @333fred @CyrusNajmabadi @jaredpar 