### PR TITLE
Record-structs: Add equality members 

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3945,7 +3945,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             void reportStaticOrNotOverridableAPIInRecord(Symbol symbol, BindingDiagnosticBag diagnostics)
             {
-                if (symbol.ContainingType.IsReferenceType &&
+                if (isRecordClass &&
                     !IsSealed &&
                     ((!symbol.IsAbstract && !symbol.IsVirtual && !symbol.IsOverride) || symbol.IsSealed))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
-            if (declaration.Kind == DeclarationKind.Record)
+            if (declaration.Kind is DeclarationKind.Record or DeclarationKind.RecordStruct)
             {
                 var type = DeclaringCompilation.GetWellKnownType(WellKnownType.System_IEquatable_T).Construct(this);
                 if (baseInterfaces.IndexOf(type, SymbolEqualityComparer.AllIgnoreOptions) < 0)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperator.cs
@@ -62,16 +62,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var r2 = F.Parameter(Parameters[1]);
 
                 BoundExpression expression;
-                if (ContainingType.IsReferenceType)
+                if (ContainingType.IsRecordStruct)
+                {
+                    expression = F.Call(r1, equals, r2);
+                }
+                else
                 {
                     BoundExpression objectEqual = F.ObjectEqual(r1, r2);
                     BoundExpression recordEquals = F.LogicalAnd(F.ObjectNotEqual(r1, F.Null(F.SpecialType(SpecialType.System_Object))),
                                                             F.Call(r1, equals, r2));
                     expression = F.LogicalOr(objectEqual, recordEquals);
-                }
-                else
-                {
-                    expression = F.Call(r1, equals, r2);
                 }
 
                 F.CloseMethod(F.Block(F.Return(expression)));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperator.cs
@@ -2,22 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Globalization;
-using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Roslyn.Utilities;
-
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
     /// The record type includes synthesized '==' and '!=' operators equivalent to operators declared as follows:
-    /// 
+    ///
+    /// For record class:
     /// public static bool operator==(R? r1, R? r2)
     ///      => (object) r1 == r2 || ((object)r1 != null &amp;&amp; r1.Equals(r2));
     /// public static bool operator !=(R? r1, R? r2)
     ///      => !(r1 == r2);
-    ///        
+    ///
+    /// For record struct:
+    /// public static bool operator==(R r1, R r2)
+    ///      => r1.Equals(r2);
+    /// public static bool operator !=(R r1, R r2)
+    ///      => !(r1 == r2);
+    ///
     ///The 'Equals' method called by the '==' operator is the 'Equals(R? other)' (<see cref="SynthesizedRecordEquals"/>).
     ///The '!=' operator delegates to the '==' operator. It is an error if the operators are declared explicitly.
     /// </summary>
@@ -34,7 +35,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             try
             {
+                // For record class:
                 // => (object)r1 == r2 || ((object)r1 != null && r1.Equals(r2));
+                // For record struct:
+                // => r1.Equals(r2));
                 MethodSymbol? equals = null;
                 foreach (var member in ContainingType.GetMembers(WellKnownMemberNames.ObjectEquals))
                 {
@@ -57,11 +61,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var r1 = F.Parameter(Parameters[0]);
                 var r2 = F.Parameter(Parameters[1]);
 
-                BoundExpression objectEqual = F.ObjectEqual(r1, r2);
-                BoundExpression recordEquals = F.LogicalAnd(F.ObjectNotEqual(r1, F.Null(F.SpecialType(SpecialType.System_Object))),
+                BoundExpression expression;
+                if (ContainingType.IsReferenceType)
+                {
+                    BoundExpression objectEqual = F.ObjectEqual(r1, r2);
+                    BoundExpression recordEquals = F.LogicalAnd(F.ObjectNotEqual(r1, F.Null(F.SpecialType(SpecialType.System_Object))),
                                                             F.Call(r1, equals, r2));
+                    expression = F.LogicalOr(objectEqual, recordEquals);
+                }
+                else
+                {
+                    expression = F.Call(r1, equals, r2);
+                }
 
-                F.CloseMethod(F.Block(F.Return(F.LogicalOr(objectEqual, recordEquals))));
+                F.CloseMethod(F.Block(F.Return(expression)));
             }
             catch (SyntheticBoundNodeFactory.MissingPredefinedMember ex)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperatorBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperatorBase.cs
@@ -61,13 +61,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var compilation = DeclaringCompilation;
             var location = ReturnTypeLocation;
+            var annotation = ContainingType.IsRecordStruct ? NullableAnnotation.Oblivious : NullableAnnotation.Annotated;
             return (ReturnType: TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Boolean, location, diagnostics)),
                     Parameters: ImmutableArray.Create<ParameterSymbol>(
                                     new SourceSimpleParameterSymbol(owner: this,
-                                                                    TypeWithAnnotations.Create(ContainingType, ContainingType.IsReferenceType ? NullableAnnotation.Annotated : NullableAnnotation.Oblivious),
+                                                                    TypeWithAnnotations.Create(ContainingType, annotation),
                                                                     ordinal: 0, RefKind.None, "r1", isDiscard: false, Locations),
                                     new SourceSimpleParameterSymbol(owner: this,
-                                                                    TypeWithAnnotations.Create(ContainingType, ContainingType.IsReferenceType ? NullableAnnotation.Annotated : NullableAnnotation.Oblivious),
+                                                                    TypeWithAnnotations.Create(ContainingType, annotation),
                                                                     ordinal: 1, RefKind.None, "r2", isDiscard: false, Locations)));
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperatorBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEqualityOperatorBase.cs
@@ -13,12 +13,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
     /// The record type includes synthesized '==' and '!=' operators equivalent to operators declared as follows:
-    /// 
+    ///
+    /// For record class:
     /// public static bool operator==(R? r1, R? r2)
     ///      => (object) r1 == r2 || ((object)r1 != null &amp;&amp; r1.Equals(r2));
     /// public static bool operator !=(R? r1, R? r2)
     ///      => !(r1 == r2);
-    ///        
+    ///
+    /// For record struct:
+    /// public static bool operator==(R r1, R r2)
+    ///      => r1.Equals(r2);
+    /// public static bool operator !=(R r1, R r2)
+    ///      => !(r1 == r2);
+    ///
     ///The 'Equals' method called by the '==' operator is the 'Equals(R? other)' (<see cref="SynthesizedRecordEquals"/>).
     ///The '!=' operator delegates to the '==' operator. It is an error if the operators are declared explicitly.
     /// </summary>
@@ -57,10 +64,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (ReturnType: TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Boolean, location, diagnostics)),
                     Parameters: ImmutableArray.Create<ParameterSymbol>(
                                     new SourceSimpleParameterSymbol(owner: this,
-                                                                    TypeWithAnnotations.Create(ContainingType, NullableAnnotation.Annotated),
+                                                                    TypeWithAnnotations.Create(ContainingType, ContainingType.IsReferenceType ? NullableAnnotation.Annotated : NullableAnnotation.Oblivious),
                                                                     ordinal: 0, RefKind.None, "r1", isDiscard: false, Locations),
                                     new SourceSimpleParameterSymbol(owner: this,
-                                                                    TypeWithAnnotations.Create(ContainingType, NullableAnnotation.Annotated),
+                                                                    TypeWithAnnotations.Create(ContainingType, ContainingType.IsReferenceType ? NullableAnnotation.Annotated : NullableAnnotation.Oblivious),
                                                                     ordinal: 1, RefKind.None, "r2", isDiscard: false, Locations)));
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEquals.cs
@@ -32,7 +32,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        protected override (TypeWithAnnotations ReturnType, ImmutableArray<ParameterSymbol> Parameters, bool IsVararg, ImmutableArray<TypeParameterConstraintClause> DeclaredConstraintsForOverrideOrImplementation) MakeParametersAndBindReturnType(BindingDiagnosticBag diagnostics)
+        protected override (TypeWithAnnotations ReturnType, ImmutableArray<ParameterSymbol> Parameters, bool IsVararg, ImmutableArray<TypeParameterConstraintClause> DeclaredConstraintsForOverrideOrImplementation)
+            MakeParametersAndBindReturnType(BindingDiagnosticBag diagnostics)
         {
             var compilation = DeclaringCompilation;
             var location = ReturnTypeLocation;
@@ -62,6 +63,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 bool isRecordStruct = ContainingType.IsStructType();
                 if (isRecordStruct)
                 {
+                    // We'll produce:
+                    // virtual bool Equals(T other) =>
+                    //     field1 == other.field1 && ... && fieldN == other.fieldN;
                     retExpr = F.Literal(true);
                 }
                 else if (ContainingType.BaseTypeNoUseSiteDiagnostics.IsObjectType())

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Reflection;
-using Microsoft.Cci;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -17,11 +15,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class SynthesizedRecordGetHashCode : SynthesizedRecordObjectMethod
     {
-        private readonly PropertySymbol _equalityContract;
+        private readonly PropertySymbol? _equalityContract;
 
-        public SynthesizedRecordGetHashCode(SourceMemberContainerTypeSymbol containingType, PropertySymbol equalityContract, int memberOffset, BindingDiagnosticBag diagnostics)
+        public SynthesizedRecordGetHashCode(SourceMemberContainerTypeSymbol containingType, PropertySymbol? equalityContract, int memberOffset, BindingDiagnosticBag diagnostics)
             : base(containingType, WellKnownMemberNames.ObjectGetHashCode, memberOffset, diagnostics)
         {
+            Debug.Assert(containingType.IsReferenceType == equalityContract is not null);
             _equalityContract = equalityContract;
         }
 
@@ -29,7 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             isNullableEnabled: true,
             ContainingType.DeclaringCompilation.GetSpecialType(SpecialType.System_Int32));
 
-        protected override (TypeWithAnnotations ReturnType, ImmutableArray<ParameterSymbol> Parameters, bool IsVararg, ImmutableArray<TypeParameterConstraintClause> DeclaredConstraintsForOverrideOrImplementation) MakeParametersAndBindReturnType(BindingDiagnosticBag diagnostics)
+        protected override (TypeWithAnnotations ReturnType, ImmutableArray<ParameterSymbol> Parameters, bool IsVararg, ImmutableArray<TypeParameterConstraintClause> DeclaredConstraintsForOverrideOrImplementation)
+            MakeParametersAndBindReturnType(BindingDiagnosticBag diagnostics)
         {
             var compilation = DeclaringCompilation;
             var location = ReturnTypeLocation;
@@ -49,10 +49,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 MethodSymbol? equalityComparer_GetHashCode = null;
                 MethodSymbol? equalityComparer_get_Default = null;
-                BoundExpression currentHashValue;
+                BoundExpression? currentHashValue;
 
-                if (ContainingType.BaseTypeNoUseSiteDiagnostics.IsObjectType())
+                if (ContainingType.IsStructType())
                 {
+                    currentHashValue = null;
+                }
+                else if (ContainingType.BaseTypeNoUseSiteDiagnostics.IsObjectType())
+                {
+                    Debug.Assert(_equalityContract is not null);
                     if (_equalityContract.GetMethod is null)
                     {
                         // The equality contract isn't usable, an error was reported elsewhere
@@ -69,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // There are no base record types.
                     // Get hash code of the equality contract and combine it with hash codes for field values.
                     ensureEqualityComparerHelpers(F, ref equalityComparer_GetHashCode, ref equalityComparer_get_Default);
-                    currentHashValue = MethodBodySynthesizer.GenerateGetHashCode(equalityComparer_GetHashCode!, equalityComparer_get_Default!, F.Property(F.This(), _equalityContract), F);
+                    currentHashValue = MethodBodySynthesizer.GenerateGetHashCode(equalityComparer_GetHashCode, equalityComparer_get_Default, F.Property(F.This(), _equalityContract), F);
                 }
                 else
                 {
@@ -95,10 +100,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (!f.IsStatic)
                     {
                         ensureEqualityComparerHelpers(F, ref equalityComparer_GetHashCode, ref equalityComparer_get_Default);
-                        currentHashValue = MethodBodySynthesizer.GenerateHashCombine(currentHashValue, equalityComparer_GetHashCode!, equalityComparer_get_Default!, ref boundHashFactor,
-                                                                                     F.Field(F.This(), f),
-                                                                                     F);
+                        if (currentHashValue is null)
+                        {
+                            // EqualityComparer<field type>.Default.GetHashCode(this.field)
+                            currentHashValue = MethodBodySynthesizer.GenerateGetHashCode(equalityComparer_GetHashCode, equalityComparer_get_Default, F.Field(F.This(), f), F);
+                        }
+                        else
+                        {
+                            currentHashValue = MethodBodySynthesizer.GenerateHashCombine(currentHashValue, equalityComparer_GetHashCode, equalityComparer_get_Default, ref boundHashFactor,
+                                                                                         F.Field(F.This(), f),
+                                                                                         F);
+                        }
                     }
+                }
+
+                if (currentHashValue is null)
+                {
+                    currentHashValue = F.Literal(0);
                 }
 
                 F.CloseMethod(F.Block(F.Return(currentHashValue)));
@@ -109,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 F.CloseMethod(F.ThrowNull());
             }
 
-            static void ensureEqualityComparerHelpers(SyntheticBoundNodeFactory F, ref MethodSymbol? equalityComparer_GetHashCode, ref MethodSymbol? equalityComparer_get_Default)
+            static void ensureEqualityComparerHelpers(SyntheticBoundNodeFactory F, [NotNull] ref MethodSymbol? equalityComparer_GetHashCode, [NotNull] ref MethodSymbol? equalityComparer_get_Default)
             {
                 equalityComparer_GetHashCode ??= F.WellKnownMethod(WellKnownMember.System_Collections_Generic_EqualityComparer_T__GetHashCode);
                 equalityComparer_get_Default ??= F.WellKnownMethod(WellKnownMember.System_Collections_Generic_EqualityComparer_T__get_Default);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordGetHashCode.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public SynthesizedRecordGetHashCode(SourceMemberContainerTypeSymbol containingType, PropertySymbol? equalityContract, int memberOffset, BindingDiagnosticBag diagnostics)
             : base(containingType, WellKnownMemberNames.ObjectGetHashCode, memberOffset, diagnostics)
         {
-            Debug.Assert(containingType.IsReferenceType == equalityContract is not null);
+            Debug.Assert(containingType.IsRecordStruct == equalityContract is null);
             _equalityContract = equalityContract;
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 MethodSymbol? equalityComparer_get_Default = null;
                 BoundExpression? currentHashValue;
 
-                if (ContainingType.IsStructType())
+                if (ContainingType.IsRecordStruct)
                 {
                     currentHashValue = null;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordInequalityOperator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordInequalityOperator.cs
@@ -13,12 +13,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
     /// The record type includes synthesized '==' and '!=' operators equivalent to operators declared as follows:
-    /// 
+    ///
+    /// For record class:
     /// public static bool operator==(R? r1, R? r2)
     ///      => (object) r1 == r2 || ((object)r1 != null &amp;&amp; r1.Equals(r2));
     /// public static bool operator !=(R? r1, R? r2)
     ///      => !(r1 == r2);
-    ///        
+    ///
+    /// For record struct:
+    /// public static bool operator==(R r1, R r2)
+    ///      => r1.Equals(r2);
+    /// public static bool operator !=(R r1, R r2)
+    ///      => !(r1 == r2);
+    ///
     ///The 'Equals' method called by the '==' operator is the 'Equals(R? other)' (<see cref="SynthesizedRecordEquals"/>).
     ///The '!=' operator delegates to the '==' operator. It is an error if the operators are declared explicitly.
     /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -22,14 +21,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _typedRecordEquals = typedRecordEquals;
         }
 
-        protected override (TypeWithAnnotations ReturnType, ImmutableArray<ParameterSymbol> Parameters, bool IsVararg, ImmutableArray<TypeParameterConstraintClause> DeclaredConstraintsForOverrideOrImplementation) MakeParametersAndBindReturnType(BindingDiagnosticBag diagnostics)
+        protected override (TypeWithAnnotations ReturnType, ImmutableArray<ParameterSymbol> Parameters, bool IsVararg, ImmutableArray<TypeParameterConstraintClause> DeclaredConstraintsForOverrideOrImplementation)
+            MakeParametersAndBindReturnType(BindingDiagnosticBag diagnostics)
         {
             var compilation = DeclaringCompilation;
             var location = ReturnTypeLocation;
             return (ReturnType: TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Boolean, location, diagnostics)),
                     Parameters: ImmutableArray.Create<ParameterSymbol>(
                                     new SourceSimpleParameterSymbol(owner: this,
-                                                                    TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Object, location, diagnostics), NullableAnnotation.Annotated),
+                                                                    TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Object, location, diagnostics),
+                                                                        ContainingType.IsReferenceType ? NullableAnnotation.Annotated : NullableAnnotation.Oblivious),
                                                                     ordinal: 0, RefKind.None, "obj", isDiscard: false, Locations)),
                     IsVararg: false,
                     DeclaredConstraintsForOverrideOrImplementation: ImmutableArray<TypeParameterConstraintClause>.Empty);
