### PR TITLE
Switch to a callback form for `navigate to`

### DIFF
--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -428,14 +428,14 @@ Class Program { FileStyleUriParser f; }", async w =>
 
                 VerifyNavigateToResultItems(expecteditems, items);
 
-                var item = items.ElementAt(0);
+                var item = items.ElementAt(1);
                 var itemDisplay = item.DisplayFactory.CreateItemDisplay(item);
                 var unused = itemDisplay.Glyph;
 
                 Assert.Equal("Name", itemDisplay.Name);
                 Assert.Equal(string.Format(FeaturesResources.in_0_project_1, "DogBed", "Test"), itemDisplay.AdditionalInformation);
 
-                item = items.ElementAt(1);
+                item = items.ElementAt(0);
                 itemDisplay = item.DisplayFactory.CreateItemDisplay(item);
                 unused = itemDisplay.Glyph;
 

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -577,14 +577,14 @@ testHost, @"partial class Goo
 
                 VerifyNavigateToResultItems(expecteditems, items);
 
-                var item = items.ElementAt(0);
+                var item = items.ElementAt(1);
                 var itemDisplay = item.DisplayFactory.CreateItemDisplay(item);
                 var unused = itemDisplay.Glyph;
 
                 Assert.Equal("Name", itemDisplay.Name);
                 Assert.Equal(string.Format(FeaturesResources.in_0_project_1, "DogBed", "Test"), itemDisplay.AdditionalInformation);
 
-                item = items.ElementAt(1);
+                item = items.ElementAt(0);
                 itemDisplay = item.DisplayFactory.CreateItemDisplay(item);
                 unused = itemDisplay.Glyph;
 
