### PR TITLE
Connect open source generated files to the workspace

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -223,7 +223,6 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
-
         /// <summary>
         /// Maps an immutable array through a function that returns ValueTasks, returning the new ImmutableArray.
         /// </summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -270,6 +271,21 @@ namespace Roslyn.Utilities
 
             var builder = ArrayBuilder<TResult>.GetInstance();
             builder.AddRange(source.Select(selector));
+
+            return builder.ToImmutableAndFree();
+        }
+
+        /// <summary>
+        /// Maps an immutable array through a function that returns ValueTask, returning the new ImmutableArray.
+        /// </summary>
+        public static async ValueTask<ImmutableArray<TResult>> SelectAsArrayAsync<TItem, TResult>(this IEnumerable<TItem> source, Func<TItem, ValueTask<TResult>> selector)
+        {
+            var builder = ArrayBuilder<TResult>.GetInstance();
+
+            foreach (var item in source)
+            {
+                builder.Add(await selector(item).ConfigureAwait(false));
+            }
 
             return builder.ToImmutableAndFree();
         }

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -56,6 +56,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Rebuild.UnitTests" />
     <InternalsVisibleTo Include="Roslyn.Test.PdbUtilities" />
+    <InternalsVisibleTo Include="Roslyn.VisualStudio.Next.UnitTests" />
   </ItemGroup>
   <ItemGroup>
     <!-- TODO: Remove the below IVTs to CodeStyle Unit test projects once all analyzer/code fix tests are switched to Microsoft.CodeAnalysis.Testing -->

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
                         {
                             foreach (var documentHighlights in documentHighlightsList)
                             {
-                                await AddTagSpansAsync(context, documentHighlights).ConfigureAwait(false);
+                                AddTagSpans(context, documentHighlights);
                             }
                         }
                     }
@@ -166,15 +166,14 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
             }
         }
 
-        private static async Task AddTagSpansAsync(
+        private static void AddTagSpans(
             TaggerContext<NavigableHighlightTag> context,
             DocumentHighlights documentHighlights)
         {
             var cancellationToken = context.CancellationToken;
             var document = documentHighlights.Document;
 
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var textSnapshot = text.FindCorrespondingEditorTextSnapshot();
+            var textSnapshot = context.SpansToTag.FirstOrDefault(s => s.Document == document).SnapshotSpan.Snapshot;
             if (textSnapshot == null)
             {
                 // There is no longer an editor snapshot for this document, so we can't care about the

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -962,8 +962,8 @@ class A
             var analyzerReference = new AnalyzerImageReference(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer1, analyzer2));
             workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
             var project = workspace.CurrentSolution.Projects.Single();
-            var documentId = documentAnalysis ? project.Documents.Single().Id : null;
-            var diagnosticComputer = new DiagnosticComputer(documentId, project, span: null, AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache());
+            var document = documentAnalysis ? project.Documents.Single() : null;
+            var diagnosticComputer = new DiagnosticComputer(document, project, span: null, AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache());
             var diagnosticsMapResults = await diagnosticComputer.GetDiagnosticsAsync(analyzerIdsToRequestDiagnostics, reportSuppressedDiagnostics: false,
                 logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: CancellationToken.None);
             Assert.False(analyzer2.ReceivedSymbolCallback);
@@ -1009,7 +1009,7 @@ class A
             var diagnosticAnalyzerInfoCache = new DiagnosticAnalyzerInfoCache();
 
             var kind = actionKind == AnalyzerRegisterActionKind.SyntaxTree ? AnalysisKind.Syntax : AnalysisKind.Semantic;
-            var diagnosticComputer = new DiagnosticComputer(document.Id, project, span: null, kind, diagnosticAnalyzerInfoCache);
+            var diagnosticComputer = new DiagnosticComputer(document, project, span: null, kind, diagnosticAnalyzerInfoCache);
             var analyzerIds = new[] { analyzer.GetAnalyzerId() };
 
             // First invoke analysis with cancellation token, and verify canceled compilation and no reported diagnostics.

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                     return ImmutableArray<DocumentHighlights>.Empty;
                 }
 
-                return result.Value.SelectAsArray(h => h.Rehydrate(solution));
+                return await result.Value.SelectAsArrayAsync(h => h.RehydrateAsync(solution)).ConfigureAwait(false);
             }
 
             return await GetDocumentHighlightsInCurrentProcessAsync(

--- a/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlightsService.cs
@@ -31,8 +31,8 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
             HighlightSpans = highlightSpans;
         }
 
-        public DocumentHighlights Rehydrate(Solution solution)
-            => new(solution.GetDocument(DocumentId), HighlightSpans);
+        public async ValueTask<DocumentHighlights> RehydrateAsync(Solution solution)
+            => new(await solution.GetDocumentAsync(DocumentId, includeSourceGenerated: true).ConfigureAwait(false), HighlightSpans);
 
         public static SerializableDocumentHighlights Dehydrate(DocumentHighlights highlights)
             => new(highlights.Document.Id, highlights.HighlightSpans);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -135,6 +135,8 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Split_string_literals_on_enter}" />
                     <CheckBox x:Name="Report_invalid_placeholders_in_string_dot_format_calls"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Report_invalid_placeholders_in_string_dot_format_calls}" />
+                    <CheckBox x:Name="Enable_all_features_in_opened_files_from_source_generators"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Enable_all_features_in_opened_files_from_source_generators_experimental}" />
                 </StackPanel>
             </GroupBox>
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -26,6 +26,7 @@ using Microsoft.CodeAnalysis.SymbolSearch;
 using Microsoft.CodeAnalysis.ValidateFormatString;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.ColorSchemes;
+using Microsoft.VisualStudio.LanguageServices.Implementation;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
@@ -86,6 +87,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(EnableHighlightReferences, FeatureOnOffOptions.ReferenceHighlighting, LanguageNames.CSharp);
             BindToOption(EnableHighlightKeywords, FeatureOnOffOptions.KeywordHighlighting, LanguageNames.CSharp);
             BindToOption(RenameTrackingPreview, FeatureOnOffOptions.RenameTrackingPreview, LanguageNames.CSharp);
+            BindToOption(Enable_all_features_in_opened_files_from_source_generators, SourceGeneratedFileManager.EnableOpeningInWorkspace, () =>
+            {
+                // If the option has not been set by the user, check if the option is enabled from experimentation.
+                // If so, default to that. Otherwise default to disabled
+                return experimentationService?.IsExperimentEnabled(WellKnownExperimentNames.SourceGeneratorsEnableOpeningInWorkspace) ?? false;
+            });
 
             BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptions.DontPutOutOrRefOnStruct, LanguageNames.CSharp);
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -267,5 +267,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public static string Option_Show_Remove_Unused_References_command_in_Solution_Explorer_experimental
             => ServicesVSResources.Show_Remove_Unused_References_command_in_Solution_Explorer_experimental;
