### PR TITLE
Delete TestSupportedDiagnosticsMessageHelpLinkUri

### DIFF
--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26717")]
+        [Fact]
         public void TestSupportedDiagnosticsMessageHelpLinkUri()
         {
             using (var workspace = new AdhocWorkspace())
@@ -122,7 +122,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
                 foreach (var descriptor in diagnosticAnalyzer.SupportedDiagnostics)
                 {
-                    Assert.NotEqual("", descriptor.HelpLinkUri ?? "");
+                    if (descriptor.Id is "IDE0043" or "IDE1007" or "IDE1008" or "RemoveUnnecessaryImportsFixable" or "RE0001")
+                    {
+                        Assert.True(descriptor.HelpLinkUri == string.Empty, $"Expected empty help link for {descriptor.Id}");
+                    }
+                    else
+                    {
+                        Assert.NotEqual("", descriptor.HelpLinkUri ?? "");
+                    }
                 }
             }
         }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -109,31 +109,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        [Fact]
-        public void TestSupportedDiagnosticsMessageHelpLinkUri()
-        {
-            using (var workspace = new AdhocWorkspace())
-            {
-                var diagnosticAnalyzer = CreateDiagnosticProviderAndFixer(workspace).Item1;
-                if (diagnosticAnalyzer == null)
-                {
-                    return;
-                }
-
-                foreach (var descriptor in diagnosticAnalyzer.SupportedDiagnostics)
-                {
-                    if (descriptor.Id is "IDE0043" or "IDE1007" or "IDE1008" or "RemoveUnnecessaryImportsFixable" or "RE0001")
-                    {
-                        Assert.True(descriptor.HelpLinkUri == string.Empty, $"Expected empty help link for {descriptor.Id}");
-                    }
-                    else
-                    {
-                        Assert.NotEqual("", descriptor.HelpLinkUri ?? "");
-                    }
-                }
-            }
-        }
-
         internal override async Task<IEnumerable<Diagnostic>> GetDiagnosticsAsync(
             TestWorkspace workspace, TestParameters parameters)
         {


### PR DESCRIPTION
The first commit Investigates what failures will remain, if any, preparing for the test removal. The failures were to mock analyzers used in tests only - not for actual production analyzers.
The second commit deletes the test.

Fixes https://github.com/dotnet/roslyn/issues/51726