### PR TITLE
Revert "Make DocumentationCommentCompiler work after NormalizeWhitespace"

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -820,13 +820,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int newLineLength;
                 int end = IndexOfNewLine(text, start, out newLineLength);
                 int trimStart = GetIndexOfFirstNonWhitespaceChar(text, start, end) + substringStart;
-
-                // this happens when text ends with new line followed by whitespace
-                if (trimStart > end)
-                {
-                    break;
-                }
-
                 WriteSubStringLine(text, trimStart, end - trimStart);
                 start = end + newLineLength;
             }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -3271,48 +3271,6 @@ public class Program
                 );
         }
 
-        [WorkItem(47278, "https://github.com/dotnet/roslyn/issues/47278")]
-        [Fact]
-        public void NormalizeWhitespace()
-        {
-            var text = @"namespace Foo
-{
-    /// <summary>
-    /// This is Foo.Bar
-    /// </summary>
-    class Bar
-    {
-    }
-}";
-
-            var tree = Parse(text);
-
-            Assert.Equal(@"/// <summary>
-    /// This is Foo.Bar
-    /// </summary>
-", getDocumentationCommentString());
-
-            tree = tree.WithRootAndOptions(tree.GetRoot().NormalizeWhitespace(eol: Environment.NewLine), tree.Options);
-
-            // NormalizeWhitespace didn't change the full text, but it moved whitespace from the following whitespace trivia to the end of the documentation comment
-            Assert.Equal(text, tree.ToString());
-            Assert.Equal(@"/// <summary>
-    /// This is Foo.Bar
-    /// </summary>
-    ", getDocumentationCommentString());
-
-            var comp = CreateCompilation(tree);
-
-            var diags = new DiagnosticBag();
-
-            DocumentationCommentCompiler.WriteDocumentationCommentXml(comp, null, null, diags, default);
-
-            diags.Verify();
-
-            string getDocumentationCommentString() =>
-                tree.GetRoot().DescendantTrivia().Single(n => n.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)).ToFullString();
-        }
-
         #region Xml Test helpers
 
         /// <summary>


### PR DESCRIPTION
Reverts dotnet/roslyn#47360

This PR was merged when green but the test runs were from nearly six months in the past. Wasn't caught on merge. Reverting as it caused a massive build break. 