+
+        public static string Enable_all_features_in_opened_files_from_source_generators_experimental
+            => ServicesVSResources.Enable_all_features_in_opened_files_from_source_generators_experimental;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
@@ -208,6 +208,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         void IRunningDocumentTableEventListener.OnCloseDocument(string moniker)
         {
+            _foregroundThreadAffintizedObject.AssertIsForeground();
+
             if (_openFiles.TryGetValue(moniker, out var openFile))
             {
                 openFile.Dispose();
@@ -292,6 +294,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             private void DisconnectFromWorkspaceIfOpen()
             {
+                AssertIsForeground();
+
                 if (_workspace.IsDocumentOpen(_documentIdentity.DocumentId))
                 {
                     _workspace.OnSourceGeneratedDocumentClosed(_documentIdentity.DocumentId);
@@ -300,6 +304,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             public void Dispose()
             {
+                AssertIsForeground();
+
                 using (var readOnlyRegionEdit = _textBuffer.CreateReadOnlyRegionEdit())
                 {
                     readOnlyRegionEdit.RemoveReadOnlyRegion(_readOnlyRegion);

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 _cancellationTokenSource.Cancel();
             }
 
-            private string GeneratorDisplayName => _documentIdentity.Generator.GetType().FullName;
+            private string GeneratorDisplayName => _documentIdentity.GeneratorTypeName;
 
             public async Task UpdateBufferContentsAsync(CancellationToken cancellationToken)
             {
@@ -328,7 +328,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     else
                     {
                         // The file isn't there anymore; do we still have the generator at all?
-                        if (project.AnalyzerReferences.Any(a => a.GetGenerators(project.Language).Any(g => g.GetType().Assembly.Equals(_documentIdentity.Generator.GetType().Assembly))))
+                        if (project.AnalyzerReferences.Any(a => a.GetGenerators(project.Language).Any(g => SourceGeneratedDocumentIdentity.GetGeneratorAssemblyName(g) == _documentIdentity.GeneratorAssemblyName)))
                         {
                             windowFrameMessageToShow = string.Format(ServicesVSResources.The_generator_0_that_generated_this_file_has_stopped_generating_this_file, GeneratorDisplayName);
                             windowFrameImageMonikerToShow = KnownMonikers.StatusError;

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1635,6 +1635,9 @@ I agree to all of the foregoing:</value>
   <data name="Reference" xml:space="preserve">
     <value>Reference</value>
   </data>
+  <data name="Enable_all_features_in_opened_files_from_source_generators_experimental" xml:space="preserve">
+    <value>Enable all features in opened files from source generators (experimental)</value>
+  </data>
   <data name="Remove_Unused_References" xml:space="preserve">
     <value>Remove Unused References</value>
   </data>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Povolit diagnostiku pull Razor (experimentální, vyžaduje restart)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Povolit diagnostiku pull (experimentální, vyžaduje restart)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Razor-Pull-Diagnose aktivieren (experimentell, Neustart erforderlich)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Pull-Diagnose aktivieren (experimentell, Neustart erforderlich)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Habilitar diagnósticos "pull" de Razor (experimental, requiere reiniciar)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Habilitar diagnósticos "pull" (experimental, requiere reiniciar)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Activer les diagnostics de 'tirage (pull)' Razor (expérimental, nécessite un redémarrage)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Activer les diagnostics de 'tirage (pull)' (expérimental, nécessite un redémarrage)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Abilita diagnostica 'pull' di Razor (sperimentale, richiede il riavvio)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Abilita diagnostica 'pull' (sperimentale, richiede il riavvio)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Razor 'pull' 診断を有効にする (試験段階、再起動が必要)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">'pull' 診断を有効にする (試験段階、再起動が必要)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Razor '풀' 진단 사용(실험적, 다시 시작 필요)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">'풀' 진단 사용(실험적, 다시 시작 필요)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Włącz diagnostykę operacji „pull” oprogramowania Razor (eksperymentalne, wymaga ponownego uruchomienia)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Włącz diagnostykę operacji „pull” (eksperymentalne, wymaga ponownego uruchomienia)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Habilitar o diagnóstico de 'pull' do Razor (experimental, exige uma reinicialização)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Habilitar o diagnóstico de 'pull' (experimental, exige uma reinicialização)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Включить диагностику "pull" Razor (экспериментальная функция, требуется перезапуск)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Включить диагностику "pull" (экспериментальная функция, требуется перезапуск)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -292,6 +292,11 @@
         <target state="translated">Razor 'pull' tanılamasını etkinleştir (deneysel, yeniden başlatma gerekir)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">'Pull' tanılamasını etkinleştir (deneysel, yeniden başlatma gerekir)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -292,6 +292,11 @@
         <target state="translated">启用 Razor“拉取”诊断(实验性，需要重启)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">启用“拉取”诊断(实验性，需要重启)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -292,6 +292,11 @@
         <target state="translated">啟用 Razor 'pull' 診斷 (實驗性，需要重新啟動)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_all_features_in_opened_files_from_source_generators_experimental">
+        <source>Enable all features in opened files from source generators (experimental)</source>
+        <target state="new">Enable all features in opened files from source generators (experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">啟用 'pull' 診斷 (實驗性，需要重新啟動)</target>

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/SourceGeneratorItem.BrowseObject.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/SourceGeneratorItem.BrowseObject.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.Type_Name))]
-            public string TypeName => _sourceGeneratorItem.Generator.GetType().FullName;
+            public string TypeName => _sourceGeneratorItem.GeneratorTypeName;
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.Path))]
             public string? Path => _sourceGeneratorItem.AnalyzerReference.FullPath;

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/SourceGeneratorItem.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/SourceGeneratorItem.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 
@@ -13,14 +12,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     internal sealed partial class SourceGeneratorItem : BaseItem
     {
         public ProjectId ProjectId { get; }
-        public ISourceGenerator Generator { get; }
+
+        public string GeneratorAssemblyName { get; }
+
+        // Since the type name is also used for the display text, we can just reuse that. We'll still have an explicit
+        // property so the assembly name/type name pair that is used in other places is also used here.
+        public string GeneratorTypeName => base.Text;
         public AnalyzerReference AnalyzerReference { get; }
 
         public SourceGeneratorItem(ProjectId projectId, ISourceGenerator generator, AnalyzerReference analyzerReference)
-            : base(name: generator.GetType().FullName)
+            : base(name: SourceGeneratedDocumentIdentity.GetGeneratorTypeName(generator))
         {
             ProjectId = projectId;
-            Generator = generator;
+            GeneratorAssemblyName = SourceGeneratedDocumentIdentity.GetGeneratorAssemblyName(generator);
             AnalyzerReference = analyzerReference;
         }
 

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
@@ -70,7 +70,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             var sourceGeneratedDocuments = await project.GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false);
-            var sourceGeneratedDocumentsForGeneratorById = sourceGeneratedDocuments.Where(d => d.SourceGenerator == _parentGeneratorItem.Generator).ToDictionary(d => d.Id);
+            var sourceGeneratedDocumentsForGeneratorById =
+                sourceGeneratedDocuments.Where(d => d.SourceGeneratorAssemblyName == _parentGeneratorItem.GeneratorAssemblyName &&
+                                                    d.SourceGeneratorTypeName == _parentGeneratorItem.GeneratorTypeName)
+                .ToDictionary(d => d.Id);
 
             // We must update the list on the UI thread, since the WPF elements bound to our list expect that
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
         internal async Task VerifySolutionStateSerializationAsync(Solution solution, Checksum solutionChecksum)
         {
             var solutionObjectFromSyncObject = await GetValueAsync<SolutionStateChecksums>(solutionChecksum);
-            Assert.True(solution.State.TryGetStateChecksums(out var solutionObjectFromSolution));
+            Contract.ThrowIfFalse(solution.State.TryGetStateChecksums(out var solutionObjectFromSolution));
 
             SolutionStateEqual(solutionObjectFromSolution, solutionObjectFromSyncObject);
         }

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -24,6 +24,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests;
 using Roslyn.Test.Utilities;
+using Roslyn.Test.Utilities.TestGenerators;
 using Roslyn.Utilities;
 using Xunit;
 

--- a/src/VisualStudio/Core/Test.Next/Roslyn.VisualStudio.Next.UnitTests.csproj
+++ b/src/VisualStudio/Core/Test.Next/Roslyn.VisualStudio.Next.UnitTests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\..\Workspaces\Remote\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj">
       <Aliases>global,hub</Aliases>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\Workspaces\TestSourceGenerator\Microsoft.CodeAnalysis.TestSourceGenerator.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj" />
     <ProjectReference Include="..\..\..\EditorFeatures\TestUtilities\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.csproj" />
     <ProjectReference Include="..\..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" />

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -54,8 +54,9 @@ internal static class Program
             Assert.Equal(HelloWorldGenerator.GeneratedEnglishClassName, VisualStudio.Editor.GetSelectedText());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.SourceGenerators)]
-        public void FindReferencesForFileWithDefinitionInSourceGeneratedFile()
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.SourceGenerators)]
+        [CombinatorialData]
+        public void FindReferencesForFileWithDefinitionInSourceGeneratedFile(bool invokeFromSourceGeneratedFile)
         {
             VisualStudio.Editor.SetText(@"using System;
 internal static class Program
@@ -67,6 +68,12 @@ internal static class Program
 }");
 
             VisualStudio.Editor.PlaceCaret(HelloWorldGenerator.GeneratedEnglishClassName);
+
+            if (invokeFromSourceGeneratedFile)
+            {
+                VisualStudio.Editor.GoToDefinition($"{HelloWorldGenerator.GeneratedEnglishClassName}.cs {ServicesVSResources.generated_suffix}");
+            }
+
             VisualStudio.Editor.SendKeys(Shift(VirtualKey.F12));
 
             var programReferencesCaption = $"'{HelloWorldGenerator.GeneratedEnglishClassName}' references";

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -71,6 +71,7 @@ internal static class Program
 
             if (invokeFromSourceGeneratedFile)
             {
+                VisualStudio.Workspace.SetEnableOpeningSourceGeneratedFilesInWorkspaceExperiment(true);
                 VisualStudio.Editor.GoToDefinition($"{HelloWorldGenerator.GeneratedEnglishClassName}.cs {ServicesVSResources.generated_suffix}");
             }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -119,6 +119,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                 value: value ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.Default);
         }
 
+        public void SetEnableOpeningSourceGeneratedFilesInWorkspaceExperiment(bool value)
+        {
+            SetOption(
+                optionName: LanguageServices.Implementation.SourceGeneratedFileManager.EnableOpeningInWorkspace.Name,
+                feature: LanguageServices.Implementation.SourceGeneratedFileManager.EnableOpeningInWorkspace.Feature,
+                value: value);
+        }
+
         public void SetFeatureOption(string feature, string optionName, string language, string valueString)
             => _inProc.SetFeatureOption(feature, optionName, language, valueString);
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -122,6 +122,8 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_RenameTrackingPreview}" />
                     <CheckBox x:Name="Report_invalid_placeholders_in_string_dot_format_calls"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Report_invalid_placeholders_in_string_dot_format_calls}" />
+                    <CheckBox x:Name="Enable_all_features_in_opened_files_from_source_generators"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Enable_all_features_in_opened_files_from_source_generators_experimental}" />
                 </StackPanel>
             </GroupBox>
             

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -41,29 +41,31 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.VisualBasic)
             BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.VisualBasic)
             BindToOption(Use_64bit_analysis_process, RemoteHostOptions.OOP64Bit)
-            BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer_experimental, FeatureOnOffOptions.OfferRemoveUnusedReferences, Function()
-                                                                                                                                                       ' If the option has Not been set by the user, check if the option to remove unused references
-                                                                                                                                                       ' Is enabled from experimentation. If so, default to that. Otherwise default to disabled
-                                                                                                                                                       If experimentationService Is Nothing Then
-                                                                                                                                                           Return False
-                                                                                                                                                       End If
+            BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer_experimental, FeatureOnOffOptions.OfferRemoveUnusedReferences,
+                         Function()
+                             ' If the option has Not been set by the user, check if the option to remove unused references
+                             ' Is enabled from experimentation. If so, default to that. Otherwise default to disabled
+                             If experimentationService Is Nothing Then
+                                 Return False
+                             End If
 
-                                                                                                                                                       Return experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RemoveUnusedReferences)
-                                                                                                                                                   End Function)
+                             Return experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RemoveUnusedReferences)
+                         End Function)
 
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.VisualBasic)
             BindToOption(SeparateImportGroups, GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.VisualBasic)
             BindToOption(SuggestForTypesInReferenceAssemblies, SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.VisualBasic)
             BindToOption(SuggestForTypesInNuGetPackages, SymbolSearchOptions.SuggestForTypesInNuGetPackages, LanguageNames.VisualBasic)
