### PR TITLE
Use OptimizedVSCompletionList in LSP scenarios (3.7x serialization speed improvement)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
     <VisualStudioEditorPackagesVersion>16.9.220</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>5.0.0-alpha1.19409.1</ILAsmPackageVersion>
     <ILDAsmPackageVersion>5.0.0-preview.1.20112.8</ILDAsmPackageVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.9.150</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.10.139</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>16.9.30921.310</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftBuildPackagesVersion>16.5.0</MicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -131,11 +131,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 lspCompletionItems.Add(lspCompletionItem);
             }
 
-            return new LSP.VSCompletionList
+            var completionList = new LSP.VSCompletionList
             {
                 Items = lspCompletionItems.ToArray(),
                 SuggestionMode = list.SuggestionModeItem != null,
             };
+            var optimizedCompletionList = new LSP.OptimizedVSCompletionList(completionList);
+            return optimizedCompletionList;
 
             // Local functions
             bool IsValidTriggerCharacterForDocument(Document document, char triggerCharacter)


### PR DESCRIPTION
- The optimized completion list type offers "fast" serialization (3.7x). ([Original PR](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/308940) with perf results)
- This is dependent upon a VS LSP Platform PR getting in: https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/312367 (MERGED, waiting for insertion)
- Update language server protocol package version.

Part of dotnet/aspnetcore#30232