### PR TITLE
Enable CodeActions support for XAML

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
@@ -56,7 +56,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             var experimentationService = Workspace.Services.GetRequiredService<IExperimentationService>();
             var isLspExperimentEnabled = experimentationService.IsExperimentEnabled(StringConstants.EnableLspIntelliSense);
 
-            return isLspExperimentEnabled ? XamlCapabilities.None : XamlCapabilities.Current;
+            var capabilities = isLspExperimentEnabled ? XamlCapabilities.None : XamlCapabilities.Current;
+
+            // Only turn on CodeAction support for client scenarios. Hosts will get non-LSP lightbulbs automatically.
+            capabilities.CodeActionProvider = new CodeActionOptions { CodeActionKinds = new[] { CodeActionKind.QuickFix, CodeActionKind.Refactor } };
+            capabilities.CodeActionsResolveProvider = true;
+
+            return capabilities;
         }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/CodeActions/CodeActionsHandlerProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/CodeActions/CodeActionsHandlerProvider.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editor.Xaml;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
+{
+    /// <summary>
+    /// Exports all the code action handlers together to ensure they
+    /// share the same code actions cache state.
+    /// </summary>
+    /// <remarks>
+    /// Same as C# and VB but for XAML. See also <seealso cref="Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActionsHandlerProvider"/>.
+    /// </remarks>
+    [ExportLspRequestHandlerProvider(StringConstants.XamlLanguageName), Shared]
+    [ProvidesMethod(LSP.Methods.TextDocumentCodeActionName)]
+    [ProvidesMethod(LSP.MSLSPMethods.TextDocumentCodeActionResolveName)]
+    [ProvidesCommand(CodeActionsHandler.RunCodeActionCommandName)]
+    internal class CodeActionsHandlerProvider : AbstractRequestHandlerProvider
+    {
+        private readonly ICodeFixService _codeFixService;
+        private readonly ICodeRefactoringService _codeRefactoringService;
+        private readonly IThreadingContext _threadingContext;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CodeActionsHandlerProvider(
+            ICodeFixService codeFixService,
+            ICodeRefactoringService codeRefactoringService,
+            IThreadingContext threadingContext)
+        {
+            _codeFixService = codeFixService;
+            _codeRefactoringService = codeRefactoringService;
+            _threadingContext = threadingContext;
+        }
+
+        public override ImmutableArray<IRequestHandler> CreateRequestHandlers()
+        {
+            var codeActionsCache = new CodeActionsCache();
+            return ImmutableArray.Create<IRequestHandler>(
+                new CodeActionsHandler(codeActionsCache, _codeFixService, _codeRefactoringService),
+                new CodeActionResolveHandler(codeActionsCache, _codeFixService, _codeRefactoringService),
+                new RunCodeActionHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _threadingContext));
+        }
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -33,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactory;
         private readonly IThreadingContext _threadingContext;
         private readonly Dictionary<IVsHierarchy, VisualStudioProject> _xamlProjects = new();
-        private readonly Dictionary<uint, DocumentId> _rdtDocumentIds = new();
+        private readonly ConcurrentDictionary<string, DocumentId> _documentIds = new ConcurrentDictionary<string, DocumentId>(StringComparer.OrdinalIgnoreCase);
 
         private RunningDocumentTable? _rdt;
         private IVsSolution? _vsSolution;
@@ -67,18 +68,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 return null;
             }
 
-            if (_threadingContext.JoinableTaskContext.IsOnMainThread)
+            if (_documentIds.TryGetValue(filePath, out var documentId))
             {
-                return EnsureDocument(filePath);
+                return documentId;
             }
-            else
-            {
-                return _threadingContext.JoinableTaskFactory.Run(async () =>
-                {
-                    await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+            documentId = GetDocumentId(filePath);
+            if (documentId != null)
+            {
+                _documentIds.TryAdd(filePath, documentId);
+            }
+            return documentId;
+
+            DocumentId? GetDocumentId(string path)
+            {
+                if (_threadingContext.JoinableTaskContext.IsOnMainThread)
+                {
                     return EnsureDocument(filePath);
-                });
+                }
+                else
+                {
+                    return _threadingContext.JoinableTaskFactory.Run(async () =>
+                    {
+                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                        return EnsureDocument(filePath);
+                    });
+                }
             }
         }
 
@@ -143,7 +159,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 project.AddSourceFile(filePath);
 
                 var documentId = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Single(d => d.ProjectId == project.Id);
-                _rdtDocumentIds[docCookie] = documentId;
+                _documentIds[filePath] = documentId;
 
                 // Remove the following when https://github.com/dotnet/roslyn/issues/49879 is fixed
                 var document = _workspace.CurrentSolution.GetRequiredDocument(documentId);
@@ -160,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 }
             }
 
-            if (_rdtDocumentIds.TryGetValue(docCookie, out var docId))
+            if (_documentIds.TryGetValue(filePath, out var docId))
             {
                 return docId;
             }
@@ -205,20 +221,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 project.RemoveSourceFile(oldMoniker);
             }
 
-            _rdtDocumentIds.Remove(docCookie);
+            _documentIds.TryRemove(oldMoniker, out _);
 
             if (isXaml)
             {
                 project.AddSourceFile(newMoniker);
 
                 var documentId = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(newMoniker).Single(d => d.ProjectId == project.Id);
-                _rdtDocumentIds[docCookie] = documentId;
+                _documentIds[newMoniker] = documentId;
             }
         }
 
-        private void OnDocumentClosed(uint docCookie)
+        private void OnDocumentClosed(string filePath)
         {
-            if (_rdtDocumentIds.TryGetValue(docCookie, out var documentId))
+            if (_documentIds.TryGetValue(filePath, out var documentId))
             {
                 var document = _workspace.CurrentSolution.GetDocument(documentId);
                 if (document?.FilePath != null)
@@ -226,7 +242,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                     var project = _xamlProjects.Values.SingleOrDefault(p => p.Id == document.Project.Id);
                     project?.RemoveSourceFile(document.FilePath);
                 }
-                _rdtDocumentIds.Remove(docCookie);
+                _documentIds.TryRemove(filePath, out _);
             }
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService_IVsRunningDocTableEvents3.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService_IVsRunningDocTableEvents3.cs
@@ -49,7 +49,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
         {
             if (dwReadLocksRemaining == 0 && dwEditLocksRemaining == 0)
             {
-                OnDocumentClosed(docCookie);
+                var docInfo = _rdt.GetDocumentInfo(docCookie);
+                OnDocumentClosed(docInfo.Moniker);
             }
 
             return VSConstants.S_OK;


### PR DESCRIPTION
Enable CodeActions support for XAML using its own provider and CodeActionCache. The handlers are actually shared with Roslyn as is.

Switch to using a path to DocumentId cache in the XamlProjectService to avoid unnecessary and sometimes dangerous transitions to the main thread during TrackOpenDocument calls.