### PR TITLE
Fix for: "Information Loss" caused by use of default in SyntaxNode-Update methods #51997

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class BlockSyntax
     {
         public BlockSyntax Update(SyntaxToken openBraceToken, SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
-            => Update(attributeLists: AttributeLists, openBraceToken, statements, closeBraceToken);
+            => Update(AttributeLists, openBraceToken, statements, closeBraceToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class BlockSyntax
     {
         public BlockSyntax Update(SyntaxToken openBraceToken, SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
-            => Update(attributeLists: default, openBraceToken, statements, closeBraceToken);
+            => Update(attributeLists: AttributeLists, openBraceToken, statements, closeBraceToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class BreakStatementSyntax
     {
         public BreakStatementSyntax Update(SyntaxToken breakKeyword, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, breakKeyword, semicolonToken);
+            => Update(AttributeLists, breakKeyword, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class BreakStatementSyntax
     {
         public BreakStatementSyntax Update(SyntaxToken breakKeyword, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, breakKeyword, semicolonToken);
+            => Update(attributeLists: AttributeLists, breakKeyword, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/CheckedStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CheckedStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class CheckedStatementSyntax
     {
         public CheckedStatementSyntax Update(SyntaxToken keyword, BlockSyntax block)
-            => Update(attributeLists: AttributeLists, keyword, block);
+            => Update(AttributeLists, keyword, block);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/CheckedStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CheckedStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class CheckedStatementSyntax
     {
         public CheckedStatementSyntax Update(SyntaxToken keyword, BlockSyntax block)
-            => Update(attributeLists: default, keyword, block);
+            => Update(attributeLists: AttributeLists, keyword, block);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ContinueStatementSyntax
     {
         public ContinueStatementSyntax Update(SyntaxToken continueKeyword, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, continueKeyword, semicolonToken);
+            => Update(attributeLists: AttributeLists, continueKeyword, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ContinueStatementSyntax
     {
         public ContinueStatementSyntax Update(SyntaxToken continueKeyword, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, continueKeyword, semicolonToken);
+            => Update(AttributeLists, continueKeyword, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/DoStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/DoStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class DoStatementSyntax
     {
         public DoStatementSyntax Update(SyntaxToken doKeyword, StatementSyntax statement, SyntaxToken whileKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, doKeyword, statement, whileKeyword, openParenToken, condition, closeParenToken, semicolonToken);
+            => Update(AttributeLists, doKeyword, statement, whileKeyword, openParenToken, condition, closeParenToken, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/DoStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/DoStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class DoStatementSyntax
     {
         public DoStatementSyntax Update(SyntaxToken doKeyword, StatementSyntax statement, SyntaxToken whileKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, doKeyword, statement, whileKeyword, openParenToken, condition, closeParenToken, semicolonToken);
+            => Update(attributeLists: AttributeLists, doKeyword, statement, whileKeyword, openParenToken, condition, closeParenToken, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/EmptyStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/EmptyStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class EmptyStatementSyntax
     {
         public EmptyStatementSyntax Update(SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, semicolonToken);
+            => Update(AttributeLists, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/EmptyStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/EmptyStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class EmptyStatementSyntax
     {
         public EmptyStatementSyntax Update(SyntaxToken semicolonToken)
-            => Update(attributeLists: default, semicolonToken);
+            => Update(attributeLists: AttributeLists, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/EventDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/EventDeclarationSyntax.cs
@@ -12,12 +12,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     {
         public EventDeclarationSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken eventKeyword, TypeSyntax type, ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, SyntaxToken identifier, AccessorListSyntax accessorList)
         {
-            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList, semicolonToken: SemicolonToken);
+            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList, SemicolonToken);
         }
 
         public EventDeclarationSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken eventKeyword, TypeSyntax type, ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, SyntaxToken identifier, SyntaxToken semicolonToken)
         {
-            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList: AccessorList, semicolonToken);
+            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, AccessorList, semicolonToken);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/EventDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/EventDeclarationSyntax.cs
@@ -12,12 +12,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     {
         public EventDeclarationSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken eventKeyword, TypeSyntax type, ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, SyntaxToken identifier, AccessorListSyntax accessorList)
         {
-            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList, semicolonToken: default);
+            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList, semicolonToken: SemicolonToken);
         }
 
         public EventDeclarationSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken eventKeyword, TypeSyntax type, ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, SyntaxToken identifier, SyntaxToken semicolonToken)
         {
-            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList: null, semicolonToken);
+            return Update(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList: AccessorList, semicolonToken);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/ExpressionStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ExpressionStatementSyntax.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         }
 
         public ExpressionStatementSyntax Update(ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, expression, semicolonToken);
+            => Update(AttributeLists, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ExpressionStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ExpressionStatementSyntax.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         }
 
         public ExpressionStatementSyntax Update(ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, expression, semicolonToken);
+            => Update(attributeLists: AttributeLists, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/FixedStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/FixedStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class FixedStatementSyntax
     {
         public FixedStatementSyntax Update(SyntaxToken fixedKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, fixedKeyword, openParenToken, declaration, closeParenToken, statement);
+            => Update(AttributeLists, fixedKeyword, openParenToken, declaration, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/FixedStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/FixedStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class FixedStatementSyntax
     {
         public FixedStatementSyntax Update(SyntaxToken fixedKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: default, fixedKeyword, openParenToken, declaration, closeParenToken, statement);
+            => Update(attributeLists: AttributeLists, fixedKeyword, openParenToken, declaration, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ForEachStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ForEachStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ForEachStatementSyntax
     {
         public ForEachStatementSyntax Update(SyntaxToken forEachKeyword, SyntaxToken openParenToken, TypeSyntax type, SyntaxToken identifier, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(awaitKeyword: default, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
+            => Update(awaitKeyword: AwaitKeyword, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
 
         public ForEachStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken forEachKeyword, SyntaxToken openParenToken, TypeSyntax type, SyntaxToken identifier, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: default, awaitKeyword, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
+            => Update(attributeLists: AttributeLists, awaitKeyword, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ForEachStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ForEachStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ForEachStatementSyntax
     {
         public ForEachStatementSyntax Update(SyntaxToken forEachKeyword, SyntaxToken openParenToken, TypeSyntax type, SyntaxToken identifier, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(awaitKeyword: AwaitKeyword, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
+            => Update(AwaitKeyword, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
 
         public ForEachStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken forEachKeyword, SyntaxToken openParenToken, TypeSyntax type, SyntaxToken identifier, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, awaitKeyword, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
+            => Update(AttributeLists, awaitKeyword, forEachKeyword, openParenToken, type, identifier, inKeyword, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ForEachVariableStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ForEachVariableStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ForEachVariableStatementSyntax
     {
         public ForEachVariableStatementSyntax Update(SyntaxToken forEachKeyword, SyntaxToken openParenToken, ExpressionSyntax variable, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(awaitKeyword: default, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
+            => Update(awaitKeyword: AwaitKeyword, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
 
         public ForEachVariableStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken forEachKeyword, SyntaxToken openParenToken, ExpressionSyntax variable, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: default, awaitKeyword, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
+            => Update(attributeLists: AttributeLists, awaitKeyword, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ForEachVariableStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ForEachVariableStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ForEachVariableStatementSyntax
     {
         public ForEachVariableStatementSyntax Update(SyntaxToken forEachKeyword, SyntaxToken openParenToken, ExpressionSyntax variable, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(awaitKeyword: AwaitKeyword, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
+            => Update(AwaitKeyword, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
 
         public ForEachVariableStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken forEachKeyword, SyntaxToken openParenToken, ExpressionSyntax variable, SyntaxToken inKeyword, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, awaitKeyword, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
+            => Update(AttributeLists, awaitKeyword, forEachKeyword, openParenToken, variable, inKeyword, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ForStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ForStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ForStatementSyntax
     {
         public ForStatementSyntax Update(SyntaxToken forKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, SeparatedSyntaxList<ExpressionSyntax> initializers, SyntaxToken firstSemicolonToken, ExpressionSyntax condition, SyntaxToken secondSemicolonToken, SeparatedSyntaxList<ExpressionSyntax> incrementors, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: default, forKeyword, openParenToken, declaration, initializers, firstSemicolonToken, condition, secondSemicolonToken, incrementors, closeParenToken, statement);
+            => Update(attributeLists: AttributeLists, forKeyword, openParenToken, declaration, initializers, firstSemicolonToken, condition, secondSemicolonToken, incrementors, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ForStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ForStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ForStatementSyntax
     {
         public ForStatementSyntax Update(SyntaxToken forKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, SeparatedSyntaxList<ExpressionSyntax> initializers, SyntaxToken firstSemicolonToken, ExpressionSyntax condition, SyntaxToken secondSemicolonToken, SeparatedSyntaxList<ExpressionSyntax> incrementors, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, forKeyword, openParenToken, declaration, initializers, firstSemicolonToken, condition, secondSemicolonToken, incrementors, closeParenToken, statement);
+            => Update(AttributeLists, forKeyword, openParenToken, declaration, initializers, firstSemicolonToken, condition, secondSemicolonToken, incrementors, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/GotoStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/GotoStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class GotoStatementSyntax
     {
         public GotoStatementSyntax Update(SyntaxToken gotoKeyword, SyntaxToken caseOrDefaultKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken);
+            => Update(AttributeLists, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/GotoStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/GotoStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class GotoStatementSyntax
     {
         public GotoStatementSyntax Update(SyntaxToken gotoKeyword, SyntaxToken caseOrDefaultKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken);
+            => Update(attributeLists: AttributeLists, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class IfStatementSyntax
     {
         public IfStatementSyntax Update(SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax @else)
-            => Update(attributeLists: default, ifKeyword, openParenToken, condition, closeParenToken, statement, @else);
+            => Update(attributeLists: AttributeLists, ifKeyword, openParenToken, condition, closeParenToken, statement, @else);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class IfStatementSyntax
     {
         public IfStatementSyntax Update(SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax @else)
-            => Update(attributeLists: AttributeLists, ifKeyword, openParenToken, condition, closeParenToken, statement, @else);
+            => Update(AttributeLists, ifKeyword, openParenToken, condition, closeParenToken, statement, @else);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/LabeledStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LabeledStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class LabeledStatementSyntax
     {
         public LabeledStatementSyntax Update(SyntaxToken identifier, SyntaxToken colonToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, identifier, colonToken, statement);
+            => Update(AttributeLists, identifier, colonToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/LabeledStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LabeledStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class LabeledStatementSyntax
     {
         public LabeledStatementSyntax Update(SyntaxToken identifier, SyntaxToken colonToken, StatementSyntax statement)
-            => Update(attributeLists: default, identifier, colonToken, statement);
+            => Update(attributeLists: AttributeLists, identifier, colonToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/LocalDeclarationStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LocalDeclarationStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class LocalDeclarationStatementSyntax
     {
         public LocalDeclarationStatementSyntax Update(SyntaxTokenList modifiers, VariableDeclarationSyntax declaration, SyntaxToken semicolonToken)
-            => Update(awaitKeyword: AwaitKeyword, usingKeyword: UsingKeyword, modifiers, declaration, semicolonToken);
+            => Update(AwaitKeyword, UsingKeyword, modifiers, declaration, semicolonToken);
 
         public LocalDeclarationStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken usingKeyword, SyntaxTokenList modifiers, VariableDeclarationSyntax declaration, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, awaitKeyword, usingKeyword, modifiers, declaration, semicolonToken);
+            => Update(AttributeLists, awaitKeyword, usingKeyword, modifiers, declaration, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/LocalDeclarationStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LocalDeclarationStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class LocalDeclarationStatementSyntax
     {
         public LocalDeclarationStatementSyntax Update(SyntaxTokenList modifiers, VariableDeclarationSyntax declaration, SyntaxToken semicolonToken)
-            => Update(awaitKeyword: default, usingKeyword: default, modifiers, declaration, semicolonToken);
+            => Update(awaitKeyword: AwaitKeyword, usingKeyword: UsingKeyword, modifiers, declaration, semicolonToken);
 
         public LocalDeclarationStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken usingKeyword, SyntaxTokenList modifiers, VariableDeclarationSyntax declaration, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, awaitKeyword, usingKeyword, modifiers, declaration, semicolonToken);
+            => Update(attributeLists: AttributeLists, awaitKeyword, usingKeyword, modifiers, declaration, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/LocalFunctionStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LocalFunctionStatementSyntax.cs
@@ -4,6 +4,18 @@
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+namespace Microsoft.CodeAnalysis.CSharp.Syntax
+{
+    public partial class LocalFunctionStatementSyntax
+    {
+        // Preserved as shipped public API for binary compatibility
+        public LocalFunctionStatementSyntax Update(SyntaxTokenList modifiers, TypeSyntax returnType, SyntaxToken identifier, TypeParameterListSyntax typeParameterList, ParameterListSyntax parameterList, SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody, SyntaxToken semicolonToken)
+        {
+            return Update(attributeLists: AttributeLists, modifiers, returnType, identifier, typeParameterList, parameterList, constraintClauses, body, expressionBody, semicolonToken);
+        }
+    }
+}
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
     public partial class SyntaxFactory
@@ -18,18 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static LocalFunctionStatementSyntax LocalFunctionStatement(SyntaxTokenList modifiers, TypeSyntax returnType, SyntaxToken identifier, TypeParameterListSyntax typeParameterList, ParameterListSyntax parameterList, SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody, SyntaxToken semicolonToken)
         {
             return LocalFunctionStatement(attributeLists: default, modifiers, returnType, identifier, typeParameterList, parameterList, constraintClauses, body, expressionBody, semicolonToken);
-        }
-    }
-}
-
-namespace Microsoft.CodeAnalysis.CSharp.Syntax
-{
-    public partial class LocalFunctionStatementSyntax
-    {
-        // Preserved as shipped public API for binary compatibility
-        public LocalFunctionStatementSyntax Update(SyntaxTokenList modifiers, TypeSyntax returnType, SyntaxToken identifier, TypeParameterListSyntax typeParameterList, ParameterListSyntax parameterList, SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody, SyntaxToken semicolonToken)
-        {
-            return Update(attributeLists: default, modifiers, returnType, identifier, typeParameterList, parameterList, constraintClauses, body, expressionBody, semicolonToken);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/LocalFunctionStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LocalFunctionStatementSyntax.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         // Preserved as shipped public API for binary compatibility
         public LocalFunctionStatementSyntax Update(SyntaxTokenList modifiers, TypeSyntax returnType, SyntaxToken identifier, TypeParameterListSyntax typeParameterList, ParameterListSyntax parameterList, SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody, SyntaxToken semicolonToken)
         {
-            return Update(attributeLists: AttributeLists, modifiers, returnType, identifier, typeParameterList, parameterList, constraintClauses, body, expressionBody, semicolonToken);
+            return Update(AttributeLists, modifiers, returnType, identifier, typeParameterList, parameterList, constraintClauses, body, expressionBody, semicolonToken);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/LockStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LockStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class LockStatementSyntax
     {
         public LockStatementSyntax Update(SyntaxToken lockKeyword, SyntaxToken openParenToken, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: default, lockKeyword, openParenToken, expression, closeParenToken, statement);
+            => Update(attributeLists: AttributeLists, lockKeyword, openParenToken, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/LockStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LockStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class LockStatementSyntax
     {
         public LockStatementSyntax Update(SyntaxToken lockKeyword, SyntaxToken openParenToken, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, lockKeyword, openParenToken, expression, closeParenToken, statement);
+            => Update(AttributeLists, lockKeyword, openParenToken, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/RefTypeSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/RefTypeSyntax.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     {
         public RefTypeSyntax Update(SyntaxToken refKeyword, TypeSyntax type)
         {
-            return Update(refKeyword, readOnlyKeyword: default, type);
+            return Update(refKeyword, readOnlyKeyword: ReadOnlyKeyword, type);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/RefTypeSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/RefTypeSyntax.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     {
         public RefTypeSyntax Update(SyntaxToken refKeyword, TypeSyntax type)
         {
-            return Update(refKeyword, readOnlyKeyword: ReadOnlyKeyword, type);
+            return Update(refKeyword, ReadOnlyKeyword, type);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ReturnStatementSyntax
     {
         public ReturnStatementSyntax Update(SyntaxToken returnKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, returnKeyword, expression, semicolonToken);
+            => Update(AttributeLists, returnKeyword, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ReturnStatementSyntax
     {
         public ReturnStatementSyntax Update(SyntaxToken returnKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, returnKeyword, expression, semicolonToken);
+            => Update(attributeLists: AttributeLists, returnKeyword, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/StackAllocArrayCreationExpressionSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/StackAllocArrayCreationExpressionSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class StackAllocArrayCreationExpressionSyntax
     {
         public StackAllocArrayCreationExpressionSyntax Update(SyntaxToken stackAllocKeyword, TypeSyntax type)
-            => Update(StackAllocKeyword, type, initializer: null);
+            => Update(StackAllocKeyword, type, initializer: Initializer);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/StackAllocArrayCreationExpressionSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/StackAllocArrayCreationExpressionSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class StackAllocArrayCreationExpressionSyntax
     {
         public StackAllocArrayCreationExpressionSyntax Update(SyntaxToken stackAllocKeyword, TypeSyntax type)
-            => Update(StackAllocKeyword, type, initializer: Initializer);
+            => Update(StackAllocKeyword, type, Initializer);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SwitchStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SwitchStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class SwitchStatementSyntax
     {
         public SwitchStatementSyntax Update(SyntaxToken switchKeyword, SyntaxToken openParenToken, ExpressionSyntax expression, SyntaxToken closeParenToken, SyntaxToken openBraceToken, SyntaxList<SwitchSectionSyntax> sections, SyntaxToken closeBraceToken)
-            => Update(attributeLists: default, switchKeyword, openParenToken, expression, closeParenToken, openBraceToken, sections, closeBraceToken);
+            => Update(attributeLists: AttributeLists, switchKeyword, openParenToken, expression, closeParenToken, openBraceToken, sections, closeBraceToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SwitchStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SwitchStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class SwitchStatementSyntax
     {
         public SwitchStatementSyntax Update(SyntaxToken switchKeyword, SyntaxToken openParenToken, ExpressionSyntax expression, SyntaxToken closeParenToken, SyntaxToken openBraceToken, SyntaxList<SwitchSectionSyntax> sections, SyntaxToken closeBraceToken)
-            => Update(attributeLists: AttributeLists, switchKeyword, openParenToken, expression, closeParenToken, openBraceToken, sections, closeBraceToken);
+            => Update(AttributeLists, switchKeyword, openParenToken, expression, closeParenToken, openBraceToken, sections, closeBraceToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ThrowStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ThrowStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ThrowStatementSyntax
     {
         public ThrowStatementSyntax Update(SyntaxToken throwKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, throwKeyword, expression, semicolonToken);
+            => Update(attributeLists: AttributeLists, throwKeyword, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/ThrowStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ThrowStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ThrowStatementSyntax
     {
         public ThrowStatementSyntax Update(SyntaxToken throwKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, throwKeyword, expression, semicolonToken);
+            => Update(AttributeLists, throwKeyword, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class TryStatementSyntax
     {
         public TryStatementSyntax Update(SyntaxToken tryKeyword, BlockSyntax block, SyntaxList<CatchClauseSyntax> catches, FinallyClauseSyntax @finally)
-            => Update(attributeLists: default, tryKeyword, block, catches, @finally);
+            => Update(attributeLists: AttributeLists, tryKeyword, block, catches, @finally);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class TryStatementSyntax
     {
         public TryStatementSyntax Update(SyntaxToken tryKeyword, BlockSyntax block, SyntaxList<CatchClauseSyntax> catches, FinallyClauseSyntax @finally)
-            => Update(attributeLists: AttributeLists, tryKeyword, block, catches, @finally);
+            => Update(AttributeLists, tryKeyword, block, catches, @finally);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/UnsafeStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/UnsafeStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class UnsafeStatementSyntax
     {
         public UnsafeStatementSyntax Update(SyntaxToken unsafeKeyword, BlockSyntax block)
-            => Update(attributeLists: default, unsafeKeyword, block);
+            => Update(attributeLists: AttributeLists, unsafeKeyword, block);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/UnsafeStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/UnsafeStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class UnsafeStatementSyntax
     {
         public UnsafeStatementSyntax Update(SyntaxToken unsafeKeyword, BlockSyntax block)
-            => Update(attributeLists: AttributeLists, unsafeKeyword, block);
+            => Update(AttributeLists, unsafeKeyword, block);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/UsingStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/UsingStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class UsingStatementSyntax
     {
         public UsingStatementSyntax Update(SyntaxToken usingKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(awaitKeyword: AwaitKeyword, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
+            => Update(AwaitKeyword, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
 
         public UsingStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken usingKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, awaitKeyword, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
+            => Update(AttributeLists, awaitKeyword, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/UsingStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/UsingStatementSyntax.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class UsingStatementSyntax
     {
         public UsingStatementSyntax Update(SyntaxToken usingKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(awaitKeyword: default, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
+            => Update(awaitKeyword: AwaitKeyword, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
 
         public UsingStatementSyntax Update(SyntaxToken awaitKeyword, SyntaxToken usingKeyword, SyntaxToken openParenToken, VariableDeclarationSyntax declaration, ExpressionSyntax expression, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: default, awaitKeyword, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
+            => Update(attributeLists: AttributeLists, awaitKeyword, usingKeyword, openParenToken, declaration, expression, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/WhileStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/WhileStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class WhileStatementSyntax
     {
         public WhileStatementSyntax Update(SyntaxToken whileKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: AttributeLists, whileKeyword, openParenToken, condition, closeParenToken, statement);
+            => Update(AttributeLists, whileKeyword, openParenToken, condition, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/WhileStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/WhileStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class WhileStatementSyntax
     {
         public WhileStatementSyntax Update(SyntaxToken whileKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement)
-            => Update(attributeLists: default, whileKeyword, openParenToken, condition, closeParenToken, statement);
+            => Update(attributeLists: AttributeLists, whileKeyword, openParenToken, condition, closeParenToken, statement);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/YieldStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/YieldStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class YieldStatementSyntax
     {
         public YieldStatementSyntax Update(SyntaxToken yieldKeyword, SyntaxToken returnOrBreakKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: AttributeLists, yieldKeyword, returnOrBreakKeyword, expression, semicolonToken);
+            => Update(AttributeLists, yieldKeyword, returnOrBreakKeyword, expression, semicolonToken);
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/YieldStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/YieldStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class YieldStatementSyntax
     {
         public YieldStatementSyntax Update(SyntaxToken yieldKeyword, SyntaxToken returnOrBreakKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
-            => Update(attributeLists: default, yieldKeyword, returnOrBreakKeyword, expression, semicolonToken);
+            => Update(attributeLists: AttributeLists, yieldKeyword, returnOrBreakKeyword, expression, semicolonToken);
     }
 }
 


### PR DESCRIPTION
See: #51997