### PR TITLE
Fix global option service to handle non-default values from persisters

### DIFF
--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -336,6 +336,12 @@ namespace Microsoft.CodeAnalysis.Options
 
             _currentValues = _currentValues.Add(optionKey, value);
 
+            // Track options with non-default values from serializers as changed options.
+            if (!object.Equals(value, optionKey.Option.DefaultValue))
+            {
+                _changedOptionKeys = _changedOptionKeys.Add(optionKey);
+            }
+
             return value;
         }
 

--- a/src/Workspaces/CoreTest/Host/WorkspaceServices/TestOptionService.cs
+++ b/src/Workspaces/CoreTest/Host/WorkspaceServices/TestOptionService.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
@@ -15,7 +17,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     internal static class TestOptionService
     {
-        public static OptionServiceFactory.OptionService GetService(Workspace workspace, IOptionProvider? optionProvider = null)
+        public static OptionServiceFactory.OptionService GetService(Workspace workspace, IOptionProvider? optionProvider = null, IOptionPersisterProvider? optionPersisterProvider = null)
         {
             var mefHostServices = (IMefHostExportProvider)workspace.Services.HostServices;
             var workspaceThreadingService = mefHostServices.GetExportedValues<IWorkspaceThreadingService>().SingleOrDefault();
@@ -25,13 +27,42 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 {
                     new Lazy<IOptionProvider, LanguageMetadata>(() => optionProvider ??= new TestOptionsProvider(), new LanguageMetadata(LanguageNames.CSharp))
                 },
-                Enumerable.Empty<Lazy<IOptionPersisterProvider>>()), workspaceServices: workspace.Services);
+                new[]
+                {
+                    new Lazy<IOptionPersisterProvider>(() => optionPersisterProvider ??= new TestOptionsPersisterProvider())
+                }),
+                workspaceServices: workspace.Services);
         }
 
         internal class TestOptionsProvider : IOptionProvider
         {
             public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
                 new Option<bool>("Test Feature", "Test Name", false));
+        }
+
+        internal sealed class TestOptionsPersisterProvider : IOptionPersisterProvider
+        {
+            private readonly ValueTask<IOptionPersister> _optionPersisterTask;
+
+            public TestOptionsPersisterProvider(IOptionPersister? optionPersister = null)
+                => _optionPersisterTask = new(optionPersister ?? new TestOptionsPersister());
+
+            public ValueTask<IOptionPersister> GetOrCreatePersisterAsync(CancellationToken cancellationToken)
+                => _optionPersisterTask;
+        }
+
+        internal sealed class TestOptionsPersister : IOptionPersister
+        {
+            private ImmutableDictionary<OptionKey, object?> _options = ImmutableDictionary<OptionKey, object?>.Empty;
+
+            public bool TryFetch(OptionKey optionKey, out object? value)
+                => _options.TryGetValue(optionKey, out value);
+
+            public bool TryPersist(OptionKey optionKey, object? value)
+            {
+                _options = _options.SetItem(optionKey, value);
+                return true;
+            }
         }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
@@ -292,6 +292,36 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             Assert.Equal(newOptionValue, serializableOptionSet.GetOption(changedOptionKey));
         }
 
+        [Fact, WorkItem(1128126, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1128126")]
+        public void TestPersistedTodoCommentOptions()
+        {
+            var hostServices = FeaturesTestCompositions.Features.AddParts(typeof(TestOptionsServiceFactory)).GetHostServices();
+
+            using var workspace = new AdhocWorkspace(hostServices);
+            var option = TodoCommentOptions.TokenList;
+            var newOptionValue = option.DefaultValue + "|name:value";
+
+            var persister = new TestOptionService.TestOptionsPersister();
+            var persisted = persister.TryPersist(option, newOptionValue);
+            Assert.True(persisted);
+            Assert.True(persister.TryFetch(option, out var persistedValue));
+            Assert.Equal(newOptionValue, persistedValue);
+
+            var provider = ((IMefHostExportProvider)hostServices).GetExportedValues<IOptionProvider>().OfType<TodoCommentOptionsProvider>().FirstOrDefault();
+            var persisterProvider = new TestOptionService.TestOptionsPersisterProvider(persister);
+            var optionService = TestOptionService.GetService(workspace, provider, persisterProvider);
+            var optionSet = optionService.GetOptions();
+            var optionKey = new OptionKey(option);
+            Assert.Equal(newOptionValue, (string?)optionSet.GetOption(optionKey));
+
+            var languages = ImmutableHashSet.Create(LanguageNames.CSharp);
+            var serializableOptionSet = optionService.GetSerializableOptionsSnapshot(languages);
+            var changedOptions = serializableOptionSet.GetChangedOptions();
+            var changedOptionKey = Assert.Single(changedOptions);
+            Assert.Equal(optionKey, changedOptionKey);
+            Assert.Equal(newOptionValue, serializableOptionSet.GetOption(changedOptionKey));
+        }
+
         [Fact]
         public void TestPerLanguageCodeStyleOptions()
         {


### PR DESCRIPTION
Fixes [AB#1128126](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1128126)

Currently, the global option service only tracks explicitly changed option keys. This means options that have non-default values from option persisters are not part of tracked changed option keys, which leads to GlobalOptionService.SetOptions to ignore these options until an actual new solution snapshot is produced with the non-default option value.

Verified customer repro and added unit test failure prior to the fix.