### PR TITLE
Update TypeKind doc comment

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/TypeKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeKind.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
         Array = 1,
 
         /// <summary>
-        /// Type is a class.
+        /// Type is a class or a record.
         /// </summary>
         Class = 2,
 


### PR DESCRIPTION
Fixes #47946

While a record is indeed a class, I think it's still beneficial to explicitly state that in the documentation comment.