### PR TITLE
Rebuild extern aliases

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -927,12 +927,15 @@ namespace Microsoft.Cci
             // COFF header Timestamp field (4 byte int)
             // COFF header SizeOfImage field (4 byte int)
             // MVID (Guid, 24 bytes)
-            foreach (var metadataReference in module.CommonCompilation.ExternalReferences)
+            var referenceManager = module.CommonCompilation.GetBoundReferenceManager();
+            foreach (var pair in referenceManager.GetReferencedAssemblyAliases())
             {
-                if (metadataReference is PortableExecutableReference portableReference && portableReference.FilePath is object)
+                if (referenceManager.GetMetadataReference(pair.AssemblySymbol) is PortableExecutableReference { FilePath: { } } portableReference)
                 {
                     var fileName = PathUtilities.GetFileName(portableReference.FilePath);
-                    var peReader = GetReader(portableReference);
+                    var peReader = pair.AssemblySymbol.GetISymbol() is IAssemblySymbol assemblySymbol
+                        ? assemblySymbol.GetMetadata().GetAssembly().ManifestModule.PEReaderOpt
+                        : null;
 
                     // Don't write before checking that we can get a peReader for the metadata reference
                     if (peReader is null)
@@ -945,8 +948,8 @@ namespace Microsoft.Cci
                     builder.WriteByte(0);
 
                     // Extern alias
-                    if (portableReference.Properties.Aliases.Any())
-                        builder.WriteUTF8(string.Join(",", portableReference.Properties.Aliases));
+                    if (pair.Aliases.Length > 0)
+                        builder.WriteUTF8(string.Join(",", pair.Aliases));
 
                     // Always null terminate the extern alias list
                     builder.WriteByte(0);
@@ -976,22 +979,6 @@ namespace Microsoft.Cci
                 parent: EntityHandle.ModuleDefinition,
                 kind: _debugMetadataOpt.GetOrAddGuid(PortableCustomDebugInfoKinds.CompilationMetadataReferences),
                 value: _debugMetadataOpt.GetOrAddBlob(builder));
-
-            static PEReader GetReader(PortableExecutableReference peReference)
-            {
-                switch (peReference.GetMetadata())
-                {
-                    case AssemblyMetadata assemblyMetadata:
-                        {
-                            var assembly = assemblyMetadata.GetAssembly();
-                            return assembly.ManifestModule?.PEReaderOpt;
-                        }
-                    case ModuleMetadata moduleMetadata:
-                        return moduleMetadata.Module.PEReaderOpt;
-                    default:
-                        return null;
-                }
-            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Enumerates all referenced assemblies and their aliases.
         /// </summary>
-        internal abstract IEnumerable<(IAssemblySymbolInternal, ImmutableArray<string>)> GetReferencedAssemblyAliases();
+        internal abstract IEnumerable<(IAssemblySymbolInternal AssemblySymbol, ImmutableArray<string> Aliases)> GetReferencedAssemblyAliases();
 
         internal abstract MetadataReference? GetMetadataReference(IAssemblySymbolInternal? assemblySymbol);
         internal abstract ImmutableArray<MetadataReference> ExplicitReferences { get; }
@@ -710,7 +710,7 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        internal override IEnumerable<(IAssemblySymbolInternal, ImmutableArray<string>)> GetReferencedAssemblyAliases()
+        internal override IEnumerable<(IAssemblySymbolInternal AssemblySymbol, ImmutableArray<string> Aliases)> GetReferencedAssemblyAliases()
         {
             for (int i = 0; i < ReferencedAssemblies.Length; i++)
             {

--- a/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
+++ b/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
@@ -340,16 +340,34 @@ namespace Microsoft.CodeAnalysis.Rebuild
                 var imageSize = blobReader.ReadInt32();
                 var mvid = blobReader.ReadGuid();
 
-                yield return new MetadataReferenceInfo(
-                    timestamp,
-                    imageSize,
-                    name,
-                    mvid,
-                    string.IsNullOrEmpty(externAliases)
-                        ? ImmutableArray<string>.Empty
-                        : externAliases.Split(',').ToImmutableArray(),
-                    kind,
-                    embedInteropTypes);
+                if (string.IsNullOrEmpty(externAliases))
+                {
+                    yield return new MetadataReferenceInfo(
+                        timestamp,
+                        imageSize,
+                        name,
+                        mvid,
+                        externAlias: null,
+                        kind,
+                        embedInteropTypes);
+                }
+                else
+                {
+                    foreach (var alias in externAliases.Split(','))
+                    {
+                        // The "global" alias is an invention of the tooling on top of the compiler. 
+                        // The compiler itself just sees "global" as a reference without any aliases
+                        // and we need to mimic that here.
+                        yield return new MetadataReferenceInfo(
+                            timestamp,
+                            imageSize,
+                            name,
+                            mvid,
+                            alias == "global" ? null : alias,
+                            kind,
+                            embedInteropTypes);
+                    }
+                }
             }
         }
 

--- a/src/Compilers/Core/Rebuild/MetadataReferenceInfo.cs
+++ b/src/Compilers/Core/Rebuild/MetadataReferenceInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
         public readonly string Name;
         public readonly FileInfo FileInfo;
         public readonly Guid Mvid;
-        public readonly ImmutableArray<string> ExternAliases;
+        public readonly string? ExternAlias;
         public readonly MetadataImageKind Kind;
         public readonly bool EmbedInteropTypes;
 
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
             int imageSize,
             string name,
             Guid mvid,
-            ImmutableArray<string> externAliases,
+            string? externAlias,
             MetadataImageKind kind,
             bool embedInteropTypes)
         {
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
             ImageSize = imageSize;
             Name = name;
             Mvid = mvid;
-            ExternAliases = externAliases;
+            ExternAlias = externAlias;
             Kind = kind;
             EmbedInteropTypes = embedInteropTypes;
             FileInfo = new FileInfo(name);

--- a/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
+++ b/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
@@ -104,6 +104,41 @@ class Library
     }
 }
 ");