-            BindToOption(AddMissingImportsOnPaste, FeatureOnOffOptions.AddImportsOnPaste, LanguageNames.VisualBasic, Function()
-                                                                                                                         ' If the option has Not been set by the user, check if the option to enable imports on paste
-                                                                                                                         ' Is enabled from experimentation. If so, default to that. Otherwise default to disabled
-                                                                                                                         If experimentationService Is Nothing Then
-                                                                                                                             Return False
-                                                                                                                         End If
+            BindToOption(AddMissingImportsOnPaste, FeatureOnOffOptions.AddImportsOnPaste, LanguageNames.VisualBasic,
+                         Function()
+                             ' If the option has Not been set by the user, check if the option to enable imports on paste
+                             ' Is enabled from experimentation. If so, default to that. Otherwise default to disabled
+                             If experimentationService Is Nothing Then
+                                 Return False
+                             End If
 
-                                                                                                                         Return experimentationService.IsExperimentEnabled(WellKnownExperimentNames.ImportsOnPasteDefaultEnabled)
-                                                                                                                     End Function)
+                             Return experimentationService.IsExperimentEnabled(WellKnownExperimentNames.ImportsOnPasteDefaultEnabled)
+                         End Function)
 
             BindToOption(EnableOutlining, FeatureOnOffOptions.Outlining, LanguageNames.VisualBasic)
             BindToOption(Show_outlining_for_declaration_level_constructs, BlockStructureOptions.ShowOutliningForDeclarationLevelConstructs, LanguageNames.VisualBasic)
@@ -88,6 +90,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(RenameTrackingPreview, FeatureOnOffOptions.RenameTrackingPreview, LanguageNames.VisualBasic)
             BindToOption(ShowRemarksInQuickInfo, QuickInfoOptions.ShowRemarksInQuickInfo, LanguageNames.VisualBasic)
             BindToOption(NavigateToObjectBrowser, VisualStudioNavigationOptions.NavigateToObjectBrowser, LanguageNames.VisualBasic)
+            BindToOption(Enable_all_features_in_opened_files_from_source_generators, SourceGeneratedFileManager.EnableOpeningInWorkspace,
+                         Function()
+                             ' If the option has not been set by the user, check if the option Is enabled from experimentation.
+                             ' If so, default to that. Otherwise default to disabled
+                             Return If(experimentationService?.IsExperimentEnabled(WellKnownExperimentNames.SourceGeneratorsEnableOpeningInWorkspace), False)
+                         End Function)
 
             BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptions.DontPutOutOrRefOnStruct, LanguageNames.VisualBasic)
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -283,5 +283,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Public ReadOnly Property Option_Show_Remove_Unused_References_command_in_Solution_Explorer_experimental As String =
             ServicesVSResources.Show_Remove_Unused_References_command_in_Solution_Explorer_experimental
+
+        Public ReadOnly Property Enable_all_features_in_opened_files_from_source_generators_experimental As String =
+             ServicesVSResources.Enable_all_features_in_opened_files_from_source_generators_experimental
     End Module
 End Namespace

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string OOPServerGC = "Roslyn.OOPServerGC";
         public const string ImportsOnPasteDefaultEnabled = "Roslyn.ImportsOnPasteDefaultEnabled";
         public const string LspTextSyncEnabled = "Roslyn.LspTextSyncEnabled";
+        public const string SourceGeneratorsEnableOpeningInWorkspace = "Roslyn.SourceGeneratorsEnableOpeningInWorkspace";
         public const string RemoveUnusedReferences = "Roslyn.RemoveUnusedReferences";
         public const string LSPCompletion = "Roslyn.LSP.Completion";
         public const string UnnamedSymbolCompletionDisabled = "Roslyn.UnnamedSymbolCompletionDisabled";

--- a/src/Workspaces/Core/Portable/Remote/WellKnownSynchronizationKind.cs
+++ b/src/Workspaces/Core/Portable/Remote/WellKnownSynchronizationKind.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         SolutionAttributes,
         ProjectAttributes,
         DocumentAttributes,
+        SourceGeneratedDocumentIdentity,
 
         CompilationOptions,
         ParseOptions,

--- a/src/Workspaces/Core/Portable/Remote/WellKnownSynchronizationKind.cs
+++ b/src/Workspaces/Core/Portable/Remote/WellKnownSynchronizationKind.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CodeAnalysis.Serialization
         OptionSet,
 
         SerializableSourceText,
-        RecoverableSourceText,
 
         //
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializationExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                 SerializableSourceText _ => WellKnownSynchronizationKind.SerializableSourceText,
                 SourceText _ => WellKnownSynchronizationKind.SourceText,
                 OptionSet _ => WellKnownSynchronizationKind.OptionSet,
+                SourceGeneratedDocumentIdentity _ => WellKnownSynchronizationKind.SourceGeneratedDocumentIdentity,
                 _ => throw ExceptionUtilities.UnexpectedValue(value),
             };
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializationExtensions.cs
@@ -34,7 +34,6 @@ namespace Microsoft.CodeAnalysis.Serialization
                 ProjectReference _ => WellKnownSynchronizationKind.ProjectReference,
                 MetadataReference _ => WellKnownSynchronizationKind.MetadataReference,
                 AnalyzerReference _ => WellKnownSynchronizationKind.AnalyzerReference,
-                TextDocumentState _ => WellKnownSynchronizationKind.RecoverableSourceText,
                 SerializableSourceText _ => WellKnownSynchronizationKind.SerializableSourceText,
                 SourceText _ => WellKnownSynchronizationKind.SourceText,
                 OptionSet _ => WellKnownSynchronizationKind.OptionSet,

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                     case WellKnownSynchronizationKind.ParseOptions:
                     case WellKnownSynchronizationKind.ProjectReference:
                     case WellKnownSynchronizationKind.OptionSet:
+                    case WellKnownSynchronizationKind.SourceGeneratedDocumentIdentity:
                         return Checksum.Create(kind, value, this);
 
                     case WellKnownSynchronizationKind.MetadataReference:
@@ -124,6 +125,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                     case WellKnownSynchronizationKind.SolutionAttributes:
                     case WellKnownSynchronizationKind.ProjectAttributes:
                     case WellKnownSynchronizationKind.DocumentAttributes:
+                    case WellKnownSynchronizationKind.SourceGeneratedDocumentIdentity:
                         ((IObjectWritable)value).WriteTo(writer);
                         return;
 
@@ -197,6 +199,8 @@ namespace Microsoft.CodeAnalysis.Serialization
                         return (T)(object)ProjectInfo.ProjectAttributes.ReadFrom(reader);
                     case WellKnownSynchronizationKind.DocumentAttributes:
                         return (T)(object)DocumentInfo.DocumentAttributes.ReadFrom(reader);
+                    case WellKnownSynchronizationKind.SourceGeneratedDocumentIdentity:
+                        return (T)(object)SourceGeneratedDocumentIdentity.ReadFrom(reader);
                     case WellKnownSynchronizationKind.CompilationOptions:
                         return (T)(object)DeserializeCompilationOptions(reader, cancellationToken);
                     case WellKnownSynchronizationKind.ParseOptions:

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumWithChildren.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumWithChildren.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis
         ///
         /// Use this method to gain access to potentially incomplete semantics quickly.
         /// </summary>
-        internal Document WithFrozenPartialSemantics(CancellationToken cancellationToken)
+        internal virtual Document WithFrozenPartialSemantics(CancellationToken cancellationToken)
         {
             var solution = this.Project.Solution;
             var workspace = solution.Workspace;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis
                 : "";
         }
 
