### PR TITLE
Changed LSP completion resolve to not cache data on items.

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -246,8 +246,7 @@ namespace Roslyn.Test.Utilities
             string? insertText = null,
             string? sortText = null,
             string? filterText = null,
-            string? displayText = null,
-            int resultId = 0)
+            long resultId = 0)
         {
             var position = await document.GetPositionFromLinePositionAsync(
                 ProtocolConversions.PositionToLinePosition(request.Position), CancellationToken.None).ConfigureAwait(false);
@@ -265,10 +264,6 @@ namespace Roslyn.Test.Utilities
                 Kind = kind,
                 Data = JObject.FromObject(new CompletionResolveData()
                 {
-                    DisplayText = displayText ?? label,
-                    TextDocument = request.TextDocument,
-                    Position = request.Position,
-                    CompletionTrigger = completionTrigger,
                     ResultId = resultId,
                 }),
                 Preselect = preselect

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var completionTrigger = await ProtocolConversions.LSPToRoslynCompletionTriggerAsync(request.Context, document, position, cancellationToken).ConfigureAwait(false);
 
             var list = await completionService.GetCompletionsAsync(document, position, completionTrigger, options: completionOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
-            if (list == null || list.Items.IsEmpty)
+            if (list == null || list.Items.IsEmpty || cancellationToken.IsCancellationRequested)
             {
                 return null;
             }
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var commitCharactersRuleCache = new Dictionary<ImmutableArray<CharacterSetModificationRule>, ImmutableArray<string>>();
 
             // Cache the completion list so we can avoid recomputation in the resolve handler
-            var resultId = await _completionListCache.UpdateCacheAsync(list, cancellationToken).ConfigureAwait(false);
+            var resultId = _completionListCache.UpdateCache(request.TextDocument, list);
 
             // Feature flag to enable the return of TextEdits instead of InsertTexts (will increase payload size).
             // Flag is defined in VisualStudio\Core\Def\PackageRegistration.pkgdef.
@@ -223,10 +223,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     Kind = GetCompletionKind(item.Tags),
                     Data = new CompletionResolveData
                     {
-                        TextDocument = request.TextDocument,
-                        Position = request.Position,
-                        DisplayText = item.DisplayText,
-                        CompletionTrigger = completionTrigger,
                         ResultId = resultId,
                     },
                     Preselect = item.Rules.SelectionBehavior == CompletionItemSelectionBehavior.HardSelection,

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionListCache.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionListCache.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
-using Roslyn.Utilities;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
 {
@@ -23,12 +21,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
 
         /// <summary>
         /// Multiple cache requests or updates may be received concurrently.
-        /// We need this sempahore to ensure that we aren't making concurrent
+        /// We need this lock to ensure that we aren't making concurrent
         /// modifications to _nextResultId or _resultIdToCompletionList.
         /// </summary>
-        private readonly SemaphoreSlim _semaphore = new(1);
+        private readonly object _accessLock = new object();
 
-        #region protected by _semaphore
+        #region protected by _accessLock
         /// <summary>
         /// The next resultId available to use.
         /// </summary>
@@ -38,12 +36,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
         /// Keeps track of the resultIds in the cache and their associated
         /// completion list.
         /// </summary>
-        private readonly List<(long, CompletionList)> _resultIdToCompletionList = new();
+        private readonly List<CacheEntry> _resultIdToCompletionList = new();
         #endregion
-
-        public CompletionListCache()
-        {
-        }
 
         /// <summary>
         /// Adds a completion list to the cache. If the cache reaches its maximum size, the oldest completion
@@ -52,9 +46,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
         /// <returns>
         /// The generated resultId associated with the passed in completion list.
         /// </returns>
-        public async Task<long> UpdateCacheAsync(CompletionList completionList, CancellationToken cancellationToken)
+        public long UpdateCache(LSP.TextDocumentIdentifier textDocument, CompletionList completionList)
         {
-            using (await _semaphore.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+            lock (_accessLock)
             {
                 // If cache exceeds maximum size, remove the oldest list in the cache
                 if (_resultIdToCompletionList.Count >= MaxCacheSize)
@@ -66,7 +60,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
                 var resultId = _nextResultId++;
 
                 // Add passed in completion list to cache
-                _resultIdToCompletionList.Add((resultId, completionList));
+                var cacheEntry = new CacheEntry(resultId, textDocument, completionList);
+                _resultIdToCompletionList.Add(cacheEntry);
 
                 // Return generated resultId so completion list can later be retrieved from cache
                 return resultId;
@@ -77,16 +72,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
         /// Attempts to return the completion list in the cache associated with the given resultId.
         /// Returns null if no match is found.
         /// </summary>
-        public async Task<CompletionList?> GetCachedCompletionListAsync(long resultId, CancellationToken cancellationToken)
+        public CacheEntry? GetCachedCompletionList(long resultId)
         {
-            using (await _semaphore.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+            lock (_accessLock)
             {
-                foreach (var (cachedResultId, cachedCompletionList) in _resultIdToCompletionList)
+                foreach (var cacheEntry in _resultIdToCompletionList)
                 {
-                    if (cachedResultId == resultId)
+                    if (cacheEntry.ResultId == resultId)
                     {
                         // We found a match - return completion list
-                        return cachedCompletionList;
+                        return cacheEntry;
                     }
                 }
 
@@ -106,8 +101,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             public TestAccessor(CompletionListCache completionListCache)
                 => _completionListCache = completionListCache;
 
-            public List<(long, CompletionList)> GetCacheContents()
+            public List<CacheEntry> GetCacheContents()
                 => _completionListCache._resultIdToCompletionList;
         }
+
+        public record CacheEntry(long ResultId, LSP.TextDocumentIdentifier TextDocument, CompletionList CompletionList);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveData.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveData.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+#nullable enable
 
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveData.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveData.cs
@@ -4,9 +4,7 @@
 
 #nullable disable
 
-using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -17,14 +15,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// </summary>
     internal class CompletionResolveData
     {
-        public TextDocumentIdentifier TextDocument { get; set; }
-
-        public Position Position { get; set; }
-
-        public string DisplayText { get; set; }
-
-        public CompletionTrigger CompletionTrigger { get; set; }
-
         /// <summary>
         /// ID associated with the item's completion list.
         /// </summary>

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveData.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveData.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
 using Microsoft.VisualStudio.Text.Adornments;
 using Newtonsoft.Json.Linq;
@@ -31,15 +33,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _completionListCache = completionListCache;
         }
 
-        private static CompletionResolveData GetCompletionResolveData(LSP.CompletionItem request)
+        private CompletionListCache.CacheEntry? GetCompletionListCacheEntry(LSP.CompletionItem request)
         {
             Contract.ThrowIfNull(request.Data);
+            var resolveData = ((JToken)request.Data).ToObject<CompletionResolveData>();
+            if (resolveData?.ResultId == null)
+            {
+                return null;
+            }
 
-            return ((JToken)request.Data).ToObject<CompletionResolveData>();
+            var cacheEntry = _completionListCache.GetCachedCompletionList(resolveData.ResultId.Value);
+            if (cacheEntry == null)
+            {
+                // No cache for associated completion item. Log some telemetry so we can understand how frequently this actually happens.
+                Logger.Log(FunctionId.LSP_CompletionListCacheMiss, KeyValueLogMessage.NoProperty);
+            }
+
+            return cacheEntry;
         }
 
         public LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.CompletionItem request)
-            => GetCompletionResolveData(request).TextDocument;
+            => GetCompletionListCacheEntry(request)?.TextDocument;
 
         public async Task<LSP.CompletionItem> HandleRequestAsync(LSP.CompletionItem completionItem, RequestContext context, CancellationToken cancellationToken)
         {
@@ -50,35 +64,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             var completionService = document.Project.LanguageServices.GetRequiredService<CompletionService>();
-            var data = GetCompletionResolveData(completionItem);
-
-            CompletionList? list = null;
-
-            // See if we have a cache of the completion list we need
-            if (data.ResultId.HasValue)
+            var cacheEntry = GetCompletionListCacheEntry(completionItem);
+            if (cacheEntry == null)
             {
-                list = await _completionListCache.GetCachedCompletionListAsync(data.ResultId.Value, cancellationToken).ConfigureAwait(false);
+                // Don't have a cache associated with this completion item, cannot resolve.
+                return completionItem;
             }
 
-            if (list == null)
-            {
-                // We don't have a cache, so we need to recompute the list
-                var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(data.Position), cancellationToken).ConfigureAwait(false);
-                var completionOptions = await CompletionHandler.GetCompletionOptionsAsync(document, cancellationToken).ConfigureAwait(false);
-
-                list = await completionService.GetCompletionsAsync(document, position, data.CompletionTrigger, options: completionOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
-                if (list == null)
-                {
-                    return completionItem;
-                }
-            }
+            var list = cacheEntry.CompletionList;
 
             // Find the matching completion item in the completion list
-            var selectedItem = list.Items.FirstOrDefault(
-                i => data.DisplayText == i.DisplayText &&
-                    completionItem.Label.StartsWith(i.DisplayTextPrefix) &&
-                    completionItem.Label.EndsWith(i.DisplayTextSuffix));
-
+            var selectedItem = list.Items.FirstOrDefault(cachedCompletionItem => MatchesLSPCompletionItem(completionItem, cachedCompletionItem));
             if (selectedItem == null)
             {
                 return completionItem;
@@ -110,6 +106,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             completionItem.Detail = description.TaggedParts.GetFullText();
             return completionItem;
+        }
+
+        private static bool MatchesLSPCompletionItem(LSP.CompletionItem lspCompletionItem, CompletionItem completionItem)
+        {
+            if (!lspCompletionItem.Label.StartsWith(completionItem.DisplayTextPrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!lspCompletionItem.Label.EndsWith(completionItem.DisplayTextSuffix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (string.Compare(lspCompletionItem.Label, completionItem.DisplayTextPrefix.Length, completionItem.DisplayText, 0, completionItem.DisplayText.Length, StringComparison.Ordinal) != 0)
+            {
+                return false;
+            }
+
+            // All parts of the LSP completion item match the provided completion item.
+            return true;
         }
 
         // Internal for testing

--- a/src/Features/LanguageServer/Protocol/IsExternalInit.cs
+++ b/src/Features/LanguageServer/Protocol/IsExternalInit.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    // Used to compile against C# 9 in a netstandard2.0
+    internal class IsExternalInit
+    {
+    }
+}

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -37,18 +37,24 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var tags = new string[] { "Class", "Internal" };
             var completionParams = CreateCompletionParams(
                 locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
+
+            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams);
+            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "A");
+            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
-            var completionItem = await CreateCompletionItemAsync(
-                label: "A", LSP.CompletionItemKind.Class, tags, completionParams, document,
-                commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
+            // Reconstruct the completion item in our view like a client would while maintaining data
+            var clientCompletionItem = await CreateCompletionItemAsync(
+                label: "A", kind: LSP.CompletionItemKind.Class, tags: tags, request: completionParams, document: document,
+                commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A", resultId: completionResultId).ConfigureAwait(false);
+
             var description = new ClassifiedTextElement(CreateClassifiedTextRunForClass("A"));
             var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
 
-            var expected = CreateResolvedCompletionItem(completionItem, description, "class A", null);
+            var expected = CreateResolvedCompletionItem(clientCompletionItem, description, "class A", null);
 
             var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
-                testLspServer, completionItem, clientCapabilities).ConfigureAwait(false);
+                testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
             AssertJsonEquals(expected, results);
         }
 
@@ -70,15 +76,19 @@ class B : A
             var tags = new string[] { "Method", "Public" };
             var completionParams = CreateCompletionParams(
                 locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
+            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams);
+            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "M()");
+            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
-            var completionItem = await CreateCompletionItemAsync(
-                label: "M()", LSP.CompletionItemKind.Method, tags, completionParams, document,
-                commitCharacters: CompletionRules.Default.DefaultCommitCharacters).ConfigureAwait(false);
+            // Reconstruct the completion item in our view like a client would while maintaining data
+            var clientCompletionItem = await CreateCompletionItemAsync(
+                label: "M()", kind: LSP.CompletionItemKind.Method, tags: tags, request: completionParams, document: document,
+                commitCharacters: CompletionRules.Default.DefaultCommitCharacters, resultId: completionResultId).ConfigureAwait(false);
             var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
 
             var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
-                testLspServer, completionItem, clientCapabilities).ConfigureAwait(false);
+                testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
 
             Assert.NotNull(results.TextEdit);
             Assert.Null(results.InsertText);
@@ -106,11 +116,15 @@ class B : A
             var tags = new string[] { "Method", "Public" };
             var completionParams = CreateCompletionParams(
                 locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
+            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams);
+            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "M()");
+            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
-            var completionItem = await CreateCompletionItemAsync(
-                label: "M()", LSP.CompletionItemKind.Method, tags, completionParams, document,
-                commitCharacters: CompletionRules.Default.DefaultCommitCharacters).ConfigureAwait(false);
+            // Reconstruct the completion item in our view like a client would while maintaining data
+            var clientCompletionItem = await CreateCompletionItemAsync(
+                label: "M()", kind: LSP.CompletionItemKind.Method, tags: tags, request: completionParams, document: document,
+                commitCharacters: CompletionRules.Default.DefaultCommitCharacters, resultId: completionResultId).ConfigureAwait(false);
 
             // Explicitly enable snippets. This allows us to set the cursor with $0. Currently only applies to C# in Razor docs.
             var clientCapabilities = new LSP.VSClientCapabilities
@@ -129,7 +143,7 @@ class B : A
             };
 
             var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
-                testLspServer, completionItem, clientCapabilities).ConfigureAwait(false);
+                testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
 
             Assert.NotNull(results.TextEdit);
             Assert.Null(results.InsertText);
@@ -153,10 +167,9 @@ class B : A
 {
     override {|caret:|}
 }";
-            using var testLspServer = CreateTestLspServer(markup, out var locations);
+            using var testLspServer = CreateTestLspServer(markup, out _);
             var tags = new string[] { "Method", "Public" };
-            var completionParams = CreateCompletionParams(
-                locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
+
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
             var selectedItem = CodeAnalysis.Completion.CompletionItem.Create(displayText: "M");
@@ -202,6 +215,13 @@ class B : A
                 new ClassifiedTextRun("whitespace", " "),
                 new ClassifiedTextRun("class name", className)
             };
+
+        private static async Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
+        {
+            var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
+            return await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
+                completionParams, clientCapabilities, null, CancellationToken.None);
+        }
 
         private class TestCaretOutOfScopeCompletionService : CompletionService
         {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -39,8 +39,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
 
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
-            var expected = await CreateCompletionItemAsync(label: "A", LSP.CompletionItemKind.Class, new string[] { "Class", "Internal" },
-                completionParams, document, commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
+            var expected = await CreateCompletionItemAsync(label: "A", kind: LSP.CompletionItemKind.Class, tags: new string[] { "Class", "Internal" },
+                request: completionParams, document: document, commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
@@ -178,7 +178,7 @@ class A
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
             var expected = await CreateCompletionItemAsync(
-                label: "d", LSP.CompletionItemKind.Text, new string[] { "Text" }, completionParams, document, insertText: "d", sortText: "0000").ConfigureAwait(false);
+                label: "d", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, insertText: "d", sortText: "0000").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
@@ -214,7 +214,7 @@ class A
             var textEdit = GenerateTextEdit(@"\\A", startLine: 5, startChar: 19, endLine: 5, endChar: 19);
 
             var expected = await CreateCompletionItemAsync(
-                label: @"\A", LSP.CompletionItemKind.Text, new string[] { "Text" }, completionParams, document, textEdit: textEdit,
+                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, textEdit: textEdit,
                 sortText: "0000").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
@@ -251,7 +251,7 @@ class A
             var textEdit = GenerateTextEdit(@"\A", startLine: 5, startChar: 20, endLine: 5, endChar: 21);
 
             var expected = await CreateCompletionItemAsync(
-                label: @"\A", LSP.CompletionItemKind.Text, new string[] { "Text" }, completionParams, document, textEdit: textEdit,
+                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, textEdit: textEdit,
                 sortText: "0000").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
@@ -288,7 +288,7 @@ class A
             var textEdit = GenerateTextEdit(@"\\A", startLine: 5, startChar: 23, endLine: 5, endChar: 25);
 
             var expected = await CreateCompletionItemAsync(
-                label: @"\A", LSP.CompletionItemKind.Text, new string[] { "Text" }, completionParams, document, textEdit: textEdit,
+                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, textEdit: textEdit,
                 sortText: "0000").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
@@ -324,37 +324,37 @@ class A
 
             // 1 item in cache
             await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
-            var completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
+            var completionList = cache.GetCachedCompletionList(0).CompletionList;
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 1);
 
             // 2 items in cache
             await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
-            completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(0).CompletionList;
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(1, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(1).CompletionList;
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 2);
 
             // 3 items in cache
             await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
-            completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(0).CompletionList;
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(1, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(1).CompletionList;
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(2, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(2).CompletionList;
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 3);
 
             // Maximum size of cache (3) should not be exceeded - oldest item should be ejected
             await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
-            completionList = await cache.GetCachedCompletionListAsync(0, CancellationToken.None).ConfigureAwait(false);
-            Assert.Null(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(1, CancellationToken.None).ConfigureAwait(false);
+            var cacheEntry = cache.GetCachedCompletionList(0);
+            Assert.Null(cacheEntry);
+            completionList = cache.GetCachedCompletionList(1).CompletionList;
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(2, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(2).CompletionList;
             Assert.NotNull(completionList);
-            completionList = await cache.GetCachedCompletionListAsync(3, CancellationToken.None).ConfigureAwait(false);
+            completionList = cache.GetCachedCompletionList(3).CompletionList;
             Assert.NotNull(completionList);
             Assert.True(testAccessor.GetCacheContents().Count == 3);
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -512,5 +512,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         LSP_TimeInQueue = 484,
 
         Intellicode_UnknownIntent = 485,
+
+        LSP_CompletionListCacheMiss = 486,
     }
 }


### PR DESCRIPTION
- We used to cache displayText, text document, position and completion triggers on the data field of a completion item however in practice this resulted in having a pretty massive footprint on how completion lists serialized/deserialized.
  - Because completion resolve used to cache more data and now we don't I added a telemetry event to capture how often a cache miss actually happens
  - As part of this I had to migrate the `CompletionListCache` to be synchronous so that we can synchronously resolve cache entries at completion resolve time.
- Updated tests to reflect new resolve behavior. As part of doing this I had to expand the completion resolve tests to actually generate completion lists so caches were properly updated. Ultimately this more accurately reflects what happens in real scenarios.
- Wanted to use records so added an `IsExternalInit.cs` file to enable record usage in netstandard2.0.

## Benchmark results

**Scenario:** Typing `@` in a Razor file and getting a basic C# completion list.

Optimized = true represents utilizing the Optimized completion list (which Roslyn does now) and unoptimized represents anyone who's consuming Roslyn's completion list who doesn't use the optimized completion list structure.

### Before (817KB)
|                                                    Method | Optimized |      Mean |     Error |    StdDev |   Op/s |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|---------------------------------------------------------- |---------- |----------:|----------:|----------:|-------:|----------:|---------:|---------:|----------:|
| 'Completion List Roundtrip Serialization/Deserialization' |     False | 29.301 ms | 0.5816 ms | 0.6698 ms |  34.13 | 1718.7500 | 937.5000 | 250.0000 |    9.8 MB |
|                           'Completion List Serialization' |     False | 10.223 ms | 0.1926 ms | 0.1608 ms |  97.82 |  625.0000 | 250.0000 | 234.3750 |   3.27 MB |
|                         'Completion List Deserialization' |     False | 18.653 ms | 0.3708 ms | 0.5882 ms |  53.61 | 1062.5000 | 531.2500 |        - |   6.52 MB |
| 'Completion List Roundtrip Serialization/Deserialization' |      True | 19.509 ms | 0.3308 ms | 0.3094 ms |  51.26 | 1218.7500 | 718.7500 | 218.7500 |   7.03 MB |
|                           'Completion List Serialization' |      True |  2.121 ms | 0.0259 ms | 0.0216 ms | 471.46 |  199.2188 | 167.9688 | 164.0625 |    1.1 MB |
|                         'Completion List Deserialization' |      True | 18.869 ms | 0.3342 ms | 0.3849 ms |  53.00 | 1062.5000 | 531.2500 |        - |   6.52 MB |

### After (458KB)
|                                                    Method | Optimized |      Mean |     Error |    StdDev |   Op/s |     Gen 0 |    Gen 1 |    Gen 2 |  Allocated |
|---------------------------------------------------------- |---------- |----------:|----------:|----------:|-------:|----------:|---------:|---------:|-----------:|
| 'Completion List Roundtrip Serialization/Deserialization' |     False | 19.438 ms | 0.3835 ms | 0.3400 ms |  51.45 | 1093.7500 | 406.2500 | 125.0000 | 7216.06 KB |
|                           'Completion List Serialization' |     False |  8.355 ms | 0.0735 ms | 0.0651 ms | 119.68 |  437.5000 | 171.8750 | 125.0000 | 2839.71 KB |
|                         'Completion List Deserialization' |     False | 10.303 ms | 0.2045 ms | 0.5701 ms |  97.06 |  625.0000 | 312.5000 |        - | 3844.78 KB |
| 'Completion List Roundtrip Serialization/Deserialization' |      True | 10.847 ms | 0.2057 ms | 0.2021 ms |  92.20 |  656.2500 | 234.3750 | 109.3750 | 4458.84 KB |
|                           'Completion List Serialization' |      True |  1.163 ms | 0.0064 ms | 0.0060 ms | 860.16 |  123.0469 | 123.0469 | 123.0469 |  614.06 KB |
|                         'Completion List Deserialization' |      True | 10.103 ms | 0.2004 ms | 0.3909 ms |  98.98 |  625.0000 | 312.5000 |        - | 3844.78 KB |

### Results (Optimized = true)

**Roundtrip Improvement:** 1.8x
**Serialization Improvement:** 1.82x
**Deserialization Improvement:** 1.87x

Part of dotnet/aspnetcore#30232