### PR TITLE
Rebuild compilations that use top-level statements

### DIFF
--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -116,7 +116,6 @@ try {
   " --exclude netcoreapp3.1\VBSyntaxGenerator.dll" +
 
   # Compilation Errors
-  " --exclude net5.0\IOperationGenerator.dll" +
   " --exclude net472\Microsoft.CodeAnalysis.CSharp.Scripting.Desktop.UnitTests.dll" +
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.CSharp.Scripting.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.CSharp.Scripting.dll" +

--- a/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
+++ b/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
@@ -136,12 +136,11 @@ namespace BuildValidator
             ? OutputKind.ConsoleApplication
             : OutputKind.DynamicallyLinkedLibrary;
 
-        public string? GetMainTypeName() => GetMainMethodInfo() is { } tuple
-            ? tuple.MainTypeName
-            : null;
-
-        public string? GetMainMethodName() => GetMainMethodInfo() is { } tuple
-            ? tuple.MainMethodName
+        // Here we only want to give the caller the main type name if the main method is named "Main" per convention.
+        // If the main method has another name, we have to assume that specifying a main type name won't work.
+        // For example, if the compilation uses top-level statements.
+        public string? GetMainTypeName() => GetMainMethodInfo() is (string typeName, WellKnownMemberNames.EntryPointMethodName)
+            ? typeName
             : null;
 
         private (string MainTypeName, string MainMethodName)? GetMainMethodInfo()

--- a/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
+++ b/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
@@ -136,9 +136,6 @@ namespace BuildValidator
             ? OutputKind.ConsoleApplication
             : OutputKind.DynamicallyLinkedLibrary;
 
-        // Here we only want to give the caller the main type name if the main method is named "Main" per convention.
-        // If the main method has another name, we have to assume that specifying a main type name won't work.
-        // For example, if the compilation uses top-level statements.
         public string? GetMainTypeName() => GetMainMethodInfo()?.MainTypeName;
 
         public (string MainTypeName, string MainMethodName)? GetMainMethodInfo()
@@ -152,6 +149,10 @@ namespace BuildValidator
             var mdReader = PeReader.GetMetadataReader();
             var methodDefinition = mdReader.GetMethodDefinition(header.EntryPoint);
             var methodName = mdReader.GetString(methodDefinition.Name);
+
+            // Here we only want to give the caller the main method name and containing type name if the method is named "Main" per convention.
+            // If the main method has another name, we have to assume that specifying a main type name won't work.
+            // For example, if the compilation uses top-level statements.
             if (methodName != WellKnownMemberNames.EntryPointMethodName)
             {
                 return null;

--- a/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
+++ b/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
@@ -139,11 +139,9 @@ namespace BuildValidator
         // Here we only want to give the caller the main type name if the main method is named "Main" per convention.
         // If the main method has another name, we have to assume that specifying a main type name won't work.
         // For example, if the compilation uses top-level statements.
-        public string? GetMainTypeName() => GetMainMethodInfo() is (string typeName, WellKnownMemberNames.EntryPointMethodName)
-            ? typeName
-            : null;
+        public string? GetMainTypeName() => GetMainMethodInfo()?.MainTypeName;
 
-        private (string MainTypeName, string MainMethodName)? GetMainMethodInfo()
+        public (string MainTypeName, string MainMethodName)? GetMainMethodInfo()
         {
             if (!(PdbReader.DebugMetadataHeader is { } header) ||
                 header.EntryPoint.IsNil)
@@ -154,6 +152,11 @@ namespace BuildValidator
             var mdReader = PeReader.GetMetadataReader();
             var methodDefinition = mdReader.GetMethodDefinition(header.EntryPoint);
             var methodName = mdReader.GetString(methodDefinition.Name);
+            if (methodName != WellKnownMemberNames.EntryPointMethodName)
+            {
+                return null;
+            }
+
             var typeHandle = methodDefinition.GetDeclaringType();
             var typeDefinition = mdReader.GetTypeDefinition(typeHandle);
             var typeName = mdReader.GetString(typeDefinition.Name);

--- a/src/Compilers/Core/RebuildTest/CSharpRebuildTests.cs
+++ b/src/Compilers/Core/RebuildTest/CSharpRebuildTests.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System;
+using System.Reflection.PortableExecutable;
+using BuildValidator;
+using Castle.Core.Logging;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using System.IO;
+using System.Threading;
+using Microsoft.CodeAnalysis.VisualBasic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
+{
+    public class CSharpRebuildTests : CSharpTestBase
+    {
+        [Fact]
+        public void TopLevelStatements()
+        {
+            const string path = "test";
+
+            var original = CreateCompilation(
+                @"System.Console.WriteLine(""I'm using top-level statements!"");",
+                options: TestOptions.DebugExe);
+
+            original.VerifyDiagnostics();
+
+            var originalBytes = original.EmitToArray(new EmitOptions(debugInformationFormat: DebugInformationFormat.Embedded));
+            var peReader = new PEReader(originalBytes);
+            Assert.True(peReader.TryOpenAssociatedPortablePdb(path, path => null, out var provider, out _));
+            var pdbReader = provider!.GetMetadataReader();
+
+            var factory = LoggerFactory.Create(configure => { });
+            var logger = factory.CreateLogger(path);
+            var bc = new BuildConstructor(logger);
+
+            var optionsReader = new CompilationOptionsReader(logger, pdbReader, peReader);
+
+            var sources = original.SyntaxTrees.Select(st =>
+            {
+                var text = st.GetText();
+                return new ResolvedSource(OnDiskPath: null, text, new SourceFileInfo(path, text.ChecksumAlgorithm, text.GetChecksum().ToArray(), text, embeddedCompressedHash: null));
+            }).ToImmutableArray();
+            var references = original.References.ToImmutableArray();
+            var (compilation, isError) = bc.CreateCompilation(optionsReader, path, sources, references);
+
+            Assert.False(isError);
+            compilation.VerifyEmitDiagnostics();
+        }
+    }
+}

--- a/src/Compilers/Core/RebuildTest/CSharpRebuildTests.cs
+++ b/src/Compilers/Core/RebuildTest/CSharpRebuildTests.cs
@@ -44,9 +44,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 return new ResolvedSource(OnDiskPath: null, text, new SourceFileInfo(path, text.ChecksumAlgorithm, text.GetChecksum().ToArray(), text, embeddedCompressedHash: null));
             }).ToImmutableArray();
             var references = original.References.ToImmutableArray();
-            var (compilation, isError) = bc.CreateCompilation(optionsReader, path, sources, references);
-
-            Assert.False(isError);
+            var compilation = bc.CreateCompilation(optionsReader, path, sources, references);
             compilation.VerifyEmitDiagnostics();
         }
     }

--- a/src/Compilers/Core/RebuildTest/CSharpRebuildTests.cs
+++ b/src/Compilers/Core/RebuildTest/CSharpRebuildTests.cs
@@ -2,24 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System;
 using System.Reflection.PortableExecutable;
 using BuildValidator;
-using Castle.Core.Logging;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using System.IO;
-using System.Threading;
-using Microsoft.CodeAnalysis.VisualBasic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
 {


### PR DESCRIPTION
Closes #51802

Addresses the following error

```log
Verifying C:\Users\rikki\src\roslyn\artifacts\obj\CompilersIOperationGenerator\Release\net5.0\IOperationGenerator.dll with pdb [embedded]

  Diagnostics
    C:\Users\rikki\src\roslyn\src\Tools\Source\CompilerGeneratorTools\Source\IOperationGenerator\Program.cs(11,1): error CS1558: '<Program>$' does not have a suitable static 'Main' method
    error CS8804: Cannot specify /main if there is a compilation unit with top-level statements.
```