### PR TITLE
Pass CancellationToken in compilers layer

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2360,7 +2360,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             else if (info.Kind == SyntaxKind.ExternAliasDirective)
                             {
                                 // Record targets of used extern aliases
-                                var node = info.Tree.GetRoot().FindToken(info.Span.Start, findInsideTrivia: false).
+                                var node = info.Tree.GetRoot(cancellationToken).FindToken(info.Span.Start, findInsideTrivia: false).
                                                Parent!.FirstAncestorOrSelf<ExternAliasDirectiveSyntax>();
 
                                 if (node is object && GetExternAliasTarget(node.Identifier.ValueText, out NamespaceSymbol target))

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
             {
                 return GetOperationCore(node, cancellationToken);
             }
-            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
                 // Log a Non-fatal-watson and then ignore the crash in the attempt of getting operation
                 Debug.Assert(false, "\n" + e.ToString());

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     OnCompilationEventsGenerated_NoLock(getCompilationEvents(eventQueue, additionalFiles));
                 }
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1408,7 +1408,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     await ProcessEventAsync(completedEvent, analysisScope, analysisState, cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1467,7 +1467,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 return completedEvent;
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -2687,7 +2687,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     return GetOperationsToAnalyze(operationBlocksToAnalyze);
                 }
-                catch (Exception ex) when (ex is InsufficientExecutionStackException || FatalError.ReportAndCatchUnlessCanceled(ex))
+                catch (Exception ex) when (ex is InsufficientExecutionStackException || FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))
                 {
                     // the exception filter will short-circuit if `ex` is `InsufficientExecutionStackException` (from OperationWalker)
                     // and no non-fatal-watson will be logged as a result.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -593,7 +593,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getPendingEventsOpt: null, taskToken, cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -868,7 +868,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     FreeDriver(driver);
                 }
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -961,7 +961,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1008,7 +1008,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     }
                 }
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1138,7 +1138,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     await WaitForExecutingTaskAsync(executingTreeTask.Item1, alwaysYield: true).ConfigureAwait(false);
                 }
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }
@@ -1356,7 +1356,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var executionTime = GetAnalyzerExecutionTime(analyzer);
                 return new AnalyzerTelemetryInfo(actionCounts, suppressionActionCounts, executionTime);
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 Debug.Assert(controlFlowGraph.OriginalOperation == operation);
                 return controlFlowGraph;
             }
-            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
                 // Log a Non-fatal-watson and then ignore the crash in the attempt of getting flow graph.
                 Debug.Assert(false, "\n" + e.ToString());

--- a/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
+++ b/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     getSymbol As Boolean,
                                                     builder As ArrayBuilder(Of DeclarationInfo),
                                                     cancellationToken As CancellationToken)
-            ComputeDeclarationsCore(model, model.SyntaxTree.GetRoot(),
+            ComputeDeclarationsCore(model, model.SyntaxTree.GetRoot(cancellationToken),
                                     Function(node, level) Not node.Span.OverlapsWith(span) OrElse InvalidLevel(level),
                                     getSymbol, builder, Nothing, cancellationToken)
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/UnprocessedDocumentationCommentFinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/UnprocessedDocumentationCommentFinder.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Public Shared Sub ReportUnprocessed(tree As SyntaxTree, filterSpanWithinTree As TextSpan?, diagnostics As DiagnosticBag, cancellationToken As CancellationToken)
                     If tree.ReportDocumentationCommentDiagnostics() Then
                         Dim finder As New MislocatedDocumentationCommentFinder(diagnostics, filterSpanWithinTree, cancellationToken)
-                        finder.Visit(tree.GetRoot())
+                        finder.Visit(tree.GetRoot(cancellationToken))
                     End If
                 End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -2399,7 +2399,7 @@ _Default:
             Dim tupleTypeSyntax = TryCast(elementSyntax.Parent, TupleTypeSyntax)
 
             If tupleTypeSyntax IsNot Nothing Then
-                Return TryCast(GetSymbolInfo(tupleTypeSyntax).Symbol, TupleTypeSymbol)?.TupleElements.ElementAtOrDefault(tupleTypeSyntax.Elements.IndexOf(elementSyntax))
+                Return TryCast(GetSymbolInfo(tupleTypeSyntax, cancellationToken).Symbol, TupleTypeSymbol)?.TupleElements.ElementAtOrDefault(tupleTypeSyntax.Elements.IndexOf(elementSyntax))
             End If
 
             Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -988,7 +988,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 Case SyntaxKind.CompilationUnit
                                     namespaceToLookInForImplicitType = Me._sourceModule.RootNamespace
                                 Case SyntaxKind.NamespaceBlock
-                                    namespaceToLookInForImplicitType = GetDeclaredSymbol(DirectCast(statementSyntax.Parent, NamespaceBlockSyntax))
+                                    namespaceToLookInForImplicitType = GetDeclaredSymbol(DirectCast(statementSyntax.Parent, NamespaceBlockSyntax), cancellationToken)
                             End Select
 
                             If namespaceToLookInForImplicitType IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
@@ -480,7 +480,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 Dim currentTree = syntaxRef.SyntaxTree
-                Dim node As VisualBasicSyntaxNode = syntaxRef.GetVisualBasicSyntax()
+                Dim node As VisualBasicSyntaxNode = syntaxRef.GetVisualBasicSyntax(cancellationToken)
                 Select Case node.Kind
                     Case SyntaxKind.IdentifierName
                         ValidateNamespaceNameSyntax(DirectCast(node, IdentifierNameSyntax), diagnostics, reportedNamespaceMismatch)

--- a/src/Compilers/VisualBasic/Portable/Syntax/BeginOfBlockSyntaxReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/BeginOfBlockSyntaxReference.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Protected Overrides Function Translate(reference As SyntaxReference, cancellationToken As CancellationToken) As SyntaxNode
-            Return SyntaxFacts.BeginOfBlockStatementIfAny(reference.GetSyntax())
+            Return SyntaxFacts.BeginOfBlockStatementIfAny(reference.GetSyntax(cancellationToken))
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Syntax/NamespaceDeclarationSyntaxReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/NamespaceDeclarationSyntaxReference.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Protected Overrides Function Translate(reference As SyntaxReference, cancellationToken As CancellationToken) As SyntaxNode
-            Dim node = reference.GetSyntax()
+            Dim node = reference.GetSyntax(cancellationToken)
 
             ' If the node is a name syntax, it's something like "X" or "X.Y" in :
             '    Namespace X.Y.Z


### PR DESCRIPTION
Redo of https://github.com/dotnet/roslyn/pull/52247

This cleans up passing cancellation tokens in the compiler layer