### PR TITLE
Remove misleading default value for TodoCommentOptions.TokenList

### DIFF
--- a/src/EditorFeatures/CSharpTest/TodoComment/NoCompilationTodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/NoCompilationTodoCommentTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Editor.Implementation.TodoComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
     {
         protected override TestWorkspace CreateWorkspace(string codeWithMarker)
         {
-            return TestWorkspace.CreateWorkspace(XElement.Parse(
+            var workspace = TestWorkspace.CreateWorkspace(XElement.Parse(
 $@"<Workspace>
     <Project Language=""NoCompilation"">
         <Document>{codeWithMarker}</Document>
@@ -36,6 +37,9 @@ $@"<Workspace>
                 typeof(NoCompilationContentTypeDefinitions),
                 typeof(NoCompilationContentTypeLanguageService),
                 typeof(NoCompilationTodoCommentService)));
+
+            workspace.SetOptions(workspace.Options.WithChangedOption(TodoCommentOptions.TokenList, DefaultTokenList));
+            return workspace;
         }
 
         [Fact, WorkItem(1192024, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1192024")]

--- a/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Implementation.TodoComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities.TodoComments;
@@ -16,7 +17,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
     public class TodoCommentTests : AbstractTodoCommentTests
     {
         protected override TestWorkspace CreateWorkspace(string codeWithMarker)
-            => TestWorkspace.CreateCSharp(codeWithMarker);
+        {
+            var workspace = TestWorkspace.CreateCSharp(codeWithMarker);
+            workspace.SetOptions(workspace.Options.WithChangedOption(TodoCommentOptions.TokenList, DefaultTokenList));
+            return workspace;
+        }
 
         [Fact]
         public async Task SingleLineTodoComment_Colon()

--- a/src/EditorFeatures/TestUtilities/TodoComments/AbtractTodoCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/TodoComments/AbtractTodoCommentTests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.TodoComments
 {
     public abstract class AbstractTodoCommentTests
     {
+        protected const string DefaultTokenList = "HACK:1|TODO:1|UNDONE:1|UnresolvedMergeConflict:0";
+
         protected abstract TestWorkspace CreateWorkspace(string codeWithMarker);
 
         protected async Task TestAsync(string codeWithMarker)
@@ -38,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.TodoComments
             var document = workspace.CurrentSolution.GetDocument(documentId);
             var service = document.GetLanguageService<ITodoCommentService>();
             var todoComments = await service.GetTodoCommentsAsync(document,
-                TodoCommentDescriptor.Parse(TodoCommentOptions.TokenList.DefaultValue),
+                TodoCommentDescriptor.Parse(workspace.Options.GetOption(TodoCommentOptions.TokenList)),
                 CancellationToken.None);
 
             using var _ = ArrayBuilder<TodoCommentData>.GetInstance(out var converted);

--- a/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Test.Utilities.TodoComments
@@ -12,7 +13,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TodoComment
         Inherits AbstractTodoCommentTests
 
         Protected Overrides Function CreateWorkspace(codeWithMarker As String) As TestWorkspace
-            Return TestWorkspace.CreateVisualBasic(codeWithMarker)
+            Dim workspace = TestWorkspace.CreateVisualBasic(codeWithMarker)
+            workspace.SetOptions(workspace.Options.WithChangedOption(TodoCommentOptions.TokenList, DefaultTokenList))
+            Return workspace
         End Function
 
         <Fact>

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
@@ -29,6 +29,9 @@ namespace Microsoft.CodeAnalysis.TodoComments
             ImmutableArray<TodoCommentDescriptor> commentDescriptors,
             CancellationToken cancellationToken)
         {
+            if (commentDescriptors.IsEmpty)
+                return ImmutableArray<TodoComment>.Empty;
+
             cancellationToken.ThrowIfCancellationRequested();
 
             // strongly hold onto text and tree

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/CommentTaskTokenSerializer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/CommentTaskTokenSerializer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     continue;
                 }
 
-                result.Add($"{commentToken.Text}:{((int)commentToken.Priority).ToString()}");
+                result.Add($"{commentToken.Text}:{(int)commentToken.Priority}");
             }
 
             return string.Join("|", result);

--- a/src/Workspaces/Core/Portable/TodoComments/TodoCommentOptions.cs
+++ b/src/Workspaces/Core/Portable/TodoComments/TodoCommentOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
 {
     internal static class TodoCommentOptions
     {
-        public static readonly Option<string> TokenList = new(nameof(TodoCommentOptions), nameof(TokenList), defaultValue: "HACK:1|TODO:1|UNDONE:1|UnresolvedMergeConflict:0");
+        public static readonly Option<string> TokenList = new(nameof(TodoCommentOptions), nameof(TokenList), defaultValue: "");
     }
 
     [ExportOptionProvider, Shared]


### PR DESCRIPTION
This change removes the default value from `TodoCommentOptions.TokenList`. The previous default value was problematic in two ways:

1. When the default value was used, the solution crawler would compute a bunch of data for documents which would be discarded later when the true value was loaded
2. The default value allowed bugs like [this](https://developercommunity.visualstudio.com/t/custom-task-list-tokens-no-longer-working-in-vs-20/1041405) to be hidden for a long time, since it was difficult to tell when the correct value was used compared to a default that was "close" to correct (for some users)

A fast path was added to reduce the amount of work performed by the solution crawler if it runs with a defaulted option.

⚠️ This change is going to make it very obvious that we have a severe bug in OOP options synchronization. In 100% of cases I tested, TODO comments are using the default value and not the value set by users.