### PR TITLE
[LSP] Respect settings passed in by LSP in AutoInsertHandler

### DIFF
--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
@@ -283,7 +283,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
                             return;
                         }
 
-                        var changesAfterReturn = _service.GetTextChangeAfterReturnAsync(context.Value, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+                        var documentOptions = context.Value.Document.GetOptionsAsync().WaitAndGetResult(CancellationToken.None);
+                        var changesAfterReturn = _service.GetTextChangeAfterReturnAsync(context.Value, documentOptions, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
                         if (changesAfterReturn != null)
                         {
                             using var caretPreservingTransaction = new CaretPreservingEditTransaction(EditorFeaturesResources.Brace_Completion, _undoHistory, _editorOperations);

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -83,19 +83,13 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
 
         public override async Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(
             BraceCompletionContext context,
-            CancellationToken cancellationToken)
-            => await GetTextChangeAfterReturnAsync(context, documentOptions: null, cancellationToken).ConfigureAwait(false);
-
-        public override async Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(
-            BraceCompletionContext context,
-            DocumentOptionSet? documentOptions,
+            DocumentOptionSet documentOptions,
             CancellationToken cancellationToken)
         {
             var document = context.Document;
             var closingPoint = context.ClosingPoint;
             var openingPoint = context.OpeningPoint;
             var originalDocumentText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            documentOptions ??= await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             // check whether shape of the braces are what we support
             // shape must be either "{|}" or "{ }". | is where caret is. otherwise, we don't do any special behavior

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -51,6 +51,8 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
 
         public override async Task<BraceCompletionResult?> GetTextChangesAfterCompletionAsync(BraceCompletionContext braceCompletionContext, CancellationToken cancellationToken)
         {
+            var documentOptions = await braceCompletionContext.Document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+
             // After the closing brace is completed we need to format the span from the opening point to the closing point.
             // E.g. when the user triggers completion for an if statement ($$ is the caret location) we insert braces to get
             // if (true){$$}
@@ -63,6 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
                 shouldHonorAutoFormattingOnCloseBraceOption: true,
                 // We're not trying to format the indented block here, so no need to pass in additional rules.
                 braceFormattingIndentationRules: ImmutableArray<AbstractFormattingRule>.Empty,
+                documentOptions,
                 cancellationToken).ConfigureAwait(false);
 
             if (formattingChanges.IsEmpty)
@@ -78,13 +81,21 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             return new BraceCompletionResult(formattingChanges, caretLocation);
         }
 
-        public override async Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext context, CancellationToken cancellationToken)
+        public override async Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(
+            BraceCompletionContext context,
+            CancellationToken cancellationToken)
+            => await GetTextChangeAfterReturnAsync(context, documentOptions: null, cancellationToken).ConfigureAwait(false);
+
+        public override async Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(
+            BraceCompletionContext context,
+            DocumentOptionSet? documentOptions,
+            CancellationToken cancellationToken)
         {
             var document = context.Document;
             var closingPoint = context.ClosingPoint;
             var openingPoint = context.OpeningPoint;
             var originalDocumentText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            documentOptions ??= await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             // check whether shape of the braces are what we support
             // shape must be either "{|}" or "{ }". | is where caret is. otherwise, we don't do any special behavior
@@ -123,6 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
                 closingPoint,
                 shouldHonorAutoFormattingOnCloseBraceOption: false,
                 braceFormattingIndentationRules: GetBraceIndentationFormattingRules(documentOptions),
+                documentOptions,
                 cancellationToken).ConfigureAwait(false);
             closingPoint = newClosingPoint;
             var formattedText = textToFormat.WithChanges(formattingChanges);
@@ -233,6 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             int closingPoint,
             bool shouldHonorAutoFormattingOnCloseBraceOption,
             ImmutableArray<AbstractFormattingRule> braceFormattingIndentationRules,
+            DocumentOptionSet documentOptions,
             CancellationToken cancellationToken)
         {
             var option = document.Project.Solution.Options.GetOption(BraceCompletionOptions.AutoFormattingOnCloseBrace, document.Project.Language);
@@ -268,7 +281,6 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
                 }
             }
 
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var style = documentOptions.GetOption(FormattingOptions.SmartIndent);
             if (style == FormattingOptions.IndentStyle.Smart)
             {
@@ -290,7 +302,8 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
 
             var spanToFormat = TextSpan.FromBounds(Math.Max(startPoint, 0), endPoint);
             var rules = document.GetFormattingRules(spanToFormat, braceFormattingIndentationRules);
-            var result = Formatter.GetFormattingResult(root, SpecializedCollections.SingletonEnumerable(spanToFormat), document.Project.Solution.Workspace, documentOptions, rules, cancellationToken);
+            var result = Formatter.GetFormattingResult(
+                root, SpecializedCollections.SingletonEnumerable(spanToFormat), document.Project.Solution.Workspace, documentOptions, rules, cancellationToken);
             if (result == null)
             {
                 return (ImmutableArray<TextChange>.Empty, closingPoint);

--- a/src/Features/Core/Portable/BraceCompletion/AbstractBraceCompletionService.cs
+++ b/src/Features/Core/Portable/BraceCompletion/AbstractBraceCompletionService.cs
@@ -66,10 +66,7 @@ namespace Microsoft.CodeAnalysis.BraceCompletion
         public virtual Task<BraceCompletionResult?> GetTextChangesAfterCompletionAsync(BraceCompletionContext braceCompletionContext, CancellationToken cancellationToken)
             => SpecializedTasks.Default<BraceCompletionResult?>();
 
-        public virtual Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, CancellationToken cancellationToken)
-            => SpecializedTasks.Default<BraceCompletionResult?>();
-
-        public virtual Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, DocumentOptionSet? documentOptions, CancellationToken cancellationToken)
+        public virtual Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, DocumentOptionSet documentOptions, CancellationToken cancellationToken)
             => SpecializedTasks.Default<BraceCompletionResult?>();
 
         public virtual async Task<bool> CanProvideBraceCompletionAsync(char brace, int openingPosition, Document document, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/BraceCompletion/AbstractBraceCompletionService.cs
+++ b/src/Features/Core/Portable/BraceCompletion/AbstractBraceCompletionService.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -66,6 +67,9 @@ namespace Microsoft.CodeAnalysis.BraceCompletion
             => SpecializedTasks.Default<BraceCompletionResult?>();
 
         public virtual Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, CancellationToken cancellationToken)
