### PR TITLE
Handle expressions and method calls

### DIFF
--- a/src/EditorFeatures/Core/ValueTracking/IValueTrackingService.cs
+++ b/src/EditorFeatures/Core/ValueTracking/IValueTrackingService.cs
@@ -6,15 +6,16 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ValueTracking
 {
     internal interface IValueTrackingService : IWorkspaceService
     {
-        Task<ImmutableArray<ValueTrackedItem>> TrackValueSourceAsync(Solution solution, ISymbol symbol, CancellationToken cancellationToken);
-        Task TrackValueSourceAsync(Solution solution, ISymbol symbol, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken);
+        Task<ImmutableArray<ValueTrackedItem>> TrackValueSourceAsync(TextSpan selection, Document document, CancellationToken cancellationToken);
+        Task TrackValueSourceAsync(TextSpan selection, Document document, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<ValueTrackedItem>> TrackValueSourceAsync(Solution solution, ValueTrackedItem previousTrackedItem, CancellationToken cancellationToken);
-        Task TrackValueSourceAsync(Solution solution, ValueTrackedItem previousTrackedItem, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken);
+        Task<ImmutableArray<ValueTrackedItem>> TrackValueSourceAsync(ValueTrackedItem previousTrackedItem, CancellationToken cancellationToken);
+        Task TrackValueSourceAsync(ValueTrackedItem previousTrackedItem, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackedItem.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackedItem.cs
@@ -43,6 +43,12 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             Document = document;
         }
 
+        public override string ToString()
+        {
+            var subText = SourceText.GetSubText(Span);
+            return subText.ToString();
+        }
+
         public static async Task<ValueTrackedItem?> TryCreateAsync(Solution solution, Location location, ISymbol symbol, ValueTrackedItem? parent = null, CancellationToken cancellationToken = default)
         {
             Contract.ThrowIfNull(location.SourceTree);

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.FindReferencesProgress.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.FindReferencesProgress.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ValueTracking
+{
+    internal partial class ValueTrackingService
+    {
+        private class FindReferencesProgress : IStreamingFindReferencesProgress, IStreamingProgressTracker
+        {
+            private readonly CancellationToken _cancellationToken;
+            private readonly ValueTrackingProgressCollector _valueTrackingProgressCollector;
+            public FindReferencesProgress(ValueTrackingProgressCollector valueTrackingProgressCollector, CancellationToken cancellationToken = default)
+            {
+                _valueTrackingProgressCollector = valueTrackingProgressCollector;
+                _cancellationToken = cancellationToken;
+            }
+
+            public IStreamingProgressTracker ProgressTracker => this;
+
+            public ValueTask AddItemsAsync(int count) => new();
+
+            public ValueTask ItemCompletedAsync() => new();
+
+            public ValueTask OnCompletedAsync() => new();
+
+            public ValueTask OnDefinitionFoundAsync(ISymbol symbol) => new();
+
+            public ValueTask OnFindInDocumentCompletedAsync(Document document) => new();
+
+            public ValueTask OnFindInDocumentStartedAsync(Document document) => new();
+
+            public async ValueTask OnReferenceFoundAsync(ISymbol symbol, ReferenceLocation location)
+            {
+                if (!location.Location.IsInSource)
+                {
+                    return;
+                }
+
+                var solution = location.Document.Project.Solution;
+
+                if (symbol is IMethodSymbol methodSymbol)
+                {
+                    if (methodSymbol.IsConstructor())
+                    {
+                        await TrackConstructorAsync(location).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // If we're searching for references to a method, we don't want to store the symbol as that method again. Instead
+                        // we want to track the invocations and how to follow their source
+                        await TrackMethodInvocationArgumentsAsync(location).ConfigureAwait(false);
+                    }
+                }
+                else if (location.IsWrittenTo)
+                {
+                    var syntaxFacts = location.Document.GetRequiredLanguageService<ISyntaxFactsService>();
+                    var node = location.Location.FindNode(CancellationToken.None);
+
+                    if (syntaxFacts.IsLeftSideOfAnyAssignment(node))
+                    {
+                        await AddItemsFromAssignmentAsync(location.Document, node, _valueTrackingProgressCollector, _cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await _valueTrackingProgressCollector.TryReportAsync(solution, location.Location, symbol, _cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            public ValueTask OnStartedAsync() => new();
+
+            private async Task TrackConstructorAsync(ReferenceLocation referenceLocation)
+            {
+                var document = referenceLocation.Document;
+                var span = referenceLocation.Location.SourceSpan;
+
+                var syntaxRoot = await document.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
+                var originalNode = syntaxRoot.FindNode(span);
+
+                if (originalNode is null)
+                {
+                    return;
+                }
+
+                var semanticModel = await document.GetRequiredSemanticModelAsync(_cancellationToken).ConfigureAwait(false);
+                var operation = semanticModel.GetOperation(originalNode.Parent, _cancellationToken);
+                if (operation is not IObjectCreationOperation objectCreationOperation)
+                {
+                    return;
+                }
+
+                await TrackArgumentsAsync(objectCreationOperation.Arguments, document).ConfigureAwait(false);
+            }
+
+            private async Task TrackMethodInvocationArgumentsAsync(ReferenceLocation referenceLocation)
+            {
+                var document = referenceLocation.Document;
+                var span = referenceLocation.Location.SourceSpan;
+
+                var syntaxRoot = await document.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
+                var originalNode = syntaxRoot.FindNode(span);
+
+                if (originalNode is null)
+                {
+                    return;
+                }
+
+                var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+                var invocationSyntax = originalNode.FirstAncestorOrSelf<SyntaxNode>(syntaxFacts.IsInvocationExpression);
+                if (invocationSyntax is null)
+                {
+                    return;
+                }
+
+                var semanticModel = await document.GetRequiredSemanticModelAsync(_cancellationToken).ConfigureAwait(false);
+                var operation = semanticModel.GetOperation(invocationSyntax, _cancellationToken);
+                if (operation is not IInvocationOperation invocationOperation)
+                {
+                    return;
+                }
+
+                await TrackArgumentsAsync(invocationOperation.Arguments, document).ConfigureAwait(false);
+            }
+
+            private async Task TrackArgumentsAsync(ImmutableArray<IArgumentOperation> argumentOperations, Document document)
+            {
+                var collectorsAndArgumentMap = argumentOperations
+                    .Select(argument => (collector: CreateCollector(), argument))
+                    .ToImmutableArray();
+
+                var tasks = collectorsAndArgumentMap
+                    .Select(pair => TrackExpressionAsync(pair.argument.Value, document, pair.collector, _cancellationToken));
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                var items = collectorsAndArgumentMap
+                    .Select(pair => pair.collector)
+                    .SelectMany(collector => collector.GetItems())
+                    .Reverse(); // ProgressCollector uses a Stack, and we want to maintain the order by arguments, so reverse
+
+                foreach (var item in items)
+                {
+                    _valueTrackingProgressCollector.Report(item);
+                }
+
+                ValueTrackingProgressCollector CreateCollector()
+                {
+                    var collector = new ValueTrackingProgressCollector();
+                    collector.Parent = _valueTrackingProgressCollector.Parent;
+                    return collector;
+                }
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
@@ -5,18 +5,27 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Elfie.Model;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ValueTracking
 {
     [ExportWorkspaceService(typeof(IValueTrackingService)), Shared]
-    internal class ValueTrackingService : IValueTrackingService
+    internal partial class ValueTrackingService : IValueTrackingService
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -40,7 +49,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             ValueTrackingProgressCollector progressCollector,
             CancellationToken cancellationToken)
         {
-            var symbol = await GetSelectedSymbolAsync(selection, document, cancellationToken).ConfigureAwait(false);
+            var (symbol, node) = await GetSelectedSymbolAsync(selection, document, cancellationToken).ConfigureAwait(false);
 
             if (symbol
                 is IPropertySymbol
@@ -48,24 +57,33 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                 or ILocalSymbol
                 or IParameterSymbol)
             {
+                RoslynDebug.AssertNotNull(node);
+
                 var solution = document.Project.Solution;
+                var declaringSyntaxReferences = symbol.DeclaringSyntaxReferences;
+                var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
-                // Add all initializations of the symbol. Those are not caught in 
-                // the reference finder but should still show up in the tree
-                foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
+                // If the selection is within a declaration of the symbol, we want to include
+                // all declarations and assignments of the symbol
+                if (declaringSyntaxReferences.Any(r => r.Span.IntersectsWith(selection)))
                 {
-                    var location = Location.Create(syntaxRef.SyntaxTree, syntaxRef.Span);
-                    var item = await ValueTrackedItem.TryCreateAsync(solution, location, symbol, parent: null, cancellationToken).ConfigureAwait(false);
-                    if (item is not null)
+                    // Add all initializations of the symbol. Those are not caught in 
+                    // the reference finder but should still show up in the tree
+                    foreach (var syntaxRef in declaringSyntaxReferences)
                     {
-                        progressCollector.Report(item);
+                        var location = Location.Create(syntaxRef.SyntaxTree, syntaxRef.Span);
+                        await progressCollector.TryReportAsync(solution, location, symbol, cancellationToken).ConfigureAwait(false);
                     }
-                }
 
-                var findReferenceProgressCollector = new FindReferencesProgress(progressCollector);
-                await SymbolFinder.FindReferencesAsync(
-                    symbol, solution, findReferenceProgressCollector,
-                    documents: null, FindReferencesSearchOptions.Default, cancellationToken).ConfigureAwait(false);
+                    await TrackVariableSymbolAsync(symbol, document, progressCollector, cancellationToken).ConfigureAwait(false);
+                }
+                // The selection is not on a declaration, check that the node
+                // is on the left side of an assignment. If so, populate so we can
+                // track the RHS values that contribute to this value
+                else if (syntaxFacts.IsLeftSideOfAnyAssignment(node))
+                {
+                    await AddItemsFromAssignmentAsync(document, node, progressCollector, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 
@@ -78,15 +96,174 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             return progressTracker.GetItems();
         }
 
-        public Task TrackValueSourceAsync(
+        public async Task TrackValueSourceAsync(
             ValueTrackedItem previousTrackedItem,
             ValueTrackingProgressCollector progressCollector,
             CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            progressCollector.Parent = previousTrackedItem;
+
+            switch (previousTrackedItem.Symbol)
+            {
+                case ILocalSymbol:
+                case IPropertySymbol:
+                case IFieldSymbol:
+                    {
+                        // The "output" is a variable assignment, track places where it gets assigned
+                        await TrackVariableSymbolAsync(previousTrackedItem.Symbol, previousTrackedItem.Document, progressCollector, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+
+                case IParameterSymbol parameterSymbol:
+                    {
+                        // The "output" is method calls, so track where this method is invoked for the parameter
+                        await TrackParameterSymbolAsync(parameterSymbol, previousTrackedItem.Document, progressCollector, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+
+                case IMethodSymbol methodSymbol:
+                    {
+                        // The "output" is from a method, meaning it has a return our out param that is used. Track those 
+                        await TrackMethodSymbolAsync(methodSymbol, previousTrackedItem.Document, progressCollector, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+            }
         }
 
-        private static async Task<ISymbol?> GetSelectedSymbolAsync(TextSpan textSpan, Document document, CancellationToken cancellationToken)
+        private static async Task TrackVariableSymbolAsync(ISymbol symbol, Document document, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken)
+        {
+            var findReferenceProgressCollector = new FindReferencesProgress(progressCollector);
+            await SymbolFinder.FindReferencesAsync(
+                                    symbol,
+                                    document.Project.Solution,
+                                    findReferenceProgressCollector,
+                                    documents: null, FindReferencesSearchOptions.Default, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task TrackParameterSymbolAsync(
+            IParameterSymbol parameterSymbol,
+            Document document,
+            ValueTrackingProgressCollector progressCollector,
+            CancellationToken cancellationToken)
+        {
+            var containingMethod = (IMethodSymbol)parameterSymbol.ContainingSymbol;
+            var findReferenceProgressCollector = new FindReferencesProgress(progressCollector);
+            await SymbolFinder.FindReferencesAsync(
+                containingMethod,
+                document.Project.Solution,
+                findReferenceProgressCollector,
+                documents: null, FindReferencesSearchOptions.Default, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task TrackMethodSymbolAsync(IMethodSymbol methodSymbol, Document document, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken)
+        {
+            var hasAnyOutData = HasAValueReturn(methodSymbol) || HasAnOutOrRefParam(methodSymbol);
+            if (!hasAnyOutData)
+            {
+                // With no out data, there's nothing to do here
+                return;
+            }
+
+            // TODO: Use DFA to find meaningful returns? https://github.com/dotnet/roslyn-analyzers/blob/9e5f533cbafcc5579e4d758bc9bde27b7611ca54/docs/Writing%20dataflow%20analysis%20based%20analyzers.md 
+            if (HasAValueReturn(methodSymbol))
+            {
+                foreach (var location in methodSymbol.GetDefinitionLocationsToShow())
+                {
+                    if (location.SourceTree is null)
+                    {
+                        continue;
+                    }
+
+                    var node = location.FindNode(cancellationToken);
+                    var sourceDoc = document.Project.Solution.GetRequiredDocument(location.SourceTree);
+                    var syntaxFacts = sourceDoc.GetRequiredLanguageService<ISyntaxFactsService>();
+                    var returnStatements = node.DescendantNodesAndSelf().Where(n => syntaxFacts.IsReturnStatement(n));
+                    var semanticModel = await sourceDoc.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+                    foreach (var returnStatement in returnStatements)
+                    {
+                        var expression = syntaxFacts.GetExpressionOfReturnStatement(returnStatement);
+                        if (expression is null)
+                        {
+                            continue;
+                        }
+
+                        var operation = semanticModel.GetOperation(expression, cancellationToken);
+                        if (operation is null)
+                        {
+                            continue;
+                        }
+
+                        await TrackExpressionAsync(operation, sourceDoc, progressCollector, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            if (HasAnOutOrRefParam(methodSymbol))
+            {
+                foreach (var outOrRefParam in methodSymbol.Parameters.Where(p => p.IsRefOrOut()))
+                {
+                    if (!outOrRefParam.IsFromSource())
+                    {
+                        continue;
+                    }
+
+                    await TrackVariableSymbolAsync(outOrRefParam, document, progressCollector, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            // TODO check for Task
+            static bool HasAValueReturn(IMethodSymbol methodSymbol)
+                => methodSymbol.ReturnType.SpecialType != SpecialType.System_Void;
+
+            static bool HasAnOutOrRefParam(IMethodSymbol methodSymbol)
+                => methodSymbol.Parameters.Any(p => p.IsRefOrOut());
+        }
+
+        private static async Task TrackExpressionAsync(IOperation expressionOperation, Document document, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken)
+        {
+            if (expressionOperation.Children.Any())
+            {
+                foreach (var childOperation in expressionOperation.Children)
+                {
+                    await AddOperationAsync(childOperation).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await AddOperationAsync(expressionOperation).ConfigureAwait(false);
+            }
+
+            async Task AddOperationAsync(IOperation operation)
+            {
+                var semanticModel = operation.SemanticModel;
+                if (semanticModel is null)
+                {
+                    return;
+                }
+
+                var symbolInfo = semanticModel.GetSymbolInfo(operation.Syntax, cancellationToken);
+                if (symbolInfo.Symbol is null)
+                {
+                    if (operation is ILiteralOperation literalOperation)
+                    {
+                        await progressCollector.TryReportAsync(document.Project.Solution,
+                            operation.Syntax.GetLocation(),
+                            literalOperation.Type,
+                            cancellationToken: cancellationToken).ConfigureAwait(false);
+                    }
+
+                    return;
+                }
+
+                await progressCollector.TryReportAsync(document.Project.Solution,
+                    operation.Syntax.GetLocation(),
+                    symbolInfo.Symbol,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<(ISymbol?, SyntaxNode?)> GetSelectedSymbolAsync(TextSpan textSpan, Document document, CancellationToken cancellationToken)
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var selectedNode = root.FindNode(textSpan);
@@ -96,45 +273,35 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                 semanticModel.GetSymbolInfo(selectedNode, cancellationToken).Symbol
                 ?? semanticModel.GetDeclaredSymbol(selectedNode, cancellationToken);
 
-            return selectedSymbol;
+            return (selectedSymbol, selectedNode);
         }
 
-        private class FindReferencesProgress : IStreamingFindReferencesProgress, IStreamingProgressTracker
+
+        private static async Task AddItemsFromAssignmentAsync(Document document, SyntaxNode lhsNode, ValueTrackingProgressCollector progressCollector, CancellationToken cancellationToken)
         {
-            private readonly ValueTrackingProgressCollector _valueTrackingProgressCollector;
-            public FindReferencesProgress(ValueTrackingProgressCollector valueTrackingProgressCollector)
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var operation = semanticModel.GetOperation(lhsNode);
+            if (operation is null)
             {
-                _valueTrackingProgressCollector = valueTrackingProgressCollector;
+                return;
             }
 
-            public IStreamingProgressTracker ProgressTracker => this;
+            IAssignmentOperation? assignmentOperation = null;
 
-            public ValueTask AddItemsAsync(int count) => new();
-
-            public ValueTask ItemCompletedAsync() => new();
-
-            public ValueTask OnCompletedAsync() => new();
-
-            public ValueTask OnDefinitionFoundAsync(ISymbol symbol) => new();
-
-            public ValueTask OnFindInDocumentCompletedAsync(Document document) => new();
-
-            public ValueTask OnFindInDocumentStartedAsync(Document document) => new();
-
-            public async ValueTask OnReferenceFoundAsync(ISymbol symbol, ReferenceLocation location)
+            while (assignmentOperation is null
+                && operation is not null)
             {
-                if (location.IsWrittenTo)
-                {
-                    var solution = location.Document.Project.Solution;
-                    var item = await ValueTrackedItem.TryCreateAsync(solution, location.Location, symbol, parent: null, CancellationToken.None).ConfigureAwait(false);
-                    if (item is not null)
-                    {
-                        _valueTrackingProgressCollector.Report(item);
-                    }
-                }
+                assignmentOperation = operation as IAssignmentOperation;
+                operation = operation.Parent;
             }
 
-            public ValueTask OnStartedAsync() => new();
+            if (assignmentOperation is null)
+            {
+                return;
+            }
+
+            var rhsOperation = assignmentOperation.Value;
+            await TrackExpressionAsync(rhsOperation, document, progressCollector, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             if (symbolInfo.Symbol is null)
             {
                 if (operation is ILiteralOperation { Type: not null } literalOperation)
-{
+                {
                     await progressCollector.TryReportAsync(document.Project.Solution,
                         operation.Syntax.GetLocation(),
                         literalOperation.Type!,
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                     }
                 }
             }
-            else if (operation is IReturnOperation returnOperation)
+            else if (operation is IReturnOperation { ReturnedValue: not null } returnOperation)
             {
                 // For return operations we want to track
                 // the value returned in case it has invocations

--- a/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
@@ -20,26 +20,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ValueTracking
             var cursorDocument = testWorkspace.DocumentWithCursor;
             var document = testWorkspace.CurrentSolution.GetRequiredDocument(cursorDocument.Id);
             var textSpan = new TextSpan(cursorDocument.CursorPosition!.Value, 0);
-            var symbol = await GetSelectedSymbolAsync(textSpan, document, cancellationToken);
             var service = testWorkspace.Services.GetRequiredService<IValueTrackingService>();
-            return await service.TrackValueSourceAsync(testWorkspace.CurrentSolution, symbol, cancellationToken);
+            return await service.TrackValueSourceAsync(textSpan, document, cancellationToken);
 
         }
 
-        internal static async Task<ISymbol> GetSelectedSymbolAsync(TextSpan textSpan, Document document, CancellationToken cancellationToken)
+        internal static async Task<ImmutableArray<ValueTrackedItem>> GetTrackedItemsAsync(TestWorkspace testWorkspace, ValueTrackedItem item, CancellationToken cancellationToken = default)
         {
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var selectedNode = root.FindNode(textSpan);
-
-            Assert.NotNull(selectedNode);
-
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var selectedSymbol =
-                semanticModel.GetSymbolInfo(selectedNode, cancellationToken).Symbol
-                ?? semanticModel.GetDeclaredSymbol(selectedNode, cancellationToken);
-
-            Assert.NotNull(selectedSymbol);
-            return selectedSymbol!;
+            var service = testWorkspace.Services.GetRequiredService<IValueTrackingService>();
+            return await service.TrackValueSourceAsync(item, cancellationToken);
         }
 
         internal static void ValidateItem(ValueTrackedItem item, int line)

--- a/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.ValueTracking
 {
@@ -31,9 +32,56 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ValueTracking
             return await service.TrackValueSourceAsync(item, cancellationToken);
         }
 
-        internal static void ValidateItem(ValueTrackedItem item, int line)
+        internal static async Task<ImmutableArray<ValueTrackedItem>> ValidateChildrenAsync(TestWorkspace testWorkspace, ValueTrackedItem item, int[] lines, CancellationToken cancellationToken = default)
+        {
+            var children = await GetTrackedItemsAsync(testWorkspace, item, cancellationToken);
+
+            Assert.Equal(lines.Length, children.Length);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                ValidateItem(children[i], lines[i]);
+            }
+
+            return children;
+        }
+
+        internal static async Task<ImmutableArray<ValueTrackedItem>> ValidateChildrenAsync(TestWorkspace testWorkspace, ValueTrackedItem item, (int line, string text)[] childInfo, CancellationToken cancellationToken = default)
+        {
+            var children = await GetTrackedItemsAsync(testWorkspace, item, cancellationToken);
+
+            Assert.Equal(childInfo.Length, children.Length);
+
+            for (var i = 0; i < childInfo.Length; i++)
+            {
+                ValidateItem(children[i], childInfo[i].line, childInfo[i].text);
+            }
+
+            return children;
+        }
+
+        internal static async Task ValidateChildrenEmptyAsync(TestWorkspace testWorkspace, ValueTrackedItem item, CancellationToken cancellationToken = default)
+        {
+            var children = await GetTrackedItemsAsync(testWorkspace, item, cancellationToken);
+            Assert.Empty(children);
+        }
+
+        internal static async Task ValidateChildrenEmptyAsync(TestWorkspace testWorkspace, IEnumerable<ValueTrackedItem> items, CancellationToken cancellationToken = default)
+        {
+            foreach (var item in items)
+            {
+                await ValidateChildrenEmptyAsync(testWorkspace, item, cancellationToken);
+            }
+        }
+
+        internal static void ValidateItem(ValueTrackedItem item, int line, string? text = null)
         {
             Assert.Equal(line, item.LineSpan.Start);
+
+            if (text is not null)
+            {
+                Assert.Equal(text, item.ToString());
+            }
         }
     }
 }

--- a/src/EditorFeatures/Test/ValueTracking/CSharpValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/CSharpValueTrackingTests.cs
@@ -251,7 +251,6 @@ class Other
                     17 // |> c.SetS(s); [Code.cs:17]
                 });
 
-
             items = await ValidateChildrenAsync(
                 workspace,
                 items.Single(),
@@ -369,7 +368,6 @@ class Program
                 {
                     23 // |> c.SetS(s); [Code.cs:23]
                 });
-
 
             items = await ValidateChildrenAsync(
                 workspace,

--- a/src/EditorFeatures/Test/ValueTracking/CSharpValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/CSharpValueTrackingTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Xunit;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.ValueTracking
 {
@@ -182,7 +183,7 @@ namespace $$N
         }
 
         [Fact]
-        public async Task PropertyAssignment1()
+        public async Task MethodTracking1()
         {
             var code =
 @"
@@ -207,7 +208,22 @@ class Other
 
     public void CallS(C c)
     {
-        CallS(c, ""defaultstring"");
+        CallS(c, CalculateDefault(c));
+    }
+
+    private string CalculateDefault(C c)
+    {
+        if (c is null)
+        {
+            return ""null"";
+        }
+
+        if (string.IsNullOrEmpty(c.S))
+        {
+            return ""defaultstring"";
+        }
+
+        return """";
     }
 }
 ";
@@ -217,15 +233,195 @@ class Other
             //
             // S = s; [Code.cs:7]
             //  |> S = [|s|] [Code.cs:7]
-            //      |> public void [|SetS|](string s) [Code.cs:5]
-            //          |> c.SetS(s); [Code.cs:17]
-            //  |> S = ""; [Code.cs:4]
-            Assert.Equal(2, initialItems.Length);
+            //    |> c.SetS(s); [Code.cs:17]
+            //      |> CallS([|c|], CalculateDefault(c)) [Code.cs:22]
+            //      |> CallS(c, [|CalculateDefault(c)|]) [Code.cs:22]
+            //         |>  return "" [Code.cs:37]
+            //         |>  return "defaultstring" [Code.cs:34]
+            //         |> return "null" [Code.cs:29]
+            // 
+            Assert.Equal(1, initialItems.Length);
             ValidateItem(initialItems[0], 7);
-            ValidateItem(initialItems[1], 3);
 
-            //var items = await GetTrackedItemsAsync(workspace, initialItems[0]);
-            //Assert.Equal(1, items.Length);
+            var items = await ValidateChildrenAsync(
+                workspace,
+                initialItems.Single(),
+                lines: new[]
+                {
+                    17 // |> c.SetS(s); [Code.cs:17]
+                });
+
+
+            items = await ValidateChildrenAsync(
+                workspace,
+                items.Single(),
+                childInfo: new[]
+                {
+                    (22, "c" ), // |> CallS([|c|], CalculateDefault(c)) [Code.cs:22]
+                    (22, "CalculateDefault" ) // |> CallS(c, [|CalculateDefault(c)|]) [Code.cs:22]
+                });
+
+            var referenceC = items[0];
+            await ValidateChildrenEmptyAsync(workspace, referenceC);
+
+            var calculateDefaultCall = items[1];
+            var children = await ValidateChildrenAsync(
+                workspace,
+                calculateDefaultCall,
+                childInfo: new[]
+                {
+                    (37, "\"\""), // |>  return "" [Code.cs:37]
+                    (34, "\"defaultstring\""), // |>  return "defaultstring" [Code.cs:34]
+                    (29, "\"null\""), // |> return "null" [Code.cs:29]
+                });
+
+            foreach (var child in children)
+            {
+                await ValidateChildrenEmptyAsync(workspace, child);
+            }
+        }
+
+        [Fact]
+        public async Task MethodTracking2()
+        {
+            var code =
+@"
+class C
+{
+    public string S { get; set; } = """""";
+
+    public void SetS(string s)
+    {
+        S$$ = s;
+    }
+
+    public string GetS() => S;
+}
+
+class Other
+{
+    private readonly string _adornment;
+    public Other(string adornment)
+    {
+        _adornment = adornment;
+    }
+
+    public void CallS(C c, string s)
+    {
+        c.SetS(s);
+    }
+
+    public void CallS(C c)
+    {
+        CallS(c, CalculateDefault(c) + _adornment);
+    }
+
+    private string CalculateDefault(C c)
+    {
+        if (c is null)
+        {
+            return ""null"";
+        }
+
+        if (string.IsNullOrEmpty(c.S))
+        {
+            return ""defaultstring"";
+        }
+
+        return """";
+    }
+}
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        var other = new Other(""some value"");
+        var c = new C();
+        other.CallS(c);
+    }
+}
+";
+            using var workspace = TestWorkspace.CreateCSharp(code);
+            var initialItems = await GetTrackedItemsAsync(workspace);
+
+            //
+            // S = s; [Code.cs:7]
+            //  |> S = [|s|] [Code.cs:7]
+            //    |> c.SetS(s); [Code.cs:23]
+            //      |> CallS([|c|], CalculateDefault(c) + _adornment) [Code.cs:28]
+            //        |> other.CallS([|c|]); [Code.cs:53]
+            //      |> CallS(c, CalculateDefault(c) + [|_adornment|]) [Code.cs:28]
+            //        |> _adornment = [|adornment|]; [Code.cs:18]
+            //          |> var other = new Other([|"some value"|]); [Code.cs:51]
+            //      |> CallS(c, [|CalculateDefault(c)|] + _adornment) [Code.cs:28]
+            //        |>  return "" [Code.cs:37]
+            //        |>  return "defaultstring" [Code.cs:34]
+            //        |> return "null" [Code.cs:29]
+            // 
+            Assert.Equal(1, initialItems.Length);
+            ValidateItem(initialItems[0], 7);
+
+            var items = await ValidateChildrenAsync(
+                workspace,
+                initialItems.Single(),
+                lines: new[]
+                {
+                    23 // |> c.SetS(s); [Code.cs:23]
+                });
+
+
+            items = await ValidateChildrenAsync(
+                workspace,
+                items.Single(),
+                childInfo: new[]
+                {
+                    (28, "c" ), // |> CallS([|c|], CalculateDefault(c) + _adornment) [Code.cs:28]
+                    (28, "_adornment" ), // |> CallS(c, CalculateDefault(c) + [|_adornment|]) [Code.cs:28]
+                    (28, "CalculateDefault(c)" ), // |> CallS(c, [|CalculateDefault|](c) + _adornment) [Code.cs:28]
+                });
+
+            var referenceC = items[0];
+            var children = await ValidateChildrenAsync(
+                workspace,
+                referenceC,
+                childInfo: new[]
+                {
+                    (53, "c"), // |> other.CallS([|c|]); [Code.cs:53]
+                });
+
+            await ValidateChildrenEmptyAsync(workspace, children);
+
+            var adornmentAssignment = items[1];
+            children = await ValidateChildrenAsync(
+                workspace,
+                adornmentAssignment,
+                childInfo: new[]
+                {
+                    (18, "adornment"), // |> _adornment = [|adornment|] [Code.cs:18]
+                });
+
+            children = await ValidateChildrenAsync(
+                workspace,
+                children.Single(),
+                childInfo: new[]
+                {
+                    (51, "\"some value\"") // |> var other = new Other([|"some value"|]); [Code.cs:51]
+                });
+            await ValidateChildrenEmptyAsync(workspace, children);
+
+            var calculateDefaultCall = items[2];
+            children = await ValidateChildrenAsync(
+                workspace,
+                calculateDefaultCall,
+                childInfo: new[]
+                {
+                    (43, "\"\""), // |>  return "" [Code.cs:37]
+                    (40, "\"defaultstring\""), // |>  return "defaultstring" [Code.cs:34]
+                    (35, "\"null\""), // |> return "null" [Code.cs:29]
+                });
+
+            await ValidateChildrenEmptyAsync(workspace, children);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
         private readonly IValueTrackingService _valueTrackingService;
         private readonly ValueTrackedItem _trackedItem;
 
-
         public ValueTrackedTreeItemViewModel(
             ValueTrackedItem trackedItem,
             Solution solution,

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
@@ -110,7 +110,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
         private async Task<ImmutableArray<ValueTrackingTreeItemViewModel>> CalculateChildrenAsync(CancellationToken cancellationToken)
         {
             var valueTrackedItems = await _valueTrackingService.TrackValueSourceAsync(
-                _solution,
                 _trackedItem,
                 cancellationToken).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             var valueTrackingService = solution.Workspace.Services.GetRequiredService<IValueTrackingService>();
             var classificationFormatMap = _classificationFormatMapService.GetClassificationFormatMap(textView);
 
-            var childItems = await valueTrackingService.TrackValueSourceAsync(solution, item, cancellationToken).ConfigureAwait(false);
+            var childItems = await valueTrackingService.TrackValueSourceAsync(item, cancellationToken).ConfigureAwait(false);
             var childViewModels = childItems.SelectAsArray(child => CreateViewModel(child));
 
             RoslynDebug.AssertNotNull(location.SourceTree);

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
@@ -87,19 +87,19 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             }
 
             _threadingContext.JoinableTaskFactory.RunAsync(async () =>
-            {
-                var selectedSymbol = await  GetSelectedSymbolAsync(textSpan, document, cancellationToken).ConfigureAwait(false);
-                if (selectedSymbol is null)
                 {
-                    // TODO: Show error dialog
-                    return;
-                }
+                    var selectedSymbol = await GetSelectedSymbolAsync(textSpan, document, cancellationToken).ConfigureAwait(false);
+                    if (selectedSymbol is null)
+                    {
+                        // TODO: Show error dialog
+                        return;
+                    }
 
-                var syntaxTree = document.GetRequiredSyntaxTreeSynchronously(cancellationToken);
-                var location = Location.Create(syntaxTree, textSpan);
+                    var syntaxTree = document.GetRequiredSyntaxTreeSynchronously(cancellationToken);
+                    var location = Location.Create(syntaxTree, textSpan);
 
-                await ShowToolWindowAsync(args.TextView, selectedSymbol, location, document.Project.Solution, cancellationToken).ConfigureAwait(false);
-            });
+                    await ShowToolWindowAsync(args.TextView, selectedSymbol, location, document.Project.Solution, cancellationToken).ConfigureAwait(false);
+                });
 
             return true;
         }


### PR DESCRIPTION
The service should now handle tracking expressions and method calls from previous items correctly. It's hard to explain all done here, but the tests added should highlight new functionality pretty well. 

TODO: VB Tests