### PR TITLE
Add missing [Fact] in ConversionCompletionProviderTests

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ConversionCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ConversionCompletionProviderTests.cs
@@ -1472,6 +1472,8 @@ namespace N
                 referencedLanguage: LanguageNames.CSharp);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(47511, "https://github.com/dotnet/roslyn/issues/47511")]
         public async Task TestEditorBrowsableOnConversionIsRespected_EditorBrowsableStateNever_InheritedConversion_2()
         {
             var markup = @"


### PR DESCRIPTION
Follow up to #47511

I missed placing the `[Fact]` attribute on one test method.

CC @CyrusNajmabadi