### PR TITLE
Use absolute project paths when loading a Solution Filter

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
                 // Load project if we have an empty project filter and the project path is present.
                 if (projectfilter.IsEmpty ||
-                    projectfilter.Contains(project.RelativePath))
+                    projectfilter.Contains(project.AbsolutePath))
                 {
                     projectPaths.Add(project.RelativePath);
                 }


### PR DESCRIPTION
When trying to use the solution filter support in dotnet-format, tests failed on non-windows platforms because of MSBuild converts directory separators to the platform's default.