-        private static ValueSource<TreeAndVersion> CreateLazyFullyParsedTree(
+        protected static ValueSource<TreeAndVersion> CreateLazyFullyParsedTree(
             ValueSource<TextAndVersion> newTextSource,
             ProjectId cacheKey,
             string? filePath,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1730,6 +1730,21 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Returns a new Solution that will always produce a specific output for a generated file. This is used only in the
+        /// implementation of <see cref="TextExtensions.GetOpenDocumentInCurrentContextWithChanges"/> where if a user has a source
+        /// generated file open, we need to make sure everything lines up.
+        /// </summary>
+        internal Document WithFrozenSourceGeneratedDocument(SourceGeneratedDocumentIdentity documentIdentity, SourceText text)
+        {
+            var newState = _state.WithFrozenSourceGeneratedDocument(documentIdentity, text);
+            var newSolution = newState != _state ? new Solution(newState) : this;
+            var newDocumentState = newState.TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentIdentity.DocumentId);
+            Contract.ThrowIfNull(newDocumentState, "Because we just froze this document, it should always exist.");
+            var newProject = newSolution.GetRequiredProject(newDocumentState.Id.ProjectId);
+            return newProject.GetOrCreateSourceGeneratedDocument(newDocumentState);
+        }
+
+        /// <summary>
         /// Gets an objects that lists the added, changed and removed projects between
         /// this solution and the specified solution.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -912,14 +912,17 @@ namespace Microsoft.CodeAnalysis
                                         {
                                             // NOTE: the use of generatedSource.SyntaxTree to fetch the path and options is OK,
                                             // since the tree is a lazy tree and that won't trigger the parse.
+                                            var identity = SourceGeneratedDocumentIdentity.Generate(
+                                                ProjectState.Id,
+                                                generatedSource.HintName,
+                                                generatorResult.Generator,
+                                                generatedSource.SyntaxTree.FilePath);
+
                                             generatedDocumentsBuilder.Add(
                                                 SourceGeneratedDocumentState.Create(
-                                                    generatedSource.HintName,
+                                                    identity,
                                                     generatedSource.SourceText,
-                                                    CreateStableSourceGeneratedDocumentId(ProjectState.Id, generatorResult.Generator, generatedSource.HintName),
-                                                    generatedSource.SyntaxTree.FilePath,
                                                     generatedSource.SyntaxTree.Options,
-                                                    generatorResult.Generator,
                                                     this.ProjectState.LanguageServices,
                                                     solution.Services));
 
@@ -985,35 +988,6 @@ namespace Microsoft.CodeAnalysis
 
                     return null;
                 }
-            }
-
-            private static DocumentId CreateStableSourceGeneratedDocumentId(ProjectId projectId, ISourceGenerator generator, string hintName)
-            {
-                // We want the DocumentId generated for a generated output to be stable between Compilations; this is so features that track
-                // a document by DocumentId can find it after some change has happened that requires generators to run again.
-                // To achieve this we'll just do a crytographic hash of the generator name and hint name; the choice of a cryptographic hash
-                // as opposed to a more generic string hash is we actually want to ensure we don't have collisions.
-                var generatorName = generator.GetType().FullName;
-                Contract.ThrowIfNull(generatorName);
-
-                // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
-                // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
-                var projectIdBytes = projectId.Id.ToByteArray();
-                using var _ = ArrayBuilder<byte>.GetInstance(capacity: (generatorName.Length + hintName.Length + 1) * 2 + projectIdBytes.Length, out var hashInput);
-                hashInput.AddRange(projectIdBytes);
-                hashInput.AddRange(Encoding.Unicode.GetBytes(generatorName));
-
-                // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
-                // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
-                hashInput.AddRange(0, 0);
-                hashInput.AddRange(Encoding.Unicode.GetBytes(hintName));
-
-                // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary.
-                var hash = System.Security.Cryptography.SHA256.Create().ComputeHash(hashInput.ToArray());
-                Array.Resize(ref hash, 16);
-                var guid = new Guid(hash);
-
-                return DocumentId.CreateFromSerialized(projectId, guid, hintName);
             }
 
             /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -1028,7 +1028,6 @@ namespace Microsoft.CodeAnalysis
             {
                 try
                 {
-
                     // if we already have the compilation and its right kind then use it.
                     if (this.ProjectState.LanguageServices == fromProject.LanguageServices
                         && this.TryGetCompilation(out var compilation))

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -903,9 +903,15 @@ namespace Microsoft.CodeAnalysis
                     ISourceGenerator generator,
                     string hintName)
                 {
+                    var generatorAssemblyName = SourceGeneratedDocumentIdentity.GetGeneratorAssemblyName(generator);
+                    var generatorTypeName = SourceGeneratedDocumentIdentity.GetGeneratorTypeName(generator);
+
                     foreach (var state in states.States)
                     {
-                        if (state.SourceGenerator != generator)
+                        if (state.SourceGeneratorAssemblyName != generatorAssemblyName)
+                            continue;
+
+                        if (state.SourceGeneratorTypeName != generatorTypeName)
                             continue;
 
                         if (state.HintName != hintName)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
@@ -1,0 +1,209 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal partial class SolutionState
+    {
+        /// <summary>
+        /// An implementation of <see cref="ICompilationTracker"/> that takes a compilation from another compilation tracker and updates it
+        /// to return a generated document with a specific content, regardless of what the generator actually produces. In other words, it says
+        /// "take the compilation this other thing produced, and pretend the generator gave this content, even if it wouldn't."
+        /// </summary>
+        private class GeneratedFileReplacingCompilationTracker : ICompilationTracker
+        {
+            private readonly ICompilationTracker _underlyingTracker;
+            private readonly SourceGeneratedDocumentState _replacedGeneratedDocumentState;
+
+            /// <summary>
+            /// The lazily-produced compilation that has the generated document updated. This is initialized by call to
+            /// <see cref="GetCompilationAsync"/>.
+            /// </summary>
+            [DisallowNull]
+            private Compilation? _compilationWithReplacement;
+
+            public GeneratedFileReplacingCompilationTracker(ICompilationTracker underlyingTracker, SourceGeneratedDocumentState replacementDocumentState)
+            {
+                _underlyingTracker = underlyingTracker;
+                _replacedGeneratedDocumentState = replacementDocumentState;
+            }
+
+            public bool HasCompilation => _underlyingTracker.HasCompilation;
+
+            public ProjectState ProjectState => _underlyingTracker.ProjectState;
+
+            public ICompilationTracker Clone()
+            {
+                return new GeneratedFileReplacingCompilationTracker(_underlyingTracker.Clone(), _replacedGeneratedDocumentState);
+            }
+
+            public bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool? ContainsSymbolsWithNameFromDeclarationOnlyCompilation(Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken)
+            {
+                // TODO: This only needs to be implemented if a feature that operates from a source generated file needs to search for declarations
+                // with other names; those APIs are only used by certain code fixes which isn't a need for now. This will need to be fixed up when
+                // we complete https://github.com/dotnet/roslyn/issues/49533.
+                throw new NotImplementedException();
+            }
+
+            public bool? ContainsSymbolsWithNameFromDeclarationOnlyCompilation(string name, SymbolFilter filter, CancellationToken cancellationToken)
+            {
+                // TODO: This only needs to be implemented if a feature that operates from a source generated file needs to search for declarations
+                // with other names; those APIs are only used by certain code fixes which isn't a need for now. This will need to be fixed up when
+                // we complete https://github.com/dotnet/roslyn/issues/49533.
+                throw new NotImplementedException();
+            }
+
+            public ICompilationTracker Fork(ProjectState newProject, CompilationAndGeneratorDriverTranslationAction? translate = null, bool clone = false, CancellationToken cancellationToken = default)
+            {
+                // TODO: This only needs to be implemented if a feature that operates from a source generated file then makes
+                // further mutations to that project, which isn't needed for now. This will be need to be fixed up when we complete
+                // https://github.com/dotnet/roslyn/issues/49533.
+                throw new NotImplementedException();
+            }
+
+            public ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState docState, SyntaxTree tree, CancellationToken cancellationToken)
+            {
+                // Because we override SourceGeneratedDocument.WithFrozenPartialSemantics directly, we shouldn't be able to get here.
+                throw ExceptionUtilities.Unreachable;
+            }
+
+            public async Task<Compilation> GetCompilationAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                // Fast path if we've definitely already done this before
+                if (_compilationWithReplacement != null)
+                {
+                    return _compilationWithReplacement;
+                }
+
+                var underlyingCompilation = await _underlyingTracker.GetCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
+                var underlyingSourceGeneratedDocuments = await _underlyingTracker.GetSourceGeneratedDocumentStatesAsync(solution, cancellationToken).ConfigureAwait(false);
+
+                underlyingSourceGeneratedDocuments.TryGetState(_replacedGeneratedDocumentState.Id, out var existingState);
+
+                Compilation newCompilation;
+
+                var newSyntaxTree = await _replacedGeneratedDocumentState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+
+                if (existingState != null)
+                {
+                    // The generated file still exists in the underlying compilation, but the contents may not match the open file if the open file
+                    // is stale. Replace the syntax tree so we have a tree that matches the text.
+                    var existingSyntaxTree = await existingState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                    newCompilation = underlyingCompilation.ReplaceSyntaxTree(existingSyntaxTree, newSyntaxTree);
+                }
+                else
+                {
+                    // The existing output no longer exists in the underlying compilation. This could happen if the user made
+                    // an edit which would cause this file to no longer exist, but they're still operating on an open representation
+                    // of that file. To ensure that this snapshot is still usable, we'll just add this document back in. This is not a
+                    // semantically correct operation, but working on stale snapshots never has that guarantee.
+                    newCompilation = underlyingCompilation.AddSyntaxTrees(newSyntaxTree);
+                }
+
+                Interlocked.CompareExchange(ref _compilationWithReplacement, newCompilation, null);
+
+                return _compilationWithReplacement;
+            }
+
+            public Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                return _underlyingTracker.GetDependentSemanticVersionAsync(solution, cancellationToken);
+            }
+
+            public Task<VersionStamp> GetDependentVersionAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                return _underlyingTracker.GetDependentVersionAsync(solution, cancellationToken);
+            }
+
+            public async Task<MetadataReference> GetMetadataReferenceAsync(SolutionState solution, ProjectState fromProject, ProjectReference projectReference, CancellationToken cancellationToken)
+            {
+                var compilation = await GetCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
+
+                // If it's the same language we can just make a CompilationReference
+                if (this.ProjectState.LanguageServices == fromProject.LanguageServices)
+                {
+                    return compilation.ToMetadataReference(projectReference.Aliases, projectReference.EmbedInteropTypes);
+                }
+                else
+                {
+                    var version = await GetDependentSemanticVersionAsync(solution, cancellationToken).ConfigureAwait(false);
+                    return MetadataOnlyReference.GetOrBuildReference(solution, projectReference, compilation, version, cancellationToken);
+                }
+            }
+
+            public CompilationReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference)
+            {
+                // This method is used if you're forking a solution with partial semantics, and used to quickly produce references.
+                // So this method should only be called if:
+                //
+                // 1. Project A has a open source generated document, and this CompilationTracker represents A
+                // 2. Project B references that A, and is being frozen for partial semantics.
+                //
+                // We generally don't use partial semantics in a different project than the open file, so this isn't a scenario we need to support.
+                throw new NotImplementedException();
+            }
+
+            public async ValueTask<TextDocumentStates<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                var underlyingGeneratedDocumentStates = await _underlyingTracker.GetSourceGeneratedDocumentStatesAsync(solution, cancellationToken).ConfigureAwait(false);
+
+                if (underlyingGeneratedDocumentStates.Contains(_replacedGeneratedDocumentState.Id))
+                {
+                    // The generated file still exists in the underlying compilation, but the contents may not match the open file if the open file
+                    // is stale. Replace the syntax tree so we have a tree that matches the text.
+                    return underlyingGeneratedDocumentStates.SetState(_replacedGeneratedDocumentState.Id, _replacedGeneratedDocumentState);
+                }
+                else
+                {
+                    // The generated output no longer exists in the underlying compilation. This could happen if the user made
+                    // an edit which would cause this file to no longer exist, but they're still operating on an open representation
+                    // of that file. To ensure that this snapshot is still usable, we'll just add this document back in. This is not a
+                    // semantically correct operation, but working on stale snapshots never has that guarantee.
+                    return underlyingGeneratedDocumentStates.AddRange(ImmutableArray.Create(_replacedGeneratedDocumentState));
+                }
+            }
+
+            public IEnumerable<SyntaxTree>? GetSyntaxTreesWithNameFromDeclarationOnlyCompilation(Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken)
+            {
+                return _underlyingTracker.GetSyntaxTreesWithNameFromDeclarationOnlyCompilation(predicate, filter, cancellationToken);
+            }
+
+            public Task<bool> HasSuccessfullyLoadedAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                return _underlyingTracker.HasSuccessfullyLoadedAsync(solution, cancellationToken);
+            }
+
+            public bool TryGetCompilation([NotNullWhen(true)] out Compilation? compilation)
+            {
+                compilation = _compilationWithReplacement;
+                return compilation != null;
+            }
+
+            public SourceGeneratedDocumentState? TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(DocumentId documentId)
+            {
+                if (documentId == _replacedGeneratedDocumentState.Id)
+                {
+                    return _replacedGeneratedDocumentState;
+                }
+                else
+                {
+                    return _underlyingTracker.TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentId);
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
@@ -48,7 +48,15 @@ namespace Microsoft.CodeAnalysis
 
             public bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary)
             {
-                throw new NotImplementedException();
+                if (_compilationWithReplacement == null)
+                {
+                    // We don't have a compilation yet, so this couldn't have came from us
+                    return false;
+                }
+                else
+                {
+                    return UnrootedSymbolSet.Create(_compilationWithReplacement).ContainsAssemblyOrModuleOrDynamic(symbol, primary);
+                }
             }
 
             public bool? ContainsSymbolsWithNameFromDeclarationOnlyCompilation(Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal partial class SolutionState
+    {
+        private interface ICompilationTracker
+        {
+            /// <summary>
+            /// Returns true if this tracker currently either points to a compilation, has an in-progress
+            /// compilation being computed, or has a skeleton reference.  Note: this is simply a weak
+            /// statement about the tracker at this exact moment in time.  Immediately after this returns
+            /// the tracker might change and may no longer have a final compilation (for example, if the
+            /// retainer let go of it) or might not have an in-progress compilation (for example, if the
+            /// background compiler finished with it).
+            /// 
+            /// Because of the above limitations, this should only be used by clients as a weak form of
+            /// information about the tracker.  For example, a client may see that a tracker has no
+            /// compilation and may choose to throw it away knowing that it could be reconstructed at a
+            /// later point if necessary.
+            /// </summary>
+            bool HasCompilation { get; }
+            ProjectState ProjectState { get; }
+
+            ICompilationTracker Clone();
+
+            /// <summary>
+            /// Returns <see langword="true"/> if this <see cref="Project"/>/<see cref="Compilation"/> could produce the
+            /// given <paramref name="symbol"/>.  The symbol must be a <see cref="IAssemblySymbol"/>, <see
+            /// cref="IModuleSymbol"/> or <see cref="IDynamicTypeSymbol"/>.
+            /// </summary>
+            /// <remarks>
+            /// If <paramref name="primary"/> is true, then <see cref="Compilation.References"/> will not be considered
+            /// when answering this question.  In other words, if <paramref name="symbol"/>  is an <see
+            /// cref="IAssemblySymbol"/> and <paramref name="primary"/> is <see langword="true"/> then this will only
+            /// return true if the symbol is <see cref="Compilation.Assembly"/>.  If <paramref name="primary"/> is
+            /// false, then it can return true if <paramref name="symbol"/> is <see cref="Compilation.Assembly"/> or any
+            /// of the symbols returned by <see cref="Compilation.GetAssemblyOrModuleSymbol(MetadataReference)"/> for
+            /// any of the references of the <see cref="Compilation.References"/>.
+            /// </remarks>
+            bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary);
+            bool? ContainsSymbolsWithNameFromDeclarationOnlyCompilation(Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken);
+            bool? ContainsSymbolsWithNameFromDeclarationOnlyCompilation(string name, SymbolFilter filter, CancellationToken cancellationToken);
+            ICompilationTracker Fork(ProjectState newProject, CompilationAndGeneratorDriverTranslationAction? translate = null, bool clone = false, CancellationToken cancellationToken = default);
+            ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState docState, SyntaxTree tree, CancellationToken cancellationToken);
+            Task<Compilation> GetCompilationAsync(SolutionState solution, CancellationToken cancellationToken);
+            Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionState solution, CancellationToken cancellationToken);
+            Task<VersionStamp> GetDependentVersionAsync(SolutionState solution, CancellationToken cancellationToken);
+
+            /// <summary>
+            /// Get a metadata reference to this compilation info's compilation with respect to
+            /// another project. For cross language references produce a skeletal assembly. If the
+            /// compilation is not available, it is built. If a skeletal assembly reference is
+            /// needed and does not exist, it is also built.
+            /// </summary>
+            Task<MetadataReference> GetMetadataReferenceAsync(SolutionState solution, ProjectState fromProject, ProjectReference projectReference, CancellationToken cancellationToken);
+            CompilationReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference);
+            ValueTask<TextDocumentStates<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(SolutionState solution, CancellationToken cancellationToken);
+            IEnumerable<SyntaxTree>? GetSyntaxTreesWithNameFromDeclarationOnlyCompilation(Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken);
+            Task<bool> HasSuccessfullyLoadedAsync(SolutionState solution, CancellationToken cancellationToken);
+            bool TryGetCompilation([NotNullWhen(true)] out Compilation? compilation);
+            SourceGeneratedDocumentState? TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(DocumentId documentId);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.UnrootedSymbolSet.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -50,7 +52,7 @@ namespace Microsoft.CodeAnalysis
             /// </summary>
             public readonly ImmutableArray<(int hashCode, WeakReference<ISymbol> symbol)> SecondaryReferencedSymbols;
 
