### PR TITLE
Correctly handle conversions in null coalescing

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -635,7 +635,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <remarks>
         /// Implicit and explicit user-defined conversions are described in section 6.4 of the C# language specification.
         /// </remarks>
-        [MemberNotNullWhen(true, nameof(Method), nameof(MethodSymbol))]
         public bool IsUserDefined
         {
             get

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -634,6 +635,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <remarks>
         /// Implicit and explicit user-defined conversions are described in section 6.4 of the C# language specification.
         /// </remarks>
+        [MemberNotNullWhen(true, nameof(Method), nameof(MethodSymbol))]
         public bool IsUserDefined
         {
             get


### PR DESCRIPTION
We weren't correctly using the results of the left conversion for cases when the rhs of a null-coalescing assignment determines the output type and was a user-defined conversion. I've also added tests for #29955, which I don't believe needs to be addressed as I couldn't find any scenario that was broken due to it.

Fixes https://github.com/dotnet/roslyn/issues/51975. Fixes https://github.com/dotnet/roslyn/issues/29955.
