### PR TITLE
Hot Reload watch service

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
                 var mockCompilationOutputsProvider = new Func<Project, CompilationOutputs>(_ => new MockCompilationOutputs(Guid.NewGuid()));
 
-                var debuggingSession = new DebuggingSession(solution, mockCompilationOutputsProvider);
+                var debuggingSession = new DebuggingSession(solution, mockCompilationOutputsProvider, SpecializedCollections.EmptyEnumerable<KeyValuePair<DocumentId, CommittedSolution.DocumentState>>());
 
                 if (initialState != CommittedSolution.DocumentState.None)
                 {

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -132,13 +132,13 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
             // StartDebuggingSession
 
             var called = false;
-            mockEncService.StartDebuggingSessionImpl = solution =>
+            mockEncService.StartDebuggingSessionImpl = (solution, captureMatchingDocuments) =>
             {
                 Assert.Equal("proj", solution.Projects.Single().Name);
                 called = true;
             };
 
-            await proxy.StartDebuggingSessionAsync(localWorkspace.CurrentSolution, CancellationToken.None).ConfigureAwait(false);
+            await proxy.StartDebuggingSessionAsync(localWorkspace.CurrentSolution, captureMatchingDocuments: false, CancellationToken.None).ConfigureAwait(false);
             Assert.True(called);
 
             // StartEditSession

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Func<Solution, SolutionActiveStatementSpanProvider, ManagedInstructionId, LinePositionSpan?>? GetCurrentActiveStatementPositionImpl;
 
         public Func<Document, DocumentActiveStatementSpanProvider, ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>? GetAdjustedActiveStatementSpansImpl;
-        public Action<Solution>? StartDebuggingSessionImpl;
+        public Action<Solution, bool>? StartDebuggingSessionImpl;
         public StartEditSession? StartEditSessionImpl;
         public EndSession? EndDebuggingSessionImpl;
         public EndSession? EndEditSessionImpl;
@@ -76,8 +76,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public void OnSourceFileUpdated(Document document)
             => OnSourceFileUpdatedImpl?.Invoke(document);
 
-        public void StartDebuggingSession(Solution solution)
-            => StartDebuggingSessionImpl?.Invoke(solution);
+        public ValueTask StartDebuggingSessionAsync(Solution solution, bool captureMatchingDocuments, CancellationToken cancellationToken)
+        {
+            StartDebuggingSessionImpl?.Invoke(solution, captureMatchingDocuments);
+            return default;
+        }
 
         public void StartEditSession(IManagedEditAndContinueDebuggerService debuggerService, out ImmutableArray<DocumentId> documentsToReanalyze)
         {

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public EndSession? EndDebuggingSessionImpl;
         public EndSession? EndEditSessionImpl;
         public Func<Solution, SolutionActiveStatementSpanProvider, string?, bool>? HasChangesImpl;
-        public Func<Solution, SolutionActiveStatementSpanProvider, (ManagedModuleUpdates, ImmutableArray<DiagnosticData>)>? EmitSolutionUpdateImpl;
+        public Func<Solution, SolutionActiveStatementSpanProvider, EmitSolutionUpdateResults>? EmitSolutionUpdateImpl;
         public Func<Solution, ManagedInstructionId, bool?>? IsActiveStatementInExceptionRegionImpl;
         public Action<Document>? OnSourceFileUpdatedImpl;
         public Action? CommitSolutionUpdateImpl;
@@ -39,8 +39,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public void DiscardSolutionUpdate()
             => DiscardSolutionUpdateImpl?.Invoke();
 
-        public ValueTask<(ManagedModuleUpdates Updates, ImmutableArray<DiagnosticData> Diagnostics)>
-            EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
+        public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
             => new((EmitSolutionUpdateImpl ?? throw new NotImplementedException()).Invoke(solution, activeStatementSpanProvider));
 
         public void EndDebuggingSession(out ImmutableArray<DocumentId> documentsToReanalyze)

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -14,6 +14,8 @@ using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using System.IO;
 using System.Text;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -88,11 +90,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         private readonly object _guard = new();
 
-        public CommittedSolution(DebuggingSession debuggingSession, Solution solution)
+        public CommittedSolution(DebuggingSession debuggingSession, Solution solution, IEnumerable<KeyValuePair<DocumentId, DocumentState>> initialDocumentStates)
         {
             _solution = solution;
             _debuggingSession = debuggingSession;
             _documentState = new Dictionary<DocumentId, DocumentState>();
+            _documentState.AddRange(initialDocumentStates);
         }
 
         // test only
@@ -101,6 +104,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             lock (_guard)
             {
                 _documentState[documentId] = state;
+            }
+        }
+
+        // test only
+        internal ImmutableArray<(DocumentId id, DocumentState state)> Test_GetDocumentStates()
+        {
+            lock (_guard)
+            {
+                return _documentState.SelectAsArray(e => (e.Key, e.Value));
             }
         }
 
@@ -200,7 +212,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return (null, DocumentState.None);
             }
 