+            => SpecializedTasks.Default<BraceCompletionResult?>();
+
+        public virtual Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, DocumentOptionSet? documentOptions, CancellationToken cancellationToken)
             => SpecializedTasks.Default<BraceCompletionResult?>();
 
         public virtual async Task<bool> CanProvideBraceCompletionAsync(char brace, int openingPosition, Document document, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/BraceCompletion/IBraceCompletionService.cs
+++ b/src/Features/Core/Portable/BraceCompletion/IBraceCompletionService.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.BraceCompletion
@@ -50,6 +51,11 @@ namespace Microsoft.CodeAnalysis.BraceCompletion
         /// Get any text changes that should be applied after the enter key is typed inside a brace completion context.
         /// </summary>
         Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get any text changes that should be applied after the enter key is typed inside a brace completion context using custom document options.
+        /// </summary>
+        Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, DocumentOptionSet documentOptions, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the brace completion context if the caret is located between an already completed

--- a/src/Features/Core/Portable/BraceCompletion/IBraceCompletionService.cs
+++ b/src/Features/Core/Portable/BraceCompletion/IBraceCompletionService.cs
@@ -50,11 +50,6 @@ namespace Microsoft.CodeAnalysis.BraceCompletion
         /// <summary>
         /// Get any text changes that should be applied after the enter key is typed inside a brace completion context.
         /// </summary>
-        Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Get any text changes that should be applied after the enter key is typed inside a brace completion context using custom document options.
-        /// </summary>
         Task<BraceCompletionResult?> GetTextChangeAfterReturnAsync(BraceCompletionContext braceCompletionContext, DocumentOptionSet documentOptions, CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
@@ -5,9 +5,6 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Extensions;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
@@ -224,7 +221,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.OnAutoInsert
 		$0
 	}
 }";
-            await VerifyMarkupAndExpected("\n", markup, expected, useTabs: true);
+            await VerifyMarkupAndExpected("\n", markup, expected, useTabs: true, tabSize: 4);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
@@ -307,22 +304,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.OnAutoInsert
             await VerifyNoResult("\n", markup);
         }
 
