### PR TITLE
F5 Hot Reload

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 debuggingSession.Test_SetNonRemappableRegions(nonRemappableRegions ?? ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty);
 
                 var telemetry = new EditSessionTelemetry();
-                EditSession = new EditSession(debuggingSession, telemetry);
+                EditSession = new EditSession(debuggingSession, telemetry, inBreakState: true);
             }
 
             public void Dispose()

--- a/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
                 var mockCompilationOutputsProvider = new Func<Project, CompilationOutputs>(_ => new MockCompilationOutputs(Guid.NewGuid()));
 
-                var debuggingSession = new DebuggingSession(solution, mockCompilationOutputsProvider, SpecializedCollections.EmptyEnumerable<KeyValuePair<DocumentId, CommittedSolution.DocumentState>>());
+                var debuggingSession = new DebuggingSession(solution, mockDebuggerService, mockCompilationOutputsProvider, SpecializedCollections.EmptyEnumerable<KeyValuePair<DocumentId, CommittedSolution.DocumentState>>());
 
                 if (initialState != CommittedSolution.DocumentState.None)
                 {
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 debuggingSession.Test_SetNonRemappableRegions(nonRemappableRegions ?? ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty);
 
                 var telemetry = new EditSessionTelemetry();
-                EditSession = new EditSession(debuggingSession, telemetry, mockDebuggerService);
+                EditSession = new EditSession(debuggingSession, telemetry);
             }
 
             public void Dispose()

--- a/src/EditorFeatures/Test/EditAndContinue/Helpers/ActiveStatementTestHelpers.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/Helpers/ActiveStatementTestHelpers.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
+{
+    internal static class ActiveStatementTestHelpers
+    {
+        internal static ImmutableArray<ManagedActiveStatementDebugInfo> GetActiveStatementDebugInfos(
+            string[] markedSources,
+            string extension = ".cs",
+            int[]? methodRowIds = null,
+            Guid[]? modules = null,
+            int[]? methodVersions = null,
+            int[]? ilOffsets = null,
+            ActiveStatementFlags[]? flags = null)
+        {
+            IEnumerable<(TextSpan Span, int Id, SourceText Text, string DocumentName, DocumentId DocumentId)> EnumerateAllSpans()
+            {
+                var sourceIndex = 0;
+                foreach (var markedSource in markedSources)
+                {
+                    var documentName = Path.Combine(TempRoot.Root, TestWorkspace.GetDefaultTestSourceDocumentName(sourceIndex, extension));
+                    var documentId = DocumentId.CreateNewId(ProjectId.CreateNewId(), documentName);
+                    var text = SourceText.From(markedSource);
+
+                    foreach (var (span, id) in ActiveStatementsDescription.GetActiveSpans(markedSource))
+                    {
+                        yield return (span, id, text, documentName, documentId);
+                    }
+
+                    sourceIndex++;
+                }
+            }
+
+            IEnumerable<ManagedActiveStatementDebugInfo> Enumerate()
+            {
+                var moduleId = new Guid("00000000-0000-0000-0000-000000000001");
+                var threadId = new Guid("00000000-0000-0000-0000-000000000010");
+
+                var index = 0;
+                foreach (var (span, id, text, documentName, documentId) in EnumerateAllSpans().OrderBy(s => s.Id))
+                {
+                    yield return new ManagedActiveStatementDebugInfo(
+                        new ManagedInstructionId(
+                            new ManagedMethodId(
+                                (modules != null) ? modules[index] : moduleId,
+                                new ManagedModuleMethodId(
+                                    token: 0x06000000 | (methodRowIds != null ? methodRowIds[index] : index + 1),
+                                    version: (methodVersions != null) ? methodVersions[index] : 1)),
+                            ilOffset: (ilOffsets != null) ? ilOffsets[index] : 0),
+                        documentName: documentName,
+                        sourceSpan: text.Lines.GetLinePositionSpan(span).ToSourceSpan(),
+                        flags: (flags != null) ? flags[index] : ((id == 0 ? ActiveStatementFlags.IsLeafFrame : ActiveStatementFlags.IsNonLeafFrame) | ActiveStatementFlags.MethodUpToDate));
+
+                    index++;
+                }
+            }
+
+            return Enumerate().ToImmutableArray();
+        }
+
+        public static string Delete(string src, string marker)
+        {
+            while (true)
+            {
+                var startStr = "/*delete" + marker;
+                var endStr = "*/";
+                var start = src.IndexOf(startStr);
+                if (start == -1)
+                {
+                    return src;
+                }
+
+                var end = src.IndexOf(endStr, start + startStr.Length) + endStr.Length;
+                src = src.Substring(0, start) + src.Substring(end);
+            }
+        }
+
+        /// <summary>
+        /// Inserts new lines into the text at the position indicated by /*insert<paramref name="marker"/>[{number-of-lines-to-insert}]*/.
+        /// </summary>
+        public static string InsertNewLines(string src, string marker)
+        {
+            while (true)
+            {
+                var startStr = "/*insert" + marker + "[";
+                var endStr = "*/";
+
+                var start = src.IndexOf(startStr);
+                if (start == -1)
+                {
+                    return src;
+                }
+
+                var startOfLineCount = start + startStr.Length;
+                var endOfLineCount = src.IndexOf(']', startOfLineCount);
+                var lineCount = int.Parse(src.Substring(startOfLineCount, endOfLineCount - startOfLineCount));
+
+                var end = src.IndexOf(endStr, endOfLineCount) + endStr.Length;
+
+                src = src.Substring(0, start) + string.Join("", Enumerable.Repeat(Environment.NewLine, lineCount)) + src.Substring(end);
+            }
+        }
+
+        public static string Update(string src, string marker)
+            => InsertNewLines(Delete(src, marker), marker);
+
+        public static string InspectActiveStatement(ActiveStatement statement)
+            => $"{statement.Ordinal}: {statement.Span} flags=[{statement.Flags}] pdid={statement.PrimaryDocumentId.DebugName} docs=[{string.Join(",", statement.DocumentIds.Select(d => d.DebugName))}]";
+
+        public static string InspectActiveStatementAndInstruction(ActiveStatement statement)
+            => InspectActiveStatement(statement) + " " + statement.InstructionId.GetDebuggerDisplay();
+
+        public static string InspectActiveStatementAndInstruction(ActiveStatement statement, SourceText text)
+            => InspectActiveStatementAndInstruction(statement) + $" '{GetFirstLineText(statement.Span, text)}'";
+
+        public static string InspectActiveStatementUpdate(ManagedActiveStatementUpdate update)
+            => $"{update.Method.GetDebuggerDisplay()} IL_{update.ILOffset:X4}: {update.NewSpan.GetDebuggerDisplay()}";
+
+        public static IEnumerable<string> InspectNonRemappableRegions(ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> regions)
+            => regions.OrderBy(r => r.Key.Token).Select(r => $"{r.Key.Method.GetDebuggerDisplay()} | {string.Join(", ", r.Value.Select(r => r.GetDebuggerDisplay()))}");
+
+        public static string InspectExceptionRegionUpdate(ManagedExceptionRegionUpdate r)
+            => $"{r.Method.GetDebuggerDisplay()} | {r.NewSpan.GetDebuggerDisplay()} Delta={r.Delta}";
+
+        public static string GetFirstLineText(LinePositionSpan span, SourceText text)
+            => text.Lines[span.Start.Line].ToString().Trim();
+    }
+}

