### PR TITLE
Move IDE0066 'ContainsDirectives' check from analyzer to code fix

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
@@ -36,11 +36,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
         private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
         {
             var switchStatement = context.Node;
-            if (switchStatement.ContainsDirectives)
-            {
-                return;
-            }
-
             var syntaxTree = switchStatement.SyntaxTree;
 
             if (((CSharpParseOptions)syntaxTree.Options).LanguageVersion < LanguageVersion.CSharp8)

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -37,6 +37,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                 bool shouldMoveNextStatementToSwitchExpression,
                 bool generateDeclaration)
             {
+                if (switchStatement.ContainsDirectives)
+                {
+                    // Do not rewrite statements with preprocessor directives
+                    return switchStatement;
+                }
+
                 var rewriter = new Rewriter(isAllThrowStatements: nodeToGenerate == SyntaxKind.ThrowStatement);
 
                 // Rewrite the switch statement as a switch expression.

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -44,6 +44,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var switchLocation = context.Diagnostics.First().AdditionalLocations[0];
+            var switchStatement = (SwitchStatementSyntax)switchLocation.FindNode(getInnermostNodeForTie: true, context.CancellationToken);
+            if (switchStatement.ContainsDirectives)
+            {
+                // Avoid providing code fixes for switch statements containing directives
+                return Task.CompletedTask;
+            }
+
             context.RegisterCodeFix(
                 new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
                 context.Diagnostics);

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -980,7 +980,7 @@ class Program
 
         [WorkItem(37872, "https://github.com/dotnet/roslyn/issues/37872")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
-        public async Task TestMissingOnDirectives()
+        public async Task TestMissingFixOnDirectives()
         {
             var code = @"class Program
 {
@@ -988,7 +988,7 @@ class Program
 
     static int GetValue(int input)
     {
-        switch (input)
+        [|switch|] (input)
         {
             case 1:
                 return 42;
@@ -1007,6 +1007,81 @@ class Program
 }";
 
             await VerifyCS.VerifyCodeFixAsync(code, code);
+        }
+
+        [WorkItem(37872, "https://github.com/dotnet/roslyn/issues/37872")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        public async Task TestMissingFixAllOnDirectives()
+        {
+            var code = @"class Program
+{
+    static void Main() { }
+
+    static int GetValue(int input)
+    {
+        [|switch|] (input)
+        {
+            case 1:
+                return 42;
+            default:
+                return 80;
+        }
+
+        [|switch|] (input)
+        {
+            case 1:
+                return 42;
+            case 2:
+#if PLATFORM_UNIX
+                return 50;
+#else
+                return 51;
+#endif
+            case 3:
+                return 79;
+            default:
+                return 80;
+        }
+    }
+}";
+            var fixedCode = @"class Program
+{
+    static void Main() { }
+
+    static int GetValue(int input)
+    {
+        return input switch
+        {
+            1 => 42,
+            _ => 80,
+        };
+        [|switch|] (input)
+        {
+            case 1:
+                return 42;
+            case 2:
+#if PLATFORM_UNIX
+                return 50;
+#else
+                return 51;
+#endif
+            case 3:
+                return 79;
+            default:
+                return 80;
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                FixedState =
+                {
+                    Sources = { fixedCode },
+                    MarkupHandling = MarkupMode.Allow,
+                },
+            }.RunAsync();
         }
 
         [WorkItem(37950, "https://github.com/dotnet/roslyn/issues/37950")]


### PR DESCRIPTION
* Switch statements that can be converted to switch expressions produce warning IDE0066 (no change from before)
* Switch statements that cannot be _automatically_ converted to switch expressions still produce IDE0066, but opt out of the automated Fix and Fix All operations

Fixes #49660