### PR TITLE
Delete AssertEx.Throws

### DIFF
--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -732,25 +732,6 @@ namespace Roslyn.Test.Utilities
                 expectedValueSourceLine: expectedValueSourceLine);
         }
 
-        public static void Throws<TException>(Action action, Action<TException> checker = null)
-            where TException : Exception
-        {
-            try
-            {
-                action();
-            }
-            catch (Exception e)
-            {
-                if (e is AggregateException agg && agg.InnerExceptions.Count == 1)
-                {
-                    e = agg.InnerExceptions[0];
-                }
-
-                Assert.Equal(typeof(TException), e.GetType());
-                checker?.Invoke((TException)e);
-            }
-        }
-
         public static void Equal(bool[,] expected, Func<int, int, bool> getResult, int size)
         {
             Equal<bool>(expected, getResult, (b1, b2) => b1 == b2, b => b ? "true" : "false", "{0,-6:G}", size);

--- a/src/EditorFeatures/Test2/Simplification/SimplifierAPITests.vb
+++ b/src/EditorFeatures/Test2/Simplification/SimplifierAPITests.vb
@@ -11,142 +11,128 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
     Public Class SimplifierAPITests
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestExpandAsync()
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim expandedNode = Simplifier.ExpandAsync(Of SyntaxNode)(Nothing, Nothing).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "node"))
-        End Sub
+        Public Async Function TestExpandAsync() As Task
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("node",
+                Function()
+                    Return Simplifier.ExpandAsync(Of SyntaxNode)(Nothing, Nothing)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestExpandAsync2()
+        Public Async Function TestExpandAsync2() As Task
             Dim node = GetSyntaxNode()
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim expandedNode = Simplifier.ExpandAsync(node, Nothing).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "document"))
-        End Sub
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("document",
+                Function() As Task
+                    Return Simplifier.ExpandAsync(node, Nothing)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Sub TestExpand()
-            AssertEx.Throws(Of ArgumentNullException)(
+            Assert.Throws(Of ArgumentNullException)("node",
                 Sub()
-                    Dim expandedNode = Simplifier.Expand(Of SyntaxNode)(Nothing, Nothing, Nothing)
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "node"))
+                    Simplifier.Expand(Of SyntaxNode)(Nothing, Nothing, Nothing)
+                End Sub)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Sub TestExpand2()
             Dim node = GetSyntaxNode()
-            AssertEx.Throws(Of ArgumentNullException)(
+            Assert.Throws(Of ArgumentNullException)("semanticModel",
                 Sub()
-                    Dim expandedNode = Simplifier.Expand(node, Nothing, Nothing)
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "semanticModel"))
+                    Simplifier.Expand(node, Nothing, Nothing)
+                End Sub)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Sub TestExpand3()
             Dim node = GetSyntaxNode()
             Dim semanticModel = GetSemanticModel()
-            AssertEx.Throws(Of ArgumentNullException)(
+            Assert.Throws(Of ArgumentNullException)("workspace",
                 Sub()
-                    Dim expandedNode = Simplifier.Expand(node, semanticModel, Nothing)
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "workspace"))
+                    Simplifier.Expand(node, semanticModel, Nothing)
+                End Sub)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestTokenExpandAsync()
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim expandedNode = Simplifier.ExpandAsync(Nothing, Nothing).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "document"))
-        End Sub
+        Public Async Function TestTokenExpandAsync() As Task
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("document",
+                Function()
+                    Return Simplifier.ExpandAsync(Nothing, Nothing)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Sub TestTokenExpand()
-            AssertEx.Throws(Of ArgumentNullException)(
+            Assert.Throws(Of ArgumentNullException)("semanticModel",
                 Sub()
                     Dim expandedNode = Simplifier.Expand(Nothing, Nothing, Nothing)
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "semanticModel"))
+                End Sub)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Sub TestTokenExpand2()
             Dim semanticModel = GetSemanticModel()