@@ -672,8 +672,8 @@ class Test
             {
                 var expectedItems = new List<NavigateToItem>
                 {
+                    new NavigateToItem("Goo", NavigateToItemKind.Class, "csharp", "Goo", null, s_emptyExactPatternMatch, null),
                     new NavigateToItem("Goo", NavigateToItemKind.Method, "csharp", "Goo", null, s_emptyExactPatternMatch, null),
-                    new NavigateToItem("Goo", NavigateToItemKind.Class, "csharp", "Goo", null, s_emptyExactPatternMatch, null)
                 };
                 var items = await _aggregator.GetItemsAsync("Goo");
                 VerifyNavigateToResultItems(expectedItems, items);

--- a/src/EditorFeatures/TestUtilities/NavigateTo/NavigateToTestAggregator.Callback.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/NavigateToTestAggregator.Callback.cs
@@ -17,7 +17,7 @@ namespace Roslyn.Test.EditorUtilities.NavigateTo
     {
         private sealed class Callback : INavigateToCallback
         {
-            private readonly ConcurrentBag<NavigateToItem> _itemsReceived;
+            private readonly List<NavigateToItem> _itemsReceived = new();
 
             private readonly TaskCompletionSource<IEnumerable<NavigateToItem>> _taskCompletionSource =
                 new TaskCompletionSource<IEnumerable<NavigateToItem>>();
@@ -27,11 +27,13 @@ namespace Roslyn.Test.EditorUtilities.NavigateTo
                 Contract.ThrowIfNull(options);
 
                 Options = options;
-                _itemsReceived = new ConcurrentBag<NavigateToItem>();
             }
 
             public void AddItem(NavigateToItem item)
-                => _itemsReceived.Add(item);
+            {
+                lock (_itemsReceived)
+                    _itemsReceived.Add(item);
+            }
 
             public void Done()
                 => _taskCompletionSource.SetResult(_itemsReceived);

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -680,8 +680,8 @@ End Sub
 End Class", Async Function(w)
                 Dim expectedItems = New List(Of NavigateToItem) From
                     {
-                        New NavigateToItem("Goo", NavigateToItemKind.Method, "vb", Nothing, Nothing, s_emptyExactPatternMatch, Nothing),
-                        New NavigateToItem("Goo", NavigateToItemKind.Class, "vb", Nothing, Nothing, s_emptyExactPatternMatch, Nothing)
+                        New NavigateToItem("Goo", NavigateToItemKind.Class, "vb", Nothing, Nothing, s_emptyExactPatternMatch, Nothing),
+                        New NavigateToItem("Goo", NavigateToItemKind.Method, "vb", Nothing, Nothing, s_emptyExactPatternMatch, Nothing)
                     }
 
                 Dim items As List(Of NavigateToItem) = (Await _aggregator.GetItemsAsync("Goo")).ToList()

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         IImmutableSet<string> KindsProvided { get; }
         bool CanFilter { get; }
 
-        Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
-        Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken);
+        Task SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, CancellationToken cancellationToken);
+        Task SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -2,19 +2,63 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal interface IRemoteNavigateToSearchService
     {
-        ValueTask<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(
-            PinnedSolutionInfo solutionInfo, DocumentId documentId, string searchPattern, ImmutableArray<string> kinds, CancellationToken cancellationToken);
+        ValueTask SearchDocumentAsync(
+            PinnedSolutionInfo solutionInfo, DocumentId documentId, string searchPattern, ImmutableArray<string> kinds, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
 
-        ValueTask<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(
-            PinnedSolutionInfo solutionInfo, ProjectId projectId, ImmutableArray<DocumentId> priorityDocumentIds, string searchPattern, ImmutableArray<string> kinds, CancellationToken cancellationToken);
+        ValueTask SearchProjectAsync(
+            PinnedSolutionInfo solutionInfo, ProjectId projectId, ImmutableArray<DocumentId> priorityDocumentIds, string searchPattern, ImmutableArray<string> kinds, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
+
+        public interface ICallback
+        {
+            ValueTask OnResultFoundAsync(RemoteServiceCallbackId callbackId, SerializableNavigateToSearchResult result);
+        }
+    }
+
+    [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteNavigateToSearchService)), Shared]
+    internal sealed class NavigateToSearchServiceServerCallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteNavigateToSearchService.ICallback
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public NavigateToSearchServiceServerCallbackDispatcher()
+        {
+        }
+
+        private new NavigateToSearchServiceCallback GetCallback(RemoteServiceCallbackId callbackId)
+            => (NavigateToSearchServiceCallback)base.GetCallback(callbackId);
+
+        public ValueTask OnResultFoundAsync(RemoteServiceCallbackId callbackId, SerializableNavigateToSearchResult result)
+            => GetCallback(callbackId).OnResultFoundAsync(result);
+    }
+
+    internal sealed class NavigateToSearchServiceCallback
+    {
+        private readonly Solution _solution;
+        private readonly Func<INavigateToSearchResult, Task> _onResultFound;
+        private readonly CancellationToken _cancellationToken;
+
+        public NavigateToSearchServiceCallback(
+            Solution solution,
+            Func<INavigateToSearchResult, Task> onResultFound,
+            CancellationToken cancellationToken)
+        {
+            _solution = solution;
+            _onResultFound = onResultFound;
+            _cancellationToken = cancellationToken;
+        }
+
+        public async ValueTask OnResultFoundAsync(SerializableNavigateToSearchResult result)
+            => await _onResultFound(await result.RehydrateAsync(_solution, _cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -183,7 +183,6 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                                 await _callback.AddItemAsync(project, result, _cancellationToken).ConfigureAwait(false);
                             };
 
-
                         var task = _currentDocument != null
                             ? service.SearchDocumentAsync(_currentDocument, _searchPattern, _kinds, onResultFound, _cancellationToken)
                             : service.SearchProjectAsync(project, priorityDocuments, _searchPattern, _kinds, onResultFound, _cancellationToken);

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 using var navigateToSearch = Logger.LogBlock(FunctionId.NavigateTo_Search, KeyValueLogMessage.Create(LogType.UserAction), _cancellationToken);
                 using var asyncToken = _asyncListener.BeginAsyncOperation(GetType() + ".Search");
                 await _progress.AddItemsAsync(_solution.Projects.Count()).ConfigureAwait(false);
-                await SearchAllProjectsAsync(isFullyLoaded).ConfigureAwait(false);
+                await SearchAllProjectsAsync().ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
         }
 
-        private async Task SearchAllProjectsAsync(bool isFullyLoaded)
+        private async Task SearchAllProjectsAsync()
         {
             var seenItems = new HashSet<INavigateToSearchResult>(NavigateToSearchResultComparer.Instance);
             var processedProjects = new HashSet<Project>();
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 // Search the active project first.  That way we can deliver results that are
                 // closer in scope to the user quicker without forcing them to do something like
                 // NavToInCurrentDoc
-                await Task.Run(() => SearchAsync(activeProject, priorityDocs, seenItems, isFullyLoaded), _cancellationToken).ConfigureAwait(false);
+                await Task.Run(() => SearchAsync(activeProject, priorityDocs, seenItems), _cancellationToken).ConfigureAwait(false);
             }
 
             // Now, process all visible docs that were not from the active project.
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             {
                 // make sure we only process this project if we didn't already process it above.
                 if (processedProjects.Add(currentProject))
-                    tasks.Add(Task.Run(() => SearchAsync(currentProject, priorityDocs.ToImmutableArray(), seenItems, isFullyLoaded), _cancellationToken));
+                    tasks.Add(Task.Run(() => SearchAsync(currentProject, priorityDocs.ToImmutableArray(), seenItems), _cancellationToken));
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             {
                 // make sure we only process this project if we didn't already process it above.
                 if (processedProjects.Add(currentProject))
-                    tasks.Add(Task.Run(() => SearchAsync(currentProject, ImmutableArray<Document>.Empty, seenItems, isFullyLoaded), _cancellationToken));
+                    tasks.Add(Task.Run(() => SearchAsync(currentProject, ImmutableArray<Document>.Empty, seenItems), _cancellationToken));
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -141,12 +141,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private async Task SearchAsync(
             Project project,
             ImmutableArray<Document> priorityDocuments,
-            HashSet<INavigateToSearchResult> seenItems,
-            bool isFullyLoaded)
+            HashSet<INavigateToSearchResult> seenItems)
         {
             try
             {
-                await SearchCoreAsync(project, priorityDocuments, seenItems, isFullyLoaded).ConfigureAwait(false);
+                await SearchCoreAsync(project, priorityDocuments, seenItems).ConfigureAwait(false);
             }
             finally
             {
@@ -157,8 +156,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private async Task SearchCoreAsync(
             Project project,
             ImmutableArray<Document> priorityDocuments,
-            HashSet<INavigateToSearchResult> seenItems,
-            bool isFullyLoaded)
+            HashSet<INavigateToSearchResult> seenItems)
         {
             if (_searchCurrentDocument && _currentDocument?.Project != project)
                 return;
@@ -171,14 +169,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                     var service = project.GetLanguageService<INavigateToSearchService>();
                     if (service != null)
                     {
-                        var searchTask = _currentDocument != null
-                            ? service.SearchDocumentAsync(_currentDocument, _searchPattern, _kinds, _cancellationToken)
-                            : service.SearchProjectAsync(project, priorityDocuments, _searchPattern, _kinds, _cancellationToken);
-
-                        var results = await searchTask.ConfigureAwait(false);
-                        if (results != null)
-                        {
-                            foreach (var result in results)
+                        Func<INavigateToSearchResult, Task> onResultFound = async (result) =>
                             {
                                 // If we're seeing a dupe in another project, then filter it out here.  The results from
                                 // the individual projects will already contain the information about all the projects
@@ -186,12 +177,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                                 lock (seenItems)
                                 {
                                     if (!seenItems.Add(result))
-                                        continue;
+                                        return;
                                 }
 
                                 await _callback.AddItemAsync(project, result, _cancellationToken).ConfigureAwait(false);
-                            }
-                        }
+                            };
+
+
+                        var task = _currentDocument != null
+                            ? service.SearchDocumentAsync(_currentDocument, _searchPattern, _kinds, onResultFound, _cancellationToken)
+                            : service.SearchProjectAsync(project, priorityDocuments, _searchPattern, _kinds, onResultFound, _cancellationToken);
+
+                        await task.ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Tools/ExternalAccess/FSharp/Internal/NavigateTo/FSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/NavigateTo/FSharpNavigateToSearchService.cs
@@ -30,16 +30,22 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.NavigateTo
 
         public bool CanFilter => _service.CanFilter;
 
-        public async Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
+        public async Task SearchDocumentAsync(
+            Document document, string searchPattern, IImmutableSet<string> kinds,
+            Func<INavigateToSearchResult, Task> onResultFound, CancellationToken cancellationToken)
         {
             var results = await _service.SearchDocumentAsync(document, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
-            return results.SelectAsArray(x => (INavigateToSearchResult)new InternalFSharpNavigateToSearchResult(x));
+            foreach (var result in results)
+                await onResultFound(new InternalFSharpNavigateToSearchResult(result)).ConfigureAwait(false);
         }
 
-        public async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, CancellationToken cancellationToken)
+        public async Task SearchProjectAsync(
+            Project project, ImmutableArray<Document> priorityDocuments, string searchPattern,
+            IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, CancellationToken cancellationToken)
         {
             var results = await _service.SearchProjectAsync(project, priorityDocuments, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
-            return results.SelectAsArray(x => (INavigateToSearchResult)new InternalFSharpNavigateToSearchResult(x));
+            foreach (var result in results)
+                await onResultFound(new InternalFSharpNavigateToSearchResult(result)).ConfigureAwait(false);
         }
     }
 }

--- a/src/Workspaces/Remote/Core/ServiceDescriptors.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptors.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Remote
             (typeof(IRemoteConvertTupleToStructCodeRefactoringService), null),
             (typeof(IRemoteSymbolFinderService), typeof(IRemoteSymbolFinderService.ICallback)),
             (typeof(IRemoteFindUsagesService), typeof(IRemoteFindUsagesService.ICallback)),
-            (typeof(IRemoteNavigateToSearchService), null),
+            (typeof(IRemoteNavigateToSearchService), typeof(IRemoteNavigateToSearchService.ICallback)),
             (typeof(IRemoteNavigationBarItemService), null),
             (typeof(IRemoteMissingImportDiscoveryService), typeof(IRemoteMissingImportDiscoveryService.ICallback)),
             (typeof(IRemoteSymbolSearchUpdateService), typeof(IRemoteSymbolSearchUpdateService.ICallback)),

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -14,63 +13,69 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal sealed class RemoteNavigateToSearchService : BrokeredServiceBase, IRemoteNavigateToSearchService
     {
-        internal sealed class Factory : FactoryBase<IRemoteNavigateToSearchService>
+        internal sealed class Factory : FactoryBase<IRemoteNavigateToSearchService, IRemoteNavigateToSearchService.ICallback>
         {
-            protected override IRemoteNavigateToSearchService CreateService(in ServiceConstructionArguments arguments)
-                => new RemoteNavigateToSearchService(arguments);
+            protected override IRemoteNavigateToSearchService CreateService(
+                in ServiceConstructionArguments arguments, RemoteCallback<IRemoteNavigateToSearchService.ICallback> callback)
+                => new RemoteNavigateToSearchService(arguments, callback);
         }
 
-        public RemoteNavigateToSearchService(in ServiceConstructionArguments arguments)
+        private readonly RemoteCallback<IRemoteNavigateToSearchService.ICallback> _callback;
+
+        public RemoteNavigateToSearchService(in ServiceConstructionArguments arguments, RemoteCallback<IRemoteNavigateToSearchService.ICallback> callback)
             : base(arguments)
         {
+            _callback = callback;
         }
 
-        public ValueTask<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(
+        public ValueTask SearchDocumentAsync(
             PinnedSolutionInfo solutionInfo,
             DocumentId documentId,
             string searchPattern,
             ImmutableArray<string> kinds,
+            RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
             return RunServiceAsync(async cancellationToken =>
             {
                 var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var document = solution.GetDocument(documentId);
-                var result = await AbstractNavigateToSearchService.SearchDocumentInCurrentProcessAsync(
-                    document, searchPattern, kinds.ToImmutableHashSet(), cancellationToken).ConfigureAwait(false);
+                var callback = GetCallback(callbackId, cancellationToken);
 
-                return Convert(result);
+                await AbstractNavigateToSearchService.SearchDocumentInCurrentProcessAsync(
+                    document, searchPattern, kinds.ToImmutableHashSet(), callback, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
 
-        public ValueTask<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(
+        public ValueTask SearchProjectAsync(
             PinnedSolutionInfo solutionInfo,
             ProjectId projectId,
             ImmutableArray<DocumentId> priorityDocumentIds,
             string searchPattern,
             ImmutableArray<string> kinds,
+            RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
             return RunServiceAsync(async cancellationToken =>
             {
                 var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var project = solution.GetProject(projectId);
+                var callback = GetCallback(callbackId, cancellationToken);
+
                 var priorityDocuments = priorityDocumentIds.Select(d => solution.GetDocument(d))
                                                            .ToImmutableArray();
 
-                var result = await AbstractNavigateToSearchService.SearchProjectInCurrentProcessAsync(
-                    project, priorityDocuments, searchPattern, kinds.ToImmutableHashSet(), cancellationToken).ConfigureAwait(false);
-
-                return Convert(result);
+                await AbstractNavigateToSearchService.SearchProjectInCurrentProcessAsync(
+                    project, priorityDocuments, searchPattern, kinds.ToImmutableHashSet(), callback, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
 
-        private static ImmutableArray<SerializableNavigateToSearchResult> Convert(
-            ImmutableArray<INavigateToSearchResult> result)
+        private Func<INavigateToSearchResult, Task> GetCallback(
+            RemoteServiceCallbackId callbackId, CancellationToken cancellationToken)
         {
-            return result.SelectAsArray(SerializableNavigateToSearchResult.Dehydrate);
+            return async r => await _callback.InvokeAsync((callback, c) =>
+                callback.OnResultFoundAsync(callbackId, SerializableNavigateToSearchResult.Dehydrate(r)),
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Navigate-To currently searching each project concurrently, but results are only reported in one batch per project.  This means a large project won't return any results until the entire project is searched.

This PR moves us to work more like the FindReferences model.  we now pass in a callback that hte server can call back into as it finds matches.  This means a result can be reported the moment it is found.  

This does not impact F# or TS as we use EA for them, and this PR proxies this new pattern to the existing bulk-api we have for those languages.
