### PR TITLE
Allow `abstract` and `sealed` modifiers on static methods/properties/events in interfaces.

### DIFF
--- a/docs/features/StaticAbstractMembersInInterfaces.md
+++ b/docs/features/StaticAbstractMembersInInterfaces.md
@@ -1,0 +1,14 @@
+Static Abstract Members In Interfaces
+=====================================
+
+An interface is allowed to specify abstract static members that implementing classes and structs are then
+required to provide an explicit or implicit implementation of. The members can be accessed off of type
+parameters that are constrained by the interface.
+
+Proposal: 
+- https://github.com/dotnet/csharplang/issues/4436
+- https://github.com/dotnet/csharplang/blob/main/proposals/statics-in-interfaces.md
+
+Feature branch: https://github.com/dotnet/roslyn/tree/features/StaticAbstractMembersInInterfaces
+
+Test plan: https://github.com/dotnet/roslyn/issues/52221

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -667,7 +667,7 @@
     <value>Type '{1}' already defines a member called '{0}' with the same parameter types</value>
   </data>
   <data name="ERR_StaticNotVirtual" xml:space="preserve">
-    <value>A static member '{0}' cannot be marked as override, virtual, or abstract</value>
+    <value>A static member cannot be marked as '{0}'</value>
   </data>
   <data name="ERR_OverrideNotNew" xml:space="preserve">
     <value>A member '{0}' marked as override cannot be marked as new or virtual</value>
@@ -6599,5 +6599,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_FunctionPointerTypesInAttributeNotSupported" xml:space="preserve">
     <value>Using a function pointer type in a 'typeof' in an attribute is not supported.</value>
+  </data>
+  <data name="IDS_FeatureStaticAbstractMembersInInterfaces" xml:space="preserve">
+    <value>static abstract members in interfaces</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -216,6 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureVarianceSafetyForStaticInterfaceMembers = MessageBase + 12791,
         IDS_FeatureConstantInterpolatedStrings = MessageBase + 12792,
         IDS_FeatureMixedDeclarationsAndExpressionsInDeconstruction = MessageBase + 12793,
+        IDS_FeatureStaticAbstractMembersInInterfaces = MessageBase + 12794,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -324,6 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# preview features.
                 case MessageID.IDS_FeatureMixedDeclarationsAndExpressionsInDeconstruction:
+                case MessageID.IDS_FeatureStaticAbstractMembersInInterfaces: // semantic check
                     return LanguageVersion.Preview;
                 // C# 9.0 features.
                 case MessageID.IDS_FeatureLambdaDiscardParameters: // semantic check

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
@@ -39,6 +39,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             out bool modifierErrors)
         {
             modifierErrors = false;
+            DeclarationModifiers reportStaticNotVirtualForModifiers = DeclarationModifiers.None;
+
+            if ((modifiers & allowedModifiers & DeclarationModifiers.Static) != 0)
+            {
+                reportStaticNotVirtualForModifiers = allowedModifiers & (DeclarationModifiers.Override | DeclarationModifiers.Virtual);
+                allowedModifiers &= ~reportStaticNotVirtualForModifiers;
+            }
+
             DeclarationModifiers errorModifiers = modifiers & ~allowedModifiers;
             DeclarationModifiers result = modifiers & allowedModifiers;
 
@@ -53,6 +61,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case DeclarationModifiers.Partial:
                         // Provide a specialized error message in the case of partial.
                         ReportPartialError(errorLocation, diagnostics, modifierTokens);
+                        break;
+
+                    case DeclarationModifiers.Override:
+                    case DeclarationModifiers.Virtual:
+                        if ((reportStaticNotVirtualForModifiers & oneError) == 0)
+                        {
+                            goto default;
+                        }
+
+                        diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, errorLocation, ModifierUtils.ConvertSingleModifierToSyntaxText(oneError));
                         break;
 
                     default:
@@ -94,25 +112,61 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Location errorLocation,
             BindingDiagnosticBag diagnostics)
         {
-            if (!hasBody && (modifiers & defaultInterfaceImplementationModifiers) != 0)
+            if ((modifiers & defaultInterfaceImplementationModifiers) != 0)
             {
                 LanguageVersion availableVersion = ((CSharpParseOptions)errorLocation.SourceTree.Options).LanguageVersion;
-                LanguageVersion requiredVersion = MessageID.IDS_DefaultInterfaceImplementation.RequiredVersion();
-                if (availableVersion < requiredVersion)
+                LanguageVersion requiredVersion;
+
+                if ((modifiers & defaultInterfaceImplementationModifiers & DeclarationModifiers.Static) != 0 &&
+                    (modifiers & defaultInterfaceImplementationModifiers & (DeclarationModifiers.Sealed | DeclarationModifiers.Abstract)) != 0)
                 {
-                    DeclarationModifiers errorModifiers = modifiers & defaultInterfaceImplementationModifiers;
-                    var requiredVersionArgument = new CSharpRequiredLanguageVersion(requiredVersion);
-                    var availableVersionArgument = availableVersion.ToDisplayString();
-                    while (errorModifiers != DeclarationModifiers.None)
+                    var reportModifiers = DeclarationModifiers.Sealed | DeclarationModifiers.Abstract;
+                    if ((modifiers & defaultInterfaceImplementationModifiers & (DeclarationModifiers.Sealed | DeclarationModifiers.Abstract)) == (DeclarationModifiers.Sealed | DeclarationModifiers.Abstract))
                     {
-                        DeclarationModifiers oneError = errorModifiers & ~(errorModifiers - 1);
-                        Debug.Assert(oneError != DeclarationModifiers.None);
-                        errorModifiers = errorModifiers & ~oneError;
-                        diagnostics.Add(ErrorCode.ERR_InvalidModifierForLanguageVersion, errorLocation,
-                                        ConvertSingleModifierToSyntaxText(oneError),
-                                        availableVersionArgument,
-                                        requiredVersionArgument);
+                        diagnostics.Add(ErrorCode.ERR_BadMemberFlag, errorLocation, ConvertSingleModifierToSyntaxText(DeclarationModifiers.Sealed));
+                        reportModifiers &= ~DeclarationModifiers.Sealed;
                     }
+
+                    requiredVersion = MessageID.IDS_FeatureStaticAbstractMembersInInterfaces.RequiredVersion();
+                    if (availableVersion < requiredVersion)
+                    {
+                        report(modifiers, reportModifiers, errorLocation, diagnostics, availableVersion, requiredVersion);
+                    }
+
+                    return; // below we will either ask for an earlier version of the language, or will not report anything
+                }
+
+                if (hasBody)
+                {
+                    if ((modifiers & defaultInterfaceImplementationModifiers & DeclarationModifiers.Static) != 0)
+                    {
+                        Binder.CheckFeatureAvailability(errorLocation.SourceTree, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, errorLocation);
+                    }
+                }
+                else
+                {
+                    requiredVersion = MessageID.IDS_DefaultInterfaceImplementation.RequiredVersion();
+                    if (availableVersion < requiredVersion)
+                    {
+                        report(modifiers, defaultInterfaceImplementationModifiers, errorLocation, diagnostics, availableVersion, requiredVersion);
+                    }
+                }
+            }
+
+            static void report(DeclarationModifiers modifiers, DeclarationModifiers unsupportedModifiers, Location errorLocation, BindingDiagnosticBag diagnostics, LanguageVersion availableVersion, LanguageVersion requiredVersion)
+            {
+                DeclarationModifiers errorModifiers = modifiers & unsupportedModifiers;
+                var requiredVersionArgument = new CSharpRequiredLanguageVersion(requiredVersion);
+                var availableVersionArgument = availableVersion.ToDisplayString();
+                while (errorModifiers != DeclarationModifiers.None)
+                {
+                    DeclarationModifiers oneError = errorModifiers & ~(errorModifiers - 1);
+                    Debug.Assert(oneError != DeclarationModifiers.None);
+                    errorModifiers = errorModifiers & ~oneError;
+                    diagnostics.Add(ErrorCode.ERR_InvalidModifierForLanguageVersion, errorLocation,
+                                    ConvertSingleModifierToSyntaxText(oneError),
+                                    availableVersionArgument,
+                                    requiredVersionArgument);
                 }
             }
         }
@@ -126,7 +180,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     mods |= DeclarationModifiers.Sealed;
                 }
             }
-            else if ((mods & (DeclarationModifiers.Static | DeclarationModifiers.Private | DeclarationModifiers.Partial | DeclarationModifiers.Virtual | DeclarationModifiers.Abstract)) == 0)
+            else if ((mods & DeclarationModifiers.Static) != 0)
+            {
+                mods &= ~DeclarationModifiers.Sealed;
+            }
+            else if ((mods & (DeclarationModifiers.Private | DeclarationModifiers.Partial | DeclarationModifiers.Virtual | DeclarationModifiers.Abstract)) == 0)
             {
                 Debug.Assert(!isExplicitInterfaceImplementation);
 
@@ -162,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return mods;
         }
 
-        private static string ConvertSingleModifierToSyntaxText(DeclarationModifiers modifier)
+        internal static string ConvertSingleModifierToSyntaxText(DeclarationModifiers modifier)
         {
             switch (modifier)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -504,6 +504,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected void CheckModifiersAndType(BindingDiagnosticBag diagnostics)
         {
+            Debug.Assert(!IsStatic || (!IsVirtual && !IsOverride)); // Otherwise 'virtual' and 'override' should have been reported and cleared earlier.
+
             Location location = this.Locations[0];
             var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
             bool isExplicitInterfaceImplementationInInterface = ContainingType.IsInterface && IsExplicitInterfaceImplementation;
@@ -512,10 +514,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 diagnostics.Add(ErrorCode.ERR_VirtualPrivate, location, this);
             }
-            else if (IsStatic && (IsOverride || IsVirtual || IsAbstract))
+            else if (IsStatic && IsAbstract && !ContainingType.IsInterface)
             {
-                // A static member '{0}' cannot be marked as override, virtual, or abstract
-                diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, this);
+                // A static member '{0}' cannot be marked as 'abstract'
+                diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, ModifierUtils.ConvertSingleModifierToSyntaxText(DeclarationModifiers.Abstract));
             }
             else if (IsReadOnly && IsStatic)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -969,7 +969,8 @@ done:
         {
             if (_containingType.IsInterface)
             {
-                if (hasBody || IsExplicitInterfaceImplementation)
+                if ((!IsStatic || MethodKind is MethodKind.StaticConstructor) &&
+                    (hasBody || IsExplicitInterfaceImplementation))
                 {
                     Binder.CheckFeatureAvailability(declarationSyntax, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, location);
                 }
@@ -978,6 +979,8 @@ done:
                 {
                     diagnostics.Add(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, location);
                 }
+
+                // PROTOTYPE(StaticAbstractMembersInInterfaces): Check runtime capability. 
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
@@ -498,6 +498,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void CheckModifiers(bool isExplicitInterfaceImplementation, bool isVararg, bool hasBody, Location location, BindingDiagnosticBag diagnostics)
         {
+            Debug.Assert(!IsStatic || (!IsVirtual && !IsOverride)); // Otherwise 'virtual' and 'override' should have been reported and cleared earlier.
+
             bool isExplicitInterfaceImplementationInInterface = isExplicitInterfaceImplementation && ContainingType.IsInterface;
 
             if (IsPartial && HasExplicitAccessModifier)
@@ -525,10 +527,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 diagnostics.Add(ErrorCode.ERR_VirtualPrivate, location, this);
             }
-            else if (IsStatic && (IsOverride || IsVirtual || IsAbstract))
+            else if (IsStatic && IsAbstract && !ContainingType.IsInterface)
             {
-                // A static member '{0}' cannot be marked as override, virtual, or abstract
-                diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, this);
+                // A static member '{0}' cannot be marked as 'abstract'
+                diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, ModifierUtils.ConvertSingleModifierToSyntaxText(DeclarationModifiers.Abstract));
             }
             else if (IsOverride && (IsNew || IsVirtual))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedConversionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedConversionSymbol.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 containingType,
                 location,
                 syntax,
-                MakeDeclarationModifiers(syntax, location, diagnostics),
+                MakeDeclarationModifiers(containingType.IsInterface, syntax, location, diagnostics),
                 hasBody: syntax.HasAnyBody(),
                 isExpressionBodied: syntax.Body == null && syntax.ExpressionBody != null,
                 isIterator: SyntaxFacts.HasYieldOperations(syntax.Body),

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 containingType,
                 location,
                 syntax,
-                MakeDeclarationModifiers(syntax, location, diagnostics),
+                MakeDeclarationModifiers(containingType.IsInterface, syntax, location, diagnostics),
                 hasBody: syntax.HasAnyBody(),
                 isExpressionBodied: syntax.Body == null && syntax.ExpressionBody != null,
                 isIterator: SyntaxFacts.HasYieldOperations(syntax.Body),

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -73,9 +73,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // SPEC: its operator body consists of a semicolon. For expression-bodied
             // SPEC: operators, the body is an expression. For all other operators,
             // SPEC: the operator body consists of a block...