@@ -43,23 +44,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             try
             {
+                if (_typedRecordEquals.ReturnType.SpecialType != SpecialType.System_Boolean)
+                {
+                    // There is a signature mismatch, an error was reported elsewhere
+                    F.CloseMethod(F.ThrowNull());
+                    return;
+                }
+
                 var paramAccess = F.Parameter(Parameters[0]);
 
                 BoundExpression expression;
                 if (ContainingType.IsStructType())
                 {
-                    throw ExceptionUtilities.Unreachable;
+                    // For record structs:
+                    //      return other is R && Equals((R)other)
+                    expression = F.LogicalAnd(
+                        F.Is(paramAccess, ContainingType),
+                        F.Call(F.This(), _typedRecordEquals, F.Convert(ContainingType, paramAccess)));
                 }
                 else
                 {
-                    if (_typedRecordEquals.ReturnType.SpecialType != SpecialType.System_Boolean)
-                    {
-                        // There is a signature mismatch, an error was reported elsewhere
-                        F.CloseMethod(F.ThrowNull());
-                        return;
-                    }
-
-                    // For classes:
+                    // For record classes:
                     //      return this.Equals(param as ContainingType);
                     expression = F.Call(F.This(), _typedRecordEquals, F.As(paramAccess, ContainingType));
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
@@ -26,11 +26,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var compilation = DeclaringCompilation;
             var location = ReturnTypeLocation;
+            var annotation = ContainingType.IsRecordStruct ? NullableAnnotation.Oblivious : NullableAnnotation.Annotated;
             return (ReturnType: TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Boolean, location, diagnostics)),
                     Parameters: ImmutableArray.Create<ParameterSymbol>(
                                     new SourceSimpleParameterSymbol(owner: this,
-                                                                    TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Object, location, diagnostics),
-                                                                        ContainingType.IsReferenceType ? NullableAnnotation.Annotated : NullableAnnotation.Oblivious),
+                                                                    TypeWithAnnotations.Create(Binder.GetSpecialType(compilation, SpecialType.System_Object, location, diagnostics), annotation),
                                                                     ordinal: 0, RefKind.None, "obj", isDiscard: false, Locations)),
                     IsVararg: false,
                     DeclaredConstraintsForOverrideOrImplementation: ImmutableArray<TypeParameterConstraintClause>.Empty);
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var paramAccess = F.Parameter(Parameters[0]);
 
                 BoundExpression expression;