-        private async Task VerifyMarkupAndExpected(string characterTyped, string markup, string expected, bool useTabs = false)
+        private async Task VerifyMarkupAndExpected(string characterTyped, string markup, string expected, bool useTabs = false, int tabSize = 4)
         {
             using var testLspServer = CreateTestLspServer(markup, out var locations);
             var locationTyped = locations["type"].Single();
 
-            if (useTabs)
-            {
-                var newSolution = testLspServer.GetCurrentSolution().WithOptions(
-                    testLspServer.GetCurrentSolution().Options.WithChangedOption(CodeAnalysis.Formatting.FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs));
-                testLspServer.TestWorkspace.TryApplyChanges(newSolution);
-            }
-
             var document = testLspServer.GetCurrentSolution().GetDocuments(locationTyped.Uri).Single();
             var documentText = await document.GetTextAsync();
 
-            var result = await RunOnAutoInsertAsync(testLspServer, characterTyped, locationTyped);
+            var result = await RunOnAutoInsertAsync(testLspServer, characterTyped, locationTyped, insertSpaces: !useTabs, tabSize);
 
             AssertEx.NotNull(result);
             Assert.Equal(InsertTextFormat.Snippet, result.TextEditFormat);
@@ -330,29 +320,43 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.OnAutoInsert
             Assert.Equal(expected, actualText);
         }
 
-        private async Task VerifyNoResult(string characterTyped, string markup)
+        private async Task VerifyNoResult(string characterTyped, string markup, bool useTabs = false, int tabSize = 4)
         {
             using var testLspServer = CreateTestLspServer(markup, out var locations);
             var locationTyped = locations["type"].Single();
             var documentText = await testLspServer.GetCurrentSolution().GetDocuments(locationTyped.Uri).Single().GetTextAsync();
 
-            var result = await RunOnAutoInsertAsync(testLspServer, characterTyped, locationTyped);
+            var result = await RunOnAutoInsertAsync(testLspServer, characterTyped, locationTyped, useTabs, tabSize);
 
             Assert.Null(result);
         }
 
-        private static async Task<LSP.DocumentOnAutoInsertResponseItem?> RunOnAutoInsertAsync(TestLspServer testLspServer, string characterTyped, LSP.Location locationTyped)
+        private static async Task<LSP.DocumentOnAutoInsertResponseItem?> RunOnAutoInsertAsync(
+            TestLspServer testLspServer,
+            string characterTyped,
+            LSP.Location locationTyped,
+            bool insertSpaces,
+            int tabSize)
         {
             return await testLspServer.ExecuteRequestAsync<LSP.DocumentOnAutoInsertParams, LSP.DocumentOnAutoInsertResponseItem?>(MSLSPMethods.OnAutoInsertName,
-                           CreateDocumentOnAutoInsertParams(characterTyped, locationTyped), new LSP.ClientCapabilities(), null, CancellationToken.None);
+                CreateDocumentOnAutoInsertParams(characterTyped, locationTyped, insertSpaces, tabSize), new LSP.ClientCapabilities(), null, CancellationToken.None);
         }
 
-        private static LSP.DocumentOnAutoInsertParams CreateDocumentOnAutoInsertParams(string characterTyped, LSP.Location locationTyped)
-            => new LSP.DocumentOnAutoInsertParams()
+        private static LSP.DocumentOnAutoInsertParams CreateDocumentOnAutoInsertParams(
+            string characterTyped,
+            LSP.Location locationTyped,
+            bool insertSpaces,
+            int tabSize)
+            => new LSP.DocumentOnAutoInsertParams
             {
                 Position = locationTyped.Range.Start,
                 Character = characterTyped,
-                TextDocument = CreateTextDocumentIdentifier(locationTyped.Uri)
+                TextDocument = CreateTextDocumentIdentifier(locationTyped.Uri),
+                Options = new LSP.FormattingOptions
+                {
+                    InsertSpaces = insertSpaces,
+                    TabSize = tabSize
+                }
             };
     }
 }


### PR DESCRIPTION
Today, LSP passes in tabs/spaces settings as part of the OnAutoInsert request. However, we do not respect these settings and instead use the document's options. We should respect the LSP settings.

This will partially fix some of the tabs vs. spaces issues seen in Razor.