### PR TITLE
XAML QuickInfo update

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Extensions/SymbolExtensions.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Extensions/SymbolExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 return Enumerable.Empty<TaggedText>();
             }
 
-            var quickInfo = await QuickInfoUtilities.CreateQuickInfoItemAsync(codeProject.Solution.Workspace, semanticModel, TextSpan.FromBounds(0, 0), ImmutableArray.Create(symbol), cancellationToken).ConfigureAwait(false);
+            var quickInfo = await QuickInfoUtilities.CreateQuickInfoItemAsync(codeProject.Solution.Workspace, semanticModel, span: default, ImmutableArray.Create(symbol), cancellationToken).ConfigureAwait(false);
             var builder = new List<TaggedText>();
             foreach (var section in quickInfo.Sections)
             {

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Extensions/SymbolExtensions.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Extensions/SymbolExtensions.cs
@@ -5,28 +5,21 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor.Xaml;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageServer.Extensions
 {
     internal static class SymbolExtensions
     {
-        private static readonly SymbolDisplayFormat s_descriptionStyle =
-            new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
-                delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
-                genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeVariance | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
-                parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeParamsRefOut,
-                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers,
-                kindOptions: SymbolDisplayKindOptions.IncludeNamespaceKeyword | SymbolDisplayKindOptions.IncludeTypeKeyword);
-
-        public static async Task<IEnumerable<TaggedText>> GetDescriptionAsync(this ISymbol symbol, TextDocument document, int offset, CancellationToken cancellationToken)
+        public static async Task<IEnumerable<TaggedText>> GetDescriptionAsync(this ISymbol symbol, TextDocument document, CancellationToken cancellationToken)
         {
             if (symbol == null)
             {
@@ -40,7 +33,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 return Enumerable.Empty<TaggedText>();
             }
 
-            // TODO: Should we get this from the code-behind document instead?
+            var symbolDisplayService = codeProject.LanguageServices.GetService<ISymbolDisplayService>();
+            if (symbolDisplayService == null)
+            {
+                return Enumerable.Empty<TaggedText>();
+            }
+
+            // Any code document will do
             var codeDocument = codeProject.Documents.FirstOrDefault();
             if (codeDocument == null)
             {
@@ -53,16 +52,51 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 return Enumerable.Empty<TaggedText>();
             }
 
-            var textContentBuilder = new List<TaggedText>();
-            textContentBuilder.AddRange(symbol.ToDisplayParts(s_descriptionStyle).ToTaggedText());
+            var description = await symbolDisplayService.ToDescriptionPartsAsync(codeProject.Solution.Workspace, semanticModel, 0, ImmutableArray.Create(symbol), SymbolDescriptionGroups.MainDescription, cancellationToken).ConfigureAwait(false);
 
-            var documentation = symbol.GetDocumentationParts(semanticModel, offset, formatter, cancellationToken);
+            var builder = new List<TaggedText>();
+            builder.AddRange(description.ToTaggedText());
+
+            var documentation = symbol.GetDocumentationParts(semanticModel, 0, formatter, cancellationToken);
             if (documentation.Any())
             {
-                textContentBuilder.AddLineBreak();
-                textContentBuilder.AddRange(documentation);
+                builder.AddLineBreak();
+                builder.AddRange(documentation);
             }
-            return textContentBuilder;
+
+            var remarksDocumentation = symbol.GetRemarksDocumentationParts(semanticModel, 0, formatter, cancellationToken);
+            if (remarksDocumentation.Any())
+            {
+                builder.AddLineBreak();
+                builder.AddLineBreak();
+                builder.AddRange(remarksDocumentation);
+            }
+
+            var returnsDocumentation = symbol.GetReturnsDocumentationParts(semanticModel, 0, formatter, cancellationToken);
+            if (returnsDocumentation.Any())
+            {
+                builder.AddLineBreak();
+                builder.AddLineBreak();
+                builder.AddText(FeaturesResources.Returns_colon);
+                builder.AddLineBreak();
+                builder.Add(new TaggedText(TextTags.ContainerStart, "  "));
+                builder.AddRange(returnsDocumentation);
+                builder.Add(new TaggedText(TextTags.ContainerEnd, string.Empty));
+            }
+
+            var valueDocumentation = symbol.GetValueDocumentationParts(semanticModel, 0, formatter, cancellationToken);
+            if (valueDocumentation.Any())
+            {
+                builder.AddLineBreak();
+                builder.AddLineBreak();
+                builder.AddText(FeaturesResources.Value_colon);
+                builder.AddLineBreak();
+                builder.Add(new TaggedText(TextTags.ContainerStart, "  "));
+                builder.AddRange(valueDocumentation);
+                builder.Add(new TaggedText(TextTags.ContainerEnd, string.Empty));
+            }
+
+            return builder;
         }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Extensions/SymbolExtensions.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Extensions/SymbolExtensions.cs
@@ -52,19 +52,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 return Enumerable.Empty<TaggedText>();
             }
 
-            var description = await symbolDisplayService.ToDescriptionPartsAsync(codeProject.Solution.Workspace, semanticModel, 0, ImmutableArray.Create(symbol), SymbolDescriptionGroups.MainDescription, cancellationToken).ConfigureAwait(false);
+            var description = await symbolDisplayService.ToDescriptionPartsAsync(codeProject.Solution.Workspace, semanticModel, position: 0, ImmutableArray.Create(symbol), SymbolDescriptionGroups.MainDescription, cancellationToken).ConfigureAwait(false);
 
             var builder = new List<TaggedText>();
             builder.AddRange(description.ToTaggedText());
 
-            var documentation = symbol.GetDocumentationParts(semanticModel, 0, formatter, cancellationToken);
+            var documentation = symbol.GetDocumentationParts(semanticModel, position: 0, formatter, cancellationToken);
             if (documentation.Any())
             {
                 builder.AddLineBreak();
                 builder.AddRange(documentation);
             }
 
-            var remarksDocumentation = symbol.GetRemarksDocumentationParts(semanticModel, 0, formatter, cancellationToken);
+            var remarksDocumentation = symbol.GetRemarksDocumentationParts(semanticModel, position: 0, formatter, cancellationToken);
             if (remarksDocumentation.Any())
             {
                 builder.AddLineBreak();
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 builder.AddRange(remarksDocumentation);
             }
 
-            var returnsDocumentation = symbol.GetReturnsDocumentationParts(semanticModel, 0, formatter, cancellationToken);
+            var returnsDocumentation = symbol.GetReturnsDocumentationParts(semanticModel, position: 0, formatter, cancellationToken);
             if (returnsDocumentation.Any())
             {
                 builder.AddLineBreak();
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 builder.Add(new TaggedText(TextTags.ContainerEnd, string.Empty));
             }
 
-            var valueDocumentation = symbol.GetValueDocumentationParts(semanticModel, 0, formatter, cancellationToken);
+            var valueDocumentation = symbol.GetValueDocumentationParts(semanticModel, position: 0, formatter, cancellationToken);
             if (valueDocumentation.Any())
             {
                 builder.AddLineBreak();

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 return completionItem;
             }
 
-            var description = await symbol.GetDescriptionAsync(document, offset, cancellationToken).ConfigureAwait(false);
+            var description = await symbol.GetDescriptionAsync(document, cancellationToken).ConfigureAwait(false);
 
             var vsCompletionItem = CloneVSCompletionItem(completionItem);
             vsCompletionItem.Description = new ClassifiedTextElement(description.Select(tp => new ClassifiedTextRun(tp.Tag.ToClassificationTypeName(), tp.Text)));

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Hover/HoverHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Hover/HoverHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
             var descriptionBuilder = new List<TaggedText>(info.Description);
             if (info.Symbol != null)
             {
-                var description = await info.Symbol.GetDescriptionAsync(document, position, cancellationToken).ConfigureAwait(false);
+                var description = await info.Symbol.GetDescriptionAsync(document, cancellationToken).ConfigureAwait(false);
                 if (description.Any())
                 {
                     if (descriptionBuilder.Any())


### PR DESCRIPTION
Updated XAML QuickInfo to show more info like C# by using ISymbolDisplayService and adding more documentation parts.

Before:
![QuickInfo-Before](https://user-images.githubusercontent.com/14282894/110995145-b4346900-832e-11eb-86a1-60066ed3f548.png)

After:
![QuickInfo-After](https://user-images.githubusercontent.com/14282894/110995175-c2828500-832e-11eb-93ce-349d66daee27.png)