-            if (hasBody && IsExtern)
+            if (IsAbstract && IsExtern)
             {
-                diagnostics.Add(ErrorCode.ERR_ExternHasBody, location, this);
+                diagnostics.Add(ErrorCode.ERR_AbstractAndExtern, location, this);
+            }
+            else if (hasBody && (IsExtern || IsAbstract))
+            {
+                Debug.Assert(!(IsAbstract && IsExtern));
+                if (IsExtern)
+                {
+                    diagnostics.Add(ErrorCode.ERR_ExternHasBody, location, this);
+                }
+                else
+                {
+                    diagnostics.Add(ErrorCode.ERR_AbstractHasBody, location, this);
+                }
             }
             else if (!hasBody && !IsExtern && !IsAbstract && !IsPartial)
             {
@@ -94,17 +106,68 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected static DeclarationModifiers MakeDeclarationModifiers(BaseMethodDeclarationSyntax syntax, Location location, BindingDiagnosticBag diagnostics)
+        protected static DeclarationModifiers MakeDeclarationModifiers(bool inInterface, BaseMethodDeclarationSyntax syntax, Location location, BindingDiagnosticBag diagnostics)
         {
-            var defaultAccess = DeclarationModifiers.Private;
+            // PROTOTYPE(StaticAbstractMembersInInterfaces): Do we need to check the lack of access modifier in an interface against language version?
+            //                                               See https://github.com/dotnet/roslyn/issues/52202
+            var defaultAccess = inInterface ? DeclarationModifiers.Public : DeclarationModifiers.Private;
             var allowedModifiers =
                 DeclarationModifiers.AccessibilityMask |
                 DeclarationModifiers.Static |
                 DeclarationModifiers.Extern |
                 DeclarationModifiers.Unsafe;
 
-            return ModifierUtils.MakeAndCheckNontypeMemberModifiers(
+            if (inInterface)
+            {
+                allowedModifiers |= DeclarationModifiers.Abstract | DeclarationModifiers.Sealed;
+            }
+
+            var result = ModifierUtils.MakeAndCheckNontypeMemberModifiers(
                 syntax.Modifiers, defaultAccess, allowedModifiers, location, diagnostics, modifierErrors: out _);
+
+            if (inInterface && syntax is OperatorDeclarationSyntax { OperatorToken: var opToken } &&
+                opToken.Kind() is not (SyntaxKind.EqualsEqualsToken or SyntaxKind.ExclamationEqualsToken))
+            {
+                if ((result & (DeclarationModifiers.Abstract | DeclarationModifiers.Sealed)) != 0)
+                {
+                    if ((result & (DeclarationModifiers.Sealed | DeclarationModifiers.Abstract)) == (DeclarationModifiers.Sealed | DeclarationModifiers.Abstract))
+                    {
+                        diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, ModifierUtils.ConvertSingleModifierToSyntaxText(DeclarationModifiers.Sealed));
+                        result &= ~DeclarationModifiers.Sealed;
+                    }
+
+                    LanguageVersion availableVersion = ((CSharpParseOptions)location.SourceTree.Options).LanguageVersion;
+                    LanguageVersion requiredVersion = MessageID.IDS_FeatureStaticAbstractMembersInInterfaces.RequiredVersion();
+
+                    if (availableVersion < requiredVersion)
+                    {
+                        var requiredVersionArgument = new CSharpRequiredLanguageVersion(requiredVersion);
+                        var availableVersionArgument = availableVersion.ToDisplayString();
+
+                        reportModifier(result, DeclarationModifiers.Abstract, location, diagnostics, requiredVersionArgument, availableVersionArgument);
+                        reportModifier(result, DeclarationModifiers.Sealed, location, diagnostics, requiredVersionArgument, availableVersionArgument);
+                    }
+
+                    result &= ~DeclarationModifiers.Sealed;
+                }
+                else if ((result & DeclarationModifiers.Static) != 0)
+                {
+                    Binder.CheckFeatureAvailability(location.SourceTree, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, location);
+                }
+            }
+
+            return result;
+
+            static void reportModifier(DeclarationModifiers result, DeclarationModifiers errorModifier, Location location, BindingDiagnosticBag diagnostics, CSharpRequiredLanguageVersion requiredVersionArgument, string availableVersionArgument)
+            {
+                if ((result & errorModifier) != 0)
+                {
+                    diagnostics.Add(ErrorCode.ERR_InvalidModifierForLanguageVersion, location,
+                                    ModifierUtils.ConvertSingleModifierToSyntaxText(errorModifier),
+                                    availableVersionArgument,
+                                    requiredVersionArgument);
+                }
+            }
         }
 
         protected abstract Location ReturnTypeLocation { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -108,8 +108,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected static DeclarationModifiers MakeDeclarationModifiers(bool inInterface, BaseMethodDeclarationSyntax syntax, Location location, BindingDiagnosticBag diagnostics)
         {
-            // PROTOTYPE(StaticAbstractMembersInInterfaces): Do we need to check the lack of access modifier in an interface against language version?
-            //                                               See https://github.com/dotnet/roslyn/issues/52202
             var defaultAccess = inInterface ? DeclarationModifiers.Public : DeclarationModifiers.Private;
             var allowedModifiers =
                 DeclarationModifiers.AccessibilityMask |
@@ -144,8 +142,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         var requiredVersionArgument = new CSharpRequiredLanguageVersion(requiredVersion);
                         var availableVersionArgument = availableVersion.ToDisplayString();
 
-                        reportModifier(result, DeclarationModifiers.Abstract, location, diagnostics, requiredVersionArgument, availableVersionArgument);
-                        reportModifier(result, DeclarationModifiers.Sealed, location, diagnostics, requiredVersionArgument, availableVersionArgument);
+                        reportModifierIfPresent(result, DeclarationModifiers.Abstract, location, diagnostics, requiredVersionArgument, availableVersionArgument);
+                        reportModifierIfPresent(result, DeclarationModifiers.Sealed, location, diagnostics, requiredVersionArgument, availableVersionArgument);
                     }
 
                     result &= ~DeclarationModifiers.Sealed;
@@ -158,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return result;
 
-            static void reportModifier(DeclarationModifiers result, DeclarationModifiers errorModifier, Location location, BindingDiagnosticBag diagnostics, CSharpRequiredLanguageVersion requiredVersionArgument, string availableVersionArgument)
+            static void reportModifierIfPresent(DeclarationModifiers result, DeclarationModifiers errorModifier, Location location, BindingDiagnosticBag diagnostics, CSharpRequiredLanguageVersion requiredVersionArgument, string availableVersionArgument)
             {
                 if ((result & errorModifier) != 0)
                 {

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -972,6 +972,11 @@
         <target state="translated">Vytvoření objektu s cílovým typem</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Sestavení {0}, které obsahuje typ {1}, se odkazuje na architekturu .NET Framework, což se nepodporuje.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Statický člen {0} nemůže být označený klíčovými slovy override, virtual nebo abstract.</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Statický člen {0} nemůže být označený klíčovými slovy override, virtual nebo abstract.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -972,6 +972,11 @@
         <target state="translated">Objekterstellung mit Zieltyp</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Die Assembly "{0}" mit dem Typ "{1}" verweist auf das .NET Framework. Dies wird nicht unterstützt.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Ein statischer Member "{0}" kann nicht als "override" , "virtual" oder "abstract" markiert werden.</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Ein statischer Member "{0}" kann nicht als "override" , "virtual" oder "abstract" markiert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -972,6 +972,11 @@
         <target state="translated">creación de objetos con tipo de destino</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">El ensamblado "{0}" que contiene el tipo "{1}" hace referencia a .NET Framework, lo cual no se admite.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Un miembro estático '{0}' no se puede marcar como invalidación, virtual o abstracto</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Un miembro estático '{0}' no se puede marcar como invalidación, virtual o abstracto</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -972,6 +972,11 @@
         <target state="translated">création d'un objet typé cible</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">L'assembly '{0}' contenant le type '{1}' référence le .NET Framework, ce qui n'est pas pris en charge.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Un membre statique '{0}' ne peut pas être marqué comme override, virtual ou abstract</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Un membre statique '{0}' ne peut pas être marqué comme override, virtual ou abstract</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -972,6 +972,11 @@
         <target state="translated">creazione di oggetti con tipo di destinazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">L'assembly '{0}' che contiene il tipo '{1}' fa riferimento a .NET Framework, che non è supportato.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Un membro statico '{0}' non può essere contrassegnato come override, virtual o abstract</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Un membro statico '{0}' non può essere contrassegnato come override, virtual o abstract</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -972,6 +972,11 @@
         <target state="translated">target-typed オブジェクトの作成</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">型 '{1}' を含むアセンブリ '{0}' が .NET Framework を参照しています。これはサポートされていません。</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">静的メンバー '{0}' を override、virtual、または abstract とすることはできません</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">静的メンバー '{0}' を override、virtual、または abstract とすることはできません</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -972,6 +972,11 @@
         <target state="translated">대상으로 형식화된 개체 만들기</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">'{1}' 형식을 포함하는 '{0}' 어셈블리가 지원되지 않는 .NET Framework를 참조합니다.</target>
@@ -3451,8 +3456,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">'{0}' 정적 멤버는 override, virtual 또는 abstract로 표시할 수 없습니다.</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">'{0}' 정적 멤버는 override, virtual 또는 abstract로 표시할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -972,6 +972,11 @@
         <target state="translated">tworzenie obiektu z typem docelowym</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Zestaw „{0}” zawierający typ „{1}” odwołuje się do platformy .NET Framework, co nie jest obsługiwane.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Statycznej składowej „{0}” nie można oznaczyć specyfikatorem override, virtual ani abstract</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Statycznej składowej „{0}” nie można oznaczyć specyfikatorem override, virtual ani abstract</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -972,6 +972,11 @@
         <target state="translated">criação de objeto de tipo de destino</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">O assembly '{0}' contendo o tipo '{1}' referencia o .NET Framework, mas não há suporte para isso.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Um membro estático "{0}" não pode ser marcado como override, virtual ou abstract</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Um membro estático "{0}" não pode ser marcado como override, virtual ou abstract</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -972,6 +972,11 @@
         <target state="translated">создание объекта с типом целевого объекта</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Сборка "{0}", содержащая тип "{1}", ссылается на платформу .NET Framework, которая не поддерживается.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">Статический член "{0}" не может быть помечен как override, virtual или abstract.</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">Статический член "{0}" не может быть помечен как override, virtual или abstract.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -972,6 +972,11 @@
         <target state="translated">hedeflenen türde nesne oluşturma</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">'{1}' türünü içeren '{0}' bütünleştirilmiş kodu, desteklenmeyen .NET Framework'e başvuruyor.</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">'{0}' statik üyesi geçersiz kılınan, sanal veya soyut olarak işaretlenemez</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">'{0}' statik üyesi geçersiz kılınan, sanal veya soyut olarak işaretlenemez</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -972,6 +972,11 @@
         <target state="translated">创建目标类型对象</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">包含类型“{1}”的程序集“{0}”引用了 .NET Framework，而此操作不受支持。</target>
@@ -3457,8 +3462,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">静态成员“{0}”不能标记为 override、virtual 或 abstract</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">静态成员“{0}”不能标记为 override、virtual 或 abstract</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -972,6 +972,11 @@
         <target state="translated">建立具目標類型的物件</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureStaticAbstractMembersInInterfaces">
+        <source>static abstract members in interfaces</source>
+        <target state="new">static abstract members in interfaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">包含類型 '{1}' 的組件 '{0}' 參考了 .NET Framework，此情形不受支援。</target>
@@ -3452,8 +3457,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticNotVirtual">
-        <source>A static member '{0}' cannot be marked as override, virtual, or abstract</source>
-        <target state="translated">靜態成員 '{0}' 不可標記為 override、virtual 或 abstract</target>
+        <source>A static member cannot be marked as '{0}'</source>
+        <target state="needs-review-translation">靜態成員 '{0}' 不可標記為 override、virtual 或 abstract</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideNotNew">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -1874,9 +1874,10 @@ class C : I
                 // (9,17): error CS0238: 'C.M3<T>()' cannot be sealed because it is not an override
                 //     sealed void M3<T>() { }
                 Diagnostic(ErrorCode.ERR_SealedNonOverride, "M3").WithArguments("C.M3<T>()").WithLocation(9, 17),
-                // (10,34): error CS0112: A static member 'C.M4<T>()' cannot be marked as override, virtual, or abstract
+                // (10,34): error CS0112: A static member cannot be marked as 'virtual'
                 //     internal static virtual void M4<T>() { }
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M4").WithArguments("C.M4<T>()").WithLocation(10, 34));
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M4").WithArguments("virtual").WithLocation(10, 34)
+                );
         }
 
         [WorkItem(542391, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542391")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -3257,21 +3257,18 @@ class Test1 : I1
             Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
             compilation1.VerifyDiagnostics(
-                // (4,22): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                // (4,16): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     static int P1 => 1;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "1").WithArguments("default interface implementation", "8.0").WithLocation(4, 22),
-                // (5,21): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "P1").WithArguments("default interface implementation", "8.0").WithLocation(4, 16),
+                // (5,16): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     static int P3 { get => 3; }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(5, 21),
-                // (6,21): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "P3").WithArguments("default interface implementation", "8.0").WithLocation(5, 16),
+                // (6,16): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     static int P5 { set => System.Console.WriteLine(5); }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(6, 21),
-                // (7,21): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "P5").WithArguments("default interface implementation", "8.0").WithLocation(6, 16),
+                // (7,16): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     static int P7 { get { return 7;} set {} }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(7, 21),
-                // (7,38): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     static int P7 { get { return 7;} set {} }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(7, 38)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "P7").WithArguments("default interface implementation", "8.0").WithLocation(7, 16)
                 );
 
             var derived = compilation1.SourceModule.GlobalNamespace.GetTypeMember("Test1");
@@ -5833,12 +5830,9 @@ class Test1 : I1
             Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
             compilation1.VerifyDiagnostics(
-                // (6,9): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //         add {} 
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "add").WithArguments("default interface implementation", "8.0").WithLocation(6, 9),
-                // (7,9): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //         remove {} 
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "remove").WithArguments("default interface implementation", "8.0").WithLocation(7, 9)
+                // (4,32): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     static event System.Action E7 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "E7").WithArguments("default interface implementation", "8.0").WithLocation(4, 32)
                 );
 
             var derived = compilation1.GlobalNamespace.GetTypeMember("Test1");
@@ -7012,15 +7006,15 @@ class Test2 : I1
                                                  targetFramework: TargetFramework.NetCoreApp);
 
             compilation1.VerifyDiagnostics(
-                // (10,24): error CS0238: 'I1.M3()' cannot be sealed because it is not an override
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     sealed static void M3() 
-                Diagnostic(ErrorCode.ERR_SealedNonOverride, "M3").WithArguments("I1.M3()").WithLocation(10, 24),
-                // (6,25): error CS0112: A static member 'I1.M2()' cannot be marked as override, virtual, or abstract
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M3").WithArguments("sealed", "9.0", "preview").WithLocation(10, 24),
+                // (6,25): error CS0112: A static member cannot be marked as 'virtual'
                 //     virtual static void M2() 
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M2").WithArguments("I1.M2()").WithLocation(6, 25),
-                // (4,26): error CS0112: A static member 'I1.M1()' cannot be marked as override, virtual, or abstract
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M2").WithArguments("virtual").WithLocation(6, 25),
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     abstract static void M1(); 
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M1").WithArguments("I1.M1()").WithLocation(4, 26),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M1").WithArguments("abstract", "9.0", "preview").WithLocation(4, 26),
                 // (21,13): error CS0539: 'Test1.M4()' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     void I1.M4() {}
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M4").WithArguments("Test1.M4()").WithLocation(21, 13),
@@ -7053,8 +7047,8 @@ class Test2 : I1
             var m2 = i1.GetMember<MethodSymbol>("M2");
 
             Assert.False(m2.IsAbstract);
-            Assert.True(m2.IsVirtual);
-            Assert.True(m2.IsMetadataVirtual());
+            Assert.False(m2.IsVirtual);
+            Assert.False(m2.IsMetadataVirtual());
             Assert.False(m2.IsSealed);
             Assert.True(m2.IsStatic);
             Assert.False(m2.IsExtern);
@@ -7068,7 +7062,7 @@ class Test2 : I1
             Assert.False(m3.IsAbstract);
             Assert.False(m3.IsVirtual);
             Assert.False(m3.IsMetadataVirtual());
-            Assert.True(m3.IsSealed);
+            Assert.False(m3.IsSealed);
             Assert.True(m3.IsStatic);
             Assert.False(m3.IsExtern);
             Assert.False(m3.IsAsync);
@@ -8610,9 +8604,9 @@ class Test2 : I1
                 // (5,27): error CS0621: 'I1.M2()': virtual or abstract members cannot be private
                 //     abstract private void M2() {} 
                 Diagnostic(ErrorCode.ERR_VirtualPrivate, "M2").WithArguments("I1.M2()").WithLocation(5, 27),
-                // (6,26): error CS0112: A static member 'I1.M3()' cannot be marked as override, virtual, or abstract
+                // (6,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     abstract static void M3() {} 
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M3").WithArguments("I1.M3()").WithLocation(6, 26),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M3").WithArguments("abstract", "9.0", "preview").WithLocation(6, 26),
                 // (11,15): error CS0535: 'Test1' does not implement interface member 'I1.M2()'
                 // class Test1 : I1
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I1").WithArguments("Test1", "I1.M2()").WithLocation(11, 15),
@@ -11293,9 +11287,6 @@ public interface I1
                 // (9,16): error CS8503: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     static int P06 {get;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P06").WithArguments("static", "7.3", "8.0").WithLocation(9, 16),
-                // (9,21): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     static int P06 {get;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(9, 21),
                 // (10,17): error CS8503: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     virtual int P07 {set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P07").WithArguments("virtual", "7.3", "8.0").WithLocation(10, 17),
@@ -12067,15 +12058,15 @@ class Test2 : I1
                                                  targetFramework: TargetFramework.NetCoreApp);
 
             compilation1.VerifyDiagnostics(
-                // (4,25): error CS0112: A static member 'I1.P1' cannot be marked as override, virtual, or abstract
+                // (4,25): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     abstract static int P1 {get;} 
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P1").WithArguments("I1.P1").WithLocation(4, 25),
-                // (6,24): error CS0112: A static member 'I1.P2' cannot be marked as override, virtual, or abstract
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P1").WithArguments("abstract", "9.0", "preview").WithLocation(4, 25),
+                // (6,24): error CS0112: A static member cannot be marked as 'virtual'
                 //     virtual static int P2 {set {}} 
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P2").WithArguments("I1.P2").WithLocation(6, 24),
-                // (8,23): error CS0238: 'I1.P3' cannot be sealed because it is not an override
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P2").WithArguments("virtual").WithLocation(6, 24),
+                // (8,23): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     sealed static int P3 => 0; 
-                Diagnostic(ErrorCode.ERR_SealedNonOverride, "P3").WithArguments("I1.P3").WithLocation(8, 23),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P3").WithArguments("sealed", "9.0", "preview").WithLocation(8, 23),
                 // (15,12): error CS0539: 'Test1.P1' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     int I1.P1 => 0;
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "P1").WithArguments("Test1.P1").WithLocation(15, 12),
@@ -12119,7 +12110,7 @@ class Test2 : I1
             var p2set = p2.SetMethod;
 
             Assert.False(p2.IsAbstract);
-            Assert.True(p2.IsVirtual);
+            Assert.False(p2.IsVirtual);
             Assert.False(p2.IsSealed);
             Assert.True(p2.IsStatic);
             Assert.False(p2.IsExtern);
@@ -12128,8 +12119,8 @@ class Test2 : I1
             Assert.Null(test1.FindImplementationForInterfaceMember(p2));
 
             Assert.False(p2set.IsAbstract);
-            Assert.True(p2set.IsVirtual);
-            Assert.True(p2set.IsMetadataVirtual());
+            Assert.False(p2set.IsVirtual);
+            Assert.False(p2set.IsMetadataVirtual());
             Assert.False(p2set.IsSealed);
             Assert.True(p2set.IsStatic);
             Assert.False(p2set.IsExtern);
@@ -12143,7 +12134,7 @@ class Test2 : I1
 
             Assert.False(p3.IsAbstract);
             Assert.False(p3.IsVirtual);
-            Assert.True(p3.IsSealed);
+            Assert.False(p3.IsSealed);
             Assert.True(p3.IsStatic);
             Assert.False(p3.IsExtern);
             Assert.False(p3.IsOverride);
@@ -12153,7 +12144,7 @@ class Test2 : I1
             Assert.False(p3get.IsAbstract);
             Assert.False(p3get.IsVirtual);
             Assert.False(p3get.IsMetadataVirtual());
-            Assert.True(p3get.IsSealed);
+            Assert.False(p3get.IsSealed);
             Assert.True(p3get.IsStatic);
             Assert.False(p3get.IsExtern);
             Assert.False(p3get.IsAsync);
@@ -14702,19 +14693,19 @@ class Test2 : I1, I2, I3, I4, I5
             ValidatePropertyModifiers_18(source1,
                 // (4,22): error CS0500: 'I1.P1.get' cannot declare a body because it is marked abstract
                 //     abstract int P1 {get => 0; set => throw null;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.P1.get"),
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.P1.get").WithLocation(4, 22),
                 // (4,32): error CS0500: 'I1.P1.set' cannot declare a body because it is marked abstract
                 //     abstract int P1 {get => 0; set => throw null;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "set").WithArguments("I1.P1.set"),
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "set").WithArguments("I1.P1.set").WithLocation(4, 32),
                 // (8,26): error CS0621: 'I2.P2': virtual or abstract members cannot be private
                 //     abstract private int P2 => 0; 
                 Diagnostic(ErrorCode.ERR_VirtualPrivate, "P2").WithArguments("I2.P2").WithLocation(8, 26),
                 // (8,32): error CS0500: 'I2.P2.get' cannot declare a body because it is marked abstract
                 //     abstract private int P2 => 0; 
                 Diagnostic(ErrorCode.ERR_AbstractHasBody, "0").WithArguments("I2.P2.get").WithLocation(8, 32),
-                // (16,25): error CS0112: A static member 'I4.P4' cannot be marked as override, virtual, or abstract
+                // (16,25): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     abstract static int P4 { get {throw null;} set {throw null;}}
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P4").WithArguments("I4.P4").WithLocation(16, 25),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P4").WithArguments("abstract", "9.0", "preview").WithLocation(16, 25),
                 // (16,30): error CS0500: 'I4.P4.get' cannot declare a body because it is marked abstract
                 //     abstract static int P4 { get {throw null;} set {throw null;}}
                 Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I4.P4.get").WithLocation(16, 30),
@@ -24102,9 +24093,9 @@ public interface I1
                 // (8,38): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     private event System.Action P05 {remove{}}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "remove").WithArguments("default interface implementation", "8.0").WithLocation(8, 38),
-                // (9,37): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                // (9,32): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     static event System.Action P06 {add{}}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "add").WithArguments("default interface implementation", "8.0").WithLocation(9, 37),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "P06").WithArguments("default interface implementation", "8.0").WithLocation(9, 32),
                 // (10,38): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     virtual event System.Action P07 {remove{}}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "remove").WithArguments("default interface implementation", "8.0").WithLocation(10, 38),
@@ -24901,15 +24892,15 @@ class Test2 : I1
                 // (8,54): error CS0073: An add or remove accessor must have a body
                 //     sealed static event System.Action P3 {add; remove;}
                 Diagnostic(ErrorCode.ERR_AddRemoveMustHaveBody, ";").WithLocation(8, 54),
-                // (6,40): error CS0112: A static member 'I1.P2' cannot be marked as override, virtual, or abstract
+                // (6,40): error CS0112: A static member cannot be marked as 'virtual'
                 //     virtual static event System.Action P2 {add {} remove{}} 
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P2").WithArguments("I1.P2").WithLocation(6, 40),
-                // (8,39): error CS0238: 'I1.P3' cannot be sealed because it is not an override
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P2").WithArguments("virtual").WithLocation(6, 40),
+                // (8,39): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     sealed static event System.Action P3 {add; remove;}
-                Diagnostic(ErrorCode.ERR_SealedNonOverride, "P3").WithArguments("I1.P3").WithLocation(8, 39),
-                // (4,41): error CS0112: A static member 'I1.P1' cannot be marked as override, virtual, or abstract
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P3").WithArguments("sealed", "9.0", "preview").WithLocation(8, 39),
+                // (4,41): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     abstract static event System.Action P1; 
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P1").WithArguments("I1.P1").WithLocation(4, 41),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P1").WithArguments("abstract", "9.0", "preview").WithLocation(4, 41),
                 // (13,28): error CS0539: 'Test1.P1' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     event System.Action I1.P1 {add {} remove{}} 
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "P1").WithArguments("Test1.P1").WithLocation(13, 28),
@@ -24953,7 +24944,7 @@ class Test2 : I1
             var p2 = i1.GetMember<EventSymbol>("P2");
 
             Assert.False(p2.IsAbstract);
-            Assert.True(p2.IsVirtual);
+            Assert.False(p2.IsVirtual);
             Assert.False(p2.IsSealed);
             Assert.True(p2.IsStatic);
             Assert.False(p2.IsExtern);