-            if (!PathUtilities.IsAbsolute(document.FilePath))
+            if (!EditAndContinueWorkspaceService.SupportsEditAndContinue(document.DocumentState))
             {
                 return (null, DocumentState.DesignTimeOnly);
             }
@@ -208,9 +220,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var sourceTextVersion = (committedDocument == null) ? await document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false) : default;
 
-            var (matchingSourceText, pdbHasDocument) = await Task.Run(
-                () => TryGetPdbMatchingSourceText(document.FilePath, sourceText.Encoding, document.Project),
-                cancellationToken).ConfigureAwait(false);
+            // run file IO on a background thread:
+            var (matchingSourceText, pdbHasDocument) = await Task.Run(() =>
+            {
+                var compilationOutputs = _debuggingSession.GetCompilationOutputs(document.Project);
+                using var debugInfoReaderProvider = GetMethodDebugInfoReader(compilationOutputs, document.Project.Name);
+                if (debugInfoReaderProvider == null)
+                {
+                    return (null, null);
+                }
+
+                var debugInfoReader = debugInfoReaderProvider.CreateEditAndContinueMethodDebugInfoReader();
+
+                Contract.ThrowIfNull(document.FilePath);
+                return TryGetPdbMatchingSourceText(debugInfoReader, document.FilePath, sourceText.Encoding);
+            }, cancellationToken).ConfigureAwait(false);
 
             lock (_guard)
             {
@@ -283,6 +307,79 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
+        internal static async Task<IEnumerable<KeyValuePair<DocumentId, CommittedSolution.DocumentState>>> GetMatchingDocumentsAsync(Solution solution, Func<Project, CompilationOutputs> compilationOutputsProvider, CancellationToken cancellationToken)
+        {
+            var projectTasks = solution.Projects.Select(async project =>
+            {
+                using var debugInfoReaderProvider = GetMethodDebugInfoReader(compilationOutputsProvider(project), project.Name);
+                if (debugInfoReaderProvider == null)
+                {
+                    return Array.Empty<DocumentId?>();
+                }
+
+                // Skip projects that do not support Roslyn EnC (e.g. F#, etc).
+                // Source files of these do not even need to be captured in the solution snapshot.
+                if (!EditAndContinueWorkspaceService.SupportsEditAndContinue(project))
+                {
+                    return Array.Empty<DocumentId?>();
+                }
+
+                var debugInfoReader = debugInfoReaderProvider.CreateEditAndContinueMethodDebugInfoReader();
+
+                var documentTasks = project.State.DocumentStates.States.Select(async documentState =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (EditAndContinueWorkspaceService.SupportsEditAndContinue(documentState))
+                    {
+                        var sourceFilePath = documentState.FilePath;
+                        Contract.ThrowIfNull(sourceFilePath);
+
+                        // Hydrate the solution snapshot with the content of the file.
+                        // It's important to do this before we start watching for changes so that we have a baseline we can compare future snapshots to.
+                        var sourceText = await documentState.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                        // TODO: https://github.com/dotnet/roslyn/issues/51993
+                        // avoid rereading the file in common case - the workspace should create source texts with the right checksum algorithm and encoding
+                        var (source, hasDocument) = TryGetPdbMatchingSourceText(debugInfoReader, sourceFilePath, sourceText.Encoding);
+                        if (source != null)
+                        {
+                            return documentState.Id;
+                        }
+                    }
+
+                    return null;
+                });
+
+                return await Task.WhenAll(documentTasks).ConfigureAwait(false);
+            });
+
+            var documentIdArrays = await Task.WhenAll(projectTasks).ConfigureAwait(false);
+
+            return documentIdArrays.SelectMany(ids => ids.WhereNotNull()).Select(id => KeyValuePairUtil.Create(id, DocumentState.MatchesBuildOutput));
+        }
+
+        private static DebugInformationReaderProvider? GetMethodDebugInfoReader(CompilationOutputs compilationOutputs, string projectName)
+        {
+            DebugInformationReaderProvider? debugInfoReaderProvider;
+            try
+            {
+                debugInfoReaderProvider = compilationOutputs.OpenPdb();
+
+                if (debugInfoReaderProvider == null)
+                {
+                    EditAndContinueWorkspaceService.Log.Write("Source file of project '{0}' doesn't match output PDB: PDB '{1}' not found", projectName, compilationOutputs.PdbDisplayPath);
+                }
+
+                return debugInfoReaderProvider;
+            }
+            catch (Exception e)
+            {
+                EditAndContinueWorkspaceService.Log.Write("Source file of project '{0}' doesn't match output PDB: error opening PDB '{1}': {2}", projectName, compilationOutputs.PdbDisplayPath, e.Message);
+                return null;
+            }
+        }
+
         public void CommitSolution(Solution solution)
         {
             lock (_guard)
@@ -291,9 +388,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private (SourceText? Source, bool? HasDocument) TryGetPdbMatchingSourceText(string sourceFilePath, Encoding? encoding, Project project)
+        private static (SourceText? Source, bool? HasDocument) TryGetPdbMatchingSourceText(EditAndContinueMethodDebugInfoReader debugInfoReader, string sourceFilePath, Encoding? encoding)
         {
-            var hasDocument = TryReadSourceFileChecksumFromPdb(sourceFilePath, project, out var symChecksum, out var algorithm);
+            var hasDocument = TryReadSourceFileChecksumFromPdb(debugInfoReader, sourceFilePath, out var symChecksum, out var algorithm);
             if (hasDocument != true)
             {
                 return (Source: null, hasDocument);
@@ -331,62 +428,31 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// False if the document is not found in the PDB.
         /// Null if it can't be determined because the PDB is not available or an error occurred while reading the PDB.
         /// </summary>
-        private bool? TryReadSourceFileChecksumFromPdb(string sourceFilePath, Project project, out ImmutableArray<byte> checksum, out SourceHashAlgorithm algorithm)
+        private static bool? TryReadSourceFileChecksumFromPdb(EditAndContinueMethodDebugInfoReader debugInfoReader, string sourceFilePath, out ImmutableArray<byte> checksum, out SourceHashAlgorithm algorithm)
         {
             checksum = default;
             algorithm = default;
 
             try
             {
-                var compilationOutputs = _debuggingSession.GetCompilationOutputs(project);
-
-                DebugInformationReaderProvider? debugInfoReaderProvider;
-                try
+                if (!debugInfoReader.TryGetDocumentChecksum(sourceFilePath, out checksum, out var algorithmId))
                 {
-                    debugInfoReaderProvider = compilationOutputs.OpenPdb();
-                }
-                catch (Exception e)
-                {
-                    EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match output PDB: error opening PDB '{1}': {2}", sourceFilePath, compilationOutputs.PdbDisplayPath, e.Message);
-                    debugInfoReaderProvider = null;
+                    EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match output PDB: no document", sourceFilePath);
+                    return false;
                 }
 
-                if (debugInfoReaderProvider == null)
+                algorithm = SourceHashAlgorithms.GetSourceHashAlgorithm(algorithmId);
+                if (algorithm == SourceHashAlgorithm.None)
                 {
-                    EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match output PDB: PDB '{1}' not found", sourceFilePath, compilationOutputs.PdbDisplayPath);
-                    return null;
+                    // This can only happen if the PDB was post-processed by a misbehaving tool.
+                    EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match PDB: unknown checksum alg", sourceFilePath);
                 }
 
-                try
-                {
-                    var debugInfoReader = debugInfoReaderProvider.CreateEditAndContinueMethodDebugInfoReader();
-                    if (!debugInfoReader.TryGetDocumentChecksum(sourceFilePath, out checksum, out var algorithmId))
-                    {
-                        EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match output PDB: no document", sourceFilePath);
-                        return false;
-                    }
-
-                    algorithm = SourceHashAlgorithms.GetSourceHashAlgorithm(algorithmId);
-                    if (algorithm == SourceHashAlgorithm.None)
-                    {
-                        // This can only happen if the PDB was post-processed by a misbehaving tool.
-                        EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match PDB: unknown checksum alg", sourceFilePath);
-                    }
-
-                    return true;
-                }
-                catch (Exception e)
-                {
-                    EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match output PDB: error reading symbols: {1}", sourceFilePath, e.Message);
-                }
-                finally
-                {
-                    debugInfoReaderProvider.Dispose();
-                }
+                return true;
             }
-            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
+            catch (Exception e)
             {
-                EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match PDB: unexpected exception: {1}", sourceFilePath, e.Message);
+                EditAndContinueWorkspaceService.Log.Write("Source '{0}' doesn't match output PDB: error reading symbols: {1}", sourceFilePath, e.Message);
             }
 
             return null;

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -3,19 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Debugging;
-using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using System.IO;
-using System.Text;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -87,14 +87,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         internal DebuggingSession(
             Solution solution,
-            Func<Project, CompilationOutputs> compilationOutputsProvider)
+            Func<Project, CompilationOutputs> compilationOutputsProvider,
+            IEnumerable<KeyValuePair<DocumentId, CommittedSolution.DocumentState>> initialDocumentStates)
         {
             _compilationOutputsProvider = compilationOutputsProvider;
             _projectModuleIds = new Dictionary<ProjectId, (Guid, Diagnostic)>();
             _projectEmitBaselines = new Dictionary<ProjectId, EmitBaseline>();
             _modulesPreparedForUpdate = new HashSet<Guid>();
 
-            LastCommittedSolution = new CommittedSolution(this, solution);
+            LastCommittedSolution = new CommittedSolution(this, solution, initialDocumentStates);
             NonRemappableRegions = ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty;
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -154,8 +154,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal static bool SupportsEditAndContinue(Project project)
             => project.LanguageServices.GetService<IEditAndContinueAnalyzer>() != null;
 
+        // Note: source generated files have relative paths: https://github.com/dotnet/roslyn/issues/51998
         internal static bool SupportsEditAndContinue(DocumentState documentState)
-            => !documentState.Attributes.DesignTimeOnly && documentState.SupportsSyntaxTree && PathUtilities.IsAbsolute(documentState.FilePath);
+            => !documentState.Attributes.DesignTimeOnly && documentState.SupportsSyntaxTree &&
+               (PathUtilities.IsAbsolute(documentState.FilePath) || documentState is SourceGeneratedDocumentState);
 
         public async ValueTask<ImmutableArray<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, DocumentActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue
+{
+    internal readonly struct EmitSolutionUpdateResults
+    {
+        public static readonly EmitSolutionUpdateResults Empty =
+            new(new ManagedModuleUpdates(ManagedModuleUpdateStatus.None, ImmutableArray<ManagedModuleUpdate>.Empty),
+                ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)>.Empty);
+
+        public readonly ManagedModuleUpdates ModuleUpdates;
+        public readonly ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)> Diagnostics;
+
+        public EmitSolutionUpdateResults(ManagedModuleUpdates moduleUpdates, ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)> diagnostics)
+        {
+            ModuleUpdates = moduleUpdates;
+            Diagnostics = diagnostics;
+        }
+
+        public ImmutableArray<DiagnosticData> GetDiagnosticData(Solution solution)
+        {
+            using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var result);
+
+            foreach (var (projectId, diagnostics) in Diagnostics)
+            {
+                var project = solution.GetRequiredProject(projectId);
+
+                foreach (var diagnostic in diagnostics)
+                {
+                    var document = solution.GetDocument(diagnostic.Location.SourceTree);
+                    var data = (document != null) ? DiagnosticData.Create(diagnostic, document) : DiagnosticData.Create(diagnostic, project);
+                    result.Add(data);
+                }
+            }
+
+            return result.ToImmutable();
+        }
+    }
+}

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         void OnSourceFileUpdated(Document document);
 