+
+            AddSourceFile("lib2.cs", @"
+extern alias SystemRuntime;
+using System;
+
+class Library
+{
+    void Method()
+    {
+        System.Reflection.Assembly a1 = null;
+        SystemRuntime::System.Reflection.Assembly a2 = null;
+        Console.WriteLine(a1);
+        Console.WriteLine(a2);
+    }
+}
+");
+
+            AddSourceFile("lib3.cs", @"
+extern alias SystemRuntime1;
+extern alias SystemRuntime2;
+using System;
+
+class Library
+{
+    void Method()
+    {
+        System.Reflection.Assembly a1 = null;
+        SystemRuntime1::System.Reflection.Assembly a2 = null;
+        SystemRuntime2::System.Reflection.Assembly a3 = null;
+        Console.WriteLine(a1);
+        Console.WriteLine(a2);
+        Console.WriteLine(a3);
+    }
+}
+");
         }
 
         public static IEnumerable<object?[]> GetCSharpData()
@@ -112,6 +147,8 @@ class Library
 
             Add(Permutate(new CommandInfo("hw.cs /target:exe /debug:embedded", "test.exe", null)));
             Add(Permutate(new CommandInfo("lib1.cs /target:library /debug:embedded", "test.dll", null)));
+            Add(Permutate(new CommandInfo("lib2.cs /target:library /r:SystemRuntime=System.Runtime.dll /debug:embedded", "test.dll", null)));
+            Add(Permutate(new CommandInfo("lib3.cs /target:library /r:SystemRuntime1=System.Runtime.dll /r:SystemRuntime2=System.Runtime.dll /debug:embedded", "test.dll", null)));
 
             return list;
 
@@ -122,7 +159,7 @@ class Library
                 return e;
             }
 
-            IEnumerable<CommandInfo> PermutateOptimizations(CommandInfo commandInfo)
+            static IEnumerable<CommandInfo> PermutateOptimizations(CommandInfo commandInfo)
             {
                 // No options at all for optimization
                 yield return commandInfo;
@@ -209,7 +246,7 @@ End Module
                 return e;
             }
 
-            IEnumerable<CommandInfo> PermutateOptimizations(CommandInfo commandInfo)
+            static IEnumerable<CommandInfo> PermutateOptimizations(CommandInfo commandInfo)
             {
                 // No options at all for optimization
                 yield return commandInfo;
@@ -231,7 +268,7 @@ End Module
                 };
             }
 
-            IEnumerable<CommandInfo> PermutateRuntime(CommandInfo commandInfo)
+            static IEnumerable<CommandInfo> PermutateRuntime(CommandInfo commandInfo)
             {
                 yield return commandInfo with
                 {

--- a/src/Compilers/Core/RebuildTest/RoundTripUtil.cs
+++ b/src/Compilers/Core/RebuildTest/RoundTripUtil.cs
@@ -62,10 +62,20 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 count++;
                 var metadataReference = metadataReferences.FirstOrDefault(x =>
                     info.Mvid == x.GetModuleVersionId() &&
-                    info.ExternAliases.SequenceEqual(x.Properties.Aliases));
+                    info.ExternAlias == GetSingleAlias(x));
                 AssertEx.NotNull(metadataReference);
+
+                string? GetSingleAlias(MetadataReference metadataReference)
+                {
+                    Assert.True(metadataReference.Properties.Aliases.Length is 0 or 1);
+                    return metadataReference.Properties.Aliases.Length == 1
+                        ? metadataReference.Properties.Aliases[0]
+                        : null;
+                }
             }
+
             Assert.Equal(metadataReferences.Length, count);
+
         }
 
         public static void VerifyRoundTrip<TCompilation>(TCompilation original)

--- a/src/Tools/BuildValidator/LocalReferenceResolver.cs
+++ b/src/Tools/BuildValidator/LocalReferenceResolver.cs
@@ -111,7 +111,7 @@ namespace BuildValidator
                     filePath: filePath,
                     properties: new MetadataReferenceProperties(
                         kind: MetadataImageKind.Assembly,
-                        aliases: reference.ExternAliases,
+                        aliases: reference.ExternAlias is null ? ImmutableArray<string>.Empty : ImmutableArray.Create(reference.ExternAlias),
                         embedInteropTypes: reference.EmbedInteropTypes)));
             }
 


### PR DESCRIPTION
The portable PDB writing code was not properly encoding external
aliases. They were being ignored since they aren't included in the
`CommonReferenceManager` as the code expected. Convertd to a more direct
way of grabbing the `PEReader` value and properly encoded the modules