### PR TITLE
Fix History of C# Language Features 404

### DIFF
--- a/docs/wiki/NuGet-packages.md
+++ b/docs/wiki/NuGet-packages.md
@@ -34,7 +34,7 @@ Below are the versions of the language available in the NuGet packages. Remember
 - ...
 - Version `3.8` includes C# 9.0 (Visual Studio 2019 version 16.8, .NET 5)
 
-See the [history of C# language features](https://github.com/dotnet/csharplang/blob/main/Language-Version-History.md) for more details.
+See the [history of C# language features](https://github.com/dotnet/csharplang/blob/master/Language-Version-History.md) for more details.
 
 ## Other packages
 


### PR DESCRIPTION
Corrected  "history of C# language features" link (was 404'ing)
If dotnet/csharplang switched to a `main` branch, the old link would work