### PR TITLE
Simplify CSharpRequiredLanguageVersion

### DIFF
--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal CSharpRequiredLanguageVersion(LanguageVersion version)
         {
-            Version = (version == LanguageVersion.Preview.MapSpecifiedToEffectiveVersion()) ? LanguageVersion.Preview : version;
+            Version = version;
         }
 
         public override string ToString() => Version.ToDisplayString();


### PR DESCRIPTION
`LanguageVersion.Preview.MapSpecifiedToEffectiveVersion()` will always return "Preview" as far as I understand. See:

https://github.com/dotnet/roslyn/blob/6da1274c9d24c2f90a48290394a951b23617f2a3/src/Compilers/CSharp/Portable/LanguageVersion.cs#L370-L384

Thus, the `Version` property is always set to `version`.

Did Preview in past used to map to a language version?

~~Could this be taken further and simplify all `new CSharpRequiredLanguageVersion(...)`, and even trying to get rid of the class (if possible)?~~ (Probably not possible - See `string? GetRequiredLanguageVersion(Diagnostic diagnostic)` - But I'll give it a try later)