### PR TITLE
Fix additional cancellation case for GetAssetsAsync

### DIFF
--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -102,7 +102,17 @@ namespace Microsoft.CodeAnalysis.Remote
                 finally
                 {
                     await localPipe.Reader.CompleteAsync(exception).ConfigureAwait(false);
-                    await pipeWriter.CompleteAsync(exception).ConfigureAwait(false);
+
+                    if (cancellationToken.IsCancellationRequested && exception is null or OperationCanceledException)
+                    {
+                        // Throw rather than close the pipe writer. The caller will coordinate cancellation and closing
+                        // of the reader and writer together.
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                    else
+                    {
+                        await pipeWriter.CompleteAsync(exception).ConfigureAwait(false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This change ensures the writer callback for `InvokeStreamingServiceAsync` only closes the pipe writer in two cases:

* All data is written
* An error (non-cancellation) occurred

For the cancellation case, `InvokeStreamingServiceAsync` manages closing the pipe writer to ensure it is coordinated with cancellation of the reader.