-        void StartDebuggingSession(Solution solution);
+        ValueTask StartDebuggingSessionAsync(Solution solution, bool captureMatchingDocuments, CancellationToken cancellationToken);
         void StartEditSession(IManagedEditAndContinueDebuggerService debuggerService, out ImmutableArray<DocumentId> documentsToReanalyze);
         void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
         void EndDebuggingSession(out ImmutableArray<DocumentId> documentsToReanalyze);

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     {
         ValueTask<ImmutableArray<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, DocumentActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
         ValueTask<bool> HasChangesAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, string? sourceFilePath, CancellationToken cancellationToken);
-        ValueTask<(ManagedModuleUpdates Updates, ImmutableArray<DiagnosticData> Diagnostics)> EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
+        ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
 
         void CommitSolutionUpdate();
         void DiscardSolutionUpdate();

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ValueTask CommitSolutionUpdateAsync(CancellationToken cancellationToken);
         ValueTask DiscardSolutionUpdateAsync(CancellationToken cancellationToken);
 
-        ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken);
+        ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, bool captureMatchingDocuments, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<DocumentId>> StartEditSessionAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<DocumentId>> EndEditSessionAsync(CancellationToken cancellationToken);
         ValueTask<ImmutableArray<DocumentId>> EndDebuggingSessionAsync(CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
@@ -149,18 +149,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private IEditAndContinueWorkspaceService GetLocalService()
             => Workspace.Services.GetRequiredService<IEditAndContinueWorkspaceService>();
 
-        public async ValueTask StartDebuggingSessionAsync(Solution solution, CancellationToken cancellationToken)
+        public async ValueTask StartDebuggingSessionAsync(Solution solution, bool captureMatchingDocuments, CancellationToken cancellationToken)
         {
             var client = await RemoteHostClient.TryGetClientAsync(Workspace, cancellationToken).ConfigureAwait(false);
             if (client == null)
             {
-                GetLocalService().StartDebuggingSession(solution);
+                await GetLocalService().StartDebuggingSessionAsync(solution, captureMatchingDocuments, cancellationToken).ConfigureAwait(false);
                 return;
             }
 
             await client.TryInvokeAsync<IRemoteEditAndContinueService>(
                 solution,
-                (service, solutionInfo, cancellationToken) => service.StartDebuggingSessionAsync(solutionInfo, cancellationToken),
+                async (service, solutionInfo, cancellationToken) => await service.StartDebuggingSessionAsync(solutionInfo, captureMatchingDocuments, cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
@@ -301,13 +301,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         public async ValueTask<ManagedModuleUpdates> EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, EditAndContinueDiagnosticUpdateSource diagnosticUpdateSource, CancellationToken cancellationToken)
         {
-            ManagedModuleUpdates updates;
-            ImmutableArray<DiagnosticData> diagnosticsByProject;
+            ManagedModuleUpdates moduleUpdates;
+            ImmutableArray<DiagnosticData> diagnosticData;
 
             var client = await RemoteHostClient.TryGetClientAsync(Workspace, cancellationToken).ConfigureAwait(false);
             if (client == null)
             {
-                (updates, diagnosticsByProject) = await GetLocalService().EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+                var results = await GetLocalService().EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+                moduleUpdates = results.ModuleUpdates;
+                diagnosticData = results.GetDiagnosticData(solution);
             }
             else
             {
@@ -319,12 +321,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (result.HasValue)
                 {
-                    (updates, diagnosticsByProject) = result.Value;
+                    (moduleUpdates, diagnosticData) = result.Value;
                 }
                 else
                 {
-                    updates = new ManagedModuleUpdates(ManagedModuleUpdateStatus.Blocked, ImmutableArray<ManagedModuleUpdate>.Empty);
-                    diagnosticsByProject = ImmutableArray<DiagnosticData>.Empty;
+                    moduleUpdates = new ManagedModuleUpdates(ManagedModuleUpdateStatus.Blocked, ImmutableArray<ManagedModuleUpdate>.Empty);
+                    diagnosticData = ImmutableArray<DiagnosticData>.Empty;
                 }
             }
 
@@ -332,9 +334,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             diagnosticUpdateSource.ClearDiagnostics();
 
             // report emit/apply diagnostics:
-            diagnosticUpdateSource.ReportDiagnostics(Workspace, solution, diagnosticsByProject);
+            diagnosticUpdateSource.ReportDiagnostics(Workspace, solution, diagnosticData);
 
-            return updates;
+            return moduleUpdates;
         }
 
         public async ValueTask CommitSolutionUpdateAsync(CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
+{
+    internal sealed class WatchHotReloadService
+    {
+        private sealed class DebuggerService : IManagedEditAndContinueDebuggerService
+        {
+            public static readonly DebuggerService Instance = new();
+
+            public Task<ImmutableArray<ManagedActiveStatementDebugInfo>> GetActiveStatementsAsync(CancellationToken cancellationToken)
+                => Task.FromResult(ImmutableArray<ManagedActiveStatementDebugInfo>.Empty);
+
+            public Task<ManagedEditAndContinueAvailability> GetAvailabilityAsync(Guid module, CancellationToken cancellationToken)
+                => Task.FromResult(new ManagedEditAndContinueAvailability(ManagedEditAndContinueAvailabilityStatus.Available));
+
+            public Task PrepareModuleForUpdateAsync(Guid module, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+        }
+
+        public readonly struct Update
+        {
+            public readonly Guid ModuleId;
+            public readonly ImmutableArray<byte> ILDelta;
+            public readonly ImmutableArray<byte> MetadataDelta;
+            public readonly ImmutableArray<byte> PdbDelta;
+
+            public Update(Guid moduleId, ImmutableArray<byte> ilDelta, ImmutableArray<byte> metadataDelta, ImmutableArray<byte> pdbDelta)
+            {
+                ModuleId = moduleId;
+                ILDelta = ilDelta;
+                MetadataDelta = metadataDelta;
+                PdbDelta = pdbDelta;
+            }
+        }
+
+        private static readonly SolutionActiveStatementSpanProvider s_solutionActiveStatementSpanProvider =
+            (_, _) => ValueTaskFactory.FromResult(ImmutableArray<TextSpan>.Empty);
+
+        private readonly IEditAndContinueWorkspaceService _encService;
+
+        public WatchHotReloadService(HostWorkspaceServices services)
+            => _encService = services.GetRequiredService<IEditAndContinueWorkspaceService>();
+
+        /// <summary>
+        /// Starts the watcher.
+        /// </summary>
+        /// <param name="solution">Solution that represents sources that match the built binaries on disk.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns></returns>
+        public async Task StartSessionAsync(Solution solution, CancellationToken cancellationToken)
+            => await _encService.StartDebuggingSessionAsync(solution, captureMatchingDocuments: true, cancellationToken).ConfigureAwait(false);
+
+        public async Task<(ImmutableArray<Update> updates, ImmutableArray<DiagnosticData> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
+        {
+            _encService.StartEditSession(DebuggerService.Instance, out _);
+
+            var (updates, diagnostics) = await _encService.EmitSolutionUpdateAsync(solution, s_solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+
+            if (updates.Status == ManagedModuleUpdateStatus.Ready)
+            {
+                _encService.CommitSolutionUpdate();
+            }
+
+            _encService.EndEditSession(out _);
+
+            if (updates.Status == ManagedModuleUpdateStatus.Blocked)
+            {
+                return default;
+            }
+
+            return (updates.Updates.SelectAsArray(update => new Update(update.Module, update.ILDelta, update.MetadataDelta, update.PdbDelta)), diagnostics);
+        }
+
+        public void EndSession()
+            => _encService.EndDebuggingSession(out _);
+    }
+}

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -30,6 +30,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.UnitTesting" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Watch" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CodeLens" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -30,7 +30,6 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.UnitTesting" />
-    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Watch" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CodeLens" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
             try
             {
                 var solution = _proxy.Workspace.CurrentSolution;
-                await _proxy.StartDebuggingSessionAsync(solution, cancellationToken).ConfigureAwait(false);
+                await _proxy.StartDebuggingSessionAsync(solution, captureMatchingDocuments: false, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        private DocumentState DocumentState => (DocumentState)State;
+        internal DocumentState DocumentState => (DocumentState)State;
 
         /// <summary>
         /// The kind of source code this document contains.

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -66,12 +66,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Remote API.
         /// </summary>
-        public ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
+        public ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, bool captureMatchingDocuments, CancellationToken cancellationToken)
         {
             return RunServiceAsync(async cancellationToken =>
             {
                 var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-                GetService().StartDebuggingSession(solution);
+                await GetService().StartDebuggingSessionAsync(solution, captureMatchingDocuments, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -155,7 +155,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 try
                 {
-                    return await service.EmitSolutionUpdateAsync(solution, CreateSolutionActiveStatementSpanProvider(callbackId), cancellationToken).ConfigureAwait(false);
+                    var results = await service.EmitSolutionUpdateAsync(solution, CreateSolutionActiveStatementSpanProvider(callbackId), cancellationToken).ConfigureAwait(false);
+                    return (results.ModuleUpdates, results.GetDiagnosticData(solution));
                 }
                 catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
                 {


### PR DESCRIPTION
Implements `WatchHotReloadService` wrapper around `IEditAndContinueWorkspaceService` that exposes EnC functionality in a shape suitable for dotnet watch. 

Adds new capability to `StartDebuggingSessionAsync` that allows the EnC service to hydrate the content of files that support EnC in the given solution snapshot and checks that the sources match the checksums stored in the PDB. Matching document ids are cached so that the validation does not need to be redone when emitting deltas later on.

Implements https://github.com/dotnet/roslyn/issues/50773