-            AssertEx.Throws(Of ArgumentNullException)(
+            Assert.Throws(Of ArgumentNullException)("workspace",
                 Sub()
                     Dim expandedNode = Simplifier.Expand(Nothing, semanticModel, Nothing)
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "workspace"))
+                End Sub)
         End Sub
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestReduceAsync()
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim simplifiedNode = Simplifier.ReduceAsync(Nothing).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "document"))
-        End Sub
+        Public Async Function TestReduceAsync() As Task
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("document",
+                Function()
+                    Return Simplifier.ReduceAsync(Nothing)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestReduceAsync2()
+        Public Async Function TestReduceAsync2() As Task
             Dim syntaxAnnotation As SyntaxAnnotation = Nothing
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim simplifiedNode = Simplifier.ReduceAsync(Nothing, syntaxAnnotation).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "document"))
-        End Sub
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("document",
+                Function()
+                    Return Simplifier.ReduceAsync(Nothing, syntaxAnnotation)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestReduceAsync3()
+        Public Async Function TestReduceAsync3() As Task
             Dim syntaxAnnotation As SyntaxAnnotation = Nothing
             Dim document = GetDocument()
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim simplifiedNode = Simplifier.ReduceAsync(document, syntaxAnnotation).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "annotation"))
-        End Sub
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("annotation",
+                Function()
+                    Return Simplifier.ReduceAsync(document, syntaxAnnotation)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestReduceAsync4()
+        Public Async Function TestReduceAsync4() As Task
             Dim textSpan As TextSpan = Nothing
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim simplifiedNode = Simplifier.ReduceAsync(Nothing, textSpan).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "document"))
-        End Sub
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("document",
+                Function()
+                    Return Simplifier.ReduceAsync(Nothing, textSpan)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestReduceAsync5()
+        Public Async Function TestReduceAsync5() As Task
             Dim spans As IEnumerable(Of TextSpan) = Nothing
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim simplifiedNode = Simplifier.ReduceAsync(Nothing, spans).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "document"))
-        End Sub
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("document",
+                Function()
+                    Return Simplifier.ReduceAsync(Nothing, spans)
+                End Function)
+        End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Sub TestReduceAsync6()
+        Public Async Function TestReduceAsync6() As Task
             Dim document = GetDocument()
             Dim spans As IEnumerable(Of TextSpan) = Nothing
-            AssertEx.Throws(Of ArgumentNullException)(
-                Sub()
-                    Dim simplifiedNode = Simplifier.ReduceAsync(document, spans).Result
-                End Sub,
-                Sub(exception) Assert.Equal(exception.ParamName, "spans"))
-        End Sub
+            Await Assert.ThrowsAsync(Of ArgumentNullException)("spans",
+                Function() As Task
+                    Return Simplifier.ReduceAsync(document, spans)
+                End Function)
+        End Function
 
         Private Shared Function GetDocument() As Document
             Dim workspace = New AdhocWorkspace()

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -807,42 +807,38 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithInvalidFileExtension()
+        public async Task TestOpenProject_WithInvalidFileExtensionAsync()
         {
             // make sure the file does in fact exist, but with an unrecognized extension
             const string ProjFileName = @"CSharpProject\CSharpProject.csproj.nyi";
             CreateFiles(GetSimpleCSharpSolutionFiles()
                 .WithFile(ProjFileName, Resources.ProjectFiles.CSharp.CSharpProject));
 
-            AssertEx.Throws<InvalidOperationException>(delegate
+            var e = await Assert.ThrowsAsync<InvalidOperationException>(async delegate
             {
-                MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(ProjFileName)).Wait();
-            },
-            (e) =>
-            {
-                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, GetSolutionFileName(ProjFileName), ".nyi");
-                Assert.Equal(expected, e.Message);
+                await MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(ProjFileName));
             });
+
+            var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, GetSolutionFileName(ProjFileName), ".nyi");
+            Assert.Equal(expected, e.Message);
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_ProjectFileExtensionAssociatedWithUnknownLanguage()
+        public async Task TestOpenProject_ProjectFileExtensionAssociatedWithUnknownLanguageAsync()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
             var projFileName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             var language = "lingo";
-            AssertEx.Throws<InvalidOperationException>(delegate
+            var e = await Assert.ThrowsAsync<InvalidOperationException>(async delegate
             {
                 var ws = MSBuildWorkspace.Create();
                 ws.AssociateFileExtensionWithLanguage("csproj", language); // non-existent language
-                ws.OpenProjectAsync(projFileName).Wait();
-            },
-            (e) =>
-            {
-                // the exception should tell us something about the language being unrecognized.
-                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_language_1_is_not_supported, projFileName, language);
-                Assert.Equal(expected, e.Message);
+                await ws.OpenProjectAsync(projFileName);
             });