--- a/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
+{
+    internal class MockDiagnosticAnalyzerService : IDiagnosticAnalyzerService
+    {
+        public readonly List<DocumentId> DocumentsToReanalyze = new();
+
+        public void Reanalyze(Workspace workspace, IEnumerable<ProjectId>? projectIds = null, IEnumerable<DocumentId>? documentIds = null, bool highPriority = false)
+            => DocumentsToReanalyze.AddRange(documentIds);
+
+        public DiagnosticAnalyzerInfoCache AnalyzerInfoCache
+            => throw new NotImplementedException();
+
+        public bool ContainsDiagnostics(Workspace workspace, ProjectId projectId)
+            => throw new NotImplementedException();
+
+        public Task ForceAnalyzeAsync(Solution solution, Action<Project> onProjectAnalyzed, ProjectId? projectId = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Workspace workspace, ProjectId? projectId = null, DocumentId? documentId = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId? projectId = null, DocumentId? documentId = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, DocumentId? documentId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, string? diagnosticIdOpt = null, bool includeSuppressedDiagnostics = false, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ImmutableArray<DiagnosticData>> GetSpecificCachedDiagnosticsAsync(Workspace workspace, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<bool> TryAppendDiagnosticsForSpanAsync(Document document, TextSpan range, ArrayBuilder<DiagnosticData> diagnostics, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -155,14 +155,9 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
 
             // StartEditSession
 
-            mockEncService.StartEditSessionImpl = (out ImmutableArray<DocumentId> documentsToReanalyze) =>
-            {
-                documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
-            };
+            mockEncService.StartEditSessionImpl = () => { };
 
-            await proxy.StartEditSessionAsync(
-                mockDiagnosticService.Object,
-                CancellationToken.None).ConfigureAwait(false);
+            await proxy.StartEditSessionAsync(CancellationToken.None).ConfigureAwait(false);
 
             VerifyReanalyzeInvocation(ImmutableArray<DocumentId>.Empty);
 
@@ -186,12 +181,9 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
 
             // EndDebuggingSession
 
-            mockEncService.EndDebuggingSessionImpl = (out ImmutableArray<DocumentId> documentsToReanalyze) =>
-            {
-                documentsToReanalyze = ImmutableArray.Create(document.Id);
-            };
+            mockEncService.EndDebuggingSessionImpl = () => { };
 
-            await proxy.EndDebuggingSessionAsync(diagnosticUpdateSource, mockDiagnosticService.Object, CancellationToken.None).ConfigureAwait(false);
+            await proxy.EndDebuggingSessionAsync(diagnosticUpdateSource, CancellationToken.None).ConfigureAwait(false);
             VerifyReanalyzeInvocation(ImmutableArray.Create(document.Id));
             Assert.Equal(1, emitDiagnosticsClearedCount);
             emitDiagnosticsClearedCount = 0;

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -153,13 +153,15 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
 
             Assert.True(called);
 
-            // StartEditSession
+            // BreakStateEntered
 
-            mockEncService.StartEditSessionImpl = () => { };
+            mockEncService.BreakStateEnteredImpl = (out ImmutableArray<DocumentId> documentsToReanalyze) =>
+            {
+                documentsToReanalyze = ImmutableArray.Create(document.Id);
+            };
 
-            await proxy.StartEditSessionAsync(CancellationToken.None).ConfigureAwait(false);
-
-            VerifyReanalyzeInvocation(ImmutableArray<DocumentId>.Empty);
+            await proxy.BreakStateEnteredAsync(mockDiagnosticService.Object, CancellationToken.None).ConfigureAwait(false);
+            VerifyReanalyzeInvocation(ImmutableArray.Create(document.Id));
 
             var activeStatement = (await remoteDebuggeeModuleMetadataProvider!.GetActiveStatementsAsync(CancellationToken.None).ConfigureAwait(false)).Single();
             Assert.Equal(as1.ActiveInstruction, activeStatement.ActiveInstruction);
@@ -169,21 +171,14 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
             var availability = await remoteDebuggeeModuleMetadataProvider!.GetAvailabilityAsync(moduleId1, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(new ManagedEditAndContinueAvailability(ManagedEditAndContinueAvailabilityStatus.NotAllowedForModule, "can't do enc"), availability);
 
-            // EndEditSession
+            // EndDebuggingSession
 
-            mockEncService.EndEditSessionImpl = (out ImmutableArray<DocumentId> documentsToReanalyze) =>
+            mockEncService.EndDebuggingSessionImpl = (out ImmutableArray<DocumentId> documentsToReanalyze) =>
             {
                 documentsToReanalyze = ImmutableArray.Create(document.Id);
             };
 
-            await proxy.EndEditSessionAsync(mockDiagnosticService.Object, CancellationToken.None).ConfigureAwait(false);
-            VerifyReanalyzeInvocation(ImmutableArray.Create(document.Id));
-
-            // EndDebuggingSession
-
-            mockEncService.EndDebuggingSessionImpl = () => { };
-
-            await proxy.EndDebuggingSessionAsync(diagnosticUpdateSource, CancellationToken.None).ConfigureAwait(false);
+            await proxy.EndDebuggingSessionAsync(diagnosticUpdateSource, mockDiagnosticService.Object, CancellationToken.None).ConfigureAwait(false);
             VerifyReanalyzeInvocation(ImmutableArray.Create(document.Id));
             Assert.Equal(1, emitDiagnosticsClearedCount);
             emitDiagnosticsClearedCount = 0;
@@ -267,10 +262,13 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
 
             // CommitSolutionUpdate
 
-            called = false;
-            mockEncService.CommitSolutionUpdateImpl = () => called = true;
-            await proxy.CommitSolutionUpdateAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.True(called);
+            mockEncService.CommitSolutionUpdateImpl = (out ImmutableArray<DocumentId> documentsToReanalyze) =>
+            {
+                documentsToReanalyze = ImmutableArray.Create(document.Id);
+            };
+
+            await proxy.CommitSolutionUpdateAsync(mockDiagnosticService.Object, CancellationToken.None).ConfigureAwait(false);
+            VerifyReanalyzeInvocation(ImmutableArray.Create(document.Id));
 
             // DiscardSolutionUpdate
 

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -131,32 +131,37 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
 
             // StartDebuggingSession
 
+            IManagedEditAndContinueDebuggerService? remoteDebuggeeModuleMetadataProvider = null;
+
             var called = false;
-            mockEncService.StartDebuggingSessionImpl = (solution, captureMatchingDocuments) =>
+            mockEncService.StartDebuggingSessionImpl = (solution, debuggerService, captureMatchingDocuments) =>
             {
                 Assert.Equal("proj", solution.Projects.Single().Name);
+                remoteDebuggeeModuleMetadataProvider = debuggerService;
                 called = true;
             };
 
-            await proxy.StartDebuggingSessionAsync(localWorkspace.CurrentSolution, captureMatchingDocuments: false, CancellationToken.None).ConfigureAwait(false);
-            Assert.True(called);
-
-            // StartEditSession
-
-            IManagedEditAndContinueDebuggerService? remoteDebuggeeModuleMetadataProvider = null;
-            mockEncService.StartEditSessionImpl = (IManagedEditAndContinueDebuggerService debuggerService, out ImmutableArray<DocumentId> documentsToReanalyze) =>
-            {
-                remoteDebuggeeModuleMetadataProvider = debuggerService;
-                documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
-            };
-
-            await proxy.StartEditSessionAsync(
-                mockDiagnosticService.Object,
+            await proxy.StartDebuggingSessionAsync(
+                localWorkspace.CurrentSolution,
                 debuggerService: new MockManagedEditAndContinueDebuggerService()
                 {
                     IsEditAndContinueAvailable = _ => new ManagedEditAndContinueAvailability(ManagedEditAndContinueAvailabilityStatus.NotAllowedForModule, "can't do enc"),
                     GetActiveStatementsImpl = () => ImmutableArray.Create(as1)
                 },
+                captureMatchingDocuments: false,
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.True(called);
+
+            // StartEditSession
+
+            mockEncService.StartEditSessionImpl = (out ImmutableArray<DocumentId> documentsToReanalyze) =>
+            {
+                documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
+            };
+
+            await proxy.StartEditSessionAsync(
+                mockDiagnosticService.Object,
                 CancellationToken.None).ConfigureAwait(false);
 
             VerifyReanalyzeInvocation(ImmutableArray<DocumentId>.Empty);

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
-    internal delegate void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
+    internal delegate void ActionOut<T>(out T arg);
 
     internal class MockEditAndContinueWorkspaceService : IEditAndContinueWorkspaceService
     {
@@ -21,19 +21,28 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
         public Func<Document, DocumentActiveStatementSpanProvider, ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>? GetAdjustedActiveStatementSpansImpl;
         public Action<Solution, IManagedEditAndContinueDebuggerService, bool>? StartDebuggingSessionImpl;
-        public Action? StartEditSessionImpl;
-        public Action? EndDebuggingSessionImpl;
-        public EndEditSession? EndEditSessionImpl;
+
+        public ActionOut<ImmutableArray<DocumentId>>? EndDebuggingSessionImpl;
         public Func<Solution, SolutionActiveStatementSpanProvider, string?, bool>? HasChangesImpl;
         public Func<Solution, SolutionActiveStatementSpanProvider, EmitSolutionUpdateResults>? EmitSolutionUpdateImpl;
         public Func<Solution, ManagedInstructionId, bool?>? IsActiveStatementInExceptionRegionImpl;
         public Action<Document>? OnSourceFileUpdatedImpl;
-        public Action? CommitSolutionUpdateImpl;
+        public ActionOut<ImmutableArray<DocumentId>>? CommitSolutionUpdateImpl;
+        public ActionOut<ImmutableArray<DocumentId>>? BreakStateEnteredImpl;
         public Action? DiscardSolutionUpdateImpl;
         public Func<Document, DocumentActiveStatementSpanProvider, ImmutableArray<Diagnostic>>? GetDocumentDiagnosticsImpl;
 
-        public void CommitSolutionUpdate()
-            => CommitSolutionUpdateImpl?.Invoke();
+        public void BreakStateEntered(out ImmutableArray<DocumentId> documentsToReanalyze)
+        {
+            documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
+            BreakStateEnteredImpl?.Invoke(out documentsToReanalyze);
+        }
+
+        public void CommitSolutionUpdate(out ImmutableArray<DocumentId> documentsToReanalyze)
+        {
+            documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
+            CommitSolutionUpdateImpl?.Invoke(out documentsToReanalyze);
+        }
 
         public void DiscardSolutionUpdate()
             => DiscardSolutionUpdateImpl?.Invoke();
@@ -41,15 +50,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
             => new((EmitSolutionUpdateImpl ?? throw new NotImplementedException()).Invoke(solution, activeStatementSpanProvider));
 
-        public void EndDebuggingSession()
-        {
-            EndDebuggingSessionImpl?.Invoke();
-        }
-
-        public void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze)
+        public void EndDebuggingSession(out ImmutableArray<DocumentId> documentsToReanalyze)
         {
             documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
-            EndEditSessionImpl?.Invoke(out documentsToReanalyze);
+            EndDebuggingSessionImpl?.Invoke(out documentsToReanalyze);
         }
 
         public ValueTask<ImmutableArray<ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>> GetBaseActiveStatementSpansAsync(Solution solution, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)
@@ -77,11 +81,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         {
             StartDebuggingSessionImpl?.Invoke(solution, debuggerService, captureMatchingDocuments);
             return default;
-        }
-
-        public void StartEditSession()
-        {
-            StartEditSessionImpl?.Invoke();
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
-    internal delegate void StartEditSession(IManagedEditAndContinueDebuggerService debuggerService, out ImmutableArray<DocumentId> documentsToReanalyze);
+    internal delegate void StartEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
     internal delegate void EndSession(out ImmutableArray<DocumentId> documentsToReanalyze);
 
     internal class MockEditAndContinueWorkspaceService : IEditAndContinueWorkspaceService
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Func<Solution, SolutionActiveStatementSpanProvider, ManagedInstructionId, LinePositionSpan?>? GetCurrentActiveStatementPositionImpl;
 
         public Func<Document, DocumentActiveStatementSpanProvider, ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>? GetAdjustedActiveStatementSpansImpl;
-        public Action<Solution, bool>? StartDebuggingSessionImpl;
+        public Action<Solution, IManagedEditAndContinueDebuggerService, bool>? StartDebuggingSessionImpl;
         public StartEditSession? StartEditSessionImpl;
         public EndSession? EndDebuggingSessionImpl;
         public EndSession? EndEditSessionImpl;
@@ -75,16 +75,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public void OnSourceFileUpdated(Document document)
             => OnSourceFileUpdatedImpl?.Invoke(document);
 
-        public ValueTask StartDebuggingSessionAsync(Solution solution, bool captureMatchingDocuments, CancellationToken cancellationToken)
+        public ValueTask StartDebuggingSessionAsync(Solution solution, IManagedEditAndContinueDebuggerService debuggerService, bool captureMatchingDocuments, CancellationToken cancellationToken)
         {
-            StartDebuggingSessionImpl?.Invoke(solution, captureMatchingDocuments);
+            StartDebuggingSessionImpl?.Invoke(solution, debuggerService, captureMatchingDocuments);
             return default;
         }
 
-        public void StartEditSession(IManagedEditAndContinueDebuggerService debuggerService, out ImmutableArray<DocumentId> documentsToReanalyze)
+        public void StartEditSession(out ImmutableArray<DocumentId> documentsToReanalyze)
         {
             documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
-            StartEditSessionImpl?.Invoke(debuggerService, out documentsToReanalyze);
+            StartEditSessionImpl?.Invoke(out documentsToReanalyze);
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
@@ -12,8 +12,7 @@ using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
-    internal delegate void StartEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
-    internal delegate void EndSession(out ImmutableArray<DocumentId> documentsToReanalyze);
+    internal delegate void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
 
     internal class MockEditAndContinueWorkspaceService : IEditAndContinueWorkspaceService
     {
@@ -22,9 +21,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
         public Func<Document, DocumentActiveStatementSpanProvider, ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>? GetAdjustedActiveStatementSpansImpl;
         public Action<Solution, IManagedEditAndContinueDebuggerService, bool>? StartDebuggingSessionImpl;
-        public StartEditSession? StartEditSessionImpl;
-        public EndSession? EndDebuggingSessionImpl;
-        public EndSession? EndEditSessionImpl;
+        public Action? StartEditSessionImpl;
+        public Action? EndDebuggingSessionImpl;
+        public EndEditSession? EndEditSessionImpl;
         public Func<Solution, SolutionActiveStatementSpanProvider, string?, bool>? HasChangesImpl;
         public Func<Solution, SolutionActiveStatementSpanProvider, EmitSolutionUpdateResults>? EmitSolutionUpdateImpl;
         public Func<Solution, ManagedInstructionId, bool?>? IsActiveStatementInExceptionRegionImpl;
@@ -42,10 +41,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
             => new((EmitSolutionUpdateImpl ?? throw new NotImplementedException()).Invoke(solution, activeStatementSpanProvider));
 
-        public void EndDebuggingSession(out ImmutableArray<DocumentId> documentsToReanalyze)
+        public void EndDebuggingSession()
         {
-            documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
-            EndDebuggingSessionImpl?.Invoke(out documentsToReanalyze);
+            EndDebuggingSessionImpl?.Invoke();
         }
 
         public void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze)
@@ -81,10 +79,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             return default;
         }
 
-        public void StartEditSession(out ImmutableArray<DocumentId> documentsToReanalyze)
+        public void StartEditSession()
         {
-            documentsToReanalyze = ImmutableArray<DocumentId>.Empty;
-            StartEditSessionImpl?.Invoke(out documentsToReanalyze);
+            StartEditSessionImpl?.Invoke();
         }
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
@@ -10,6 +10,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 {
     internal readonly struct ActiveStatementsMap
     {
+        public static readonly ActiveStatementsMap Empty =
+            new(ImmutableDictionary<DocumentId, ImmutableArray<ActiveStatement>>.Empty, ImmutableDictionary<ManagedInstructionId, ActiveStatement>.Empty);
+
         /// <summary>
         /// Groups active statements by document. 
         /// Multiple documents point to the same set of active statements if they are linked to the same underlying source file.

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -45,16 +45,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private List<IDisposable>? _lazyBaselineModuleReaders;
         private readonly object _projectEmitBaselinesGuard = new();
 
-        // Maps active statement instructions to their latest spans.
-        // Consumed by the next edit session and updated when changes are committed at the end of the edit session.
+        // Maps active statement instructions reported by the debugger to their latest spans that might not yet have been applied
+        // (remapping not triggered yet). Consumed by the next edit session and updated when changes are committed at the end of the edit session.
         //
-        // Consider a function F containing a call to function G that is updated a couple of times
-        // before the thread returns from G and is remapped to the latest version of F.
-        // '>' indicates an active statement instruction.
+        // Consider a function F containing a call to function G. While G is being executed, F is updated a couple of times (in two edit sessions)
+        // before the thread returns from G and is remapped to the latest version of F. At the start of the second edit session,
+        // the active instruction reported by the debugger is still at the original location since function F has not been remapped yet (G has not returned yet).
+        //
+        // '>' indicates an active statement instruction for non-leaf frame reported by the debugger.
+        // v1 - before first edit, G executing
+        // v2 - after first edit, G still executing
+        // v3 - after second edit and G returned
         //
         // F v1:        F v2:       F v3:
         // 0: nop       0: nop      0: nop
-        // 1> G()       1: nop      1: nop
+        // 1> G()       1> nop      1: nop
         // 2: nop       2: G()      2: nop
         // 3: nop       3: nop      3> G()
         //
@@ -85,8 +90,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         internal readonly CommittedSolution LastCommittedSolution;
 
+        internal readonly IManagedEditAndContinueDebuggerService DebuggerService;
+
         internal DebuggingSession(
             Solution solution,
+            IManagedEditAndContinueDebuggerService debuggerService,
             Func<Project, CompilationOutputs> compilationOutputsProvider,
             IEnumerable<KeyValuePair<DocumentId, CommittedSolution.DocumentState>> initialDocumentStates)
         {
@@ -95,6 +103,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _projectEmitBaselines = new Dictionary<ProjectId, EmitBaseline>();
             _modulesPreparedForUpdate = new HashSet<Guid>();
 
+            DebuggerService = debuggerService;
             LastCommittedSolution = new CommittedSolution(this, solution, initialDocumentStates);
             NonRemappableRegions = ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty;
         }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -161,7 +161,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddGeneralDiagnostic(EditAndContinueErrorCode.ErrorReadingFile, nameof(FeaturesResources.ErrorReadingFile));
             AddGeneralDiagnostic(EditAndContinueErrorCode.CannotApplyChangesUnexpectedError, nameof(FeaturesResources.CannotApplyChangesUnexpectedError));
             AddGeneralDiagnostic(EditAndContinueErrorCode.ChangesDisallowedWhileStoppedAtException, nameof(FeaturesResources.ChangesDisallowedWhileStoppedAtException));
-            AddGeneralDiagnostic(EditAndContinueErrorCode.ChangesNotAppliedWhileRunning, nameof(FeaturesResources.ChangesNotAppliedWhileRunning), DiagnosticSeverity.Warning);
             AddGeneralDiagnostic(EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee, nameof(FeaturesResources.DocumentIsOutOfSyncWithDebuggee), DiagnosticSeverity.Warning);
             AddGeneralDiagnostic(EditAndContinueErrorCode.UnableToReadSourceFileOrPdb, nameof(FeaturesResources.UnableToReadSourceFileOrPdb), DiagnosticSeverity.Warning);
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueErrorCode.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueErrorCode.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
     internal enum EditAndContinueErrorCode
     {
         ErrorReadingFile = 1,
         CannotApplyChangesUnexpectedError = 2,
-        ChangesNotAppliedWhileRunning = 3,
+        // ChangesNotAppliedWhileRunning = 3, // obsolete
         ChangesDisallowedWhileStoppedAtException = 4,
         DocumentIsOutOfSyncWithDebuggee = 5,
         UnableToReadSourceFileOrPdb = 6,

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             // Note that we may return empty deltas if all updates have been deferred.
             // The debugger will still call commit or discard on the update batch.
-            return new EmitSolutionUpdateResults(solutionUpdate.ModuleUpdates, solutionUpdate.Diagnostics);
+            return new EmitSolutionUpdateResults(solutionUpdate.ModuleUpdates, solutionUpdate.Diagnostics, solutionUpdate.DocumentsWithRudeEdits);
         }
 
         public void CommitSolutionUpdate(out ImmutableArray<DocumentId> documentsToReanalyze)

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         internal readonly DebuggingSession DebuggingSession;
         internal readonly EditSessionTelemetry Telemetry;
-        internal readonly IManagedEditAndContinueDebuggerService DebuggerService;
 
         private readonly ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> _nonRemappableRegions;
 
@@ -59,12 +58,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         internal EditSession(
             DebuggingSession debuggingSession,
-            EditSessionTelemetry telemetry,
-            IManagedEditAndContinueDebuggerService debuggerService)
+            EditSessionTelemetry telemetry)
         {
             DebuggingSession = debuggingSession;
             Telemetry = telemetry;
-            DebuggerService = debuggerService;
 
             _nonRemappableRegions = debuggingSession.NonRemappableRegions;
 
@@ -86,7 +83,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <returns><see langword="default"/> if the module is not loaded.</returns>
         public async Task<ImmutableArray<Diagnostic>?> GetModuleDiagnosticsAsync(Guid mvid, string projectDisplayName, CancellationToken cancellationToken)
         {
-            var availability = await DebuggerService.GetAvailabilityAsync(mvid, cancellationToken).ConfigureAwait(false);
+            var availability = await DebuggingSession.DebuggerService.GetAvailabilityAsync(mvid, cancellationToken).ConfigureAwait(false);
             if (availability.Status == ManagedEditAndContinueAvailabilityStatus.ModuleNotLoaded)
             {
                 return null;
@@ -106,7 +103,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             try
             {
                 // Last committed solution reflects the state of the source that is in sync with the binaries that are loaded in the debuggee.
-                return CreateActiveStatementsMap(await DebuggerService.GetActiveStatementsAsync(cancellationToken).ConfigureAwait(false));
+                return CreateActiveStatementsMap(await DebuggingSession.DebuggerService.GetActiveStatementsAsync(cancellationToken).ConfigureAwait(false));
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {

--- a/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EmitSolutionUpdateResults.cs
@@ -3,10 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -14,15 +17,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     {
         public static readonly EmitSolutionUpdateResults Empty =
             new(new ManagedModuleUpdates(ManagedModuleUpdateStatus.None, ImmutableArray<ManagedModuleUpdate>.Empty),
-                ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)>.Empty);
+                ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)>.Empty,
+                ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)>.Empty);
 
         public readonly ManagedModuleUpdates ModuleUpdates;
         public readonly ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)> Diagnostics;
+        public readonly ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> DocumentsWithRudeEdits;
 
-        public EmitSolutionUpdateResults(ManagedModuleUpdates moduleUpdates, ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)> diagnostics)
+        public EmitSolutionUpdateResults(
+            ManagedModuleUpdates moduleUpdates,
+            ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)> diagnostics,
+            ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> documentsWithRudeEdits)
         {
             ModuleUpdates = moduleUpdates;
             Diagnostics = diagnostics;
+            DocumentsWithRudeEdits = documentsWithRudeEdits;
         }
 
         public ImmutableArray<DiagnosticData> GetDiagnosticData(Solution solution)
@@ -42,6 +51,32 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             return result.ToImmutable();
+        }
+
+        public async Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(Solution solution, CancellationToken cancellationToken)
+        {
+            using var _ = ArrayBuilder<Diagnostic>.GetInstance(out var diagnostics);
+
+            // add rude edits:
+            foreach (var (documentId, documentRudeEdits) in DocumentsWithRudeEdits)
+            {
+                var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfNull(document);
+
+                var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                foreach (var documentRudeEdit in documentRudeEdits)
+                {
+                    diagnostics.Add(documentRudeEdit.ToDiagnostic(tree));
+                }
+            }
+
+            // add emit diagnostics:
+            foreach (var (_, projectEmitDiagnostics) in Diagnostics)
+            {
+                diagnostics.AddRange(projectEmitDiagnostics);
+            }
+
+            return diagnostics.ToImmutable();
         }
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         void OnSourceFileUpdated(Document document);
 
-        ValueTask StartDebuggingSessionAsync(Solution solution, bool captureMatchingDocuments, CancellationToken cancellationToken);
-        void StartEditSession(IManagedEditAndContinueDebuggerService debuggerService, out ImmutableArray<DocumentId> documentsToReanalyze);
+        ValueTask StartDebuggingSessionAsync(Solution solution, IManagedEditAndContinueDebuggerService debuggerService, bool captureMatchingDocuments, CancellationToken cancellationToken);
+        void StartEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
         void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
         void EndDebuggingSession(out ImmutableArray<DocumentId> documentsToReanalyze);
 

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         void OnSourceFileUpdated(Document document);
 
         ValueTask StartDebuggingSessionAsync(Solution solution, IManagedEditAndContinueDebuggerService debuggerService, bool captureMatchingDocuments, CancellationToken cancellationToken);
-        void StartEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
+        void StartEditSession();
         void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
-        void EndDebuggingSession(out ImmutableArray<DocumentId> documentsToReanalyze);
+        void EndDebuggingSession();
 
         ValueTask<bool?> IsActiveStatementInExceptionRegionAsync(Solution solution, ManagedInstructionId instructionId, CancellationToken cancellationToken);
         ValueTask<LinePositionSpan?> GetCurrentActiveStatementPositionAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, ManagedInstructionId instructionId, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
@@ -19,15 +17,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ValueTask<bool> HasChangesAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, string? sourceFilePath, CancellationToken cancellationToken);
         ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
 
-        void CommitSolutionUpdate();
+        void CommitSolutionUpdate(out ImmutableArray<DocumentId> documentsToReanalyze);
         void DiscardSolutionUpdate();
 
         void OnSourceFileUpdated(Document document);
 
         ValueTask StartDebuggingSessionAsync(Solution solution, IManagedEditAndContinueDebuggerService debuggerService, bool captureMatchingDocuments, CancellationToken cancellationToken);
-        void StartEditSession();
-        void EndEditSession(out ImmutableArray<DocumentId> documentsToReanalyze);
-        void EndDebuggingSession();
+        void BreakStateEntered(out ImmutableArray<DocumentId> documentsToReanalyze);
+        void EndDebuggingSession(out ImmutableArray<DocumentId> documentsToReanalyze);
 
         ValueTask<bool?> IsActiveStatementInExceptionRegionAsync(Solution solution, ManagedInstructionId instructionId, CancellationToken cancellationToken);
         ValueTask<LinePositionSpan?> GetCurrentActiveStatementPositionAsync(Solution solution, SolutionActiveStatementSpanProvider activeStatementSpanProvider, ManagedInstructionId instructionId, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -34,9 +34,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ValueTask DiscardSolutionUpdateAsync(CancellationToken cancellationToken);
 
         ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, bool captureMatchingDocuments, CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<DocumentId>> StartEditSessionAsync(CancellationToken cancellationToken);
+        ValueTask StartEditSessionAsync(CancellationToken cancellationToken);
         ValueTask<ImmutableArray<DocumentId>> EndEditSessionAsync(CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<DocumentId>> EndDebuggingSessionAsync(CancellationToken cancellationToken);
+        ValueTask EndDebuggingSessionAsync(CancellationToken cancellationToken);
 
         ValueTask<ImmutableArray<ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>> GetBaseActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>> GetAdjustedActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -28,7 +28,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ValueTask<ImmutableArray<DiagnosticData>> GetDocumentDiagnosticsAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, CancellationToken cancellationToken);
         ValueTask<bool> HasChangesAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, string? sourceFilePath, CancellationToken cancellationToken);
 
-        ValueTask<(ManagedModuleUpdates Updates, ImmutableArray<DiagnosticData> Diagnostics)> EmitSolutionUpdateAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
+        ValueTask<(ManagedModuleUpdates Updates, ImmutableArray<DiagnosticData> Diagnostics, ImmutableArray<DocumentId> DocumentsWithRudeEdits)> EmitSolutionUpdateAsync(
+            PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
 
         ValueTask<ImmutableArray<DocumentId>> CommitSolutionUpdateAsync(CancellationToken cancellationToken);
         ValueTask DiscardSolutionUpdateAsync(CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -33,8 +33,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ValueTask CommitSolutionUpdateAsync(CancellationToken cancellationToken);
         ValueTask DiscardSolutionUpdateAsync(CancellationToken cancellationToken);
 
-        ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, bool captureMatchingDocuments, CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<DocumentId>> StartEditSessionAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
+        ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, bool captureMatchingDocuments, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<DocumentId>> StartEditSessionAsync(CancellationToken cancellationToken);
         ValueTask<ImmutableArray<DocumentId>> EndEditSessionAsync(CancellationToken cancellationToken);
         ValueTask<ImmutableArray<DocumentId>> EndDebuggingSessionAsync(CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -30,13 +30,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         ValueTask<(ManagedModuleUpdates Updates, ImmutableArray<DiagnosticData> Diagnostics)> EmitSolutionUpdateAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
 
-        ValueTask CommitSolutionUpdateAsync(CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<DocumentId>> CommitSolutionUpdateAsync(CancellationToken cancellationToken);
         ValueTask DiscardSolutionUpdateAsync(CancellationToken cancellationToken);
 
         ValueTask StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, bool captureMatchingDocuments, CancellationToken cancellationToken);
-        ValueTask StartEditSessionAsync(CancellationToken cancellationToken);
-        ValueTask<ImmutableArray<DocumentId>> EndEditSessionAsync(CancellationToken cancellationToken);
-        ValueTask EndDebuggingSessionAsync(CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<DocumentId>> BreakStateEnteredAsync(CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<DocumentId>> EndDebuggingSessionAsync(CancellationToken cancellationToken);
 
         ValueTask<ImmutableArray<ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>> GetBaseActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>> GetAdjustedActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
@@ -16,29 +16,33 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public readonly ImmutableArray<IDisposable> ModuleReaders;
         public readonly ImmutableArray<(ProjectId ProjectId, EmitBaseline Baseline)> EmitBaselines;
         public readonly ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)> Diagnostics;
+        public readonly ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> DocumentsWithRudeEdits;
 
         public SolutionUpdate(
             ManagedModuleUpdates moduleUpdates,
             ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
             ImmutableArray<IDisposable> moduleReaders,
             ImmutableArray<(ProjectId ProjectId, EmitBaseline Baseline)> emitBaselines,
-            ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostics)> diagnostics)
+            ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostics)> diagnostics,
+            ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> documentsWithRudeEdits)
         {
             ModuleUpdates = moduleUpdates;
             NonRemappableRegions = nonRemappableRegions;
             EmitBaselines = emitBaselines;
             ModuleReaders = moduleReaders;
             Diagnostics = diagnostics;
+            DocumentsWithRudeEdits = documentsWithRudeEdits;
         }
 
-        public static SolutionUpdate Blocked()
-            => Blocked(ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostics)>.Empty);
-
-        public static SolutionUpdate Blocked(ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostics)> diagnostics) => new(
-            new(ManagedModuleUpdateStatus.Blocked, ImmutableArray<ManagedModuleUpdate>.Empty),
-            ImmutableArray<(Guid, ImmutableArray<(ManagedModuleMethodId, NonRemappableRegion)>)>.Empty,
-            ImmutableArray<IDisposable>.Empty,
-            ImmutableArray<(ProjectId, EmitBaseline)>.Empty,
-            diagnostics);
+        public static SolutionUpdate Blocked(
+            ImmutableArray<(ProjectId, ImmutableArray<Diagnostic>)> diagnostics,
+            ImmutableArray<(DocumentId, ImmutableArray<RudeEditDiagnostic>)> documentsWithRudeEdits)
+            => new(
+                new(ManagedModuleUpdateStatus.Blocked, ImmutableArray<ManagedModuleUpdate>.Empty),
+                ImmutableArray<(Guid, ImmutableArray<(ManagedModuleMethodId, NonRemappableRegion)>)>.Empty,
+                ImmutableArray<IDisposable>.Empty,
+                ImmutableArray<(ProjectId, EmitBaseline)>.Empty,
+                diagnostics,
+                documentsWithRudeEdits);
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
@@ -67,16 +66,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
 
         public async Task<(ImmutableArray<Update> updates, ImmutableArray<Diagnostic> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
         {
-            _encService.StartEditSession();
-
             var results = await _encService.EmitSolutionUpdateAsync(solution, s_solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 
             if (results.ModuleUpdates.Status == ManagedModuleUpdateStatus.Ready)
             {
-                _encService.CommitSolutionUpdate();
+                _encService.CommitSolutionUpdate(out _);
             }
-
-            _encService.EndEditSession(out _);
 
             if (results.ModuleUpdates.Status == ManagedModuleUpdateStatus.Blocked)
             {
@@ -92,6 +87,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
         }
 
         public void EndSession()
-            => _encService.EndDebuggingSession();
+            => _encService.EndDebuggingSession(out _);
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -63,11 +63,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns></returns>
         public async Task StartSessionAsync(Solution solution, CancellationToken cancellationToken)
-            => await _encService.StartDebuggingSessionAsync(solution, captureMatchingDocuments: true, cancellationToken).ConfigureAwait(false);
+            => await _encService.StartDebuggingSessionAsync(solution, DebuggerService.Instance, captureMatchingDocuments: true, cancellationToken).ConfigureAwait(false);
 
         public async Task<(ImmutableArray<Update> updates, ImmutableArray<Diagnostic> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
         {
-            _encService.StartEditSession(DebuggerService.Instance, out _);
+            _encService.StartEditSession(out _);
 
             var results = await _encService.EmitSolutionUpdateAsync(solution, s_solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
 
         public async Task<(ImmutableArray<Update> updates, ImmutableArray<Diagnostic> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
         {
-            _encService.StartEditSession(out _);
+            _encService.StartEditSession();
 
             var results = await _encService.EmitSolutionUpdateAsync(solution, s_solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 
@@ -92,6 +92,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
         }
 
         public void EndSession()
-            => _encService.EndDebuggingSession(out _);
+            => _encService.EndDebuggingSession();
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 using Roslyn.Utilities;
@@ -81,7 +82,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
             var updates = results.ModuleUpdates.Updates.SelectAsArray(
                 update => new Update(update.Module, update.ILDelta, update.MetadataDelta, update.PdbDelta));
 
-            var diagnostics = results.Diagnostics.SelectMany(d => d.Diagnostic).ToImmutableArray();
+            var diagnostics = await results.GetAllDiagnosticsAsync(solution, cancellationToken).ConfigureAwait(false);
 
             return (updates, diagnostics);
         }

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
             try
             {
-                await _proxy.StartEditSessionAsync(_diagnosticService, cancellationToken).ConfigureAwait(false);
+                await _proxy.StartEditSessionAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
             try
             {
-                await _proxy.EndDebuggingSessionAsync(_diagnosticUpdateSource, _diagnosticService, cancellationToken).ConfigureAwait(false);
+                await _proxy.EndDebuggingSessionAsync(_diagnosticUpdateSource, cancellationToken).ConfigureAwait(false);
 
                 Contract.ThrowIfNull(_debuggingSessionConnection);
                 _debuggingSessionConnection.Dispose();

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
             {
                 var solution = _proxy.Workspace.CurrentSolution;
                 var activeStatementSpanProvider = GetActiveStatementSpanProvider(solution);
-                return await _proxy.EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, _diagnosticUpdateSource, cancellationToken).ConfigureAwait(false);
+                return await _proxy.EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, _diagnosticService, _diagnosticUpdateSource, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
             {

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -79,23 +80,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Remote API.
         /// </summary>
-        public ValueTask StartEditSessionAsync(CancellationToken cancellationToken)
+        public ValueTask<ImmutableArray<DocumentId>> BreakStateEnteredAsync(CancellationToken cancellationToken)
         {
             return RunServiceAsync(cancellationToken =>
             {
-                GetService().StartEditSession();
-                return default;
-            }, cancellationToken);
-        }
-
-        /// <summary>
-        /// Remote API.
-        /// </summary>
-        public ValueTask<ImmutableArray<DocumentId>> EndEditSessionAsync(CancellationToken cancellationToken)
-        {
-            return RunServiceAsync(cancellationToken =>
-            {
-                GetService().EndEditSession(out var documentsToReanalyze);
+                GetService().BreakStateEntered(out var documentsToReanalyze);
                 return new ValueTask<ImmutableArray<DocumentId>>(documentsToReanalyze);
             }, cancellationToken);
         }
@@ -103,12 +92,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Remote API.
         /// </summary>
-        public ValueTask EndDebuggingSessionAsync(CancellationToken cancellationToken)
+        public ValueTask<ImmutableArray<DocumentId>> EndDebuggingSessionAsync(CancellationToken cancellationToken)
         {
             return RunServiceAsync(cancellationToken =>
             {
-                GetService().EndDebuggingSession();
-                return default;
+                GetService().EndDebuggingSession(out var documentsToReanalyze);
+                return new ValueTask<ImmutableArray<DocumentId>>(documentsToReanalyze);
             }, cancellationToken);
         }
 
@@ -170,12 +159,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Remote API.
         /// </summary>
-        public ValueTask CommitSolutionUpdateAsync(CancellationToken cancellationToken)
+        public ValueTask<ImmutableArray<DocumentId>> CommitSolutionUpdateAsync(CancellationToken cancellationToken)
         {
             return RunServiceAsync(cancellationToken =>
             {
-                GetService().CommitSolutionUpdate();
-                return default;
+                GetService().CommitSolutionUpdate(out var documentsToReanalyze);
+                return new ValueTask<ImmutableArray<DocumentId>>(documentsToReanalyze);
             }, cancellationToken);
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -79,14 +79,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Remote API.
         /// </summary>
-        public ValueTask<ImmutableArray<DocumentId>> StartEditSessionAsync(CancellationToken cancellationToken)
+        public ValueTask StartEditSessionAsync(CancellationToken cancellationToken)
         {
-            return RunServiceAsync((Func<CancellationToken, ValueTask<ImmutableArray<DocumentId>>>)(cancellationToken =>
+            return RunServiceAsync(cancellationToken =>
             {
-                GetService().StartEditSession(out var documentsToReanalyze);
-
-                return new ValueTask<ImmutableArray<DocumentId>>(documentsToReanalyze);
-            }), cancellationToken);
+                GetService().StartEditSession();
+                return default;
+            }, cancellationToken);
         }
 
         /// <summary>
@@ -104,12 +103,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Remote API.
         /// </summary>
-        public ValueTask<ImmutableArray<DocumentId>> EndDebuggingSessionAsync(CancellationToken cancellationToken)
+        public ValueTask EndDebuggingSessionAsync(CancellationToken cancellationToken)
         {
             return RunServiceAsync(cancellationToken =>
             {
-                GetService().EndDebuggingSession(out var documentsToReanalyze);
-                return new ValueTask<ImmutableArray<DocumentId>>(documentsToReanalyze);
+                GetService().EndDebuggingSession();
+                return default;
             }, cancellationToken);
         }
 


### PR DESCRIPTION
Implements Roslyn side of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1286563.

This change enables the debugger to query for and apply updates while the app being debugged is running, as opposed to when it's at a break state.
Previously Roslyn allowed changes to be made while the app is running but reported a warning that these changes won't be applied until the app is broken and resumed.

The previous Roslyn-debugger protocol required the following operation sequence:
`StartDebuggingSession` (`StartEditSession` `EmitSolutionUpdate` (`CommitSolutionUpdate` | `DiscardSolutionUpdate` | rude edits reported) `EndEditSession`)* `EndDebuggingSession`

This PR changes the sequence to:
`StartDebuggingSession` (`EnterBreakState`? `EmitSolutionUpdate` (`CommitSolutionUpdate` | `DiscardSolutionUpdate` | rude edits reported ))* `EndDebuggingSession`

- `StartDebuggingSession` now starts _run state_ edit session.
- `EnterBreakState` closes current _run state_ edit session and opens a new, _break state_ edit session with active statements provided by the debugger
- `CommitSolutionUpdate` closes current edit session and opens a new _run state_ edit session (without active statements)
- `DiscardSolutionUpdate` is called when Reports no rude edits but other EnC providers fail (2-phase commit), it keeps the current edit session open, the user can try to apply the changes again (not changed in this PR)
- rude edits reported - when rude edits are reported from `EmitSolutionUpdate` the edit session remains open as well, the user can fix them and try apply again (not changed in this PR)
- `EndDebuggingSession` now closes current edit session.

Follow ups:
- [ ] Active statement remapping needs to handle mix of Hot Reload and EnC udpates: https://github.com/dotnet/roslyn/issues/52100
- [ ] Debugger needs to enable Alt+F10 command (apply changes) in run mode

