### PR TITLE
Fix doc comment

### DIFF
--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -16,11 +16,10 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.PatternMatching
 {
     /// <summary>
-    /// The pattern matcher is thread-safe.  However, it maintains an internal cache of
-    /// information as it is used.  Therefore, you should not keep it around forever and should get
-    /// and release the matcher appropriately once you no longer need it.
-    /// Also, while the pattern matcher is culture aware, it uses the culture specified in the
-    /// constructor.
+    /// The pattern matcher is not thread-safe.  Do not use the pattern matcher across mutiple threads concurrently.  It
+    /// also keeps an internal cache of data for speeding up operations.  As such, it should be disposed when done to
+    /// release the cached data back. and release the matcher appropriately once you no longer need it. Also, while the
+    /// pattern matcher is culture aware, it uses the culture specified in the constructor.
     /// </summary>
     internal abstract partial class PatternMatcher : IDisposable
     {


### PR DESCRIPTION
The doc comment for PatternMatcher is incorrect.  it states it is threadsafe when it is not.  SPecifically, internally for each 'chunk' of the pattern it breaks out, it keeps a 'similarity cache' of hte last thing it was matched against.  this is so that checking it repeatedly against the same name (common with things like overloads, or candidate strings with similar portions) can jsut return the previously computed result.  this cache is mutable and is not safe for concurrent mutation.

I have audited all users and have seen that no one does actually use this across threads.  However, the docs shouldn't convey the wrong info here.