-            public UnrootedSymbolSet(
+            private UnrootedSymbolSet(
                 WeakReference<IAssemblySymbol> primaryAssemblySymbol,
                 WeakReference<ITypeSymbol?> primaryDynamicSymbol,
                 ImmutableArray<(int hashCode, WeakReference<ISymbol> symbol)> secondaryReferencedSymbols)
@@ -58,6 +60,86 @@ namespace Microsoft.CodeAnalysis
                 PrimaryAssemblySymbol = primaryAssemblySymbol;
                 PrimaryDynamicSymbol = primaryDynamicSymbol;
                 SecondaryReferencedSymbols = secondaryReferencedSymbols;
+            }
+
+            public static UnrootedSymbolSet Create(Compilation compilation)
+            {
+                var primaryAssembly = new WeakReference<IAssemblySymbol>(compilation.Assembly);
+
+                // The dynamic type is also unrooted (i.e. doesn't point back at the compilation or source
+                // assembly).  So we have to keep track of it so we can get back from it to a project in case the 
+                // underlying compilation is GC'ed.
+                var primaryDynamic = new WeakReference<ITypeSymbol?>(
+                    compilation.Language == LanguageNames.CSharp ? compilation.DynamicType : null);
+
+                // PERF: Preallocate this array so we don't have to resize it as we're adding assembly symbols.
+                using var _ = ArrayBuilder<(int hashcode, WeakReference<ISymbol> symbol)>.GetInstance(
+                    compilation.ExternalReferences.Length + compilation.DirectiveReferences.Length, out var secondarySymbols);
+
+                foreach (var reference in compilation.References)
+                {
+                    var symbol = compilation.GetAssemblyOrModuleSymbol(reference);
+                    if (symbol == null)
+                        continue;
+
+                    secondarySymbols.Add((ReferenceEqualityComparer.GetHashCode(symbol), new WeakReference<ISymbol>(symbol)));
+                }
+
+                // Sort all the secondary symbols by their hash.  This will allow us to easily binary search for
+                // them afterwards. Note: it is fine for multiple symbols to have the same reference hash.  The
+                // search algorithm will account for that.
+                secondarySymbols.Sort(WeakSymbolComparer.Instance);
+                return new UnrootedSymbolSet(primaryAssembly, primaryDynamic, secondarySymbols.ToImmutable());
+            }
+
+            public bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary)
+            {
+                if (primary)
+                {
+                    return symbol.Equals(this.PrimaryAssemblySymbol.GetTarget()) ||
+                           symbol.Equals(this.PrimaryDynamicSymbol.GetTarget());
+                }
+                else
+                {
+                    var secondarySymbols = this.SecondaryReferencedSymbols;
+
+                    var symbolHash = ReferenceEqualityComparer.GetHashCode(symbol);
+
+                    // The secondary symbol array is sorted by the symbols' hash codes.  So do a binary search to find
+                    // the location we should start looking at.
+                    var index = secondarySymbols.BinarySearch((symbolHash, null!), WeakSymbolComparer.Instance);
+                    if (index < 0)
+                        return false;
+
+                    // Could have multiple symbols with the same hash.  They will all be placed next to each other,
+                    // so walk backward to hit the first.
+                    while (index > 0 && secondarySymbols[index - 1].hashCode == symbolHash)
+                        index--;
+
+                    // Now, walk forward through the stored symbols with the same hash looking to see if any are a reference match.
+                    while (index < secondarySymbols.Length && secondarySymbols[index].hashCode == symbolHash)
+                    {
+                        var cached = secondarySymbols[index].symbol;
+                        if (cached.TryGetTarget(out var otherSymbol) && otherSymbol == symbol)
+                            return true;
+
+                        index++;
+                    }
+
+                    return false;
+                }
+            }
+
+            private class WeakSymbolComparer : IComparer<(int hashcode, WeakReference<ISymbol> symbol)>
+            {
+                public static readonly WeakSymbolComparer Instance = new WeakSymbolComparer();
+
+                private WeakSymbolComparer()
+                {
+                }
+
+                public int Compare((int hashcode, WeakReference<ISymbol> symbol) x, (int hashcode, WeakReference<ISymbol> symbol) y)
+                    => x.hashcode - y.hashcode;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -44,14 +44,14 @@ namespace Microsoft.CodeAnalysis
                                                                 .Select(s => s.GetChecksumAsync(cancellationToken));
 
                     var serializer = _solutionServices.Workspace.Services.GetService<ISerializerService>();
-                    var infoChecksum = serializer.CreateChecksum(SolutionAttributes, cancellationToken);
+                    var attributesChecksum = serializer.CreateChecksum(SolutionAttributes, cancellationToken);
                     var optionsChecksum = serializer.CreateChecksum(Options, cancellationToken);
 
                     var analyzerReferenceChecksums = ChecksumCache.GetOrCreate<AnalyzerReferenceChecksumCollection>(AnalyzerReferences,
                         _ => new AnalyzerReferenceChecksumCollection(AnalyzerReferences.Select(r => serializer.CreateChecksum(r, cancellationToken)).ToArray()));
 
                     var projectChecksums = await Task.WhenAll(projectChecksumTasks).ConfigureAwait(false);
-                    return new SolutionStateChecksums(infoChecksum, optionsChecksum, new ProjectChecksumCollection(projectChecksums), analyzerReferenceChecksums);
+                    return new SolutionStateChecksums(attributesChecksum, optionsChecksum, new ProjectChecksumCollection(projectChecksums), analyzerReferenceChecksums);
                 }
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +18,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial class SolutionState
     {
-        public bool TryGetStateChecksums(out SolutionStateChecksums stateChecksums)
+        public bool TryGetStateChecksums([NotNullWhen(true)] out SolutionStateChecksums? stateChecksums)
             => _lazyChecksums.TryGetValue(out stateChecksums);
 
         public Task<SolutionStateChecksums> GetStateChecksumsAsync(CancellationToken cancellationToken)
@@ -43,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                                                                 .Where(s => RemoteSupportedLanguages.IsSupported(s.Language))
                                                                 .Select(s => s.GetChecksumAsync(cancellationToken));
 
-                    var serializer = _solutionServices.Workspace.Services.GetService<ISerializerService>();
+                    var serializer = _solutionServices.Workspace.Services.GetRequiredService<ISerializerService>();
                     var attributesChecksum = serializer.CreateChecksum(SolutionAttributes, cancellationToken);
                     var optionsChecksum = serializer.CreateChecksum(Options, cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
@@ -19,7 +19,8 @@ namespace Microsoft.CodeAnalysis
         private new SourceGeneratedDocumentState State => (SourceGeneratedDocumentState)base.State;
 
         // TODO: make this public. Tracked by https://github.com/dotnet/roslyn/issues/50546
-        internal ISourceGenerator SourceGenerator => State.SourceGenerator;
+        internal string SourceGeneratorAssemblyName => Identity.GeneratorAssemblyName;
+        internal string SourceGeneratorTypeName => Identity.GeneratorTypeName;
         public string HintName => State.HintName;
         internal SourceGeneratedDocumentIdentity Identity => State.Identity;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
@@ -19,5 +19,6 @@ namespace Microsoft.CodeAnalysis
         // TODO: make this public. Tracked by https://github.com/dotnet/roslyn/issues/50546
         internal ISourceGenerator SourceGenerator => State.SourceGenerator;
         public string HintName => State.HintName;
+        internal SourceGeneratedDocumentIdentity Identity => State.Identity;
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
@@ -20,5 +22,14 @@ namespace Microsoft.CodeAnalysis
         internal ISourceGenerator SourceGenerator => State.SourceGenerator;
         public string HintName => State.HintName;
         internal SourceGeneratedDocumentIdentity Identity => State.Identity;
+
+        internal override Document WithFrozenPartialSemantics(CancellationToken cancellationToken)
+        {
+            // For us to implement frozen partial semantics here with a source generated document,
+            // we'd need to potentially deal with the combination where that happens on a snapshot that was already
+            // forked; rather than trying to deal with that combo we'll just fall back to not doing anything special
+            // which is allowed.
+            return this;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -49,8 +49,10 @@ namespace Microsoft.CodeAnalysis
             hashInput.AddRange(0, 0);
             hashInput.AddRange(Encoding.Unicode.GetBytes(hintName));
 
-            // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary.
-            var hash = System.Security.Cryptography.SHA256.Create().ComputeHash(hashInput.ToArray());
+            // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary. The only requirement
+            // is it must be collision resistant, and provide enough bits to fill a GUID.
+            using var crytpoAlgorithm = System.Security.Cryptography.SHA256.Create();
+            var hash = crytpoAlgorithm.ComputeHash(hashInput.ToArray());
             Array.Resize(ref hash, 16);
             var guid = new Guid(hash);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A small struct that holds the values that define the identity of a source generated document, and don't change
+    /// as new generations happen. This is mostly for convenience as we are reguarly working with this combination of values.
+    /// </summary>
+    internal readonly struct SourceGeneratedDocumentIdentity
+    {
+        public DocumentId DocumentId { get; }
+        public string HintName { get; }
+        public ISourceGenerator Generator { get; }
+        public string FilePath { get; }
+
+        public SourceGeneratedDocumentIdentity(DocumentId documentId, string hintName, ISourceGenerator generator, string filePath)
+        {
+            DocumentId = documentId;
+            HintName = hintName;
+            Generator = generator;
+            FilePath = filePath;
+        }
+
+        public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath)
+        {
+            // We want the DocumentId generated for a generated output to be stable between Compilations; this is so features that track
+            // a document by DocumentId can find it after some change has happened that requires generators to run again.
+            // To achieve this we'll just do a crytographic hash of the generator name and hint name; the choice of a cryptographic hash
+            // as opposed to a more generic string hash is we actually want to ensure we don't have collisions.
+            var generatorName = generator.GetType().FullName;
+            Contract.ThrowIfNull(generatorName);
+
+            // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
+            // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
+            var projectIdBytes = projectId.Id.ToByteArray();
+            using var _ = ArrayBuilder<byte>.GetInstance(capacity: (generatorName.Length + hintName.Length + 1) * 2 + projectIdBytes.Length, out var hashInput);
+            hashInput.AddRange(projectIdBytes);
+            hashInput.AddRange(Encoding.Unicode.GetBytes(generatorName));
+
+            // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
+            // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
+            hashInput.AddRange(0, 0);
+            hashInput.AddRange(Encoding.Unicode.GetBytes(hintName));
+
+            // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary.
+            var hash = System.Security.Cryptography.SHA256.Create().ComputeHash(hashInput.ToArray());
+            Array.Resize(ref hash, 16);
+            var guid = new Guid(hash);
+
+            var documentId = DocumentId.CreateFromSerialized(projectId, guid, hintName);
+
+            return new SourceGeneratedDocumentIdentity(documentId, hintName, generator, filePath);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -11,10 +11,9 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class SourceGeneratedDocumentState : DocumentState
     {
-        private readonly SourceGeneratedDocumentIdentity _identity;
-
-        public string HintName => _identity.HintName;
-        public ISourceGenerator SourceGenerator => _identity.Generator;
+        public SourceGeneratedDocumentIdentity Identity { get; }
+        public string HintName => Identity.HintName;
+        public ISourceGenerator SourceGenerator => Identity.Generator;
 
         public static SourceGeneratedDocumentState Create(
             SourceGeneratedDocumentIdentity documentIdentity,
@@ -61,7 +60,7 @@ namespace Microsoft.CodeAnalysis
             ValueSource<TreeAndVersion> treeSource)
             : base(languageServices, solutionServices, documentServiceProvider, attributes, options, sourceText: null, textSource, treeSource)
         {
-            _identity = documentIdentity;
+            Identity = documentIdentity;
         }
 
         // The base allows for parse options to be null for non-C#/VB languages, but we'll always have parse options
@@ -83,7 +82,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             return Create(
-                _identity,
+                Identity,
                 sourceText,
                 ParseOptions,
                 this.LanguageServices,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -18,40 +17,21 @@ namespace Microsoft.CodeAnalysis
         public static SourceGeneratedDocumentState Create(
             string hintName,
             SourceText generatedSourceText,
-            SyntaxTree generatedSyntaxTree,
             DocumentId documentId,
+            string? filePath,
+            ParseOptions parseOptions,
             ISourceGenerator sourceGenerator,
             HostLanguageServices languageServices,
-            SolutionServices solutionServices,
-            CancellationToken cancellationToken)
+            SolutionServices solutionServices)
         {
-            var options = generatedSyntaxTree.Options;
-            var filePath = generatedSyntaxTree.FilePath;
-
             var textAndVersion = TextAndVersion.Create(generatedSourceText, VersionStamp.Create());
-            ValueSource<TextAndVersion> textSource = new ConstantValueSource<TextAndVersion>(textAndVersion);
-
-            var root = generatedSyntaxTree.GetRoot(cancellationToken);
-            Contract.ThrowIfNull(languageServices.SyntaxTreeFactory, "We should not have a generated syntax tree for a language that doesn't support trees.");
-
-            if (languageServices.SyntaxTreeFactory.CanCreateRecoverableTree(root))
-            {
-                // We will only create recoverable text if we can create a recoverable tree; if we created a
-                // recoverable text but not a new tree, it would mean tree.GetText() could still potentially return
-                // the non-recoverable text, but asking the document directly for it's text would give a recoverable
-                // text with a different object identity.
-                textSource = CreateRecoverableText(textAndVersion, solutionServices);
-
-                generatedSyntaxTree = languageServices.SyntaxTreeFactory.CreateRecoverableTree(
-                    documentId.ProjectId,
-                    filePath: generatedSyntaxTree.FilePath,
-                    options,
-                    textSource,
-                    generatedSourceText.Encoding,
-                    root);
-            }
-
-            var treeAndVersion = TreeAndVersion.Create(generatedSyntaxTree, textAndVersion.Version);
+            var textSource = new ConstantValueSource<TextAndVersion>(textAndVersion);
+            var treeSource = CreateLazyFullyParsedTree(
+                textSource,
+                documentId.ProjectId,
+                filePath,
+                parseOptions,
+                languageServices);
 
             return new SourceGeneratedDocumentState(
                 languageServices,
@@ -61,14 +41,13 @@ namespace Microsoft.CodeAnalysis
                     documentId,
                     name: hintName,
                     folders: SpecializedCollections.EmptyReadOnlyList<string>(),
-                    options.Kind,
+                    parseOptions.Kind,
                     filePath: filePath,
                     isGenerated: true,
                     designTimeOnly: false),
-                options,
-                sourceText: null, // don't strongly hold the text
+                parseOptions,
                 textSource,
-                treeAndVersion,
+                treeSource,
                 sourceGenerator,
                 hintName);
         }
@@ -78,60 +57,44 @@ namespace Microsoft.CodeAnalysis
             SolutionServices solutionServices,
             IDocumentServiceProvider? documentServiceProvider,
             DocumentInfo.DocumentAttributes attributes,
-            ParseOptions? options,
-            SourceText? sourceText,
+            ParseOptions options,
             ValueSource<TextAndVersion> textSource,
-            TreeAndVersion treeAndVersion,
+            ValueSource<TreeAndVersion> treeSource,
             ISourceGenerator sourceGenerator,
             string hintName)
-            : base(languageServices, solutionServices, documentServiceProvider, attributes, options, sourceText, textSource, new ConstantValueSource<TreeAndVersion>(treeAndVersion))
+            : base(languageServices, solutionServices, documentServiceProvider, attributes, options, sourceText: null, textSource, treeSource)
         {
             SourceGenerator = sourceGenerator;
             HintName = hintName;
         }
 
-        /// <summary>
-        /// Equivalent to calling <see cref="DocumentState.GetSyntaxTree(CancellationToken)"/>, but avoids the implicit requirement of a cancellation token since
-        /// we can always get the tree right away.
-        /// </summary>
-        /// <remarks>
-        /// We won't expose this through <see cref="SourceGeneratedDocument"/> in case the implementation changes.
-        /// </remarks>
-        public SyntaxTree SyntaxTree
-        {
-            get
-            {
-                // We are always holding onto the SyntaxTree object with a ConstantValueSource, so we can just fetch this
-                // without any extra work. Unlike normal documents where we don't even have a tree object until we've fetched text and
-                // the tree the first time, the generated case we start with a tree and text and then wrap it.
-                return GetSyntaxTree(CancellationToken.None);
-            }
-        }
+        // The base allows for parse options to be null for non-C#/VB languages, but we'll always have parse options
+        public new ParseOptions ParseOptions => base.ParseOptions!;
 
         protected override TextDocumentState UpdateText(ValueSource<TextAndVersion> newTextSource, PreservationMode mode, bool incremental)
         {
             throw new NotSupportedException(WorkspacesResources.The_contents_of_a_SourceGeneratedDocument_may_not_be_changed);
         }
 
-        public SourceGeneratedDocumentState WithUpdatedGeneratedContent(SourceText sourceText, SyntaxTree lazySyntaxTree, ParseOptions parseOptions, CancellationToken cancellationToken)
+        public SourceGeneratedDocumentState WithUpdatedGeneratedContent(SourceText sourceText, ParseOptions parseOptions)
         {
             if (TryGetText(out var existingText) &&
                 Checksum.From(existingText.GetChecksum()) == Checksum.From(sourceText.GetChecksum()) &&
-                SyntaxTree.Options.Equals(parseOptions))
+                ParseOptions.Equals(parseOptions))
             {
                 // We can reuse this instance directly
                 return this;
             }
 
-            return SourceGeneratedDocumentState.Create(
+            return Create(
                 this.HintName,
                 sourceText,
-                lazySyntaxTree,
                 this.Id,
+                this.FilePath,
+                ParseOptions,
                 this.SourceGenerator,
                 this.LanguageServices,
-                this.solutionServices,
-                cancellationToken);
+                this.solutionServices);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -13,7 +13,8 @@ namespace Microsoft.CodeAnalysis
     {
         public SourceGeneratedDocumentIdentity Identity { get; }
         public string HintName => Identity.HintName;
-        public ISourceGenerator SourceGenerator => Identity.Generator;
+        public string SourceGeneratorAssemblyName => Identity.GeneratorAssemblyName;
+        public string SourceGeneratorTypeName => Identity.GeneratorTypeName;
 
         public static SourceGeneratedDocumentState Create(
             SourceGeneratedDocumentIdentity documentIdentity,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -153,11 +152,13 @@ namespace Microsoft.CodeAnalysis.Serialization
 
             if (searchingChecksumsLeft.Remove(CompilationOptions))
             {
+                Contract.ThrowIfNull(state.CompilationOptions, "We should not be trying to serialize a project with no compilation options; RemoteSupportedLanguages.IsSupported should have filtered it out.");
                 result[CompilationOptions] = state.CompilationOptions;
             }
 
             if (searchingChecksumsLeft.Remove(ParseOptions))
             {
+                Contract.ThrowIfNull(state.ParseOptions, "We should not be trying to serialize a project with no compilation options; RemoteSupportedLanguages.IsSupported should have filtered it out.");
                 result[ParseOptions] = state.ParseOptions;
             }
 
@@ -252,7 +253,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         public static IReadOnlyList<T> GetOrCreate<T>(IReadOnlyList<T> unorderedList, ConditionalWeakTable<object, object>.CreateValueCallback orderedListGetter)
             => (IReadOnlyList<T>)s_cache.GetValue(unorderedList, orderedListGetter);
 
-        public static bool TryGetValue(object value, out Checksum checksum)
+        public static bool TryGetValue(object value, [NotNullWhen(true)] out Checksum? checksum)
         {
             // same key should always return same checksum
             if (!s_cache.TryGetValue(value, out var result))

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.Serialization
 {
     internal sealed class SolutionStateChecksums : ChecksumWithChildren
     {
-        public SolutionStateChecksums(Checksum infoChecksum, Checksum optionsChecksum, ProjectChecksumCollection projectChecksums, AnalyzerReferenceChecksumCollection analyzerReferenceChecksums)
-            : this(new object[] { infoChecksum, optionsChecksum, projectChecksums, analyzerReferenceChecksums })
+        public SolutionStateChecksums(Checksum attributesChecksum, Checksum optionsChecksum, ProjectChecksumCollection projectChecksums, AnalyzerReferenceChecksumCollection analyzerReferenceChecksums)
+            : this(new object[] { attributesChecksum, optionsChecksum, projectChecksums, analyzerReferenceChecksums })
         {
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
@@ -45,9 +45,14 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 var solution = workspace.CurrentSolution;
                 var id = workspace.GetDocumentIdInCurrentContext(text.Container);
-                if (id == null || !solution.ContainsDocument(id))
+                if (id == null)
                 {
                     return null;
+                }
+
+                if (workspace.TryGetOpenSourceGeneratedDocumentIdentity(id, out var documentIdentity))
+                {
+                    return solution.WithFrozenSourceGeneratedDocument(documentIdentity, text);
                 }
 
                 // We update all linked files to ensure they are all in sync. Otherwise code might try to jump from

--- a/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
@@ -27,6 +27,14 @@ namespace Microsoft.CodeAnalysis.Text
 
                 var solution = workspace.CurrentSolution;
 
+                if (workspace.TryGetOpenSourceGeneratedDocumentIdentity(documentId, out var documentIdentity))
+                {
+                    // For source generated documents, we won't count them as linked across multiple projects; this is because
+                    // the generated documents in each target may have different source so other features might be surprised if we
+                    // return the same documents but with different text. So in this case, we'll just return a single document.
+                    return ImmutableArray.Create(solution.WithFrozenSourceGeneratedDocument(documentIdentity, text));
+                }
+
                 var relatedIds = solution.GetRelatedDocumentIds(documentId);
                 solution = solution.WithDocumentText(relatedIds, text, PreservationMode.PreserveIdentity);
                 return relatedIds.SelectAsArray((id, solution) => solution.GetRequiredDocument(id), solution);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis
         private readonly Dictionary<SourceTextContainer, OneOrMany<DocumentId>> _bufferToAssociatedDocumentsMap = new();
 
         private readonly Dictionary<DocumentId, TextTracker> _textTrackers = new();
+        private readonly Dictionary<DocumentId, SourceTextContainer> _documentToAssociatedBufferMap = new();
 
         /// <summary>
         /// True if this workspace supports manually opening and closing documents.
@@ -88,16 +89,21 @@ namespace Microsoft.CodeAnalysis
                 _projectToOpenDocumentsMap.MultiRemove(documentId.ProjectId, documentId);
 
                 // Stop tracking the buffer or update the documentId associated with the buffer.
-                if (_textTrackers.TryGetValue(documentId, out var tracker))
+                if (_documentToAssociatedBufferMap.TryGetValue(documentId, out var textContainer))
                 {
-                    tracker.Disconnect();
-                    _textTrackers.Remove(documentId);
+                    _documentToAssociatedBufferMap.Remove(documentId);
 
-                    var currentContextDocumentId = UpdateCurrentContextMapping_NoLock(tracker.TextContainer, documentId);
+                    if (_textTrackers.TryGetValue(documentId, out var tracker))
+                    {
+                        tracker.Disconnect();
+                        _textTrackers.Remove(documentId);
+                    }
+
+                    var currentContextDocumentId = RemoveDocumentFromCurrentContextMapping_NoLock(textContainer, documentId);
                     if (currentContextDocumentId == null)
                     {
                         // No documentIds are attached to this buffer, so stop tracking it.
-                        this.UnregisterText(tracker.TextContainer);
+                        this.UnregisterText(textContainer);
                     }
                 }
             }
@@ -393,6 +399,39 @@ namespace Microsoft.CodeAnalysis
             this.RegisterText(textContainer);
         }
 
+        /// <summary>
+        /// Registers a SourceTextContainer to a source generated document. Unlike <see cref="OnDocumentOpened" />,
+        /// this doesn't result in the workspace being updated any time the contents of the container is changed; instead
+        /// this ensures that features going from the text container to the buffer back to a document get a usable document.
+        /// </summary>
+        // TODO: switch this protected once we have confidence in API shape
+        internal void OnSourceGeneratedDocumentOpened(
+            SourceGeneratedDocumentIdentity documentIdentity,
+            SourceTextContainer textContainer)
+        {
+            using (_serializationLock.DisposableWait())
+            {
+                var documentId = documentIdentity.DocumentId;
+                CheckDocumentIsClosed(documentId);
+                AddToOpenDocumentMap(documentId);
+
+                _documentToAssociatedBufferMap.Add(documentId, textContainer);
+
+                UpdateCurrentContextMapping_NoLock(textContainer, documentId, isCurrentContext: true);
+            }
+
+            this.RegisterText(textContainer);
+        }
+
+        internal void OnSourceGeneratedDocumentClosed(DocumentId documentId)
+        {
+            using (_serializationLock.DisposableWait())
+            {
+                CheckDocumentIsOpen(documentId);
+                ClearOpenDocument(documentId);
+            }
+        }
+
         private class ReuseVersionLoader : TextLoader
         {
             // Capture DocumentState instead of Document so that we don't hold onto the old solution.
@@ -436,6 +475,7 @@ namespace Microsoft.CodeAnalysis
         {
             var tracker = new TextTracker(this, documentId, textContainer, onChangedHandler);
             _textTrackers.Add(documentId, tracker);
+            _documentToAssociatedBufferMap.Add(documentId, textContainer);
             this.UpdateCurrentContextMapping_NoLock(textContainer, documentId, isCurrentContext);
             tracker.Connect();
         }
@@ -640,7 +680,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <returns>The DocumentId of the current context document attached to the textContainer, if any.</returns>
-        private DocumentId? UpdateCurrentContextMapping_NoLock(SourceTextContainer textContainer, DocumentId closedDocumentId)
+        private DocumentId? RemoveDocumentFromCurrentContextMapping_NoLock(SourceTextContainer textContainer, DocumentId closedDocumentId)
         {
             // Check if we are tracking this textContainer.
             if (!_bufferToAssociatedDocumentsMap.TryGetValue(textContainer, out var docIds))

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
+using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
-using System;
-using System.IO.Pipelines;
-using Microsoft.VisualStudio.Threading;
-using System.Diagnostics;
+using StreamJsonRpc;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             static void WriteAsset(ObjectWriter writer, ISerializerService serializer, SolutionReplicationContext context, Checksum checksum, SolutionAsset asset, CancellationToken cancellationToken)
             {
+                Debug.Assert(asset.Kind != WellKnownSynchronizationKind.Null, "We should not be sending null assets");
                 checksum.WriteTo(writer);
                 writer.WriteInt32((int)asset.Kind);
 
@@ -186,8 +187,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // in service hub, cancellation means simply closed stream
                 var result = serializerService.Deserialize<object>(kind, reader, cancellationToken);
 
-                // we should not request null assets:
-                Debug.Assert(result != null);
+                Debug.Assert(result != null, "We should not be requesting null assets");
 
                 results.Add((responseChecksum, result));
             }

--- a/src/Workspaces/Remote/Core/SolutionChecksumUpdater.cs
+++ b/src/Workspaces/Remote/Core/SolutionChecksumUpdater.cs
@@ -15,6 +15,10 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
+    /// <summary>
+    /// This class runs against the in-process workspace, and when it sees changes proactively pushes them to
+    /// the out-of-process workspace through the <see cref="IRemoteAssetSynchronizationService"/>.
+    /// </summary>
     internal sealed class SolutionChecksumUpdater : GlobalOperationAwareIdleProcessor
     {
         private readonly Workspace _workspace;

--- a/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
@@ -124,11 +124,12 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private void AddIfNeeded(HashSet<Checksum> checksums, Checksum checksum)
         {
-            Debug.Assert(checksum != Checksum.Null);
-
-            if (!_assetProvider.EnsureCacheEntryIfExists(checksum))
+            if (checksum != Checksum.Null)
             {
-                checksums.Add(checksum);
+                if (!_assetProvider.EnsureCacheEntryIfExists(checksum))
+                {
+                    checksums.Add(checksum);
+                }
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -84,6 +84,18 @@ namespace Microsoft.CodeAnalysis.Remote
                             newSolutionChecksums.AnalyzerReferences, _cancellationToken).ConfigureAwait(false));
                     }
 
+                    // The old solution should never have any frozen source generated documents -- those are only created and forked off of
+                    // a workspaces's CurrentSolution
+                    Contract.ThrowIfFalse(solution.State.FrozenSourceGeneratedDocumentState == null);
+
+                    if (newSolutionChecksums.FrozenSourceGeneratedDocumentIdentity != Checksum.Null && newSolutionChecksums.FrozenSourceGeneratedDocumentText != Checksum.Null)
+                    {
+                        var identity = await _assetProvider.GetAssetAsync<SourceGeneratedDocumentIdentity>(newSolutionChecksums.FrozenSourceGeneratedDocumentIdentity, _cancellationToken).ConfigureAwait(false);
+                        var serializableSourceText = await _assetProvider.GetAssetAsync<SerializableSourceText>(newSolutionChecksums.FrozenSourceGeneratedDocumentText, _cancellationToken).ConfigureAwait(false);
+                        var sourceText = await serializableSourceText.GetTextAsync(_cancellationToken).ConfigureAwait(false);
+                        solution = solution.WithFrozenSourceGeneratedDocument(identity, sourceText).Project.Solution;
+                    }
+
 #if DEBUG
                     // make sure created solution has same checksum as given one
                     await ValidateChecksumAsync(newSolutionChecksum, solution).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/TestUtils.cs
@@ -203,7 +203,8 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 if (child is Checksum checksum)
                 {
-                    set.Add(checksum);
+                    if (checksum != Checksum.Null)
+                        set.Add(checksum);
                 }
 
                 if (child is ChecksumCollection collection)

--- a/src/Workspaces/Remote/ServiceHub/Services/AssetSynchronization/RemoteAssetSynchronizationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/AssetSynchronization/RemoteAssetSynchronizationService.cs
@@ -12,6 +12,11 @@ using RoslynLogger = Microsoft.CodeAnalysis.Internal.Log.Logger;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
+    /// <summary>
+    /// This service is used by the <see cref="SolutionChecksumUpdater"/> to proactively update the solution snapshot in
+    /// the out-of-process workspace. We do this to limit the amount of time required to synchronize a solution over after an edit
+    /// once a feature is asking for a snapshot.
+    /// </summary>
     internal sealed class RemoteAssetSynchronizationService : BrokeredServiceBase, IRemoteAssetSynchronizationService
     {
         internal sealed class Factory : FactoryBase<IRemoteAssetSynchronizationService>

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -43,13 +43,13 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
 
         public DiagnosticComputer(
-            DocumentId? documentId,
+            TextDocument? document,
             Project project,
             TextSpan? span,
             AnalysisKind? analysisKind,
             DiagnosticAnalyzerInfoCache analyzerInfoCache)
         {
-            _document = documentId != null ? project.Solution.GetRequiredTextDocument(documentId) : null;
+            _document = document;
             _project = project;
             _span = span;
             _analysisKind = analysisKind;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 using RoslynLogger = Microsoft.CodeAnalysis.Internal.Log.Logger;
 
@@ -52,9 +53,12 @@ namespace Microsoft.CodeAnalysis.Remote
                     var documentId = arguments.DocumentId;
                     var projectId = arguments.ProjectId;
                     var project = solution.GetProject(projectId);
+                    var document = arguments.DocumentId != null
+                        ? solution.GetTextDocument(arguments.DocumentId) ?? await solution.GetSourceGeneratedDocumentAsync(arguments.DocumentId, cancellationToken).ConfigureAwait(false)
+                        : null;
                     var documentSpan = arguments.DocumentSpan;
                     var documentAnalysisKind = arguments.DocumentAnalysisKind;
-                    var diagnosticComputer = new DiagnosticComputer(documentId, project, documentSpan, documentAnalysisKind, _analyzerInfoCache);
+                    var diagnosticComputer = new DiagnosticComputer(document, project, documentSpan, documentAnalysisKind, _analyzerInfoCache);
 
                     var result = await diagnosticComputer.GetDiagnosticsAsync(
                         arguments.AnalyzerIds,

--- a/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
@@ -38,13 +38,13 @@ namespace Microsoft.CodeAnalysis.Remote
                 // (like the JS parts of a .cshtml file). Filter them out here.  This will
                 // need to be revisited if we someday support FAR between these languages.
                 var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-                var document = solution.GetDocument(documentId);
-                var documentsToSearch = ImmutableHashSet.CreateRange(
-                    documentIdsToSearch.Select(solution.GetDocument).WhereNotNull());
+                var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                var documentsToSearch = await documentIdsToSearch.SelectAsArrayAsync(id => solution.GetDocumentAsync(id, includeSourceGenerated: true, cancellationToken)).ConfigureAwait(false);
+                var documentsToSearchSet = ImmutableHashSet.CreateRange(documentsToSearch.WhereNotNull());
 
                 var service = document.GetLanguageService<IDocumentHighlightsService>();
                 var result = await service.GetDocumentHighlightsAsync(
-                    document, position, documentsToSearch, cancellationToken).ConfigureAwait(false);
+                    document, position, documentsToSearchSet, cancellationToken).ConfigureAwait(false);
 
                 return result.SelectAsArray(SerializableDocumentHighlights.Dehydrate);
             }, cancellationToken);

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.NavigationBar;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -30,7 +31,8 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
 
-                var document = solution.GetRequiredDocument(documentId);
+                var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfNull(document);
                 var navigationBarService = document.GetRequiredLanguageService<INavigationBarItemService>();
                 var result = await navigationBarService.GetItemsAsync(document, supportsCodeGeneration, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Implements the core of https://github.com/dotnet/roslyn/issues/50676.

The overall approach here is to make GetOpenDocumentInCurrentContextWithChanges work to return SourceGeneratedDocuments like anything else. The strange bit is we have to ensure the source generated document _matches_ the text that's currently in the buffer. Consider a case where:

1. The user makes a change in another file which means the generator will produce new results. That generator is running async.
2. The user switches back to the generated file and immediately invokes a command on it before we refresh the buffer contents.

In that case, the buffer contents are stale, but we need to ensure the SourceGeneratedDocument given to all our features is in sync with the actual text buffer, or otherwise spans and everything won't align. This is very similar to the general concept of the "with changes" portion of that API: you may always get a forked version of the world that doesn't represent an entirely consistent view of the entire world, but it's at least going to ensure your document matches your starting point.

In the "regular case" that the generator has already ran and we're able to confirm the contents of the text buffer still matches the generated output, this (like for regular documents) doesn't fork anything at all -- you end up with the Solution object that matches Workspace.CurrentSolution.

The implementation approach here is to ensure that when we do fork a snapshot the final Compilation has the tree matching the text present no matter what. One approach would have been to fork the compilation tracker with some extra special state that remembers to fix that up in the end but I had two concerns with that approach:

1. The compilation tracker implementation is already crazy complicated.
2. Forking the compilation tracker while a generator is running potentially now running generators twice depending on the timing.

I decided to take the approach that CompilationTracker has an interface extracted for it's actual surface area, and then when we do the forked solution we create a different implementation of that interface that forwards to the underlying implementation and then replaces out the tree at the very end. This means we don't ever have generators running twice, and the magic of swapping out the tree is all contained in the special implementation and the core implementation is untouched. I absolutely concede that the interface isn't fun (translation: I hate it too) and if somebody has a better idea please speak up!

Still to do:

- [x] Integration tests and maybe some unit tests too
- [x] Further investigation of whether we need to implement some more of the ICompilationTracker methods. In my limit testing I don't see features currently relying on it.