### PR TITLE
Enforce passing CancellationTokens were present

### DIFF
--- a/eng/config/globalconfigs/Shipping.globalconfig
+++ b/eng/config/globalconfigs/Shipping.globalconfig
@@ -4,3 +4,6 @@ dotnet_diagnostic.CA1802.severity = warning
 dotnet_diagnostic.CA2007.severity = warning
 
 dotnet_diagnostic.RS0005.severity = warning
+
+# CA2016: Forward the 'CancellationToken' parameter to methods
+dotnet_diagnostic.CA2016.severity = warning

--- a/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             // Then the type is not-apparent, and we should not use var if the user only wants
             // it for apparent types
 
-            var local = (ILocalSymbol)semanticModel.GetDeclaredSymbol(declarator);
+            var local = (ILocalSymbol)semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
             var newType = GenerateTypeSyntaxOrVar(local.Type, options);
 
             var declarationExpression = GetDeclarationExpression(
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                 }
 
                 var updatedInvocationOrCreation = updatedTopmostContainer.GetAnnotatedNodes(annotation).Single();
-                var updatedSymbolInfo = speculativeModel.GetSymbolInfo(updatedInvocationOrCreation);
+                var updatedSymbolInfo = speculativeModel.GetSymbolInfo(updatedInvocationOrCreation, cancellationToken);
 
                 if (!SymbolEquivalenceComparer.Instance.Equals(previousSymbol, updatedSymbolInfo.Symbol))
                 {

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -964,7 +964,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
 
                 return null;
             }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
             }


### PR DESCRIPTION
Depends on the following PRs being merged for CI to pass
- [x] https://github.com/dotnet/roslyn/pull/52281 Pass CancellationToken in Compilers layer
- [x] https://github.com/dotnet/roslyn/pull/52279 Pass CancellationToken at the Analyzers layer 
- [x] https://github.com/dotnet/roslyn/pull/52277 Pass CancellationTokens in the Interactive layer
- [x] https://github.com/dotnet/roslyn/pull/52275 Pass CancellationToken in the Workspace layer
- [x] https://github.com/dotnet/roslyn/pull/52278 Pass CancellationToken at Features layer
- [x] https://github.com/dotnet/roslyn/pull/52280 Pass CancellationTokens in the EditorFeature layer
- [x] https://github.com/dotnet/roslyn/pull/52276 Pass CancellationTokens in the Visual Studio layer