### PR TITLE
Simplify and fix baseline reader disposal

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -314,11 +314,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             var editSession = _editSession;
             Contract.ThrowIfNull(editSession);
 
-            var pendingUpdate = editSession.RetrievePendingUpdate();
-            foreach (var moduleReader in pendingUpdate.ModuleReaders)
-            {
-                moduleReader.Dispose();
-            }
+            _ = editSession.RetrievePendingUpdate();
         }
 
         public async ValueTask<ImmutableArray<ImmutableArray<(LinePositionSpan, ActiveStatementFlags)>>> GetBaseActiveStatementSpansAsync(Solution solution, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -755,10 +755,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 using var _1 = ArrayBuilder<ManagedModuleUpdate>.GetInstance(out var deltas);
                 using var _2 = ArrayBuilder<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)>.GetInstance(out var nonRemappableRegions);
                 using var _3 = ArrayBuilder<(ProjectId, EmitBaseline)>.GetInstance(out var emitBaselines);
-                using var _4 = ArrayBuilder<IDisposable>.GetInstance(out var readers);
-                using var _5 = ArrayBuilder<(ProjectId, ImmutableArray<Diagnostic>)>.GetInstance(out var diagnostics);
-                using var _6 = ArrayBuilder<Document>.GetInstance(out var changedOrAddedDocuments);
-                using var _7 = ArrayBuilder<(DocumentId, ImmutableArray<RudeEditDiagnostic>)>.GetInstance(out var documentsWithRudeEdits);
+                using var _4 = ArrayBuilder<(ProjectId, ImmutableArray<Diagnostic>)>.GetInstance(out var diagnostics);
+                using var _5 = ArrayBuilder<Document>.GetInstance(out var changedOrAddedDocuments);
+                using var _6 = ArrayBuilder<(DocumentId, ImmutableArray<RudeEditDiagnostic>)>.GetInstance(out var documentsWithRudeEdits);
 
                 var oldSolution = DebuggingSession.LastCommittedSolution;
 
@@ -855,7 +854,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         continue;
                     }
 
-                    if (!DebuggingSession.TryGetOrCreateEmitBaseline(newProject, readers, out var createBaselineDiagnostics, out var baseline))
+                    if (!DebuggingSession.TryGetOrCreateEmitBaseline(newProject, out var createBaselineDiagnostics, out var baseline))
                     {
                         Debug.Assert(!createBaselineDiagnostics.IsEmpty);
 
@@ -962,11 +961,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (isBlocked)
                 {
-                    foreach (var reader in readers)
-                    {
-                        reader.Dispose();
-                    }
-
                     return SolutionUpdate.Blocked(diagnostics.ToImmutable(), documentsWithRudeEdits.ToImmutable());
                 }
 
@@ -975,7 +969,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         (deltas.Count > 0) ? ManagedModuleUpdateStatus.Ready : ManagedModuleUpdateStatus.None,
                         deltas.ToImmutable()),
                     nonRemappableRegions.ToImmutable(),
-                    readers.ToImmutable(),
+
                     emitBaselines.ToImmutable(),
                     diagnostics.ToImmutable(),
                     documentsWithRudeEdits.ToImmutable());
@@ -1131,8 +1125,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 solution,
                 update.EmitBaselines,
                 update.ModuleUpdates.Updates,
-                update.NonRemappableRegions,
-                update.ModuleReaders));
+                update.NonRemappableRegions));
 
             // commit/discard was not called:
             Contract.ThrowIfFalse(previousPendingUpdate == null);

--- a/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
@@ -15,20 +15,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public readonly ImmutableArray<(ProjectId ProjectId, EmitBaseline Baseline)> EmitBaselines;
         public readonly ImmutableArray<ManagedModuleUpdate> Deltas;
         public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)> Regions)> NonRemappableRegions;
-        public readonly ImmutableArray<IDisposable> ModuleReaders;
 
         public PendingSolutionUpdate(
             Solution solution,
             ImmutableArray<(ProjectId ProjectId, EmitBaseline Baseline)> emitBaselines,
             ImmutableArray<ManagedModuleUpdate> deltas,
-            ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
-            ImmutableArray<IDisposable> moduleReaders)
+            ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions)
         {
             Solution = solution;
             EmitBaselines = emitBaselines;
             Deltas = deltas;
             NonRemappableRegions = nonRemappableRegions;
-            ModuleReaders = moduleReaders;
         }
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     {
         public readonly ManagedModuleUpdates ModuleUpdates;
         public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> NonRemappableRegions;
-        public readonly ImmutableArray<IDisposable> ModuleReaders;
         public readonly ImmutableArray<(ProjectId ProjectId, EmitBaseline Baseline)> EmitBaselines;
         public readonly ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostic)> Diagnostics;
         public readonly ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> DocumentsWithRudeEdits;
@@ -21,7 +20,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public SolutionUpdate(
             ManagedModuleUpdates moduleUpdates,
             ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
-            ImmutableArray<IDisposable> moduleReaders,
             ImmutableArray<(ProjectId ProjectId, EmitBaseline Baseline)> emitBaselines,
             ImmutableArray<(ProjectId ProjectId, ImmutableArray<Diagnostic> Diagnostics)> diagnostics,
             ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> documentsWithRudeEdits)
@@ -29,7 +27,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ModuleUpdates = moduleUpdates;
             NonRemappableRegions = nonRemappableRegions;
             EmitBaselines = emitBaselines;
-            ModuleReaders = moduleReaders;
             Diagnostics = diagnostics;
             DocumentsWithRudeEdits = documentsWithRudeEdits;
         }
@@ -40,7 +37,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             => new(
                 new(ManagedModuleUpdateStatus.Blocked, ImmutableArray<ManagedModuleUpdate>.Empty),
                 ImmutableArray<(Guid, ImmutableArray<(ManagedModuleMethodId, NonRemappableRegion)>)>.Empty,
-                ImmutableArray<IDisposable>.Empty,
                 ImmutableArray<(ProjectId, EmitBaseline)>.Empty,
                 diagnostics,
                 documentsWithRudeEdits);

--- a/src/Workspaces/Remote/ServiceHub/Services/Host/ThrowingTraceListener.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Host/ThrowingTraceListener.cs
@@ -21,7 +21,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
             }
 
-            throw new InvalidOperationException(message + Environment.NewLine + detailMessage);
+            throw new InvalidOperationException(
+                (string.IsNullOrEmpty(message) ? "Assertion failed" : message) +
+                (string.IsNullOrEmpty(detailMessage) ? "" : Environment.NewLine + detailMessage));
         }
 
         public override void Write(object o)


### PR DESCRIPTION
In rare cases, when the debugger fails to apply an EnC change and has to discard it, we released baseline readers prematurely. This can cause AV or reading invalid metadata.