### PR TITLE
draft

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -941,6 +941,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             {
                 case MemberDeclarationSyntax memberDecl: return memberDecl.Modifiers;
                 case AccessorDeclarationSyntax accessor: return accessor.Modifiers;
+                case LocalFunctionStatementSyntax or LocalDeclarationStatementSyntax or BaseParameterListSyntax: throw ExceptionUtilities.Unreachable;
             }
 
             return default;


### PR DESCRIPTION
Adding `case LocalFunctionStatementSyntax or LocalDeclarationStatementSyntax or BaseParameterListSyntax: throw ExceptionUtilities.Unreachable;` To see if `GetModifiers` is called by any of these nodes or not.
Related to https://github.com/dotnet/roslyn/issues/52290