+
+            // the exception should tell us something about the language being unrecognized.
+            var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_language_1_is_not_supported, projFileName, language);
+            Assert.Equal(expected, e.Message);
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
@@ -883,28 +879,28 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenSolution_WithNonExistentSolutionFile_Fails()
+        public async Task TestOpenSolution_WithNonExistentSolutionFile_FailsAsync()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
             var solutionFilePath = GetSolutionFileName("NonExistentSolution.sln");
 
-            AssertEx.Throws<FileNotFoundException>(() =>
+            await Assert.ThrowsAsync<FileNotFoundException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
-                workspace.OpenSolutionAsync(solutionFilePath).Wait();
+                await workspace.OpenSolutionAsync(solutionFilePath);
             });
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenSolution_WithInvalidSolutionFile_Fails()
+        public async Task TestOpenSolution_WithInvalidSolutionFile_FailsAsync()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
             var solutionFilePath = GetSolutionFileName(@"http://localhost/Invalid/InvalidSolution.sln");
 
-            AssertEx.Throws<InvalidOperationException>(() =>
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
-                workspace.OpenSolutionAsync(solutionFilePath).Wait();
+                await workspace.OpenSolutionAsync(solutionFilePath);
             });
         }
 
@@ -999,7 +995,7 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenSolution_WithInvalidProjectPath_SkipFalse_Fails()
+        public async Task TestOpenSolution_WithInvalidProjectPath_SkipFalse_Fails()
         {
             // when not skipped we should get an exception for the invalid project
 
@@ -1010,7 +1006,7 @@ class C1
             using var workspace = CreateMSBuildWorkspace();
             workspace.SkipUnrecognizedProjects = false;
 
-            AssertEx.Throws<InvalidOperationException>(() => workspace.OpenSolutionAsync(solutionFilePath).Wait());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => workspace.OpenSolutionAsync(solutionFilePath));
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
@@ -1029,7 +1025,7 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenSolution_WithNonExistentProject_SkipFalse_Fails()
+        public async Task TestOpenSolution_WithNonExistentProject_SkipFalse_Fails()
         {
             // when skipped we should see an exception for the non-existent project
 
@@ -1040,7 +1036,7 @@ class C1
             using var workspace = CreateMSBuildWorkspace();
             workspace.SkipUnrecognizedProjects = false;
 
-            AssertEx.Throws<FileNotFoundException>(() => workspace.OpenSolutionAsync(solutionFilePath).Wait());
+            await Assert.ThrowsAsync<FileNotFoundException>(() => workspace.OpenSolutionAsync(solutionFilePath));
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
@@ -1088,7 +1084,7 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenSolution_WithUnrecognizedProjectTypeGuidAndUnrecognizedExtension_WithSkipFalse_Fails()
+        public async Task TestOpenSolution_WithUnrecognizedProjectTypeGuidAndUnrecognizedExtension_WithSkipFalse_FailsAsync()
         {
             // proves that if both project type guid and file extension are unrecognized, then open project fails.
             const string NoProjFileName = @"CSharpProject\CSharpProject.noproj";
@@ -1098,42 +1094,38 @@ class C1
 
             var solutionFilePath = GetSolutionFileName(@"TestSolution.sln");
 
-            AssertEx.Throws<InvalidOperationException>(() =>
+            var e = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
                 workspace.SkipUnrecognizedProjects = false;
-                workspace.OpenSolutionAsync(solutionFilePath).Wait();
-            },
-            e =>
-            {
-                var noProjFullFileName = GetSolutionFileName(NoProjFileName);
-                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, noProjFullFileName, ".noproj");
-                Assert.Equal(expected, e.Message);
+                await workspace.OpenSolutionAsync(solutionFilePath);
             });