@@ -24966,8 +24957,8 @@ class Test2 : I1
             void ValidateAccessor2(MethodSymbol accessor)
             {
                 Assert.False(accessor.IsAbstract);
-                Assert.True(accessor.IsVirtual);
-                Assert.True(accessor.IsMetadataVirtual());
+                Assert.False(accessor.IsVirtual);
+                Assert.False(accessor.IsMetadataVirtual());
                 Assert.False(accessor.IsSealed);
                 Assert.True(accessor.IsStatic);
                 Assert.False(accessor.IsExtern);
@@ -24981,7 +24972,7 @@ class Test2 : I1
 
             Assert.False(p3.IsAbstract);
             Assert.False(p3.IsVirtual);
-            Assert.True(p3.IsSealed);
+            Assert.False(p3.IsSealed);
             Assert.True(p3.IsStatic);
             Assert.False(p3.IsExtern);
             Assert.False(p3.IsOverride);
@@ -24995,7 +24986,7 @@ class Test2 : I1
                 Assert.False(accessor.IsAbstract);
                 Assert.False(accessor.IsVirtual);
                 Assert.False(accessor.IsMetadataVirtual());
-                Assert.True(accessor.IsSealed);
+                Assert.False(accessor.IsSealed);
                 Assert.True(accessor.IsStatic);
                 Assert.False(accessor.IsExtern);
                 Assert.False(accessor.IsAsync);
@@ -27055,12 +27046,9 @@ class Test2 : I1, I2, I3, I4, I5
                 // (20,39): error CS8703: The modifier 'extern' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     extern sealed event System.Action P5;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P5").WithArguments("extern", "7.3", "8.0").WithLocation(20, 39),
-                // (26,9): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //         add => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "add").WithArguments("default interface implementation", "8.0").WithLocation(26, 9),
-                // (27,9): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //         remove => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "remove").WithArguments("default interface implementation", "8.0").WithLocation(27, 9),
+                // (24,32): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     static event System.Action P6
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "P6").WithArguments("default interface implementation", "8.0").WithLocation(24, 32),
                 // (8,40): warning CS0626: Method, operator, or accessor 'I2.P2.remove' is marked external and has no attributes on it. Consider adding a DllImport attribute to specify the external implementation.
                 //     virtual extern event System.Action P2;
                 Diagnostic(ErrorCode.WRN_ExternMethodNoImplementation, "P2").WithArguments("I2.P2.remove").WithLocation(8, 40),
@@ -27379,9 +27367,9 @@ class Test2 : I1, I2, I3, I4, I5
                 // (16,44): error CS8712: 'I4.P4': abstract event cannot use event accessor syntax
                 //     abstract static event System.Action P4 { add {throw null;} remove {throw null;}}
                 Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I4.P4").WithLocation(16, 44),
-                // (16,41): error CS0112: A static member 'I4.P4' cannot be marked as override, virtual, or abstract
+                // (16,41): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
                 //     abstract static event System.Action P4 { add {throw null;} remove {throw null;}}
-                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P4").WithArguments("I4.P4").WithLocation(16, 41),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P4").WithArguments("abstract", "9.0", "preview").WithLocation(16, 41),
                 // (20,41): error CS0106: The modifier 'override' is not valid for this item
                 //     override sealed event System.Action P5 { add {throw null;} remove {throw null;}}
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "P5").WithArguments("override").WithLocation(20, 41),
@@ -39260,48 +39248,24 @@ class Test2 : I1
                 // (4,16): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     static int F1 {get; set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F1").WithArguments("static", "7.3", "8.0").WithLocation(4, 16),
-                // (4,20): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     static int F1 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(4, 20),
-                // (4,25): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     static int F1 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(4, 25),
                 // (5,23): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     public static int F2 {get; set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F2").WithArguments("static", "7.3", "8.0").WithLocation(5, 23),
                 // (5,23): error CS8703: The modifier 'public' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     public static int F2 {get; set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F2").WithArguments("public", "7.3", "8.0").WithLocation(5, 23),
-                // (5,27): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     public static int F2 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(5, 27),
-                // (5,32): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     public static int F2 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(5, 32),
                 // (6,25): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     internal static int F3 {get; set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F3").WithArguments("static", "7.3", "8.0").WithLocation(6, 25),
                 // (6,25): error CS8703: The modifier 'internal' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     internal static int F3 {get; set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F3").WithArguments("internal", "7.3", "8.0").WithLocation(6, 25),
-                // (6,29): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     internal static int F3 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(6, 29),
-                // (6,34): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     internal static int F3 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(6, 34),
                 // (7,24): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     private static int F4 {get; set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F4").WithArguments("static", "7.3", "8.0").WithLocation(7, 24),
                 // (7,24): error CS8703: The modifier 'private' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     private static int F4 {get; set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F4").WithArguments("private", "7.3", "8.0").WithLocation(7, 24),
-                // (7,28): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     private static int F4 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(7, 28),
-                // (7,33): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     private static int F4 {get; set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(7, 33),
                 // (9,18): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     public class TestHelper
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "TestHelper").WithArguments("default interface implementation", "8.0").WithLocation(9, 18)
@@ -39437,36 +39401,24 @@ class Test2 : I1
                 // (4,16): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     static int F1 {get;} = 1;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F1").WithArguments("static", "7.3", "8.0").WithLocation(4, 16),
-                // (4,20): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     static int F1 {get;} = 1;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(4, 20),
                 // (5,23): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     public static int F2 {get;} = 2;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F2").WithArguments("static", "7.3", "8.0").WithLocation(5, 23),
                 // (5,23): error CS8703: The modifier 'public' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     public static int F2 {get;} = 2;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F2").WithArguments("public", "7.3", "8.0").WithLocation(5, 23),
-                // (5,27): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     public static int F2 {get;} = 2;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(5, 27),
                 // (6,25): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     internal static int F3 {get;} = 3;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F3").WithArguments("static", "7.3", "8.0").WithLocation(6, 25),
                 // (6,25): error CS8703: The modifier 'internal' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     internal static int F3 {get;} = 3;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F3").WithArguments("internal", "7.3", "8.0").WithLocation(6, 25),
-                // (6,29): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     internal static int F3 {get;} = 3;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(6, 29),
                 // (7,24): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     private static int F4 {get;} = 4;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F4").WithArguments("static", "7.3", "8.0").WithLocation(7, 24),
                 // (7,24): error CS8703: The modifier 'private' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     private static int F4 {get;} = 4;
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F4").WithArguments("private", "7.3", "8.0").WithLocation(7, 24),
-                // (7,28): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     private static int F4 {get;} = 4;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(7, 28),
                 // (9,18): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     public class TestHelper
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "TestHelper").WithArguments("default interface implementation", "8.0").WithLocation(9, 18)
@@ -39588,45 +39540,27 @@ class Test2 : I1
                 // (4,16): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     static int F1 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F1").WithArguments("static", "7.3", "8.0").WithLocation(4, 16),
-                // (4,20): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     static int F1 {get; private set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(4, 20),
                 // (4,33): error CS8703: The modifier 'private' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     static int F1 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "set").WithArguments("private", "7.3", "8.0").WithLocation(4, 33),
-                // (4,33): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     static int F1 {get; private set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(4, 33),
                 // (5,23): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     public static int F2 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F2").WithArguments("static", "7.3", "8.0").WithLocation(5, 23),
                 // (5,23): error CS8703: The modifier 'public' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     public static int F2 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F2").WithArguments("public", "7.3", "8.0").WithLocation(5, 23),
-                // (5,27): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     public static int F2 {get; private set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(5, 27),
                 // (5,40): error CS8703: The modifier 'private' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     public static int F2 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "set").WithArguments("private", "7.3", "8.0").WithLocation(5, 40),
-                // (5,40): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     public static int F2 {get; private set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(5, 40),
                 // (6,25): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     internal static int F3 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F3").WithArguments("static", "7.3", "8.0").WithLocation(6, 25),
                 // (6,25): error CS8703: The modifier 'internal' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     internal static int F3 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "F3").WithArguments("internal", "7.3", "8.0").WithLocation(6, 25),
