### PR TITLE
Added Razor.LanguageServer to Razor ExternalAccess Visibility

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -20,6 +20,7 @@
     <!--
       ⚠ ONLY RAZOR ASSEMBLIES MAY BE ADDED HERE ⚠
     -->
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.LanguageServer" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Workspaces" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.Editor.Razor" Key="$(RazorKey)" />


### PR DESCRIPTION
Added `Microsoft.AspNetCore.Razor.LanguageServer` as we'd like to use the new `RazorPredefinedCodeRefactoringProviderNames` in [`Microsoft.AspNetCore.Razor.LanguageServer.*`](https://github.com/dotnet/aspnetcore-tooling/blob/e86d54f89bc762a895d2a5622a63a53537e7f062/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs#L27).