### PR TITLE
Disable embedded interop types on mac

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
+++ b/src/EditorFeatures/Core.Cocoa/Microsoft.CodeAnalysis.EditorFeatures.Cocoa.csproj
@@ -41,6 +41,14 @@
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
   <ItemGroup>
+    <!--
+      Mono doesn't support embedded interop types, and this package has a targets file that turns it on for all VS SDK librarys, and
+      the package ends up being transitively brought in. To combat this for Mac, we can explictly include the package and exclude
+      its assets so its targets file is not used.
+    -->
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)" ExcludeAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>


### PR DESCRIPTION
This unblocks VS for Mac 8.10 insertions, namely https://github.com/xamarin/vsmac/pull/3378, by disabling EmbeddedInteropTypes which is not supported on Mono.

Previously this fix was done at a platform level but I'm guessing that recent editor dependency updates have broken that fix.