-                // (6,29): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     internal static int F3 {get; private set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "get").WithArguments("default interface implementation", "8.0").WithLocation(6, 29),
                 // (6,42): error CS8703: The modifier 'private' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
                 //     internal static int F3 {get; private set;}
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "set").WithArguments("private", "7.3", "8.0").WithLocation(6, 42),
-                // (6,42): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //     internal static int F3 {get; private set;}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "set").WithArguments("default interface implementation", "8.0").WithLocation(6, 42),
                 // (8,18): error CS8652: The feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     public class TestHelper
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "TestHelper").WithArguments("default interface implementation", "8.0").WithLocation(8, 18)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -1,0 +1,4141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
+{
+    public class StaticAbstractMembersInInterfacesTests : CSharpTestBase
+    {
+        [Fact]
+        public void MethodModifiers_01()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static void M01()
+    ; 
+
+    virtual static void M02()
+    ; 
+
+    sealed static void M03() 
+    ; 
+
+    override static void M04() 
+    ; 
+
+    abstract virtual static void M05()
+    ; 
+
+    abstract sealed static void M06()
+    ; 
+
+    abstract override static void M07()
+    ; 
+
+    virtual sealed static void M08() 
+    ; 
+
+    virtual override static void M09() 
+    ; 
+
+    sealed override static void M10() 
+    ; 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static void M01()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "9.0", "preview").WithLocation(4, 26),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (7,25): error CS0501: 'I1.M02()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M02").WithArguments("I1.M02()").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static void M03() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "9.0", "preview").WithLocation(10, 24),
+                // (10,24): error CS0501: 'I1.M03()' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed static void M03() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M03").WithArguments("I1.M03()").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (13,26): error CS0501: 'I1.M04()' must declare a body because it is not marked abstract, extern, or partial
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M04").WithArguments("I1.M04()").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "9.0", "preview").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "9.0", "preview").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "9.0", "preview").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "9.0", "preview").WithLocation(25, 32),
+                // (25,32): error CS0501: 'I1.M08()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M08").WithArguments("I1.M08()").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (28,34): error CS0501: 'I1.M09()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M09").WithArguments("I1.M09()").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "9.0", "preview").WithLocation(31, 33),
+                // (31,33): error CS0501: 'I1.M10()' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M10").WithArguments("I1.M10()").WithLocation(31, 33)
+                );
+
+            ValidateMethodModifiers_01(compilation1);
+        }
+
+        private static void ValidateMethodModifiers_01(CSharpCompilation compilation1)
+        {
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("M01");
+
+            Assert.True(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.True(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            var m02 = i1.GetMember<MethodSymbol>("M02");
+
+            Assert.False(m02.IsAbstract);
+            Assert.False(m02.IsVirtual);
+            Assert.False(m02.IsMetadataVirtual());
+            Assert.False(m02.IsSealed);
+            Assert.True(m02.IsStatic);
+            Assert.False(m02.IsExtern);
+            Assert.False(m02.IsAsync);
+            Assert.False(m02.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m02));
+
+            var m03 = i1.GetMember<MethodSymbol>("M03");
+
+            Assert.False(m03.IsAbstract);
+            Assert.False(m03.IsVirtual);
+            Assert.False(m03.IsMetadataVirtual());
+            Assert.False(m03.IsSealed);
+            Assert.True(m03.IsStatic);
+            Assert.False(m03.IsExtern);
+            Assert.False(m03.IsAsync);
+            Assert.False(m03.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m03));
+
+            var m04 = i1.GetMember<MethodSymbol>("M04");
+
+            Assert.False(m04.IsAbstract);
+            Assert.False(m04.IsVirtual);
+            Assert.False(m04.IsMetadataVirtual());
+            Assert.False(m04.IsSealed);
+            Assert.True(m04.IsStatic);
+            Assert.False(m04.IsExtern);
+            Assert.False(m04.IsAsync);
+            Assert.False(m04.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m04));
+
+            var m05 = i1.GetMember<MethodSymbol>("M05");
+
+            Assert.True(m05.IsAbstract);
+            Assert.False(m05.IsVirtual);
+            Assert.True(m05.IsMetadataVirtual());
+            Assert.False(m05.IsSealed);
+            Assert.True(m05.IsStatic);
+            Assert.False(m05.IsExtern);
+            Assert.False(m05.IsAsync);
+            Assert.False(m05.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m05));
+
+            var m06 = i1.GetMember<MethodSymbol>("M06");
+
+            Assert.True(m06.IsAbstract);
+            Assert.False(m06.IsVirtual);
+            Assert.True(m06.IsMetadataVirtual());
+            Assert.False(m06.IsSealed);
+            Assert.True(m06.IsStatic);
+            Assert.False(m06.IsExtern);
+            Assert.False(m06.IsAsync);
+            Assert.False(m06.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m06));
+
+            var m07 = i1.GetMember<MethodSymbol>("M07");
+
+            Assert.True(m07.IsAbstract);
+            Assert.False(m07.IsVirtual);
+            Assert.True(m07.IsMetadataVirtual());
+            Assert.False(m07.IsSealed);
+            Assert.True(m07.IsStatic);
+            Assert.False(m07.IsExtern);
+            Assert.False(m07.IsAsync);
+            Assert.False(m07.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m07));
+
+            var m08 = i1.GetMember<MethodSymbol>("M08");
+
+            Assert.False(m08.IsAbstract);
+            Assert.False(m08.IsVirtual);
+            Assert.False(m08.IsMetadataVirtual());
+            Assert.False(m08.IsSealed);
+            Assert.True(m08.IsStatic);
+            Assert.False(m08.IsExtern);
+            Assert.False(m08.IsAsync);
+            Assert.False(m08.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m08));
+
+            var m09 = i1.GetMember<MethodSymbol>("M09");
+
+            Assert.False(m09.IsAbstract);
+            Assert.False(m09.IsVirtual);
+            Assert.False(m09.IsMetadataVirtual());
+            Assert.False(m09.IsSealed);
+            Assert.True(m09.IsStatic);
+            Assert.False(m09.IsExtern);
+            Assert.False(m09.IsAsync);
+            Assert.False(m09.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m09));
+
+            var m10 = i1.GetMember<MethodSymbol>("M10");
+
+            Assert.False(m10.IsAbstract);
+            Assert.False(m10.IsVirtual);
+            Assert.False(m10.IsMetadataVirtual());
+            Assert.False(m10.IsSealed);
+            Assert.True(m10.IsStatic);
+            Assert.False(m10.IsExtern);
+            Assert.False(m10.IsAsync);
+            Assert.False(m10.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m10));
+        }
+
+        [Fact]
+        public void MethodModifiers_02()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static void M01()
+    {}
+
+    virtual static void M02()
+    {}
+
+    sealed static void M03() 
+    {}
+
+    override static void M04() 
+    {}
+
+    abstract virtual static void M05()
+    {}
+
+    abstract sealed static void M06()
+    {}
+
+    abstract override static void M07()
+    {}
+
+    virtual sealed static void M08() 
+    {}
+
+    virtual override static void M09() 
+    {}
+
+    sealed override static void M10() 
+    {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static void M01()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "9.0", "preview").WithLocation(4, 26),
+                // (4,26): error CS0500: 'I1.M01()' cannot declare a body because it is marked abstract
+                //     abstract static void M01()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M01").WithArguments("I1.M01()").WithLocation(4, 26),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static void M03() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "9.0", "preview").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "9.0", "preview").WithLocation(16, 34),
+                // (16,34): error CS0500: 'I1.M05()' cannot declare a body because it is marked abstract
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M05").WithArguments("I1.M05()").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "9.0", "preview").WithLocation(19, 33),
+                // (19,33): error CS0500: 'I1.M06()' cannot declare a body because it is marked abstract
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M06").WithArguments("I1.M06()").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "9.0", "preview").WithLocation(22, 35),
+                // (22,35): error CS0500: 'I1.M07()' cannot declare a body because it is marked abstract
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M07").WithArguments("I1.M07()").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "9.0", "preview").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "9.0", "preview").WithLocation(31, 33)
+                );
+
+            ValidateMethodModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void MethodModifiers_03()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static void M01()
+    ; 
+
+    virtual static void M02()
+    ; 
+
+    sealed static void M03() 
+    ; 
+
+    override static void M04() 
+    ; 
+
+    abstract virtual static void M05()
+    ; 
+
+    abstract sealed static void M06()
+    ; 
+
+    abstract override static void M07()
+    ; 
+
+    virtual sealed static void M08() 
+    ; 
+
+    virtual override static void M09() 
+    ; 
+
+    sealed override static void M10() 
+    ; 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (7,25): error CS0501: 'I1.M02()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M02").WithArguments("I1.M02()").WithLocation(7, 25),
+                // (10,24): error CS0501: 'I1.M03()' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed static void M03() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M03").WithArguments("I1.M03()").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (13,26): error CS0501: 'I1.M04()' must declare a body because it is not marked abstract, extern, or partial
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M04").WithArguments("I1.M04()").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS0501: 'I1.M08()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M08").WithArguments("I1.M08()").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (28,34): error CS0501: 'I1.M09()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M09").WithArguments("I1.M09()").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS0501: 'I1.M10()' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M10").WithArguments("I1.M10()").WithLocation(31, 33)
+                );
+
+            ValidateMethodModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void MethodModifiers_04()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static void M01()
+    {}
+
+    virtual static void M02()
+    {}
+
+    sealed static void M03() 
+    {}
+
+    override static void M04() 
+    {}
+
+    abstract virtual static void M05()
+    {}
+
+    abstract sealed static void M06()
+    {}
+
+    abstract override static void M07()
+    {}
+
+    virtual sealed static void M08() 
+    {}
+
+    virtual override static void M09() 
+    {}
+
+    sealed override static void M10() 
+    {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS0500: 'I1.M01()' cannot declare a body because it is marked abstract
+                //     abstract static void M01()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M01").WithArguments("I1.M01()").WithLocation(4, 26),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS0500: 'I1.M05()' cannot declare a body because it is marked abstract
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M05").WithArguments("I1.M05()").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS0500: 'I1.M06()' cannot declare a body because it is marked abstract
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M06").WithArguments("I1.M06()").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS0500: 'I1.M07()' cannot declare a body because it is marked abstract
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M07").WithArguments("I1.M07()").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33)
+                );
+
+            ValidateMethodModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void MethodModifiers_05()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static void M01()
+    ; 
+
+    virtual static void M02()
+    ; 
+
+    sealed static void M03() 
+    ; 
+
+    override static void M04() 
+    ; 
+
+    abstract virtual static void M05()
+    ; 
+
+    abstract sealed static void M06()
+    ; 
+
+    abstract override static void M07()
+    ; 
+
+    virtual sealed static void M08() 
+    ; 
+
+    virtual override static void M09() 
+    ; 
+
+    sealed override static void M10() 
+    ; 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static void M01()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "7.3", "preview").WithLocation(4, 26),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (7,25): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M02").WithArguments("static", "7.3", "8.0").WithLocation(7, 25),
+                // (7,25): error CS0501: 'I1.M02()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M02").WithArguments("I1.M02()").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static void M03() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "7.3", "preview").WithLocation(10, 24),
+                // (10,24): error CS0501: 'I1.M03()' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed static void M03() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M03").WithArguments("I1.M03()").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (13,26): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M04").WithArguments("static", "7.3", "8.0").WithLocation(13, 26),
+                // (13,26): error CS0501: 'I1.M04()' must declare a body because it is not marked abstract, extern, or partial
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M04").WithArguments("I1.M04()").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "7.3", "preview").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "7.3", "preview").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "7.3", "preview").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "7.3", "preview").WithLocation(25, 32),
+                // (25,32): error CS0501: 'I1.M08()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M08").WithArguments("I1.M08()").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (28,34): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M09").WithArguments("static", "7.3", "8.0").WithLocation(28, 34),
+                // (28,34): error CS0501: 'I1.M09()' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M09").WithArguments("I1.M09()").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "7.3", "preview").WithLocation(31, 33),
+                // (31,33): error CS0501: 'I1.M10()' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M10").WithArguments("I1.M10()").WithLocation(31, 33)
+                );
+
+            ValidateMethodModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void MethodModifiers_06()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static void M01()
+    {}
+
+    virtual static void M02()
+    {}
+
+    sealed static void M03() 
+    {}
+
+    override static void M04() 
+    {}
+
+    abstract virtual static void M05()
+    {}
+
+    abstract sealed static void M06()
+    {}
+
+    abstract override static void M07()
+    {}
+
+    virtual sealed static void M08() 
+    {}
+
+    virtual override static void M09() 
+    {}
+
+    sealed override static void M10() 
+    {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static void M01()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "7.3", "preview").WithLocation(4, 26),
+                // (4,26): error CS0500: 'I1.M01()' cannot declare a body because it is marked abstract
+                //     abstract static void M01()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M01").WithArguments("I1.M01()").WithLocation(4, 26),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (7,25): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual static void M02()
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M02").WithArguments("default interface implementation", "8.0").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static void M03() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "7.3", "preview").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (13,26): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     override static void M04() 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M04").WithArguments("default interface implementation", "8.0").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "7.3", "preview").WithLocation(16, 34),
+                // (16,34): error CS0500: 'I1.M05()' cannot declare a body because it is marked abstract
+                //     abstract virtual static void M05()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M05").WithArguments("I1.M05()").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "7.3", "preview").WithLocation(19, 33),
+                // (19,33): error CS0500: 'I1.M06()' cannot declare a body because it is marked abstract
+                //     abstract sealed static void M06()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M06").WithArguments("I1.M06()").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "7.3", "preview").WithLocation(22, 35),
+                // (22,35): error CS0500: 'I1.M07()' cannot declare a body because it is marked abstract
+                //     abstract override static void M07()
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M07").WithArguments("I1.M07()").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static void M08() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "7.3", "preview").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (28,34): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual override static void M09() 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M09").WithArguments("default interface implementation", "8.0").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static void M10() 
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "7.3", "preview").WithLocation(31, 33)
+                );
+
+            ValidateMethodModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void SealedStaticConstructor_01()
+        {
+            var source1 =
+@"
+interface I1
+{
+    sealed static I1() {}
+}
+
+partial interface I2
+{
+    partial sealed static I2();
+}
+
+partial interface I2
+{
+    partial static I2() {}
+}
+
+partial interface I3
+{
+    partial static I3();
+}
+
+partial interface I3
+{
+    partial sealed static I3() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,19): error CS0106: The modifier 'sealed' is not valid for this item
+                //     sealed static I1() {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I1").WithArguments("sealed").WithLocation(4, 19),
+                // (9,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial sealed static I2();
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(9, 5),
+                // (9,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial sealed static I2();
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(9, 5),
+                // (9,27): error CS0106: The modifier 'sealed' is not valid for this item
+                //     partial sealed static I2();
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("sealed").WithLocation(9, 27),
+                // (14,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial static I2() {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(14, 5),
+                // (14,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial static I2() {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(14, 5),
+                // (14,20): error CS0111: Type 'I2' already defines a member called 'I2' with the same parameter types
+                //     partial static I2() {}
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "I2").WithArguments("I2", "I2").WithLocation(14, 20),
+                // (19,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial static I3();
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(19, 5),
+                // (19,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial static I3();
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(19, 5),
+                // (24,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial sealed static I3() {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(24, 5),
+                // (24,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'record', 'struct', 'interface', or a method return type.
+                //     partial sealed static I3() {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(24, 5),
+                // (24,27): error CS0106: The modifier 'sealed' is not valid for this item
+                //     partial sealed static I3() {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I3").WithArguments("sealed").WithLocation(24, 27),
+                // (24,27): error CS0111: Type 'I3' already defines a member called 'I3' with the same parameter types
+                //     partial sealed static I3() {}
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "I3").WithArguments("I3", "I3").WithLocation(24, 27)
+                );
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>(".cctor");
+
+            Assert.False(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.False(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+        }
+
+        [Fact]
+        public void SealedStaticConstructor_02()
+        {
+            var source1 =
+@"
+partial interface I2
+{
+    sealed static partial I2();
+}
+
+partial interface I2
+{
+    static partial I2() {}
+}
+
+partial interface I3
+{
+    static partial I3();
+}
+
+partial interface I3
+{
+    sealed static partial I3() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,19): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
+                //     sealed static partial I2();
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(4, 19),
+                // (4,27): error CS0501: 'I2.I2()' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed static partial I2();
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "I2").WithArguments("I2.I2()").WithLocation(4, 27),
+                // (4,27): error CS0542: 'I2': member names cannot be the same as their enclosing type
+                //     sealed static partial I2();
+                Diagnostic(ErrorCode.ERR_MemberNameSameAsType, "I2").WithArguments("I2").WithLocation(4, 27),
+                // (9,12): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
+                //     static partial I2() {}
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(9, 12),
+                // (9,20): error CS0542: 'I2': member names cannot be the same as their enclosing type
+                //     static partial I2() {}
+                Diagnostic(ErrorCode.ERR_MemberNameSameAsType, "I2").WithArguments("I2").WithLocation(9, 20),
+                // (9,20): error CS0111: Type 'I2' already defines a member called 'I2' with the same parameter types
+                //     static partial I2() {}
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "I2").WithArguments("I2", "I2").WithLocation(9, 20),
+                // (9,20): error CS0161: 'I2.I2()': not all code paths return a value
+                //     static partial I2() {}
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "I2").WithArguments("I2.I2()").WithLocation(9, 20),
+                // (14,12): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
+                //     static partial I3();
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(14, 12),
+                // (14,20): error CS0501: 'I3.I3()' must declare a body because it is not marked abstract, extern, or partial
+                //     static partial I3();
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "I3").WithArguments("I3.I3()").WithLocation(14, 20),
+                // (14,20): error CS0542: 'I3': member names cannot be the same as their enclosing type
+                //     static partial I3();
+                Diagnostic(ErrorCode.ERR_MemberNameSameAsType, "I3").WithArguments("I3").WithLocation(14, 20),
+                // (19,19): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
+                //     sealed static partial I3() {}
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(19, 19),
+                // (19,27): error CS0542: 'I3': member names cannot be the same as their enclosing type
+                //     sealed static partial I3() {}
+                Diagnostic(ErrorCode.ERR_MemberNameSameAsType, "I3").WithArguments("I3").WithLocation(19, 27),
+                // (19,27): error CS0111: Type 'I3' already defines a member called 'I3' with the same parameter types
+                //     sealed static partial I3() {}
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "I3").WithArguments("I3", "I3").WithLocation(19, 27),
+                // (19,27): error CS0161: 'I3.I3()': not all code paths return a value
+                //     sealed static partial I3() {}
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "I3").WithArguments("I3.I3()").WithLocation(19, 27)
+                );
+        }
+
+        [Fact]
+        public void AbstractStaticConstructor_01()
+        {
+            var source1 =
+@"
+interface I1
+{
+    abstract static I1();
+}
+
+interface I2
+{
+    abstract static I2() {}
+}
+
+interface I3
+{
+    static I3();
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,21): error CS0106: The modifier 'abstract' is not valid for this item
+                //     abstract static I1();
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I1").WithArguments("abstract").WithLocation(4, 21),
+                // (9,21): error CS0106: The modifier 'abstract' is not valid for this item
+                //     abstract static I2() {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("abstract").WithLocation(9, 21),
+                // (14,12): error CS0501: 'I3.I3()' must declare a body because it is not marked abstract, extern, or partial
+                //     static I3();
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "I3").WithArguments("I3.I3()").WithLocation(14, 12)
+                );
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>(".cctor");
+
+            Assert.False(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.False(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+        }
+
+        [Fact]
+        public void PartialSealedStatic_01()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    sealed static partial void M01();
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics();
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("M01");
+
+            Assert.False(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.False(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialDefinition());
+            Assert.Null(m01.PartialImplementationPart);
+        }
+
+        [Fact]
+        public void PartialSealedStatic_02()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    sealed static partial void M01();
+}
+partial interface I1
+{
+    sealed static partial void M01() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            ValidatePartialSealedStatic_02(compilation1);
+        }
+
+        private static void ValidatePartialSealedStatic_02(CSharpCompilation compilation1)
+        {
+            compilation1.VerifyDiagnostics();
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("M01");
+
+            Assert.False(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.False(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialDefinition());
+
+            m01 = m01.PartialImplementationPart;
+
+            Assert.False(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.False(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialImplementation());
+        }
+
+        [Fact]
+        public void PartialSealedStatic_03()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    static partial void M01();
+}
+partial interface I1
+{
+    sealed static partial void M01() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            ValidatePartialSealedStatic_02(compilation1);
+        }
+
+        [Fact]
+        public void PartialSealedStatic_04()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    sealed static partial void M01();
+}
+partial interface I1
+{
+    static partial void M01() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            ValidatePartialSealedStatic_02(compilation1);
+        }
+
+        [Fact]
+        public void PartialAbstractStatic_01()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    abstract static partial void M01();
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,34): error CS0750: A partial method cannot have the 'abstract' modifier
+                //     abstract static partial void M01();
+                Diagnostic(ErrorCode.ERR_PartialMethodInvalidModifier, "M01").WithLocation(4, 34)
+                );
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("M01");
+
+            Assert.True(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.True(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialDefinition());
+            Assert.Null(m01.PartialImplementationPart);
+        }
+
+        [Fact]
+        public void PartialAbstractStatic_02()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    abstract static partial void M01();
+}
+partial interface I1
+{
+    abstract static partial void M01() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,34): error CS0750: A partial method cannot have the 'abstract' modifier
+                //     abstract static partial void M01();
+                Diagnostic(ErrorCode.ERR_PartialMethodInvalidModifier, "M01").WithLocation(4, 34),
+                // (8,34): error CS0500: 'I1.M01()' cannot declare a body because it is marked abstract
+                //     abstract static partial void M01() {}
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M01").WithArguments("I1.M01()").WithLocation(8, 34),
+                // (8,34): error CS0750: A partial method cannot have the 'abstract' modifier
+                //     abstract static partial void M01() {}
+                Diagnostic(ErrorCode.ERR_PartialMethodInvalidModifier, "M01").WithLocation(8, 34)
+                );
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("M01");
+
+            Assert.True(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.True(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialDefinition());
+
+            m01 = m01.PartialImplementationPart;
+
+            Assert.True(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.True(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialImplementation());
+        }
+
+        [Fact]
+        public void PartialAbstractStatic_03()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    abstract static partial void M01();
+}
+partial interface I1
+{
+    static partial void M01() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,34): error CS0750: A partial method cannot have the 'abstract' modifier
+                //     abstract static partial void M01();
+                Diagnostic(ErrorCode.ERR_PartialMethodInvalidModifier, "M01").WithLocation(4, 34)
+                );
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("M01");
+
+            Assert.True(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.True(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialDefinition());
+
+            m01 = m01.PartialImplementationPart;
+
+            Assert.False(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.False(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialImplementation());
+        }
+
+        [Fact]
+        public void PartialAbstractStatic_04()
+        {
+            var source1 =
+@"
+partial interface I1
+{
+    static partial void M01();
+}
+partial interface I1
+{
+    abstract static partial void M01() {}
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (8,34): error CS0500: 'I1.M01()' cannot declare a body because it is marked abstract
+                //     abstract static partial void M01() {}
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "M01").WithArguments("I1.M01()").WithLocation(8, 34),
+                // (8,34): error CS0750: A partial method cannot have the 'abstract' modifier
+                //     abstract static partial void M01() {}
+                Diagnostic(ErrorCode.ERR_PartialMethodInvalidModifier, "M01").WithLocation(8, 34)
+                );
+
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("M01");
+
+            Assert.False(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.False(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialDefinition());
+
+            m01 = m01.PartialImplementationPart;
+
+            Assert.True(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.True(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            Assert.True(m01.IsPartialImplementation());
+        }
+
+        [Fact]
+        public void PrivateAbstractStatic_01()
+        {
+            var source1 =
+@"
+interface I1
+{
+    private abstract static void M01();
+    private abstract static bool P01 { get; }
+    private abstract static event System.Action E01;
+    private abstract static I1 operator+ (I1 x);
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,34): error CS0621: 'I1.M01()': virtual or abstract members cannot be private
+                //     private abstract static void M01();
+                Diagnostic(ErrorCode.ERR_VirtualPrivate, "M01").WithArguments("I1.M01()").WithLocation(4, 34),
+                // (5,34): error CS0621: 'I1.P01': virtual or abstract members cannot be private
+                //     private abstract static bool P01 { get; }
+                Diagnostic(ErrorCode.ERR_VirtualPrivate, "P01").WithArguments("I1.P01").WithLocation(5, 34),
+                // (6,49): error CS0621: 'I1.E01': virtual or abstract members cannot be private
+                //     private abstract static event System.Action E01;
+                Diagnostic(ErrorCode.ERR_VirtualPrivate, "E01").WithArguments("I1.E01").WithLocation(6, 49),
+                // (7,40): error CS0558: User-defined operator 'I1.operator +(I1)' must be declared static and public
+                //     private abstract static I1 operator+ (I1 x);
+                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "+").WithArguments("I1.operator +(I1)").WithLocation(7, 40)
+                );
+        }
+
+        [Fact]
+        public void PropertyModifiers_01()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static bool M01 { get
+    ; } 
+
+    virtual static bool M02 { get
+    ; } 
+
+    sealed static bool M03 { get
+    ; } 
+
+    override static bool M04 { get
+    ; } 
+
+    abstract virtual static bool M05 { get
+    ; } 
+
+    abstract sealed static bool M06 { get
+    ; } 
+
+    abstract override static bool M07 { get
+    ; } 
+
+    virtual sealed static bool M08 { get
+    ; } 
+
+    virtual override static bool M09 { get
+    ; } 
+
+    sealed override static bool M10 { get
+    ; } 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static bool M01 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "9.0", "preview").WithLocation(4, 26),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static bool M03 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "9.0", "preview").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "9.0", "preview").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "9.0", "preview").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "9.0", "preview").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "9.0", "preview").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "9.0", "preview").WithLocation(31, 33)
+                );
+
+            ValidatePropertyModifiers_01(compilation1);
+        }
+
+        private static void ValidatePropertyModifiers_01(CSharpCompilation compilation1)
+        {
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+
+            {
+                var m01 = i1.GetMember<PropertySymbol>("M01");
+
+                Assert.True(m01.IsAbstract);
+                Assert.False(m01.IsVirtual);
+                Assert.False(m01.IsSealed);
+                Assert.True(m01.IsStatic);
+                Assert.False(m01.IsExtern);
+                Assert.False(m01.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+                var m02 = i1.GetMember<PropertySymbol>("M02");
+
+                Assert.False(m02.IsAbstract);
+                Assert.False(m02.IsVirtual);
+                Assert.False(m02.IsSealed);
+                Assert.True(m02.IsStatic);
+                Assert.False(m02.IsExtern);
+                Assert.False(m02.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m02));
+
+                var m03 = i1.GetMember<PropertySymbol>("M03");
+
+                Assert.False(m03.IsAbstract);
+                Assert.False(m03.IsVirtual);
+                Assert.False(m03.IsSealed);
+                Assert.True(m03.IsStatic);
+                Assert.False(m03.IsExtern);
+                Assert.False(m03.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m03));
+
+                var m04 = i1.GetMember<PropertySymbol>("M04");
+
+                Assert.False(m04.IsAbstract);
+                Assert.False(m04.IsVirtual);
+                Assert.False(m04.IsSealed);
+                Assert.True(m04.IsStatic);
+                Assert.False(m04.IsExtern);
+                Assert.False(m04.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m04));
+
+                var m05 = i1.GetMember<PropertySymbol>("M05");
+
+                Assert.True(m05.IsAbstract);
+                Assert.False(m05.IsVirtual);
+                Assert.False(m05.IsSealed);
+                Assert.True(m05.IsStatic);
+                Assert.False(m05.IsExtern);
+                Assert.False(m05.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m05));
+
+                var m06 = i1.GetMember<PropertySymbol>("M06");
+
+                Assert.True(m06.IsAbstract);
+                Assert.False(m06.IsVirtual);
+                Assert.False(m06.IsSealed);
+                Assert.True(m06.IsStatic);
+                Assert.False(m06.IsExtern);
+                Assert.False(m06.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m06));
+
+                var m07 = i1.GetMember<PropertySymbol>("M07");
+
+                Assert.True(m07.IsAbstract);
+                Assert.False(m07.IsVirtual);
+                Assert.False(m07.IsSealed);
+                Assert.True(m07.IsStatic);
+                Assert.False(m07.IsExtern);
+                Assert.False(m07.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m07));
+
+                var m08 = i1.GetMember<PropertySymbol>("M08");
+
+                Assert.False(m08.IsAbstract);
+                Assert.False(m08.IsVirtual);
+                Assert.False(m08.IsSealed);
+                Assert.True(m08.IsStatic);
+                Assert.False(m08.IsExtern);
+                Assert.False(m08.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m08));
+
+                var m09 = i1.GetMember<PropertySymbol>("M09");
+
+                Assert.False(m09.IsAbstract);
+                Assert.False(m09.IsVirtual);
+                Assert.False(m09.IsSealed);
+                Assert.True(m09.IsStatic);
+                Assert.False(m09.IsExtern);
+                Assert.False(m09.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m09));
+
+                var m10 = i1.GetMember<PropertySymbol>("M10");
+
+                Assert.False(m10.IsAbstract);
+                Assert.False(m10.IsVirtual);
+                Assert.False(m10.IsSealed);
+                Assert.True(m10.IsStatic);
+                Assert.False(m10.IsExtern);
+                Assert.False(m10.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m10));
+            }
+            {
+                var m01 = i1.GetMember<PropertySymbol>("M01").GetMethod;
+
+                Assert.True(m01.IsAbstract);
+                Assert.False(m01.IsVirtual);
+                Assert.True(m01.IsMetadataVirtual());
+                Assert.False(m01.IsSealed);
+                Assert.True(m01.IsStatic);
+                Assert.False(m01.IsExtern);
+                Assert.False(m01.IsAsync);
+                Assert.False(m01.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+                var m02 = i1.GetMember<PropertySymbol>("M02").GetMethod;
+
+                Assert.False(m02.IsAbstract);
+                Assert.False(m02.IsVirtual);
+                Assert.False(m02.IsMetadataVirtual());
+                Assert.False(m02.IsSealed);
+                Assert.True(m02.IsStatic);
+                Assert.False(m02.IsExtern);
+                Assert.False(m02.IsAsync);
+                Assert.False(m02.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m02));
+
+                var m03 = i1.GetMember<PropertySymbol>("M03").GetMethod;
+
+                Assert.False(m03.IsAbstract);
+                Assert.False(m03.IsVirtual);
+                Assert.False(m03.IsMetadataVirtual());
+                Assert.False(m03.IsSealed);
+                Assert.True(m03.IsStatic);
+                Assert.False(m03.IsExtern);
+                Assert.False(m03.IsAsync);
+                Assert.False(m03.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m03));
+
+                var m04 = i1.GetMember<PropertySymbol>("M04").GetMethod;
+
+                Assert.False(m04.IsAbstract);
+                Assert.False(m04.IsVirtual);
+                Assert.False(m04.IsMetadataVirtual());
+                Assert.False(m04.IsSealed);
+                Assert.True(m04.IsStatic);
+                Assert.False(m04.IsExtern);
+                Assert.False(m04.IsAsync);
+                Assert.False(m04.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m04));
+
+                var m05 = i1.GetMember<PropertySymbol>("M05").GetMethod;
+
+                Assert.True(m05.IsAbstract);
+                Assert.False(m05.IsVirtual);
+                Assert.True(m05.IsMetadataVirtual());
+                Assert.False(m05.IsSealed);
+                Assert.True(m05.IsStatic);
+                Assert.False(m05.IsExtern);
+                Assert.False(m05.IsAsync);
+                Assert.False(m05.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m05));
+
+                var m06 = i1.GetMember<PropertySymbol>("M06").GetMethod;
+
+                Assert.True(m06.IsAbstract);
+                Assert.False(m06.IsVirtual);
+                Assert.True(m06.IsMetadataVirtual());
+                Assert.False(m06.IsSealed);
+                Assert.True(m06.IsStatic);
+                Assert.False(m06.IsExtern);
+                Assert.False(m06.IsAsync);
+                Assert.False(m06.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m06));
+
+                var m07 = i1.GetMember<PropertySymbol>("M07").GetMethod;
+
+                Assert.True(m07.IsAbstract);
+                Assert.False(m07.IsVirtual);
+                Assert.True(m07.IsMetadataVirtual());
+                Assert.False(m07.IsSealed);
+                Assert.True(m07.IsStatic);
+                Assert.False(m07.IsExtern);
+                Assert.False(m07.IsAsync);
+                Assert.False(m07.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m07));
+
+                var m08 = i1.GetMember<PropertySymbol>("M08").GetMethod;
+
+                Assert.False(m08.IsAbstract);
+                Assert.False(m08.IsVirtual);
+                Assert.False(m08.IsMetadataVirtual());
+                Assert.False(m08.IsSealed);
+                Assert.True(m08.IsStatic);
+                Assert.False(m08.IsExtern);
+                Assert.False(m08.IsAsync);
+                Assert.False(m08.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m08));
+
+                var m09 = i1.GetMember<PropertySymbol>("M09").GetMethod;
+
+                Assert.False(m09.IsAbstract);
+                Assert.False(m09.IsVirtual);
+                Assert.False(m09.IsMetadataVirtual());
+                Assert.False(m09.IsSealed);
+                Assert.True(m09.IsStatic);
+                Assert.False(m09.IsExtern);
+                Assert.False(m09.IsAsync);
+                Assert.False(m09.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m09));
+
+                var m10 = i1.GetMember<PropertySymbol>("M10").GetMethod;
+
+                Assert.False(m10.IsAbstract);
+                Assert.False(m10.IsVirtual);
+                Assert.False(m10.IsMetadataVirtual());
+                Assert.False(m10.IsSealed);
+                Assert.True(m10.IsStatic);
+                Assert.False(m10.IsExtern);
+                Assert.False(m10.IsAsync);
+                Assert.False(m10.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m10));
+            }
+        }
+
+        [Fact]
+        public void PropertyModifiers_02()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static bool M01 { get
+    => throw null; } 
+
+    virtual static bool M02 { get
+    => throw null; } 
+
+    sealed static bool M03 { get
+    => throw null; } 
+
+    override static bool M04 { get
+    => throw null; } 
+
+    abstract virtual static bool M05 { get
+    { throw null; } } 
+
+    abstract sealed static bool M06 { get
+    => throw null; } 
+
+    abstract override static bool M07 { get
+    => throw null; } 
+
+    virtual sealed static bool M08 { get
+    => throw null; } 
+
+    virtual override static bool M09 { get
+    => throw null; } 
+
+    sealed override static bool M10 { get
+    => throw null; } 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static bool M01 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "9.0", "preview").WithLocation(4, 26),
+                // (4,32): error CS0500: 'I1.M01.get' cannot declare a body because it is marked abstract
+                //     abstract static bool M01 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M01.get").WithLocation(4, 32),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static bool M03 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "9.0", "preview").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "9.0", "preview").WithLocation(16, 34),
+                // (16,40): error CS0500: 'I1.M05.get' cannot declare a body because it is marked abstract
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M05.get").WithLocation(16, 40),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "9.0", "preview").WithLocation(19, 33),
+                // (19,39): error CS0500: 'I1.M06.get' cannot declare a body because it is marked abstract
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M06.get").WithLocation(19, 39),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "9.0", "preview").WithLocation(22, 35),
+                // (22,41): error CS0500: 'I1.M07.get' cannot declare a body because it is marked abstract
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M07.get").WithLocation(22, 41),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "9.0", "preview").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "9.0", "preview").WithLocation(31, 33)
+                );
+
+            ValidatePropertyModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void PropertyModifiers_03()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static bool M01 { get
+    ; } 
+
+    virtual static bool M02 { get
+    ; } 
+
+    sealed static bool M03 { get
+    ; } 
+
+    override static bool M04 { get
+    ; } 
+
+    abstract virtual static bool M05 { get
+    ; } 
+
+    abstract sealed static bool M06 { get
+    ; } 
+
+    abstract override static bool M07 { get
+    ; } 
+
+    virtual sealed static bool M08 { get
+    ; } 
+
+    virtual override static bool M09 { get
+    ; } 
+
+    sealed override static bool M10 { get
+    ; } 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33)
+                );
+
+            ValidatePropertyModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void PropertyModifiers_04()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static bool M01 { get
+    => throw null; } 
+
+    virtual static bool M02 { get
+    => throw null; } 
+
+    sealed static bool M03 { get
+    => throw null; } 
+
+    override static bool M04 { get
+    => throw null; } 
+
+    abstract virtual static bool M05 { get
+    { throw null; } } 
+
+    abstract sealed static bool M06 { get
+    => throw null; } 
+
+    abstract override static bool M07 { get
+    => throw null; } 
+
+    virtual sealed static bool M08 { get
+    => throw null; } 
+
+    virtual override static bool M09 { get
+    => throw null; } 
+
+    sealed override static bool M10 { get
+    => throw null; } 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,32): error CS0500: 'I1.M01.get' cannot declare a body because it is marked abstract
+                //     abstract static bool M01 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M01.get").WithLocation(4, 32),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,40): error CS0500: 'I1.M05.get' cannot declare a body because it is marked abstract
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M05.get").WithLocation(16, 40),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,39): error CS0500: 'I1.M06.get' cannot declare a body because it is marked abstract
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M06.get").WithLocation(19, 39),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,41): error CS0500: 'I1.M07.get' cannot declare a body because it is marked abstract
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M07.get").WithLocation(22, 41),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33)
+                );
+
+            ValidatePropertyModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void PropertyModifiers_05()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static bool M01 { get
+    ; } 
+
+    virtual static bool M02 { get
+    ; } 
+
+    sealed static bool M03 { get
+    ; } 
+
+    override static bool M04 { get
+    ; } 
+
+    abstract virtual static bool M05 { get
+    ; } 
+
+    abstract sealed static bool M06 { get
+    ; } 
+
+    abstract override static bool M07 { get
+    ; } 
+
+    virtual sealed static bool M08 { get
+    ; } 
+
+    virtual override static bool M09 { get
+    ; } 
+
+    sealed override static bool M10 { get
+    ; } 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static bool M01 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "7.3", "preview").WithLocation(4, 26),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (7,25): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M02").WithArguments("static", "7.3", "8.0").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static bool M03 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "7.3", "preview").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (13,26): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M04").WithArguments("static", "7.3", "8.0").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "7.3", "preview").WithLocation(16, 34),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "7.3", "preview").WithLocation(19, 33),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "7.3", "preview").WithLocation(22, 35),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "7.3", "preview").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (28,34): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M09").WithArguments("static", "7.3", "8.0").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "7.3", "preview").WithLocation(31, 33)
+                );
+
+            ValidatePropertyModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void PropertyModifiers_06()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static bool M01 { get
+    => throw null; } 
+
+    virtual static bool M02 { get
+    => throw null; } 
+
+    sealed static bool M03 { get
+    => throw null; } 
+
+    override static bool M04 { get
+    => throw null; } 
+
+    abstract virtual static bool M05 { get
+    { throw null; } } 
+
+    abstract sealed static bool M06 { get
+    => throw null; } 
+
+    abstract override static bool M07 { get
+    => throw null; } 
+
+    virtual sealed static bool M08 { get
+    => throw null; } 
+
+    virtual override static bool M09 { get
+    => throw null; } 
+
+    sealed override static bool M10 { get
+    => throw null; } 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,26): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static bool M01 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "7.3", "preview").WithLocation(4, 26),
+                // (4,32): error CS0500: 'I1.M01.get' cannot declare a body because it is marked abstract
+                //     abstract static bool M01 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M01.get").WithLocation(4, 32),
+                // (7,25): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 25),
+                // (7,25): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual static bool M02 { get
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M02").WithArguments("default interface implementation", "8.0").WithLocation(7, 25),
+                // (10,24): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static bool M03 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "7.3", "preview").WithLocation(10, 24),
+                // (13,26): error CS0106: The modifier 'override' is not valid for this item
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 26),
+                // (13,26): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     override static bool M04 { get
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M04").WithArguments("default interface implementation", "8.0").WithLocation(13, 26),
+                // (16,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 34),
+                // (16,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "7.3", "preview").WithLocation(16, 34),
+                // (16,40): error CS0500: 'I1.M05.get' cannot declare a body because it is marked abstract
+                //     abstract virtual static bool M05 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M05.get").WithLocation(16, 40),
+                // (19,33): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 33),
+                // (19,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "7.3", "preview").WithLocation(19, 33),
+                // (19,39): error CS0500: 'I1.M06.get' cannot declare a body because it is marked abstract
+                //     abstract sealed static bool M06 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M06.get").WithLocation(19, 39),
+                // (22,35): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 35),
+                // (22,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "7.3", "preview").WithLocation(22, 35),
+                // (22,41): error CS0500: 'I1.M07.get' cannot declare a body because it is marked abstract
+                //     abstract override static bool M07 { get
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "get").WithArguments("I1.M07.get").WithLocation(22, 41),
+                // (25,32): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 32),
+                // (25,32): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static bool M08 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "7.3", "preview").WithLocation(25, 32),
+                // (28,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 34),
+                // (28,34): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 34),
+                // (28,34): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual override static bool M09 { get
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M09").WithArguments("default interface implementation", "8.0").WithLocation(28, 34),
+                // (31,33): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 33),
+                // (31,33): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static bool M10 { get
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "7.3", "preview").WithLocation(31, 33)
+                );
+
+            ValidatePropertyModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void EventModifiers_01()
+        {
+            var source1 =
+@"#pragma warning disable CS0067 // The event is never used
+public interface I1
+{
+    abstract static event D M01
+    ;
+
+    virtual static event D M02
+    ;
+
+    sealed static event D M03
+    ;
+
+    override static event D M04
+    ;
+
+    abstract virtual static event D M05
+    ;
+
+    abstract sealed static event D M06
+    ;
+
+    abstract override static event D M07
+    ;
+
+    virtual sealed static event D M08
+    ;
+
+    virtual override static event D M09
+    ;
+
+    sealed override static event D M10
+    ;
+}
+
+public delegate void D();
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,29): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static event D M01
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "9.0", "preview").WithLocation(4, 29),
+                // (7,28): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static event D M02
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 28),
+                // (10,27): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static event D M03
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "9.0", "preview").WithLocation(10, 27),
+                // (13,29): error CS0106: The modifier 'override' is not valid for this item
+                //     override static event D M04
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 29),
+                // (16,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static event D M05
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 37),
+                // (16,37): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static event D M05
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "9.0", "preview").WithLocation(16, 37),
+                // (19,36): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static event D M06
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 36),
+                // (19,36): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static event D M06
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "9.0", "preview").WithLocation(19, 36),
+                // (22,38): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static event D M07
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 38),
+                // (22,38): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static event D M07
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "9.0", "preview").WithLocation(22, 38),
+                // (25,35): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static event D M08
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 35),
+                // (25,35): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static event D M08
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "9.0", "preview").WithLocation(25, 35),
+                // (28,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static event D M09
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 37),
+                // (28,37): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static event D M09
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 37),
+                // (31,36): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static event D M10
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 36),
+                // (31,36): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static event D M10
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "9.0", "preview").WithLocation(31, 36)
+                );
+
+            ValidateEventModifiers_01(compilation1);
+        }
+
+        private static void ValidateEventModifiers_01(CSharpCompilation compilation1)
+        {
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+
+            {
+                var m01 = i1.GetMember<EventSymbol>("M01");
+
+                Assert.True(m01.IsAbstract);
+                Assert.False(m01.IsVirtual);
+                Assert.False(m01.IsSealed);
+                Assert.True(m01.IsStatic);
+                Assert.False(m01.IsExtern);
+                Assert.False(m01.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+                var m02 = i1.GetMember<EventSymbol>("M02");
+
+                Assert.False(m02.IsAbstract);
+                Assert.False(m02.IsVirtual);
+                Assert.False(m02.IsSealed);
+                Assert.True(m02.IsStatic);
+                Assert.False(m02.IsExtern);
+                Assert.False(m02.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m02));
+
+                var m03 = i1.GetMember<EventSymbol>("M03");
+
+                Assert.False(m03.IsAbstract);
+                Assert.False(m03.IsVirtual);
+                Assert.False(m03.IsSealed);
+                Assert.True(m03.IsStatic);
+                Assert.False(m03.IsExtern);
+                Assert.False(m03.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m03));
+
+                var m04 = i1.GetMember<EventSymbol>("M04");
+
+                Assert.False(m04.IsAbstract);
+                Assert.False(m04.IsVirtual);
+                Assert.False(m04.IsSealed);
+                Assert.True(m04.IsStatic);
+                Assert.False(m04.IsExtern);
+                Assert.False(m04.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m04));
+
+                var m05 = i1.GetMember<EventSymbol>("M05");
+
+                Assert.True(m05.IsAbstract);
+                Assert.False(m05.IsVirtual);
+                Assert.False(m05.IsSealed);
+                Assert.True(m05.IsStatic);
+                Assert.False(m05.IsExtern);
+                Assert.False(m05.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m05));
+
+                var m06 = i1.GetMember<EventSymbol>("M06");
+
+                Assert.True(m06.IsAbstract);
+                Assert.False(m06.IsVirtual);
+                Assert.False(m06.IsSealed);
+                Assert.True(m06.IsStatic);
+                Assert.False(m06.IsExtern);
+                Assert.False(m06.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m06));
+
+                var m07 = i1.GetMember<EventSymbol>("M07");
+
+                Assert.True(m07.IsAbstract);
+                Assert.False(m07.IsVirtual);
+                Assert.False(m07.IsSealed);
+                Assert.True(m07.IsStatic);
+                Assert.False(m07.IsExtern);
+                Assert.False(m07.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m07));
+
+                var m08 = i1.GetMember<EventSymbol>("M08");
+
+                Assert.False(m08.IsAbstract);
+                Assert.False(m08.IsVirtual);
+                Assert.False(m08.IsSealed);
+                Assert.True(m08.IsStatic);
+                Assert.False(m08.IsExtern);
+                Assert.False(m08.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m08));
+
+                var m09 = i1.GetMember<EventSymbol>("M09");
+
+                Assert.False(m09.IsAbstract);
+                Assert.False(m09.IsVirtual);
+                Assert.False(m09.IsSealed);
+                Assert.True(m09.IsStatic);
+                Assert.False(m09.IsExtern);
+                Assert.False(m09.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m09));
+
+                var m10 = i1.GetMember<EventSymbol>("M10");
+
+                Assert.False(m10.IsAbstract);
+                Assert.False(m10.IsVirtual);
+                Assert.False(m10.IsSealed);
+                Assert.True(m10.IsStatic);
+                Assert.False(m10.IsExtern);
+                Assert.False(m10.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m10));
+            }
+
+            foreach (var addAccessor in new[] { true, false })
+            {
+                var m01 = getAccessor(i1.GetMember<EventSymbol>("M01"), addAccessor);
+
+                Assert.True(m01.IsAbstract);
+                Assert.False(m01.IsVirtual);
+                Assert.True(m01.IsMetadataVirtual());
+                Assert.False(m01.IsSealed);
+                Assert.True(m01.IsStatic);
+                Assert.False(m01.IsExtern);
+                Assert.False(m01.IsAsync);
+                Assert.False(m01.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+                var m02 = getAccessor(i1.GetMember<EventSymbol>("M02"), addAccessor);
+
+                Assert.False(m02.IsAbstract);
+                Assert.False(m02.IsVirtual);
+                Assert.False(m02.IsMetadataVirtual());
+                Assert.False(m02.IsSealed);
+                Assert.True(m02.IsStatic);
+                Assert.False(m02.IsExtern);
+                Assert.False(m02.IsAsync);
+                Assert.False(m02.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m02));
+
+                var m03 = getAccessor(i1.GetMember<EventSymbol>("M03"), addAccessor);
+
+                Assert.False(m03.IsAbstract);
+                Assert.False(m03.IsVirtual);
+                Assert.False(m03.IsMetadataVirtual());
+                Assert.False(m03.IsSealed);
+                Assert.True(m03.IsStatic);
+                Assert.False(m03.IsExtern);
+                Assert.False(m03.IsAsync);
+                Assert.False(m03.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m03));
+
+                var m04 = getAccessor(i1.GetMember<EventSymbol>("M04"), addAccessor);
+
+                Assert.False(m04.IsAbstract);
+                Assert.False(m04.IsVirtual);
+                Assert.False(m04.IsMetadataVirtual());
+                Assert.False(m04.IsSealed);
+                Assert.True(m04.IsStatic);
+                Assert.False(m04.IsExtern);
+                Assert.False(m04.IsAsync);
+                Assert.False(m04.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m04));
+
+                var m05 = getAccessor(i1.GetMember<EventSymbol>("M05"), addAccessor);
+
+                Assert.True(m05.IsAbstract);
+                Assert.False(m05.IsVirtual);
+                Assert.True(m05.IsMetadataVirtual());
+                Assert.False(m05.IsSealed);
+                Assert.True(m05.IsStatic);
+                Assert.False(m05.IsExtern);
+                Assert.False(m05.IsAsync);
+                Assert.False(m05.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m05));
+
+                var m06 = getAccessor(i1.GetMember<EventSymbol>("M06"), addAccessor);
+
+                Assert.True(m06.IsAbstract);
+                Assert.False(m06.IsVirtual);
+                Assert.True(m06.IsMetadataVirtual());
+                Assert.False(m06.IsSealed);
+                Assert.True(m06.IsStatic);
+                Assert.False(m06.IsExtern);
+                Assert.False(m06.IsAsync);
+                Assert.False(m06.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m06));
+
+                var m07 = getAccessor(i1.GetMember<EventSymbol>("M07"), addAccessor);
+
+                Assert.True(m07.IsAbstract);
+                Assert.False(m07.IsVirtual);
+                Assert.True(m07.IsMetadataVirtual());
+                Assert.False(m07.IsSealed);
+                Assert.True(m07.IsStatic);
+                Assert.False(m07.IsExtern);
+                Assert.False(m07.IsAsync);
+                Assert.False(m07.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m07));
+
+                var m08 = getAccessor(i1.GetMember<EventSymbol>("M08"), addAccessor);
+
+                Assert.False(m08.IsAbstract);
+                Assert.False(m08.IsVirtual);
+                Assert.False(m08.IsMetadataVirtual());
+                Assert.False(m08.IsSealed);
+                Assert.True(m08.IsStatic);
+                Assert.False(m08.IsExtern);
+                Assert.False(m08.IsAsync);
+                Assert.False(m08.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m08));
+
+                var m09 = getAccessor(i1.GetMember<EventSymbol>("M09"), addAccessor);
+
+                Assert.False(m09.IsAbstract);
+                Assert.False(m09.IsVirtual);
+                Assert.False(m09.IsMetadataVirtual());
+                Assert.False(m09.IsSealed);
+                Assert.True(m09.IsStatic);
+                Assert.False(m09.IsExtern);
+                Assert.False(m09.IsAsync);
+                Assert.False(m09.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m09));
+
+                var m10 = getAccessor(i1.GetMember<EventSymbol>("M10"), addAccessor);
+
+                Assert.False(m10.IsAbstract);
+                Assert.False(m10.IsVirtual);
+                Assert.False(m10.IsMetadataVirtual());
+                Assert.False(m10.IsSealed);
+                Assert.True(m10.IsStatic);
+                Assert.False(m10.IsExtern);
+                Assert.False(m10.IsAsync);
+                Assert.False(m10.IsOverride);
+                Assert.Null(i1.FindImplementationForInterfaceMember(m10));
+            }
+
+            static MethodSymbol getAccessor(EventSymbol e, bool addAccessor)
+            {
+                return addAccessor ? e.AddMethod : e.RemoveMethod;
+            }
+        }
+
+        [Fact]
+        public void EventModifiers_02()
+        {
+            var source1 =
+@"#pragma warning disable CS0067 // The event is never used
+public interface I1
+{
+    abstract static event D M01 { add {} remove {} }
+    
+
+    virtual static event D M02 { add {} remove {} }
+    
+
+    sealed static event D M03 { add {} remove {} }
+    
+
+    override static event D M04 { add {} remove {} }
+    
+
+    abstract virtual static event D M05 { add {} remove {} }
+    
+
+    abstract sealed static event D M06 { add {} remove {} }
+    
+
+    abstract override static event D M07 { add {} remove {} }
+    
+
+    virtual sealed static event D M08 { add {} remove {} }
+    
+
+    virtual override static event D M09 { add {} remove {} }
+    
+
+    sealed override static event D M10 { add {} remove {} }
+}
+
+public delegate void D();
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,29): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static event D M01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "9.0", "preview").WithLocation(4, 29),
+                // (4,33): error CS8712: 'I1.M01': abstract event cannot use event accessor syntax
+                //     abstract static event D M01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M01").WithLocation(4, 33),
+                // (7,28): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static event D M02 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 28),
+                // (10,27): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static event D M03 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "9.0", "preview").WithLocation(10, 27),
+                // (13,29): error CS0106: The modifier 'override' is not valid for this item
+                //     override static event D M04 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 29),
+                // (16,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 37),
+                // (16,37): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "9.0", "preview").WithLocation(16, 37),
+                // (16,41): error CS8712: 'I1.M05': abstract event cannot use event accessor syntax
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M05").WithLocation(16, 41),
+                // (19,36): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 36),
+                // (19,36): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "9.0", "preview").WithLocation(19, 36),
+                // (19,40): error CS8712: 'I1.M06': abstract event cannot use event accessor syntax
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M06").WithLocation(19, 40),
+                // (22,38): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 38),
+                // (22,38): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "9.0", "preview").WithLocation(22, 38),
+                // (22,42): error CS8712: 'I1.M07': abstract event cannot use event accessor syntax
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M07").WithLocation(22, 42),
+                // (25,35): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static event D M08 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 35),
+                // (25,35): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static event D M08 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "9.0", "preview").WithLocation(25, 35),
+                // (28,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static event D M09 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 37),
+                // (28,37): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static event D M09 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 37),
+                // (31,36): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static event D M10 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 36),
+                // (31,36): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static event D M10 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "9.0", "preview").WithLocation(31, 36)
+                );
+
+            ValidateEventModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void EventModifiers_03()
+        {
+            var source1 =
+@"#pragma warning disable CS0067 // The event is never used
+public interface I1
+{
+    abstract static event D M01
+    ;
+
+    virtual static event D M02
+    ;
+
+    sealed static event D M03
+    ;
+
+    override static event D M04
+    ;
+
+    abstract virtual static event D M05
+    ;
+
+    abstract sealed static event D M06
+    ;
+
+    abstract override static event D M07
+    ;
+
+    virtual sealed static event D M08
+    ;
+
+    virtual override static event D M09
+    ;
+
+    sealed override static event D M10
+    ;
+}
+
+public delegate void D();
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (7,28): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static event D M02
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 28),
+                // (13,29): error CS0106: The modifier 'override' is not valid for this item
+                //     override static event D M04
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 29),
+                // (16,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static event D M05
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 37),
+                // (19,36): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static event D M06
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 36),
+                // (22,38): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static event D M07
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 38),
+                // (25,35): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static event D M08
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 35),
+                // (28,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static event D M09
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 37),
+                // (28,37): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static event D M09
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 37),
+                // (31,36): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static event D M10
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 36)
+                );
+
+            ValidateEventModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void EventModifiers_04()
+        {
+            var source1 =
+@"#pragma warning disable CS0067 // The event is never used
+public interface I1
+{
+    abstract static event D M01 { add {} remove {} }
+    
+
+    virtual static event D M02 { add {} remove {} }
+    
+
+    sealed static event D M03 { add {} remove {} }
+    
+
+    override static event D M04 { add {} remove {} }
+    
+
+    abstract virtual static event D M05 { add {} remove {} }
+    
+
+    abstract sealed static event D M06 { add {} remove {} }
+    
+
+    abstract override static event D M07 { add {} remove {} }
+    
+
+    virtual sealed static event D M08 { add {} remove {} }
+    
+
+    virtual override static event D M09 { add {} remove {} }
+    
+
+    sealed override static event D M10 { add {} remove {} }
+}
+
+public delegate void D();
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,33): error CS8712: 'I1.M01': abstract event cannot use event accessor syntax
+                //     abstract static event D M01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M01").WithLocation(4, 33),
+                // (7,28): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static event D M02 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 28),
+                // (13,29): error CS0106: The modifier 'override' is not valid for this item
+                //     override static event D M04 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 29),
+                // (16,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 37),
+                // (16,41): error CS8712: 'I1.M05': abstract event cannot use event accessor syntax
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M05").WithLocation(16, 41),
+                // (19,36): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 36),
+                // (19,40): error CS8712: 'I1.M06': abstract event cannot use event accessor syntax
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M06").WithLocation(19, 40),
+                // (22,38): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 38),
+                // (22,42): error CS8712: 'I1.M07': abstract event cannot use event accessor syntax
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M07").WithLocation(22, 42),
+                // (25,35): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static event D M08 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 35),
+                // (28,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static event D M09 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 37),
+                // (28,37): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static event D M09 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 37),
+                // (31,36): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static event D M10 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 36)
+                );
+
+            ValidateEventModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void EventModifiers_05()
+        {
+            var source1 =
+@"#pragma warning disable CS0067 // The event is never used
+public interface I1
+{
+    abstract static event D M01
+    ;
+
+    virtual static event D M02
+    ;
+
+    sealed static event D M03
+    ;
+
+    override static event D M04
+    ;
+
+    abstract virtual static event D M05
+    ;
+
+    abstract sealed static event D M06
+    ;
+
+    abstract override static event D M07
+    ;
+
+    virtual sealed static event D M08
+    ;
+
+    virtual override static event D M09
+    ;
+
+    sealed override static event D M10
+    ;
+}
+
+public delegate void D();
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,29): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static event D M01
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "7.3", "preview").WithLocation(4, 29),
+                // (7,28): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static event D M02
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 28),
+                // (7,28): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     virtual static event D M02
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M02").WithArguments("static", "7.3", "8.0").WithLocation(7, 28),
+                // (10,27): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static event D M03
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "7.3", "preview").WithLocation(10, 27),
+                // (13,29): error CS0106: The modifier 'override' is not valid for this item
+                //     override static event D M04
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 29),
+                // (13,29): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     override static event D M04
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M04").WithArguments("static", "7.3", "8.0").WithLocation(13, 29),
+                // (16,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static event D M05
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 37),
+                // (16,37): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static event D M05
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "7.3", "preview").WithLocation(16, 37),
+                // (19,36): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static event D M06
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 36),
+                // (19,36): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static event D M06
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "7.3", "preview").WithLocation(19, 36),
+                // (22,38): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static event D M07
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 38),
+                // (22,38): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static event D M07
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "7.3", "preview").WithLocation(22, 38),
+                // (25,35): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static event D M08
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 35),
+                // (25,35): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static event D M08
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "7.3", "preview").WithLocation(25, 35),
+                // (28,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static event D M09
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 37),
+                // (28,37): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static event D M09
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 37),
+                // (28,37): error CS8703: The modifier 'static' is not valid for this item in C# 7.3. Please use language version '8.0' or greater.
+                //     virtual override static event D M09
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M09").WithArguments("static", "7.3", "8.0").WithLocation(28, 37),
+                // (31,36): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static event D M10
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 36),
+                // (31,36): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static event D M10
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "7.3", "preview").WithLocation(31, 36)
+                );
+
+            ValidateEventModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void EventModifiers_06()
+        {
+            var source1 =
+@"#pragma warning disable CS0067 // The event is never used
+public interface I1
+{
+    abstract static event D M01 { add {} remove {} }
+    
+
+    virtual static event D M02 { add {} remove {} }
+    
+
+    sealed static event D M03 { add {} remove {} }
+    
+
+    override static event D M04 { add {} remove {} }
+    
+
+    abstract virtual static event D M05 { add {} remove {} }
+    
+
+    abstract sealed static event D M06 { add {} remove {} }
+    
+
+    abstract override static event D M07 { add {} remove {} }
+    
+
+    virtual sealed static event D M08 { add {} remove {} }
+    
+
+    virtual override static event D M09 { add {} remove {} }
+    
+
+    sealed override static event D M10 { add {} remove {} }
+}
+
+public delegate void D();
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,29): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static event D M01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M01").WithArguments("abstract", "7.3", "preview").WithLocation(4, 29),
+                // (4,33): error CS8712: 'I1.M01': abstract event cannot use event accessor syntax
+                //     abstract static event D M01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M01").WithLocation(4, 33),
+                // (7,28): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual static event D M02 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M02").WithArguments("virtual").WithLocation(7, 28),
+                // (7,28): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual static event D M02 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M02").WithArguments("default interface implementation", "8.0").WithLocation(7, 28),
+                // (10,27): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static event D M03 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M03").WithArguments("sealed", "7.3", "preview").WithLocation(10, 27),
+                // (13,29): error CS0106: The modifier 'override' is not valid for this item
+                //     override static event D M04 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M04").WithArguments("override").WithLocation(13, 29),
+                // (13,29): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     override static event D M04 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M04").WithArguments("default interface implementation", "8.0").WithLocation(13, 29),
+                // (16,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M05").WithArguments("virtual").WithLocation(16, 37),
+                // (16,37): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M05").WithArguments("abstract", "7.3", "preview").WithLocation(16, 37),
+                // (16,41): error CS8712: 'I1.M05': abstract event cannot use event accessor syntax
+                //     abstract virtual static event D M05 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M05").WithLocation(16, 41),
+                // (19,36): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M06").WithArguments("sealed").WithLocation(19, 36),
+                // (19,36): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M06").WithArguments("abstract", "7.3", "preview").WithLocation(19, 36),
+                // (19,40): error CS8712: 'I1.M06': abstract event cannot use event accessor syntax
+                //     abstract sealed static event D M06 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M06").WithLocation(19, 40),
+                // (22,38): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M07").WithArguments("override").WithLocation(22, 38),
+                // (22,38): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M07").WithArguments("abstract", "7.3", "preview").WithLocation(22, 38),
+                // (22,42): error CS8712: 'I1.M07': abstract event cannot use event accessor syntax
+                //     abstract override static event D M07 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.M07").WithLocation(22, 42),
+                // (25,35): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual sealed static event D M08 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M08").WithArguments("virtual").WithLocation(25, 35),
+                // (25,35): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static event D M08 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M08").WithArguments("sealed", "7.3", "preview").WithLocation(25, 35),
+                // (28,37): error CS0112: A static member cannot be marked as 'virtual'
+                //     virtual override static event D M09 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M09").WithArguments("virtual").WithLocation(28, 37),
+                // (28,37): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static event D M09 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M09").WithArguments("override").WithLocation(28, 37),
+                // (28,37): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual override static event D M09 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M09").WithArguments("default interface implementation", "8.0").WithLocation(28, 37),
+                // (31,36): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static event D M10 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M10").WithArguments("override").WithLocation(31, 36),
+                // (31,36): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static event D M10 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "M10").WithArguments("sealed", "7.3", "preview").WithLocation(31, 36)
+                );
+
+            ValidateEventModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void OperatorModifiers_01()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static I1 operator+ (I1 x)
+    ; 
+
+    virtual static I1 operator- (I1 x)
+    ; 
+
+    sealed static I1 operator++ (I1 x)
+    ; 
+
+    override static I1 operator-- (I1 x)
+    ; 
+
+    abstract virtual static I1 operator! (I1 x)
+    ; 
+
+    abstract sealed static I1 operator~ (I1 x)
+    ; 
+
+    abstract override static I1 operator+ (I1 x, I1 y)
+    ; 
+
+    virtual sealed static I1 operator- (I1 x, I1 y)
+    ; 
+
+    virtual override static I1 operator* (I1 x, I1 y) 
+    ; 
+
+    sealed override static I1 operator/ (I1 x, I1 y)
+    ; 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,32): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static I1 operator+ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "9.0", "preview").WithLocation(4, 32),
+                // (7,31): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(7, 31),
+                // (7,31): error CS0501: 'I1.operator -(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "-").WithArguments("I1.operator -(I1)").WithLocation(7, 31),
+                // (10,30): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static I1 operator++ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "++").WithArguments("sealed", "9.0", "preview").WithLocation(10, 30),
+                // (10,30): error CS0501: 'I1.operator ++(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed static I1 operator++ (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "++").WithArguments("I1.operator ++(I1)").WithLocation(10, 30),
+                // (13,32): error CS0106: The modifier 'override' is not valid for this item
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "--").WithArguments("override").WithLocation(13, 32),
+                // (13,32): error CS0501: 'I1.operator --(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "--").WithArguments("I1.operator --(I1)").WithLocation(13, 32),
+                // (16,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!").WithArguments("virtual").WithLocation(16, 40),
+                // (16,40): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!").WithArguments("abstract", "9.0", "preview").WithLocation(16, 40),
+                // (19,39): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("sealed").WithLocation(19, 39),
+                // (19,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "~").WithArguments("abstract", "9.0", "preview").WithLocation(19, 39),
+                // (22,41): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("override").WithLocation(22, 41),
+                // (22,41): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "9.0", "preview").WithLocation(22, 41),
+                // (25,38): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(25, 38),
+                // (25,38): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "-").WithArguments("sealed", "9.0", "preview").WithLocation(25, 38),
+                // (25,38): error CS0501: 'I1.operator -(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "-").WithArguments("I1.operator -(I1, I1)").WithLocation(25, 38),
+                // (28,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("virtual").WithLocation(28, 40),
+                // (28,40): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("override").WithLocation(28, 40),
+                // (28,40): error CS0501: 'I1.operator *(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "*").WithArguments("I1.operator *(I1, I1)").WithLocation(28, 40),
+                // (31,39): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "/").WithArguments("override").WithLocation(31, 39),
+                // (31,39): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "/").WithArguments("sealed", "9.0", "preview").WithLocation(31, 39),
+                // (31,39): error CS0501: 'I1.operator /(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "/").WithArguments("I1.operator /(I1, I1)").WithLocation(31, 39)
+                );
+
+            ValidateOperatorModifiers_01(compilation1);
+        }
+
+        private static void ValidateOperatorModifiers_01(CSharpCompilation compilation1)
+        {
+            var i1 = compilation1.GetTypeByMetadataName("I1");
+            var m01 = i1.GetMember<MethodSymbol>("op_UnaryPlus");
+
+            Assert.True(m01.IsAbstract);
+            Assert.False(m01.IsVirtual);
+            Assert.True(m01.IsMetadataVirtual());
+            Assert.False(m01.IsSealed);
+            Assert.True(m01.IsStatic);
+            Assert.False(m01.IsExtern);
+            Assert.False(m01.IsAsync);
+            Assert.False(m01.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m01));
+
+            var m02 = i1.GetMember<MethodSymbol>("op_UnaryNegation");
+
+            Assert.False(m02.IsAbstract);
+            Assert.False(m02.IsVirtual);
+            Assert.False(m02.IsMetadataVirtual());
+            Assert.False(m02.IsSealed);
+            Assert.True(m02.IsStatic);
+            Assert.False(m02.IsExtern);
+            Assert.False(m02.IsAsync);
+            Assert.False(m02.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m02));
+
+            var m03 = i1.GetMember<MethodSymbol>("op_Increment");
+
+            Assert.False(m03.IsAbstract);
+            Assert.False(m03.IsVirtual);
+            Assert.False(m03.IsMetadataVirtual());
+            Assert.False(m03.IsSealed);
+            Assert.True(m03.IsStatic);
+            Assert.False(m03.IsExtern);
+            Assert.False(m03.IsAsync);
+            Assert.False(m03.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m03));
+
+            var m04 = i1.GetMember<MethodSymbol>("op_Decrement");
+
+            Assert.False(m04.IsAbstract);
+            Assert.False(m04.IsVirtual);
+            Assert.False(m04.IsMetadataVirtual());
+            Assert.False(m04.IsSealed);
+            Assert.True(m04.IsStatic);
+            Assert.False(m04.IsExtern);
+            Assert.False(m04.IsAsync);
+            Assert.False(m04.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m04));
+
+            var m05 = i1.GetMember<MethodSymbol>("op_LogicalNot");
+
+            Assert.True(m05.IsAbstract);
+            Assert.False(m05.IsVirtual);
+            Assert.True(m05.IsMetadataVirtual());
+            Assert.False(m05.IsSealed);
+            Assert.True(m05.IsStatic);
+            Assert.False(m05.IsExtern);
+            Assert.False(m05.IsAsync);
+            Assert.False(m05.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m05));
+
+            var m06 = i1.GetMember<MethodSymbol>("op_OnesComplement");
+
+            Assert.True(m06.IsAbstract);
+            Assert.False(m06.IsVirtual);
+            Assert.True(m06.IsMetadataVirtual());
+            Assert.False(m06.IsSealed);
+            Assert.True(m06.IsStatic);
+            Assert.False(m06.IsExtern);
+            Assert.False(m06.IsAsync);
+            Assert.False(m06.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m06));
+
+            var m07 = i1.GetMember<MethodSymbol>("op_Addition");
+
+            Assert.True(m07.IsAbstract);
+            Assert.False(m07.IsVirtual);
+            Assert.True(m07.IsMetadataVirtual());
+            Assert.False(m07.IsSealed);
+            Assert.True(m07.IsStatic);
+            Assert.False(m07.IsExtern);
+            Assert.False(m07.IsAsync);
+            Assert.False(m07.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m07));
+
+            var m08 = i1.GetMember<MethodSymbol>("op_Subtraction");
+
+            Assert.False(m08.IsAbstract);
+            Assert.False(m08.IsVirtual);
+            Assert.False(m08.IsMetadataVirtual());
+            Assert.False(m08.IsSealed);
+            Assert.True(m08.IsStatic);
+            Assert.False(m08.IsExtern);
+            Assert.False(m08.IsAsync);
+            Assert.False(m08.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m08));
+
+            var m09 = i1.GetMember<MethodSymbol>("op_Multiply");
+
+            Assert.False(m09.IsAbstract);
+            Assert.False(m09.IsVirtual);
+            Assert.False(m09.IsMetadataVirtual());
+            Assert.False(m09.IsSealed);
+            Assert.True(m09.IsStatic);
+            Assert.False(m09.IsExtern);
+            Assert.False(m09.IsAsync);
+            Assert.False(m09.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m09));
+
+            var m10 = i1.GetMember<MethodSymbol>("op_Division");
+
+            Assert.False(m10.IsAbstract);
+            Assert.False(m10.IsVirtual);
+            Assert.False(m10.IsMetadataVirtual());
+            Assert.False(m10.IsSealed);
+            Assert.True(m10.IsStatic);
+            Assert.False(m10.IsExtern);
+            Assert.False(m10.IsAsync);
+            Assert.False(m10.IsOverride);
+            Assert.Null(i1.FindImplementationForInterfaceMember(m10));
+        }
+
+        [Fact]
+        public void OperatorModifiers_02()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static I1 operator+ (I1 x)
+    {throw null;} 
+
+    virtual static I1 operator- (I1 x)
+    {throw null;} 
+
+    sealed static I1 operator++ (I1 x)
+    {throw null;} 
+
+    override static I1 operator-- (I1 x)
+    {throw null;} 
+
+    abstract virtual static I1 operator! (I1 x)
+    {throw null;} 
+
+    abstract sealed static I1 operator~ (I1 x)
+    {throw null;} 
+
+    abstract override static I1 operator+ (I1 x, I1 y)
+    {throw null;} 
+
+    virtual sealed static I1 operator- (I1 x, I1 y)
+    {throw null;} 
+
+    virtual override static I1 operator* (I1 x, I1 y) 
+    {throw null;} 
+
+    sealed override static I1 operator/ (I1 x, I1 y)
+    {throw null;} 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular9,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,32): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract static I1 operator+ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "9.0", "preview").WithLocation(4, 32),
+                // (4,32): error CS0500: 'I1.operator +(I1)' cannot declare a body because it is marked abstract
+                //     abstract static I1 operator+ (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "+").WithArguments("I1.operator +(I1)").WithLocation(4, 32),
+                // (7,31): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(7, 31),
+                // (10,30): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed static I1 operator++ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "++").WithArguments("sealed", "9.0", "preview").WithLocation(10, 30),
+                // (13,32): error CS0106: The modifier 'override' is not valid for this item
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "--").WithArguments("override").WithLocation(13, 32),
+                // (16,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!").WithArguments("virtual").WithLocation(16, 40),
+                // (16,40): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!").WithArguments("abstract", "9.0", "preview").WithLocation(16, 40),
+                // (16,40): error CS0500: 'I1.operator !(I1)' cannot declare a body because it is marked abstract
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "!").WithArguments("I1.operator !(I1)").WithLocation(16, 40),
+                // (19,39): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("sealed").WithLocation(19, 39),
+                // (19,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "~").WithArguments("abstract", "9.0", "preview").WithLocation(19, 39),
+                // (19,39): error CS0500: 'I1.operator ~(I1)' cannot declare a body because it is marked abstract
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "~").WithArguments("I1.operator ~(I1)").WithLocation(19, 39),
+                // (22,41): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("override").WithLocation(22, 41),
+                // (22,41): error CS8703: The modifier 'abstract' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "9.0", "preview").WithLocation(22, 41),
+                // (22,41): error CS0500: 'I1.operator +(I1, I1)' cannot declare a body because it is marked abstract
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "+").WithArguments("I1.operator +(I1, I1)").WithLocation(22, 41),
+                // (25,38): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(25, 38),
+                // (25,38): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "-").WithArguments("sealed", "9.0", "preview").WithLocation(25, 38),
+                // (28,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("virtual").WithLocation(28, 40),
+                // (28,40): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("override").WithLocation(28, 40),
+                // (31,39): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "/").WithArguments("override").WithLocation(31, 39),
+                // (31,39): error CS8703: The modifier 'sealed' is not valid for this item in C# 9.0. Please use language version 'preview' or greater.
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "/").WithArguments("sealed", "9.0", "preview").WithLocation(31, 39)
+                );
+
+            ValidateOperatorModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void OperatorModifiers_03()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static I1 operator+ (I1 x)
+    ; 
+
+    virtual static I1 operator- (I1 x)
+    ; 
+
+    sealed static I1 operator++ (I1 x)
+    ; 
+
+    override static I1 operator-- (I1 x)
+    ; 
+
+    abstract virtual static I1 operator! (I1 x)
+    ; 
+
+    abstract sealed static I1 operator~ (I1 x)
+    ; 
+
+    abstract override static I1 operator+ (I1 x, I1 y)
+    ; 
+
+    virtual sealed static I1 operator- (I1 x, I1 y)
+    ; 
+
+    virtual override static I1 operator* (I1 x, I1 y) 
+    ; 
+
+    sealed override static I1 operator/ (I1 x, I1 y)
+    ; 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (7,31): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(7, 31),
+                // (7,31): error CS0501: 'I1.operator -(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "-").WithArguments("I1.operator -(I1)").WithLocation(7, 31),
+                // (10,30): error CS0501: 'I1.operator ++(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed static I1 operator++ (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "++").WithArguments("I1.operator ++(I1)").WithLocation(10, 30),
+                // (13,32): error CS0106: The modifier 'override' is not valid for this item
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "--").WithArguments("override").WithLocation(13, 32),
+                // (13,32): error CS0501: 'I1.operator --(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "--").WithArguments("I1.operator --(I1)").WithLocation(13, 32),
+                // (16,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!").WithArguments("virtual").WithLocation(16, 40),
+                // (19,39): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("sealed").WithLocation(19, 39),
+                // (22,41): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("override").WithLocation(22, 41),
+                // (25,38): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(25, 38),
+                // (25,38): error CS0501: 'I1.operator -(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "-").WithArguments("I1.operator -(I1, I1)").WithLocation(25, 38),
+                // (28,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("virtual").WithLocation(28, 40),
+                // (28,40): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("override").WithLocation(28, 40),
+                // (28,40): error CS0501: 'I1.operator *(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "*").WithArguments("I1.operator *(I1, I1)").WithLocation(28, 40),
+                // (31,39): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "/").WithArguments("override").WithLocation(31, 39),
+                // (31,39): error CS0501: 'I1.operator /(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "/").WithArguments("I1.operator /(I1, I1)").WithLocation(31, 39)
+                );
+
+            ValidateOperatorModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void OperatorModifiers_04()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static I1 operator+ (I1 x)
+    {throw null;} 
+
+    virtual static I1 operator- (I1 x)
+    {throw null;} 
+
+    sealed static I1 operator++ (I1 x)
+    {throw null;} 
+
+    override static I1 operator-- (I1 x)
+    {throw null;} 
+
+    abstract virtual static I1 operator! (I1 x)
+    {throw null;} 
+
+    abstract sealed static I1 operator~ (I1 x)
+    {throw null;} 
+
+    abstract override static I1 operator+ (I1 x, I1 y)
+    {throw null;} 
+
+    virtual sealed static I1 operator- (I1 x, I1 y)
+    {throw null;} 
+
+    virtual override static I1 operator* (I1 x, I1 y) 
+    {throw null;} 
+
+    sealed override static I1 operator/ (I1 x, I1 y)
+    {throw null;} 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,32): error CS0500: 'I1.operator +(I1)' cannot declare a body because it is marked abstract
+                //     abstract static I1 operator+ (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "+").WithArguments("I1.operator +(I1)").WithLocation(4, 32),
+                // (7,31): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(7, 31),
+                // (13,32): error CS0106: The modifier 'override' is not valid for this item
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "--").WithArguments("override").WithLocation(13, 32),
+                // (16,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!").WithArguments("virtual").WithLocation(16, 40),
+                // (16,40): error CS0500: 'I1.operator !(I1)' cannot declare a body because it is marked abstract
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "!").WithArguments("I1.operator !(I1)").WithLocation(16, 40),
+                // (19,39): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("sealed").WithLocation(19, 39),
+                // (19,39): error CS0500: 'I1.operator ~(I1)' cannot declare a body because it is marked abstract
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "~").WithArguments("I1.operator ~(I1)").WithLocation(19, 39),
+                // (22,41): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("override").WithLocation(22, 41),
+                // (22,41): error CS0500: 'I1.operator +(I1, I1)' cannot declare a body because it is marked abstract
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "+").WithArguments("I1.operator +(I1, I1)").WithLocation(22, 41),
+                // (25,38): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(25, 38),
+                // (28,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("virtual").WithLocation(28, 40),
+                // (28,40): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("override").WithLocation(28, 40),
+                // (31,39): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "/").WithArguments("override").WithLocation(31, 39)
+                );
+
+            ValidateOperatorModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void OperatorModifiers_05()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static I1 operator+ (I1 x)
+    ; 
+
+    virtual static I1 operator- (I1 x)
+    ; 
+
+    sealed static I1 operator++ (I1 x)
+    ; 
+
+    override static I1 operator-- (I1 x)
+    ; 
+
+    abstract virtual static I1 operator! (I1 x)
+    ; 
+
+    abstract sealed static I1 operator~ (I1 x)
+    ; 
+
+    abstract override static I1 operator+ (I1 x, I1 y)
+    ; 
+
+    virtual sealed static I1 operator- (I1 x, I1 y)
+    ; 
+
+    virtual override static I1 operator* (I1 x, I1 y) 
+    ; 
+
+    sealed override static I1 operator/ (I1 x, I1 y)
+    ; 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,32): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static I1 operator+ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "7.3", "preview").WithLocation(4, 32),
+                // (7,31): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(7, 31),
+                // (7,31): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "-").WithArguments("default interface implementation", "8.0").WithLocation(7, 31),
+                // (7,31): error CS0501: 'I1.operator -(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "-").WithArguments("I1.operator -(I1)").WithLocation(7, 31),
+                // (10,30): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static I1 operator++ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "++").WithArguments("sealed", "7.3", "preview").WithLocation(10, 30),
+                // (10,30): error CS0501: 'I1.operator ++(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed static I1 operator++ (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "++").WithArguments("I1.operator ++(I1)").WithLocation(10, 30),
+                // (13,32): error CS0106: The modifier 'override' is not valid for this item
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "--").WithArguments("override").WithLocation(13, 32),
+                // (13,32): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "--").WithArguments("default interface implementation", "8.0").WithLocation(13, 32),
+                // (13,32): error CS0501: 'I1.operator --(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "--").WithArguments("I1.operator --(I1)").WithLocation(13, 32),
+                // (16,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!").WithArguments("virtual").WithLocation(16, 40),
+                // (16,40): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!").WithArguments("abstract", "7.3", "preview").WithLocation(16, 40),
+                // (19,39): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("sealed").WithLocation(19, 39),
+                // (19,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "~").WithArguments("abstract", "7.3", "preview").WithLocation(19, 39),
+                // (22,41): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("override").WithLocation(22, 41),
+                // (22,41): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "7.3", "preview").WithLocation(22, 41),
+                // (25,38): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(25, 38),
+                // (25,38): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "-").WithArguments("sealed", "7.3", "preview").WithLocation(25, 38),
+                // (25,38): error CS0501: 'I1.operator -(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "-").WithArguments("I1.operator -(I1, I1)").WithLocation(25, 38),
+                // (28,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("virtual").WithLocation(28, 40),
+                // (28,40): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("override").WithLocation(28, 40),
+                // (28,40): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "*").WithArguments("default interface implementation", "8.0").WithLocation(28, 40),
+                // (28,40): error CS0501: 'I1.operator *(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "*").WithArguments("I1.operator *(I1, I1)").WithLocation(28, 40),
+                // (31,39): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "/").WithArguments("override").WithLocation(31, 39),
+                // (31,39): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "/").WithArguments("sealed", "7.3", "preview").WithLocation(31, 39),
+                // (31,39): error CS0501: 'I1.operator /(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "/").WithArguments("I1.operator /(I1, I1)").WithLocation(31, 39)
+                );
+
+            ValidateOperatorModifiers_01(compilation1);
+        }
+
+        [Fact]
+        public void OperatorModifiers_06()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static I1 operator+ (I1 x)
+    {throw null;} 
+
+    virtual static I1 operator- (I1 x)
+    {throw null;} 
+
+    sealed static I1 operator++ (I1 x)
+    {throw null;} 
+
+    override static I1 operator-- (I1 x)
+    {throw null;} 
+
+    abstract virtual static I1 operator! (I1 x)
+    {throw null;} 
+
+    abstract sealed static I1 operator~ (I1 x)
+    {throw null;} 
+
+    abstract override static I1 operator+ (I1 x, I1 y)
+    {throw null;} 
+
+    virtual sealed static I1 operator- (I1 x, I1 y)
+    {throw null;} 
+
+    virtual override static I1 operator* (I1 x, I1 y) 
+    {throw null;} 
+
+    sealed override static I1 operator/ (I1 x, I1 y)
+    {throw null;} 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular7_3,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,32): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract static I1 operator+ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "7.3", "preview").WithLocation(4, 32),
+                // (4,32): error CS0500: 'I1.operator +(I1)' cannot declare a body because it is marked abstract
+                //     abstract static I1 operator+ (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "+").WithArguments("I1.operator +(I1)").WithLocation(4, 32),
+                // (7,31): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(7, 31),
+                // (7,31): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual static I1 operator- (I1 x)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "-").WithArguments("default interface implementation", "8.0").WithLocation(7, 31),
+                // (10,30): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed static I1 operator++ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "++").WithArguments("sealed", "7.3", "preview").WithLocation(10, 30),
+                // (13,32): error CS0106: The modifier 'override' is not valid for this item
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "--").WithArguments("override").WithLocation(13, 32),
+                // (13,32): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     override static I1 operator-- (I1 x)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "--").WithArguments("default interface implementation", "8.0").WithLocation(13, 32),
+                // (16,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!").WithArguments("virtual").WithLocation(16, 40),
+                // (16,40): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!").WithArguments("abstract", "7.3", "preview").WithLocation(16, 40),
+                // (16,40): error CS0500: 'I1.operator !(I1)' cannot declare a body because it is marked abstract
+                //     abstract virtual static I1 operator! (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "!").WithArguments("I1.operator !(I1)").WithLocation(16, 40),
+                // (19,39): error CS0106: The modifier 'sealed' is not valid for this item
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("sealed").WithLocation(19, 39),
+                // (19,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "~").WithArguments("abstract", "7.3", "preview").WithLocation(19, 39),
+                // (19,39): error CS0500: 'I1.operator ~(I1)' cannot declare a body because it is marked abstract
+                //     abstract sealed static I1 operator~ (I1 x)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "~").WithArguments("I1.operator ~(I1)").WithLocation(19, 39),
+                // (22,41): error CS0106: The modifier 'override' is not valid for this item
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("override").WithLocation(22, 41),
+                // (22,41): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "+").WithArguments("abstract", "7.3", "preview").WithLocation(22, 41),
+                // (22,41): error CS0500: 'I1.operator +(I1, I1)' cannot declare a body because it is marked abstract
+                //     abstract override static I1 operator+ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_AbstractHasBody, "+").WithArguments("I1.operator +(I1, I1)").WithLocation(22, 41),
+                // (25,38): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(25, 38),
+                // (25,38): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     virtual sealed static I1 operator- (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "-").WithArguments("sealed", "7.3", "preview").WithLocation(25, 38),
+                // (28,40): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("virtual").WithLocation(28, 40),
+                // (28,40): error CS0106: The modifier 'override' is not valid for this item
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("override").WithLocation(28, 40),
+                // (28,40): error CS8370: Feature 'default interface implementation' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //     virtual override static I1 operator* (I1 x, I1 y) 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "*").WithArguments("default interface implementation", "8.0").WithLocation(28, 40),
+                // (31,39): error CS0106: The modifier 'override' is not valid for this item
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "/").WithArguments("override").WithLocation(31, 39),
+                // (31,39): error CS8703: The modifier 'sealed' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
+                //     sealed override static I1 operator/ (I1 x, I1 y)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "/").WithArguments("sealed", "7.3", "preview").WithLocation(31, 39)
+                );
+
+            ValidateOperatorModifiers_01(compilation1);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void OperatorModifiers_07(bool use7_3)
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static bool operator== (I1 x, I1 y); 
+
+    abstract static bool operator!= (I1 x, I1 y) {return false;} 
+}
+
+public interface I2
+{
+    sealed static bool operator== (I2 x, I2 y) {return false;} 
+
+    sealed static bool operator!= (I2 x, I2 y) {return false;} 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: use7_3 ? TestOptions.Regular7_3 : TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,34): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     abstract static bool operator== (I1 x, I1 y); 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(4, 34),
+                // (6,34): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     abstract static bool operator!= (I1 x, I1 y) {return false;} 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(6, 34),
+                // (11,32): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     sealed static bool operator== (I2 x, I2 y) {return false;} 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(11, 32),
+                // (13,32): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     sealed static bool operator!= (I2 x, I2 y) {return false;} 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(13, 32)
+                );
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void OperatorModifiers_08(bool use7_3)
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static implicit operator int(I1 x); 
+
+    abstract static explicit operator bool(I1 x) {return false;} 
+}
+
+public interface I2
+{
+    sealed static implicit operator int(I2 x) {return 0;} 
+
+    sealed static explicit operator bool(I2 x) {return false;} 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: use7_3 ? TestOptions.Regular7_3 : TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,39): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     abstract static implicit operator int(I1 x); 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(4, 39),
+                // (6,39): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     abstract static explicit operator bool(I1 x) {return false;} 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "bool").WithLocation(6, 39),
+                // (11,37): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     sealed static implicit operator int(I2 x) {return 0;} 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(11, 37),
+                // (13,37): error CS0567: Interfaces cannot contain conversion, equality, or inequality operators
+                //     sealed static explicit operator bool(I2 x) {return false;} 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "bool").WithLocation(13, 37)
+                );
+        }
+
+        [Fact]
+        public void FieldModifiers_01()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static int F1; 
+    sealed static int F2; 
+    abstract int F3; 
+    sealed int F4; 
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,25): error CS0681: The modifier 'abstract' is not valid on fields. Try using a property instead.
+                //     abstract static int F1; 
+                Diagnostic(ErrorCode.ERR_AbstractField, "F1").WithLocation(4, 25),
+                // (5,23): error CS0106: The modifier 'sealed' is not valid for this item
+                //     sealed static int F2; 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "F2").WithArguments("sealed").WithLocation(5, 23),
+                // (6,18): error CS0681: The modifier 'abstract' is not valid on fields. Try using a property instead.
+                //     abstract int F3; 
+                Diagnostic(ErrorCode.ERR_AbstractField, "F3").WithLocation(6, 18),
+                // (6,18): error CS0525: Interfaces cannot contain instance fields
+                //     abstract int F3; 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainFields, "F3").WithLocation(6, 18),
+                // (7,16): error CS0106: The modifier 'sealed' is not valid for this item
+                //     sealed int F4; 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "F4").WithArguments("sealed").WithLocation(7, 16),
+                // (7,16): error CS0525: Interfaces cannot contain instance fields
+                //     sealed int F4; 
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainFields, "F4").WithLocation(7, 16)
+                );
+        }
+
+        [Fact]
+        public void ExternAbstractStatic_01()
+        {
+            var source1 =
+@"
+interface I1
+{
+    extern abstract static void M01();
+    extern abstract static bool P01 { get; }
+    extern abstract static event System.Action E01;
+    extern abstract static I1 operator+ (I1 x);
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,33): error CS0180: 'I1.M01()' cannot be both extern and abstract
+                //     extern abstract static void M01();
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "M01").WithArguments("I1.M01()").WithLocation(4, 33),
+                // (5,33): error CS0180: 'I1.P01' cannot be both extern and abstract
+                //     extern abstract static bool P01 { get; }
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "P01").WithArguments("I1.P01").WithLocation(5, 33),
+                // (6,48): error CS0180: 'I1.E01' cannot be both extern and abstract
+                //     extern abstract static event System.Action E01;
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "E01").WithArguments("I1.E01").WithLocation(6, 48),
+                // (7,39): error CS0180: 'I1.operator +(I1)' cannot be both extern and abstract
+                //     extern abstract static I1 operator+ (I1 x);
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "+").WithArguments("I1.operator +(I1)").WithLocation(7, 39)
+                );
+        }
+
+        [Fact]
+        public void ExternAbstractStatic_02()
+        {
+            var source1 =
+@"
+interface I1
+{
+    extern abstract static void M01() {}
+    extern abstract static bool P01 { get => false; }
+    extern abstract static event System.Action E01 { add {} remove {} }
+    extern abstract static I1 operator+ (I1 x) => null;
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,33): error CS0180: 'I1.M01()' cannot be both extern and abstract
+                //     extern abstract static void M01() {}
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "M01").WithArguments("I1.M01()").WithLocation(4, 33),
+                // (5,33): error CS0180: 'I1.P01' cannot be both extern and abstract
+                //     extern abstract static bool P01 { get => false; }
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "P01").WithArguments("I1.P01").WithLocation(5, 33),
+                // (6,48): error CS0180: 'I1.E01' cannot be both extern and abstract
+                //     extern abstract static event System.Action E01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "E01").WithArguments("I1.E01").WithLocation(6, 48),
+                // (6,52): error CS8712: 'I1.E01': abstract event cannot use event accessor syntax
+                //     extern abstract static event System.Action E01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_AbstractEventHasAccessors, "{").WithArguments("I1.E01").WithLocation(6, 52),
+                // (7,39): error CS0180: 'I1.operator +(I1)' cannot be both extern and abstract
+                //     extern abstract static I1 operator+ (I1 x) => null;
+                Diagnostic(ErrorCode.ERR_AbstractAndExtern, "+").WithArguments("I1.operator +(I1)").WithLocation(7, 39)
+                );
+        }
+
+        [Fact]
+        public void ExternSealedStatic_01()
+        {
+            var source1 =
+@"
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it. Consider adding a DllImport attribute to specify the external implementation.
+
+interface I1
+{
+    extern sealed static void M01();
+    extern sealed static bool P01 { get; }
+    extern sealed static event System.Action E01;
+    extern sealed static I1 operator+ (I1 x);
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void AbstractStaticInClass_01()
+        {
+            var source1 =
+@"
+abstract class C1
+{
+    public abstract static void M01();
+    public abstract static bool P01 { get; }
+    public abstract static event System.Action E01;
+    public abstract static C1 operator+ (C1 x);
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,33): error CS0112: A static member cannot be marked as 'abstract'
+                //     public abstract static void M01();
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M01").WithArguments("abstract").WithLocation(4, 33),
+                // (5,33): error CS0112: A static member cannot be marked as 'abstract'
+                //     public abstract static bool P01 { get; }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P01").WithArguments("abstract").WithLocation(5, 33),
+                // (6,48): error CS0112: A static member cannot be marked as 'abstract'
+                //     public abstract static event System.Action E01;
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "E01").WithArguments("abstract").WithLocation(6, 48),
+                // (7,39): error CS0106: The modifier 'abstract' is not valid for this item
+                //     public abstract static C1 operator+ (C1 x);
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("abstract").WithLocation(7, 39),
+                // (7,39): error CS0501: 'C1.operator +(C1)' must declare a body because it is not marked abstract, extern, or partial
+                //     public abstract static C1 operator+ (C1 x);
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "+").WithArguments("C1.operator +(C1)").WithLocation(7, 39)
+                );
+        }
+
+        [Fact]
+        public void SealedStaticInClass_01()
+        {
+            var source1 =
+@"
+class C1
+{
+    sealed static void M01() {}
+    sealed static bool P01 { get => false; }
+    sealed static event System.Action E01 { add {} remove {} }
+    public sealed static C1 operator+ (C1 x) => null;
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,24): error CS0238: 'C1.M01()' cannot be sealed because it is not an override
+                //     sealed static void M01() {}
+                Diagnostic(ErrorCode.ERR_SealedNonOverride, "M01").WithArguments("C1.M01()").WithLocation(4, 24),
+                // (5,24): error CS0238: 'C1.P01' cannot be sealed because it is not an override
+                //     sealed static bool P01 { get => false; }
+                Diagnostic(ErrorCode.ERR_SealedNonOverride, "P01").WithArguments("C1.P01").WithLocation(5, 24),
+                // (6,39): error CS0238: 'C1.E01' cannot be sealed because it is not an override
+                //     sealed static event System.Action E01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_SealedNonOverride, "E01").WithArguments("C1.E01").WithLocation(6, 39),
+                // (7,37): error CS0106: The modifier 'sealed' is not valid for this item
+                //     public sealed static C1 operator+ (C1 x) => null;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("sealed").WithLocation(7, 37)
+                );
+        }
+
+        [Fact]
+        public void AbstractStaticInStruct_01()
+        {
+            var source1 =
+@"
+struct C1
+{
+    public abstract static void M01();
+    public abstract static bool P01 { get; }
+    public abstract static event System.Action E01;
+    public abstract static C1 operator+ (C1 x);
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,33): error CS0112: A static member cannot be marked as 'abstract'
+                //     public abstract static void M01();
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "M01").WithArguments("abstract").WithLocation(4, 33),
+                // (5,33): error CS0112: A static member cannot be marked as 'abstract'
+                //     public abstract static bool P01 { get; }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P01").WithArguments("abstract").WithLocation(5, 33),
+                // (6,48): error CS0112: A static member cannot be marked as 'abstract'
+                //     public abstract static event System.Action E01;
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "E01").WithArguments("abstract").WithLocation(6, 48),
+                // (7,39): error CS0106: The modifier 'abstract' is not valid for this item
+                //     public abstract static C1 operator+ (C1 x);
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("abstract").WithLocation(7, 39),
+                // (7,39): error CS0501: 'C1.operator +(C1)' must declare a body because it is not marked abstract, extern, or partial
+                //     public abstract static C1 operator+ (C1 x);
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "+").WithArguments("C1.operator +(C1)").WithLocation(7, 39)
+                );
+        }
+
+        [Fact]
+        public void SealedStaticInstruct_01()
+        {
+            var source1 =
+@"
+class C1
+{
+    sealed static void M01() {}
+    sealed static bool P01 { get => false; }
+    sealed static event System.Action E01 { add {} remove {} }
+    public sealed static C1 operator+ (C1 x) => null;
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+
+            compilation1.VerifyDiagnostics(
+                // (4,24): error CS0238: 'C1.M01()' cannot be sealed because it is not an override
+                //     sealed static void M01() {}
+                Diagnostic(ErrorCode.ERR_SealedNonOverride, "M01").WithArguments("C1.M01()").WithLocation(4, 24),
+                // (5,24): error CS0238: 'C1.P01' cannot be sealed because it is not an override
+                //     sealed static bool P01 { get => false; }
+                Diagnostic(ErrorCode.ERR_SealedNonOverride, "P01").WithArguments("C1.P01").WithLocation(5, 24),
+                // (6,39): error CS0238: 'C1.E01' cannot be sealed because it is not an override
+                //     sealed static event System.Action E01 { add {} remove {} }
+                Diagnostic(ErrorCode.ERR_SealedNonOverride, "E01").WithArguments("C1.E01").WithLocation(6, 39),
+                // (7,37): error CS0106: The modifier 'sealed' is not valid for this item
+                //     public sealed static C1 operator+ (C1 x) => null;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "+").WithArguments("sealed").WithLocation(7, 37)
+                );
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -1075,6 +1075,7 @@ partial interface I1
             Assert.Null(i1.FindImplementationForInterfaceMember(m01));
 
             Assert.True(m01.IsPartialDefinition());
+            Assert.Same(m01, m01.PartialImplementationPart.PartialDefinitionPart);
 
             m01 = m01.PartialImplementationPart;
 
@@ -1214,6 +1215,7 @@ partial interface I1
             Assert.Null(i1.FindImplementationForInterfaceMember(m01));
 
             Assert.True(m01.IsPartialDefinition());
+            Assert.Same(m01, m01.PartialImplementationPart.PartialDefinitionPart);
 
             m01 = m01.PartialImplementationPart;
 
@@ -1268,6 +1270,7 @@ partial interface I1
             Assert.Null(i1.FindImplementationForInterfaceMember(m01));
 
             Assert.True(m01.IsPartialDefinition());
+            Assert.Same(m01, m01.PartialImplementationPart.PartialDefinitionPart);
 
             m01 = m01.PartialImplementationPart;
 
@@ -1325,6 +1328,7 @@ partial interface I1
             Assert.Null(i1.FindImplementationForInterfaceMember(m01));
 
             Assert.True(m01.IsPartialDefinition());
+            Assert.Same(m01, m01.PartialImplementationPart.PartialDefinitionPart);
 
             m01 = m01.PartialImplementationPart;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -1766,9 +1766,6 @@ class C
                 // (3,23): error CS8503: The modifier 'public' is not valid for this item in C# 7. Please use language version '8.0' or greater.
                 //     public static int P1 { get; }
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P1").WithArguments("public", "7.0", "8.0").WithLocation(3, 23),
-                // (3,28): error CS8652: The feature 'default interface implementation' is not available in C# 7. Please use language version 8.0 or greater.
-                //     public static int P1 { get; }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "get").WithArguments("default interface implementation", "8.0").WithLocation(3, 28),
                 // (4,18): error CS8503: The modifier 'abstract' is not valid for this item in C# 7. Please use language version '8.0' or greater.
                 //     abstract int P2 { static set; }
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "P2").WithArguments("abstract", "7.0", "8.0").WithLocation(4, 18),
@@ -2082,8 +2079,17 @@ interface I<T>
     }
 }
 ";
