### PR TITLE
Pass CancellationTokens in the Interactive layer

### DIFF
--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                     return new InitializedRemoteService(remoteService, result);
                 }
-                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
                 {
                     throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -123,7 +123,12 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                     return new InitializedRemoteService(remoteService, result);
                 }
-                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
+                // await ExecuteRemoteAsync above does not take cancellationToken
+                // - we don't currently support cancellation of the RPC call,
+                // but JsonRpc.InvokeAsync that we use still claims it may throw OperationCanceledException..
+                catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+#pragma warning restore CA2016
                 {
                     throw ExceptionUtilities.Unreachable;
                 }


### PR DESCRIPTION
Redo of https://github.com/dotnet/roslyn/pull/52247

This cleans up passing cancellation tokens in the interactive layer