-                if (ContainingType.IsStructType())
+                if (ContainingType.IsRecordStruct)
                 {
                     // For record structs:
                     //      return other is R && Equals((R)other)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -3569,7 +3569,6 @@ record struct A<T>;
         [Fact]
         public void RecordEquals_01()
         {
-            // PROTOTYPE(record-structs): ported
             var source = @"
 var a1 = new B();
 var a2 = new B();
@@ -3716,6 +3715,25 @@ class B
             Assert.False(recordEquals.IsOverride);
             Assert.False(recordEquals.IsSealed);
             Assert.True(recordEquals.IsImplicitlyDeclared);
+
+            var objectEquals = comp.GetMembers("A.Equals").OfType<SynthesizedRecordObjEquals>().Single();
+            Assert.Equal("System.Boolean A.Equals(System.Object obj)", objectEquals.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, objectEquals.DeclaredAccessibility);
+            Assert.False(objectEquals.IsAbstract);
+            Assert.False(objectEquals.IsVirtual);
+            Assert.True(objectEquals.IsOverride);
+            Assert.False(objectEquals.IsSealed);
+            Assert.True(objectEquals.IsImplicitlyDeclared);
+
+            MethodSymbol gethashCode = comp.GetMembers("A." + WellKnownMemberNames.ObjectGetHashCode).OfType<SynthesizedRecordGetHashCode>().Single();
+            Assert.Equal("System.Int32 A.GetHashCode()", gethashCode.ToTestDisplayString());
+            Assert.Equal(Accessibility.Public, gethashCode.DeclaredAccessibility);
+            Assert.False(gethashCode.IsStatic);
+            Assert.False(gethashCode.IsAbstract);
+            Assert.False(gethashCode.IsVirtual);
+            Assert.True(gethashCode.IsOverride);
+            Assert.False(gethashCode.IsSealed);
+            Assert.True(gethashCode.IsImplicitlyDeclared);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -2803,6 +2803,7 @@ public sealed record C
         [Fact, WorkItem(47513, "https://github.com/dotnet/roslyn/issues/47513")]
         public void GetHashCodeIsDefinedButEqualsIsNot()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 public sealed record C
 {
@@ -2816,6 +2817,7 @@ public sealed record C
         [Fact, WorkItem(47513, "https://github.com/dotnet/roslyn/issues/47513")]
         public void EqualsIsDefinedButGetHashCodeIsNot()
         {
+            // PROTOTYPE(record-structs): ported
             var src = @"
 public sealed record C
 {
@@ -16006,6 +16008,7 @@ public record A {
         [Fact]
         public void ObjectEquals_06()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"record A
 {
@@ -19956,6 +19959,7 @@ record R2 : R
         [Fact]
         public void EqualityOperators_01()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A(int X) 
@@ -20174,6 +20178,7 @@ False False True True
         [Fact]
         public void EqualityOperators_03()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -20197,6 +20202,7 @@ record A
         [Fact]
         public void EqualityOperators_04()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -20220,6 +20226,7 @@ record A
         [Fact]
         public void EqualityOperators_05()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -20241,6 +20248,7 @@ record A
         [Fact]
         public void EqualityOperators_06()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -20262,6 +20270,7 @@ record A
         [Fact]
         public void EqualityOperators_07()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -20313,6 +20322,7 @@ record A
         [CombinatorialData]
         public void EqualityOperators_09(bool useImageReference)
         {
+            // PROTOTYPE(record-structs): ported
             var source1 =
 @"
 public record A(int X) 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -17666,6 +17666,7 @@ record B : A
         [Fact]
         public void RecordEquals_01()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 abstract record A
@@ -18029,6 +18030,7 @@ True
         [InlineData("internal protected")]
         public void RecordEquals_10(string accessibility)
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 $@"
 record A
@@ -18055,6 +18057,7 @@ record A
         [InlineData("private")]
         public void RecordEquals_11(string accessibility)
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 $@"
 record A
@@ -18082,6 +18085,7 @@ record A
         [Fact]
         public void RecordEquals_12()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -18122,6 +18126,7 @@ True
         [Fact]
         public void RecordEquals_13()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -18146,6 +18151,7 @@ record A
         [Fact]
         public void RecordEquals_14()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -18357,6 +18363,7 @@ True
         [Fact]
         public void RecordEquals_19()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"
 record A
@@ -23466,6 +23473,7 @@ record C
         [Fact]
         public void IEquatableT_01()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"record A<T>;
 record B : A<int>;
@@ -23492,6 +23500,7 @@ class Program
         [Fact]
         public void IEquatableT_02()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"using System;
 record A;
@@ -23522,6 +23531,7 @@ C").VerifyDiagnostics();
         [Fact]
         public void IEquatableT_03()
         {
+            // PROTOTYPE(record-structs): ported
             var source =
 @"#nullable enable
 using System;


### PR DESCRIPTION
Add `IEquatable<T>` interface, `Equals` and `GetHashCode` methods and equality/inequality operators. 

Implements this [section of the spec](https://github.com/dotnet/csharplang/blob/main/proposals/record-structs.md#equality-members) (copied below for convenience).

Test plan: https://github.com/dotnet/roslyn/issues/51199

> ### Equality members
> 
> The synthesized equality members are similar as in a record class (`Equals` for this type, `Equals` for `object` type, `==` and `!=` operators for this type),\
> except for the lack of `EqualityContract`, null checks or inheritance.
> 
> The record struct implements `System.IEquatable<R>` and includes a synthesized strongly-typed overload of `Equals(R other)` > where `R` is the record struct.
> The method is `public`.
> The method can be declared explicitly. It is an error if the explicit declaration does not match the expected signature or accessibility.
> 
> If `Equals(R other)` is user-defined (not synthesized) but `GetHashCode` is not, a warning is produced.
> 
> ```C#
> public bool Equals(R other);
> ```
> 
> The synthesized `Equals(R)` returns `true` if and only if for each instance field `fieldN` in the record struct
> the value of `System.Collections.Generic.EqualityComparer<TN>.Default.Equals(fieldN, other.fieldN)` where `TN` is the field type is `true`.
> 
> The record struct includes synthesized `==` and `!=` operators equivalent to operators declared as follows:
> ```C#
> public static bool operator==(R r1, R r2)
>     => r1.Equals(r2);
> public static bool operator!=(R r1, R r2)
>     => !(r1 == r2);
> ```
> The `Equals` method called by the `==` operator is the `Equals(R other)` method specified above. The `!=` operator delegates to > the `==` operator. It is an error if the operators are declared explicitly.
> 
> The record struct includes a synthesized override equivalent to a method declared as follows:
> ```C#
> public override bool Equals(object? obj);
> ```
> It is an error if the override is declared explicitly. 
> The synthesized override returns `other is R temp && Equals(temp)` where `R` is the record struct.
> 
> The record struct includes a synthesized override equivalent to a method declared as follows:
> ```C#
> public override int GetHashCode();
> ```
> The method can be declared explicitly.
> 
> A warning is reported if one of `Equals(R)` and `GetHashCode()` is explicitly declared but the other method is not explicit.
> 
> The synthesized override of `GetHashCode()` returns an `int` result of combining the values of `System.Collections.Generic.EqualityComparer<TN>.Default.GetHashCode(fieldN)` for each instance field `fieldN` with `TN` being > the type of `fieldN`.
> 
> For example, consider the following record struct:
> ```C#
> record struct R1(T1 P1, T2 P2);
> ```
> 
> For this record struct, the synthesized equality members would be something like:
> [...]