-            var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
-                new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 9, Column = 37 });
+            CreateCompilation(text, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+                // (7,18): error CS0534: 'MyClass2' does not implement inherited abstract member 'MyClass.MyMethod()'
+                //     public class MyClass2 : MyClass
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "MyClass2").WithArguments("MyNamespace.MyClass2", "MyNamespace.MyClass.MyMethod()").WithLocation(7, 18),
+                // (9,37): error CS0112: A static member cannot be marked as 'override'
+                //         override public static void MyMethod()   // CS0112, remove static keyword
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "MyMethod").WithArguments("override").WithLocation(9, 37),
+                // (9,37): warning CS0114: 'MyClass2.MyMethod()' hides inherited member 'MyClass.MyMethod()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+                //         override public static void MyMethod()   // CS0112, remove static keyword
+                Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "MyMethod").WithArguments("MyNamespace.MyClass2.MyMethod()", "MyNamespace.MyClass.MyMethod()").WithLocation(9, 37)
+                );
         }
 
         [Fact]
@@ -2103,24 +2109,30 @@ class B : A
 ";
             var tree = Parse(text, options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
             CreateCompilation(tree).VerifyDiagnostics(
-    // (78): error CS0112: A static member 'B.P' cannot be marked as override, virtual, or abstract
-    //     protected static override object P { get { return null; } }
-    Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P").WithArguments("B.P").WithLocation(7, 38),
-    // (8,34): error CS0112: A static member 'B.Q' cannot be marked as override, virtual, or abstract
-    //     public static virtual object Q { get; }
-    Diagnostic(ErrorCode.ERR_StaticNotVirtual, "Q").WithArguments("B.Q").WithLocation(8, 34),
-    // (8,34): error CS8026: Feature 'readonly automatically implemented properties' is not available in C# 5. Please use language version 6 or greater.
-    //     public static virtual object Q { get; }
-    Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, "Q").WithArguments("readonly automatically implemented properties", "6").WithLocation(8, 34),
-    // (9,37): error CS0112: A static member 'B.R' cannot be marked as override, virtual, or abstract
-    //     internal static abstract object R { get; set; }
-    Diagnostic(ErrorCode.ERR_StaticNotVirtual, "R").WithArguments("B.R").WithLocation(9, 37),
-    // (9,41): error CS0513: 'B.R.get' is abstract but it is contained in non-abstract type 'B'
-    //     internal static abstract object R { get; set; }
-    Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "get").WithArguments("B.R.get", "B").WithLocation(9, 41),
-    // (9,46): error CS0513: 'B.R.set' is abstract but it is contained in non-abstract type 'B'
-    //     internal static abstract object R { get; set; }
-    Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "set").WithArguments("B.R.set", "B").WithLocation(9, 46));
+                // (5,7): error CS0534: 'B' does not implement inherited abstract member 'A.P.get'
+                // class B : A
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "B").WithArguments("B", "A.P.get").WithLocation(5, 7),
+                // (7,38): error CS0112: A static member cannot be marked as 'override'
+                //     protected static override object P { get { return null; } }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P").WithArguments("override").WithLocation(7, 38),
+                // (7,38): warning CS0114: 'B.P' hides inherited member 'A.P'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+                //     protected static override object P { get { return null; } }
+                Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "P").WithArguments("B.P", "A.P").WithLocation(7, 38),
+                // (8,34): error CS0112: A static member cannot be marked as 'virtual'
+                //     public static virtual object Q { get; }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "Q").WithArguments("virtual").WithLocation(8, 34),
+                // (8,34): error CS8026: Feature 'readonly automatically implemented properties' is not available in C# 5. Please use language version 6 or greater.
+                //     public static virtual object Q { get; }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion5, "Q").WithArguments("readonly automatically implemented properties", "6").WithLocation(8, 34),
+                // (9,37): error CS0112: A static member cannot be marked as 'abstract'
+                //     internal static abstract object R { get; set; }
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "R").WithArguments("abstract").WithLocation(9, 37),
+                // (9,41): error CS0513: 'B.R.get' is abstract but it is contained in non-abstract type 'B'
+                //     internal static abstract object R { get; set; }
+                Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "get").WithArguments("B.R.get", "B").WithLocation(9, 41),
+                // (9,46): error CS0513: 'B.R.set' is abstract but it is contained in non-abstract type 'B'
+                //     internal static abstract object R { get; set; }
+                Diagnostic(ErrorCode.ERR_AbstractInConcreteClass, "set").WithArguments("B.R.set", "B").WithLocation(9, 46));
         }
 
         [Fact]
