### PR TITLE
Support directly assigning nameof to var

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
@@ -1508,5 +1508,42 @@ public class C
             var option = TestOptions.ReleaseDll;
             CreateCompilation(source, options: option).VerifyDiagnostics();
         }
+
+        [Fact]
+        public void TestNameofDeclaredVar()
+        {
+            var source = @"
+using static System.Console;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        string s1 = nameof(s1);
+        WriteLine(s1);
+        var s2 = nameof(s2);
+        WriteLine(s2);
+        dynamic s3 = nameof(s3);
+        WriteLine(s3);
+
+/*
+        var i1 = nameof(i1).Length;
+        WriteLine(i1);
+        var i2 = (nameof(i2) + nameof(i1)).Length;
+        WriteLine(i2);
+        var i3 = (nameof(i2) + nameof(i3)).Length;
+        WriteLine(i3);
+*/
+    }
+}
+";
+            var option = TestOptions.ReleaseExe;
+            var compilation = CreateCompilationWithCSharp(source, options: option).VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput:
+@"s1
+s2
+s3
+");
+        }
     }
 }


### PR DESCRIPTION
WIP prototype for [#4384](https://github.com/dotnet/csharplang/issues/4384)

Notes:
- The current implementation adjustment breaks a test case
- It only supports expressions that contain `nameof` and return a `string`, since it uses a hack that adjusts the resulting expression type to `string`, as it's not possible to bypass the recursive calculation of the resultant type
- It seems that it would be better to postpone development of this feature until `nameof` becomes a non-contextual keyword

As a result of the last note, this PR may be closed and discarded completely until that chagne occurs.

CC @333fred 