### PR TITLE
Only update snippet model on explicit selection

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -743,7 +743,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 return;
             }
 
-            if (_state._methodNameForInsertFullMethodCall is null || _state._methodNameForInsertFullMethodCall != method.Name)
+            if (_state._methodNameForInsertFullMethodCall != method.Name)
             {
                 // Signature Help is showing a signature that wasn't part of the set this argument value completion
                 // session was created from. It's unclear how this state should be handled, so we stop processing

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -681,6 +681,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 return;
             }
 
+            if (!e.NewModel.UserSelected && _state._method is not null)
+            {
+                // This was an implicit signature change which was not triggered by user pressing up/down, and we are
+                // already showing an initialized argument completion snippet session, so avoid switching sessions.
+                return;
+            }
+
             var document = SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document is null)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             // If this is a manually-constructed snippet for a full method call, avoid formatting the snippet since
             // doing so will disrupt signature help. Check ExpansionSession instead of '_state.IsFullMethodCallSnippet'
             // because '_state._methodNameForInsertFullMethodCall' is not initialized at this point.
-            if (ErrorHandler.Succeeded(ExpansionSession.GetHeaderNode(@"node()[local-name()=""Description""]", out var descriptionNode))
+            if (ExpansionSession.TryGetHeaderNode("Description", out var descriptionNode)
                 && descriptionNode?.text == s_fullMethodCallDescriptionSentinel)
             {
                 return VSConstants.S_OK;

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -52,6 +52,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         /// </summary>
         private const string PlaceholderSnippetField = "placeholder";
 
+        /// <summary>
+        /// A generated random string which is used to identify argument completion snippets from other snippets.
+        /// </summary>
         private static readonly string s_fullMethodCallDescriptionSentinel = Guid.NewGuid().ToString("N");
 
         private readonly SignatureHelpControllerProvider _signatureHelpControllerProvider;

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/IVsExpansionSessionExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/IVsExpansionSessionExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TextManager.Interop;
+using MSXML;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
+{
+    internal static class IVsExpansionSessionExtensions
+    {
+        public static bool TryGetHeaderNode(this IVsExpansionSession expansionSession, string name, [NotNullWhen(true)] out IXMLDOMNode? node)
+        {
+            var query = name is null ? null : $@"node()[local-name()=""{name}""]";
+
+            IXMLDOMNode? localNode = null;
+            if (!ErrorHandler.Succeeded(ErrorHandler.CallWithCOMConvention(() => expansionSession.GetHeaderNode(query, out localNode))))
+            {
+                node = null;
+                return false;
+            }
+
+            node = localNode;
+            return node is not null;
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -108,6 +108,83 @@ public class Test
         }
 
         [WpfFact]
+        public void FullCycle()
+        {
+            SetUpEditor(@"
+using System;
+public class TestClass
+{
+    public void Method()
+    {$$
+    }
+
+    void Test() { }
+    void Test(int x) { }
+    void Test(int x, int y) { }
+}
+");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Enter);
+            VisualStudio.Editor.SendKeys("Test");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("Test$$", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("Test($$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$, 0)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test($$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$, 0)", assertCaretPosition: true);
+        }
+
+        [WpfFact]
+        public void ImplicitArgumentSwitching()
+        {
+            SetUpEditor(@"
+using System;
+public class TestClass
+{
+    public void Method()
+    {$$
+    }
+
+    void Test() { }
+    void Test(int x) { }
+    void Test(int x, int y) { }
+}
+");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Enter);
+            VisualStudio.Editor.SendKeys("Tes");
+
+            // Trigger the session and type '0' without waiting for the session to finish initializing
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab, VirtualKey.Tab, '0');
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$, 0)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Up);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+        }
+
+        [WpfFact]
         public void SemicolonWithTabTabCompletion()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicArgumentProvider.cs
@@ -104,6 +104,89 @@ End Class
         }
 
         [WpfFact]
+        public void FullCycle()
+        {
+            SetUpEditor(@"
+Imports System
+Public Class TestClass
+    Public Sub Method()$$
+    End Sub
+
+    Sub Test()
+    End Sub
+
+    Sub Test(x As Integer)
+    End Sub
+
+    Sub Test(x As Integer, y As Integer)
+    End Sub
+End Class
+");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Enter);
+            VisualStudio.Editor.SendKeys("Tes");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("Test$$", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("Test($$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$, 0)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test($$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$, 0)", assertCaretPosition: true);
+        }
+
+        [WpfFact]
+        public void ImplicitArgumentSwitching()
+        {
+            SetUpEditor(@"
+Imports System
+Public Class TestClass
+    Public Sub Method()$$
+    End Sub
+
+    Sub Test()
+    End Sub
+
+    Sub Test(x As Integer)
+    End Sub
+
+    Sub Test(x As Integer, y As Integer)
+    End Sub
+End Class
+");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Enter);
+            VisualStudio.Editor.SendKeys("Tes");
+
+            // Trigger the session and type '0' without waiting for the session to finish initializing
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab, VirtualKey.Tab, '0');
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Down);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$, 0)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Up);
+            VisualStudio.Editor.Verify.CurrentLineText("Test(0$$)", assertCaretPosition: true);
+        }
+
+        [WpfFact]
         public void SmartBreakLineWithTabTabCompletion()
         {
             SetUpEditor(@"


### PR DESCRIPTION
* Update snippet model on explicit selection only (breaks cycles that could occur)
* Fix `FormatSpan` interfering with SignatureHelp
* Add tests for previously-broken behaviors