### PR TITLE
Fix caret affinity in GetReferencedSymbolsToLeftOfCaretAsync

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -495,17 +495,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 iEndIndex = endIndex
             };
 
+            if (TryInsertArgumentCompletionSnippet(triggerSpan, dataBufferSpan, expansion, textSpan, cancellationToken))
+            {
+                Debug.Assert(_state.IsFullMethodCallSnippet);
+                return true;
+            }
+
             if (expansion.InsertExpansion(textSpan, textSpan, this, LanguageServiceGuid, out _state._expansionSession) == VSConstants.S_OK)
             {
                 // This expansion is not derived from a symbol, so make sure the state isn't tracking any symbol
                 // information
                 Debug.Assert(!_state.IsFullMethodCallSnippet);
-                return true;
-            }
-
-            if (TryInsertArgumentCompletionSnippet(triggerSpan, dataBufferSpan, expansion, textSpan, cancellationToken))
-            {
-                Debug.Assert(_state.IsFullMethodCallSnippet);
                 return true;
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -479,7 +479,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             }
 
             var buffer = EditorAdaptersFactoryService.GetBufferAdapter(textViewModel.DataBuffer);
-            if (buffer == null || !(buffer is IVsExpansion expansion))
+            if (buffer is not IVsExpansion expansion)
             {
                 return false;
             }
@@ -503,6 +503,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 return true;
             }
 