+
+            var noProjFullFileName = GetSolutionFileName(NoProjFileName);
+            var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, noProjFullFileName, ".noproj");
+            Assert.Equal(expected, e.Message);
         }
 
         private readonly IEnumerable<Assembly> _defaultAssembliesWithoutCSharp = MefHostServices.DefaultAssemblies.Where(a => !a.FullName.Contains("CSharp"));
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(3931, "https://github.com/dotnet/roslyn/issues/3931")]
-        public void TestOpenSolution_WithMissingLanguageLibraries_WithSkipFalse_Throws()
+        public async Task TestOpenSolution_WithMissingLanguageLibraries_WithSkipFalse_ThrowsAsync()
         {
             // proves that if the language libraries are missing then the appropriate error occurs
             CreateFiles(GetSimpleCSharpSolutionFiles());
             var solutionFilePath = GetSolutionFileName(@"TestSolution.sln");
 
-            AssertEx.Throws<InvalidOperationException>(() =>
+            var e = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace(MefHostServices.Create(_defaultAssembliesWithoutCSharp));
                 workspace.SkipUnrecognizedProjects = false;
-                workspace.OpenSolutionAsync(solutionFilePath).Wait();
-            },
-            e =>
-            {
-                var projFileName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
-                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, projFileName, ".csproj");
-                Assert.Equal(expected, e.Message);
+                await workspace.OpenSolutionAsync(solutionFilePath);
             });
+
+            var projFileName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+            var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, projFileName, ".csproj");
+            Assert.Equal(expected, e.Message);
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
@@ -1156,47 +1148,42 @@ class C1
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(3931, "https://github.com/dotnet/roslyn/issues/3931")]
-        public void TestOpenProject_WithMissingLanguageLibraries_Throws()
+        public async Task TestOpenProject_WithMissingLanguageLibraries_Throws()
         {
             // proves that if the language libraries are missing then the appropriate error occurs
             CreateFiles(GetSimpleCSharpSolutionFiles());
             var projectName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
 
             using var workspace = MSBuildWorkspace.Create(MefHostServices.Create(_defaultAssembliesWithoutCSharp));
-            AssertEx.Throws<InvalidOperationException>(() =>
-            {
-                var project = workspace.OpenProjectAsync(projectName).Result;
-            },
-            e =>
-            {
-                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, projectName, ".csproj");
-                Assert.Equal(expected, e.Message);
-            });
+            var e = await Assert.ThrowsAsync<InvalidOperationException>(() => workspace.OpenProjectAsync(projectName));
+
+            var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, projectName, ".csproj");
+            Assert.Equal(expected, e.Message);
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithInvalidFilePath_Fails()
+        public async Task TestOpenProject_WithInvalidFilePath_Fails()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
             var projectFilePath = GetSolutionFileName(@"http://localhost/Invalid/InvalidProject.csproj");
 
-            AssertEx.Throws<InvalidOperationException>(() =>
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
-                workspace.OpenProjectAsync(projectFilePath).Wait();
+                await workspace.OpenProjectAsync(projectFilePath);
             });
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithNonExistentProjectFile_Fails()
+        public async Task TestOpenProject_WithNonExistentProjectFile_FailsAsync()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
             var projectFilePath = GetSolutionFileName(@"CSharpProject\NonExistentProject.csproj");
 
-            AssertEx.Throws<FileNotFoundException>(() =>
+            await Assert.ThrowsAsync<FileNotFoundException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
-                workspace.OpenProjectAsync(projectFilePath).Wait();
+                await workspace.OpenProjectAsync(projectFilePath);
             });
         }
 
@@ -1218,17 +1205,17 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithInvalidProjectReference_SkipFalse_Fails()
+        public async Task TestOpenProject_WithInvalidProjectReference_SkipFalse_Fails()
         {
             CreateFiles(GetMultiProjectSolutionFiles()
                 .WithFile(@"VisualBasicProject\VisualBasicProject.vbproj", Resources.ProjectFiles.VisualBasic.InvalidProjectReference));
             var projectFilePath = GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj");
 
-            AssertEx.Throws<InvalidOperationException>(() =>
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
                 workspace.SkipUnrecognizedProjects = false;
-                workspace.OpenProjectAsync(projectFilePath).Wait();
+                await workspace.OpenProjectAsync(projectFilePath);
             });
         }
 