@@ -2138,12 +2150,29 @@ abstract class B : A
     internal static abstract event System.Action R;
 }
 ";
-            var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
-                new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 7, Column = 51 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 8, Column = 47 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 9, Column = 50 },
-                new ErrorDescription { Code = (int)ErrorCode.WRN_UnreferencedEvent, Line = 7, Column = 51, IsWarning = true },
-                new ErrorDescription { Code = (int)ErrorCode.WRN_UnreferencedEvent, Line = 8, Column = 47, IsWarning = true });
+            CreateCompilation(text, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+                // (7,51): error CS0112: A static member cannot be marked as 'override'
+                //     protected static override event System.Action P;
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "P").WithArguments("override").WithLocation(7, 51),
+                // (7,51): error CS0533: 'B.P' hides inherited abstract member 'A.P'
+                //     protected static override event System.Action P;
+                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "P").WithArguments("B.P", "A.P").WithLocation(7, 51),
+                // (7,51): warning CS0114: 'B.P' hides inherited member 'A.P'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+                //     protected static override event System.Action P;
+                Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "P").WithArguments("B.P", "A.P").WithLocation(7, 51),
+                // (7,51): warning CS0067: The event 'B.P' is never used
+                //     protected static override event System.Action P;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "P").WithArguments("B.P").WithLocation(7, 51),
+                // (8,47): error CS0112: A static member cannot be marked as 'virtual'
+                //     public static virtual event System.Action Q;
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "Q").WithArguments("virtual").WithLocation(8, 47),
+                // (8,47): warning CS0067: The event 'B.Q' is never used
+                //     public static virtual event System.Action Q;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Q").WithArguments("B.Q").WithLocation(8, 47),
+                // (9,50): error CS0112: A static member cannot be marked as 'abstract'
+                //     internal static abstract event System.Action R;
+                Diagnostic(ErrorCode.ERR_StaticNotVirtual, "R").WithArguments("abstract").WithLocation(9, 50)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
Spec: https://github.com/dotnet/csharplang/blob/9a0dddbf0643993db0da8f48436f2aac60bc20b1/proposals/statics-in-interfaces.md

Related to #52202.

Relevant quotes from the spec:

#### Abstract virtual members
Static interface members other than fields are allowed to also have the `abstract` modifier. Abstract static members are not allowed to have a body (or in the case of properties, the accessors are not allowed to have a body). 

``` c#
interface I<T> where T : I<T>
{
    static abstract void M();
    static abstract T P { get; set; }
    static abstract event Action E;
    static abstract T operator +(T l, T r);
}
```

#### Explicitly non-virtual static members
For symmetry with non-virtual instance members, static members should be allowed an optional `sealed` modifier, even though they are non-virtual by default:

``` c#
interface I0
{
    static sealed void M() => Console.WriteLine("Default behavior");
    
    static sealed int f = 0;
    
    static sealed int P1 { get; set; }
    static sealed int P2 { get => f; set => f = value; }
    
    static sealed event Action E1;
    static sealed event Action E2 { add => E1 += value; remove => E1 -= value; }
    
    static sealed I0 operator +(I0 l, I0 r) => l;
}
```