+            if (TryInsertArgumentCompletionSnippet(triggerSpan, dataBufferSpan, expansion, textSpan, cancellationToken))
+            {
+                Debug.Assert(_state.IsFullMethodCallSnippet);
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryInsertArgumentCompletionSnippet(SnapshotSpan triggerSpan, SnapshotSpan dataBufferSpan, IVsExpansion expansion, VsTextSpan textSpan, CancellationToken cancellationToken)
+        {
             if (!(SubjectBuffer.GetFeatureOnOffOption(CompletionOptions.EnableArgumentCompletionSnippets) ?? false))
             {
                 // Argument completion snippets are not enabled

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -722,7 +722,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var token = await semanticModel.SyntaxTree.GetTouchingTokenAsync(caretPosition.Position, cancellationToken).ConfigureAwait(false);
+
+            // GetTouchingTokenAsync prefers to return tokens to the right of the caret. Adjust the caret position one
+            // to the left to avoid this.
+            if (caretPosition.Position == 0)
+                return ImmutableArray<ISymbol>.Empty;
+
+            var token = await semanticModel.SyntaxTree.GetTouchingTokenAsync(caretPosition.Position - 1, cancellationToken).ConfigureAwait(false);
             var semanticInfo = semanticModel.GetSemanticInfo(token, document.Project.Solution.Workspace, cancellationToken);
             return semanticInfo.ReferencedSymbols;
         }

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -541,7 +541,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                     if (expansion.InsertSpecificExpansion(doc, textSpan, this, LanguageServiceGuid, pszRelativePath: null, out _state._expansionSession) == VSConstants.S_OK)
                     {
                         Debug.Assert(_state._expansionSession != null);
-                        _state._methodNameForInsertFullMethodCall = methodName;
+                        _state._methodNameForInsertFullMethodCall = methodSymbols.First().Name;
                         Debug.Assert(_state._method == null);
 
                         if (_signatureHelpControllerProvider.GetController(TextView, SubjectBuffer) is { } controller)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -58,6 +58,29 @@ public class Test
         }
 
         [WpfFact]
+        public void TabTabCompleteObjectEquals()
+        {
+            SetUpEditor(@"
+public class Test
+{
+    public void Method()
+    {
+        $$
+    }
+}
+");
+
+            VisualStudio.Editor.SendKeys("object.Equ");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("object.Equals$$", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("object.Equals(null$$)", assertCaretPosition: true);
+        }
+
+        [WpfFact]
         public void TabTabBeforeSemicolon()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -81,6 +81,32 @@ public class Test
         }
 
         [WpfFact]
+        public void TabTabCompleteNewObject()
+        {
+            SetUpEditor(@"
+public class Test
+{
+    public void Method()
+    {
+        var value = $$
+    }
+}
+");
+
+            VisualStudio.Editor.SendKeys("new obje");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("var value = new object$$", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("var value = new object($$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("var value = new object()$$", assertCaretPosition: true);
+        }
+
+        [WpfFact]
         public void TabTabBeforeSemicolon()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -58,6 +58,34 @@ public class Test
         }
 
         [WpfFact]
+        public void TabTabBeforeSemicolon()
+        {
+            SetUpEditor(@"
+public class Test
+{
+    private object f;
+
+    public void Method()
+    {
+        $$;
+    }
+}
+");
+
+            VisualStudio.Editor.SendKeys("f.ToSt");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("f.ToString$$;", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("f.ToString($$);", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("f.ToString()$$;", assertCaretPosition: true);
+        }
+
+        [WpfFact]
         public void TabTabCompletionWithArguments()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicArgumentProvider.cs
@@ -56,6 +56,27 @@ End Class
         }
 
         [WpfFact]
+        public void TabTabCompleteObjectEquals()
+        {
+            SetUpEditor(@"
+Public Class Test
+    Public Sub Method()
+        $$
+    End Sub
+End Class
+");
+
+            VisualStudio.Editor.SendKeys("Object.Equ");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("Object.Equals$$", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("Object.Equals(Nothing$$)", assertCaretPosition: true);
+        }
+
+        [WpfFact]
         public void TabTabCompletionWithArguments()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicArgumentProvider.cs
@@ -77,6 +77,30 @@ End Class
         }
 
         [WpfFact]
+        public void TabTabCompleteNewObject()
+        {
+            SetUpEditor(@"
+Public Class Test
+    Public Sub Method()
+        Dim value = $$
+    End Sub
+End Class
+");
+
+            VisualStudio.Editor.SendKeys("New Obje");
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("Dim value = New Object$$", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.SignatureHelp);
+            VisualStudio.Editor.Verify.CurrentLineText("Dim value = New Object($$)", assertCaretPosition: true);
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Tab);
+            VisualStudio.Editor.Verify.CurrentLineText("Dim value = New Object()$$", assertCaretPosition: true);
+        }
+
+        [WpfFact]
         public void TabTabCompletionWithArguments()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
@@ -177,6 +178,29 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 LoadRoslynPackage();
                 _visualStudioWorkspace.TestHookPartialSolutionsDisabled = true;
             });
+
+        /// <summary>
+        /// Reset options that are manipulated by integration tests back to their default values.
+        /// </summary>
+        public void ResetOptions()
+        {
+            ResetOption(CompletionOptions.EnableArgumentCompletionSnippets);
+            return;
+
+            // Local function
+            void ResetOption(IOption option)
+            {
+                if (option is IPerLanguageOption)
+                {
+                    SetOption(new OptionKey(option, LanguageNames.CSharp), option.DefaultValue);
+                    SetOption(new OptionKey(option, LanguageNames.VisualBasic), option.DefaultValue);
+                }
+                else
+                {
+                    SetOption(new OptionKey(option), option.DefaultValue);
+                }
+            }
+        }
 
         public void CleanUpWaitingService()
             => InvokeOnUIThread(cancellationToken =>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -56,6 +56,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void CleanUpWorkspace()
             => _inProc.CleanUpWorkspace();
 
+        public void ResetOptions()
+            => _inProc.ResetOptions();
+
         public void CleanUpWaitingService()
             => _inProc.CleanUpWaitingService();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -15,7 +15,6 @@ using EnvDTE;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature;
 using Process = System.Diagnostics.Process;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities
@@ -235,6 +234,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             // Prevent the start page from showing after each solution closes
             StartPage.SetEnabled(false);
+            Workspace.ResetOptions();
         }
 
         public void Close(bool exitHostProcess = true)


### PR DESCRIPTION
Currently argument completion does not work for the following scenario:

```csharp
await MethodAsync();
```

1. Place the caret before `;`
2. Type `ConfigureAwait`
3. Press <kbd>Tab</kbd>, <kbd>Tab</kbd>

This change fixes caret affinity to allow it to work.

---

There are now two additional bug fixes in this pull request:

1. It is now possible to use argument completion when calling `object.Equals` (previously the code would insert the `Equals` snippet, which made no sense at this location)
2. It is now possible to use argument completion for constructor calls (previously the code would fail to recognize that constructors have the name `.ctor`, and dismiss the session before providing arguments)