### PR TITLE
Better rebuild logging

### DIFF
--- a/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
+++ b/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
@@ -44,9 +44,12 @@ namespace BuildValidator
         public PEReader PeReader { get; }
         private readonly ILogger _logger;
 
+        public bool HasMetadataCompilationOptions => TryGetMetadataCompilationOptions(out _);
+
         private MetadataCompilationOptions? _metadataCompilationOptions;
         private ImmutableArray<MetadataReferenceInfo> _metadataReferenceInfo;
         private byte[]? _sourceLinkUTF8;
+
 
         public CompilationOptionsReader(ILogger logger, MetadataReader pdbReader, PEReader peReader)
         {

--- a/src/Compilers/Core/RebuildTest/OptionRoundTripTests.cs
+++ b/src/Compilers/Core/RebuildTest/OptionRoundTripTests.cs
@@ -57,10 +57,9 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 return new ResolvedSource(OnDiskPath: null, text, new SourceFileInfo(path, text.ChecksumAlgorithm, text.GetChecksum().ToArray(), text, embeddedCompressedHash: null));
             }).ToImmutableArray();
             var references = original.References.ToImmutableArray();
-            var (compilation, isError) = bc.CreateCompilation(optionsReader, path, sources, references);
+            var compilation = bc.CreateCompilation(optionsReader, path, sources, references);
 
-            Assert.False(isError);
-            Assert.Equal(platform, compilation!.Options.Platform);
+            Assert.Equal(platform, compilation.Options.Platform);
 
             // TODO: we should be able to get byte-for-byte equality here.
             // it will probably be necessary to expose some diagnostic facility in the Rebuild API to figure out what's wrong here.
@@ -108,10 +107,9 @@ End Class");
                 return new ResolvedSource(OnDiskPath: null, text, new SourceFileInfo(path, text.ChecksumAlgorithm, text.GetChecksum().ToArray(), text, embeddedCompressedHash: null));
             }).ToImmutableArray();
             var references = original.References.ToImmutableArray();
-            var (compilation, isError) = bc.CreateCompilation(optionsReader, path, sources, references);
+            var compilation = bc.CreateCompilation(optionsReader, path, sources, references);
 
-            Assert.False(isError);
-            Assert.Equal(platform, compilation!.Options.Platform);
+            Assert.Equal(platform, compilation.Options.Platform);
 
             // TODO: we should be able to get byte-for-byte equality here.
             // it will probably be necessary to expose some diagnostic facility in the Rebuild API to figure out what's wrong here.

--- a/src/Tools/BuildValidator/CompilationDiff.cs
+++ b/src/Tools/BuildValidator/CompilationDiff.cs
@@ -68,7 +68,7 @@ namespace BuildValidator
         {
             get
             {
-                EnsureRebuildReslt(RebuildResult.CompilationError);
+                EnsureRebuildResult(RebuildResult.CompilationError);
                 return _diagnostics;
             }
         }
@@ -77,7 +77,7 @@ namespace BuildValidator
         {
             get
             {
-                EnsureRebuildReslt(RebuildResult.MiscError);
+                EnsureRebuildResult(RebuildResult.MiscError);
                 Debug.Assert(_message is object);
                 return _message;
             }
@@ -169,7 +169,7 @@ namespace BuildValidator
             }
         }
 
-        private void EnsureRebuildReslt(RebuildResult result)
+        private void EnsureRebuildResult(RebuildResult result)
         {
             if (Result != result)
             {

--- a/src/Tools/BuildValidator/LocalReferenceResolver.cs
+++ b/src/Tools/BuildValidator/LocalReferenceResolver.cs
@@ -105,8 +105,6 @@ namespace BuildValidator
                 {
                     filePath = Path.Combine(Path.GetDirectoryName(filePath)!, reference.Name);
                 }
-
-
                 builder.Add(MetadataReference.CreateFromStream(
                     fileStream,
                     filePath: filePath,

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -231,7 +231,7 @@ namespace BuildValidator
             using var summary = logger.BeginScope("Summary");
             using (logger.BeginScope("Successful rebuilds"))
             {
-                foreach (var diff in assembliesCompiled.Where(a => a.Outcome == CompilationOutcome.Success))
+                foreach (var diff in assembliesCompiled.Where(a => a.Result == RebuildResult.Success))
                 {
                     logger.LogInformation($"\t{diff.AssemblyInfo.FilePath}");
                 }
@@ -239,7 +239,7 @@ namespace BuildValidator
 
             using (logger.BeginScope("Rebuilds with output differences"))
             {
-                foreach (var diff in assembliesCompiled.Where(a => a.Outcome == CompilationOutcome.BinaryDifference))
+                foreach (var diff in assembliesCompiled.Where(a => a.Result == RebuildResult.BinaryDifference))
                 {
                     logger.LogWarning($"\t{diff.AssemblyInfo.FilePath}");
                     success = false;
@@ -248,7 +248,7 @@ namespace BuildValidator
 
             using (logger.BeginScope("Rebuilds with compilation errors"))
             {
-                foreach (var diff in assembliesCompiled.Where(a => a.Outcome == CompilationOutcome.CompilationError))
+                foreach (var diff in assembliesCompiled.Where(a => a.Result == RebuildResult.CompilationError))
                 {
                     logger.LogError($"\t{diff.AssemblyInfo.FilePath} had {diff.Diagnostics.Length} diagnostics.");
                     success = false;
@@ -257,7 +257,7 @@ namespace BuildValidator
 
             using (logger.BeginScope("Rebuilds with missing references"))
             {
-                foreach (var diff in assembliesCompiled.Where(a => a.Outcome == CompilationOutcome.MissingReferences))
+                foreach (var diff in assembliesCompiled.Where(a => a.Result == RebuildResult.MissingReferences))
                 {
                     logger.LogError($"\t{diff.AssemblyInfo.FilePath}");
                     success = false;
@@ -266,9 +266,10 @@ namespace BuildValidator
 
             using (logger.BeginScope("Rebuilds with other issues"))
             {
-                foreach (var diff in assembliesCompiled.Where(a => a.Outcome == CompilationOutcome.MiscError))
+                foreach (var diff in assembliesCompiled.Where(a => a.Result == RebuildResult.MiscError))
                 {
                     logger.LogError($"{diff.AssemblyInfo.FilePath} {diff.MiscErrorMessage}");
+                    success = false;
                 }
             }
 
@@ -333,7 +334,7 @@ namespace BuildValidator
                 }
                 logResolvedSources();
 
-                Compilation? compilation = null;
+                Compilation compilation;
                 try
                 {
                     compilation = buildConstructor.CreateCompilation(

--- a/src/Tools/BuildValidator/Records.cs
+++ b/src/Tools/BuildValidator/Records.cs
@@ -12,6 +12,7 @@ namespace BuildValidator
     internal sealed record AssemblyInfo(string FilePath, Guid Mvid)
     {
         internal string FileName => Path.GetFileName(FilePath);
+        internal string TargetFramework => Path.GetFileName(Path.GetDirectoryName(FilePath))!;
     }
 
     internal sealed record PortableExecutableInfo(string FilePath, Guid Mvid, bool IsReadyToRun);


### PR DESCRIPTION
This moves our output logging to include a target framework directory.
Before we weren't doing this and we ended up with a race condition when
the same project failed to rebuild in multiple target frameworks.

Cleaned up the handling of failed `CompilationDiff` instances by turning
it into a adhoc-union