@@ -1250,17 +1237,17 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithNonExistentProjectReference_SkipFalse_Fails()
+        public async Task TestOpenProject_WithNonExistentProjectReference_SkipFalse_FailsAsync()
         {
             CreateFiles(GetMultiProjectSolutionFiles()
                 .WithFile(@"VisualBasicProject\VisualBasicProject.vbproj", Resources.ProjectFiles.VisualBasic.NonExistentProjectReference));
             var projectFilePath = GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj");
 
-            AssertEx.Throws<FileNotFoundException>(() =>
+            await Assert.ThrowsAsync<FileNotFoundException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
                 workspace.SkipUnrecognizedProjects = false;
-                workspace.OpenProjectAsync(projectFilePath).Wait();
+                await workspace.OpenProjectAsync(projectFilePath);
             });
         }
 
@@ -1283,18 +1270,18 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithUnrecognizedProjectReferenceFileExtension_SkipFalse_Fails()
+        public async Task TestOpenProject_WithUnrecognizedProjectReferenceFileExtension_SkipFalse_Fails()
         {
             CreateFiles(GetMultiProjectSolutionFiles()
                 .WithFile(@"VisualBasicProject\VisualBasicProject.vbproj", Resources.ProjectFiles.VisualBasic.UnknownProjectExtension)
                 .WithFile(@"CSharpProject\CSharpProject.noproj", Resources.ProjectFiles.CSharp.CSharpProject));
             var projectFilePath = GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj");
 
-            AssertEx.Throws<InvalidOperationException>(() =>
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 using var workspace = CreateMSBuildWorkspace();
                 workspace.SkipUnrecognizedProjects = false;
-                workspace.OpenProjectAsync(projectFilePath).Wait();
+                await workspace.OpenProjectAsync(projectFilePath);
             });
         }
 
@@ -2541,8 +2528,8 @@ class C1
             Assert.Equal(cscomment, vbcomment);
         }
 
-        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithProjectFileLocked()
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled), typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        public async Task TestOpenProject_WithProjectFileLockedAsync()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
 
@@ -2550,39 +2537,38 @@ class C1
             var projectFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             using (File.Open(projectFile, FileMode.Open, FileAccess.ReadWrite))
             {
-                AssertEx.Throws<IOException>(() =>
-                    {
-                        using var workspace = CreateMSBuildWorkspace();
-                        workspace.OpenProjectAsync(projectFile).Wait();
-                    });
+                using var workspace = CreateMSBuildWorkspace();
+                await workspace.OpenProjectAsync(projectFile);
+                var diagnostic = Assert.Single(workspace.Diagnostics);
+                Assert.Contains("The process cannot access the file", diagnostic.Message);
             }
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenProject_WithNonExistentProjectFile()
+        public async Task TestOpenProject_WithNonExistentProjectFileAsync()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
 
             // open for read-write so no-one else can read
             var projectFile = GetSolutionFileName(@"CSharpProject\NoProject.csproj");
-            AssertEx.Throws<FileNotFoundException>(() =>
+            await Assert.ThrowsAsync<FileNotFoundException>(async () =>
                 {
                     using var workspace = CreateMSBuildWorkspace();
-                    workspace.OpenProjectAsync(projectFile).Wait();
+                    await workspace.OpenProjectAsync(projectFile);
                 });
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public void TestOpenSolution_WithNonExistentSolutionFile()
+        public async Task TestOpenSolution_WithNonExistentSolutionFileAsync()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
 
             // open for read-write so no-one else can read
             var solutionFile = GetSolutionFileName(@"NoSolution.sln");
-            AssertEx.Throws<FileNotFoundException>(() =>
+            await Assert.ThrowsAsync<FileNotFoundException>(async () =>
                 {
                     using var workspace = CreateMSBuildWorkspace();
-                    workspace.OpenSolutionAsync(solutionFile).Wait();
+                    await workspace.OpenSolutionAsync(solutionFile);
                 });
         }
 


### PR DESCRIPTION
We're not entirely sure why this was added; it might have been due to lack of Assert.ThrowsAsync in whichever version of xUnit we were using, or something else. In any case, it's unnecessary today and was also broken: it would silently succeed if the passed function didn't throw any exceptions at all.