### PR TITLE
Rebuild support for OutputKind

### DIFF
--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -40,94 +40,26 @@ try {
   $rebuildArgs = ("--verbose" +
   " --assembliesPath `"$ArtifactsDir/obj/`"" +
 
-  # Configuration Issues
+# Rebuilds with output differences
+  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll" +
+  " --exclude net472\Microsoft.VisualStudio.LanguageServices.CSharp.dll" +
+  " --exclude net472\Microsoft.VisualStudio.LanguageServices.dll" +
+  " --exclude net472\Microsoft.VisualStudio.LanguageServices.Implementation.dll" +
+  " --exclude net472\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll" +
+  " --exclude net472\Roslyn.Hosting.Diagnostics.dll" +
+  " --exclude net472\Roslyn.VisualStudio.DiagnosticsWindow.dll" +
+# Rebuilds with compilation errors
+# Rebuilds with missing references
+# Rebuilds with other issues
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude net45\Microsoft.CodeAnalysis.Debugging.Package.dll" +
   " --exclude netstandard1.3\Microsoft.CodeAnalysis.Debugging.Package.dll" +
   " --exclude net45\Microsoft.CodeAnalysis.PooledObjects.Package.dll" +
   " --exclude netstandard1.3\Microsoft.CodeAnalysis.PooledObjects.Package.dll" +
+  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Workspaces.UnitTests.dll" +
   " --exclude net472\Zip\tools\vsixexpinstaller\System.ValueTuple.dll" +
   " --exclude net472\Zip\tools\vsixexpinstaller\VSIXExpInstaller.exe" +
-
-  # Rebuild differences
-  " --exclude netcoreapp3.1\BoundTreeGenerator.dll" +
-  " --exclude net472\BuildActionTelemetryTable.exe" +
-  " --exclude netcoreapp3.1\CSharpErrorFactsGenerator.dll" +
-  " --exclude net472\IdeBenchmarks.exe" +
-  " --exclude net5.0\InteractiveHost.UnitTests.dll" +
-  " --exclude net472\InteractiveHost32.exe" +
-  " --exclude net5.0-windows7.0\win10-x64\InteractiveHost64.dll" +
-  " --exclude net472\win10-x64\InteractiveHost64.exe" +
-  " --exclude net472\Microsoft.Build.Tasks.CodeAnalysis.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.Build.Tasks.CodeAnalysis.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.EditorFeatures2.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ExpressionCompiler.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ResultProvider.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.dll" +
-  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.WinRT.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.dll" +
-  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.ExpressionEvaluator.FunctionResolver.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.ExternalAccess.FSharp.UnitTests.dll" +
-  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Features.dll" +
-  " --exclude netstandard2.0\Microsoft.CodeAnalysis.Features.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.Rebuild.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.Rebuild.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.Scripting.Desktop.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.UnitTests.dll" +
-  " --exclude net5.0\Microsoft.CodeAnalysis.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.Workspaces.Desktop.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.Workspaces.UnitTests.dll" +
-  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Workspaces.UnitTests.dll" +
-  " --exclude net472\Microsoft.VisualStudio.LanguageServices.CSharp.dll" +
-  " --exclude net472\Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.dll" +
-  " --exclude net472\Microsoft.VisualStudio.LanguageServices.dll" +
-  " --exclude net472\Microsoft.VisualStudio.LanguageServices.Implementation.dll" +
-  " --exclude net472\Microsoft.VisualStudio.LanguageServices.IntegrationTests.dll" +
-  " --exclude net472\Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests.dll" +
-  " --exclude net472\Microsoft.VisualStudio.LanguageServices.VisualBasic.dll" +
-  " --exclude net472\Roslyn.Hosting.Diagnostics.dll" +
-  " --exclude net472\Roslyn.VisualStudio.DiagnosticsWindow.dll" +
-  " --exclude net472\VBCSCompiler.UnitTests.dll" +
-  " --exclude net5.0\VBCSCompiler.UnitTests.dll" +
-  " --exclude netcoreapp3.1\VBErrorFactsGenerator.dll" +
-  " --exclude netcoreapp3.1\VBSyntaxGenerator.dll" +
-
-  # Compilation Errors
-  " --exclude net472\Microsoft.CodeAnalysis.CSharp.Scripting.Desktop.UnitTests.dll" +
-  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.CSharp.Scripting.dll" +
-  " --exclude netstandard2.0\Microsoft.CodeAnalysis.CSharp.Scripting.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.DiagnosticsTests.Utilities.dll" +
-  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.EditorFeatures.dll" +
-  " --exclude netstandard2.0\Microsoft.CodeAnalysis.EditorFeatures.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures.UnitTests.dll" +
-  " --exclude netstandard2.0\Microsoft.CodeAnalysis.InteractiveHost.dll" +
-  " --exclude net472\Microsoft.CodeAnalysis.Scripting.UnitTests.dll" +
-  " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Scripting.UnitTests.dll" +
-  " --exclude net472\Roslyn.VisualStudio.Next.UnitTests.dll" +
 
   " --debugPath `"$ArtifactsDir/BuildValidator`"" +
   " --sourcePath `"$RepoRoot`"" +

--- a/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CompilationOptionNames.cs
@@ -37,5 +37,6 @@ namespace Microsoft.Cci
         public const string OptionInfer = "option-infer";
         public const string OptionExplicit = "option-explicit";
         public const string OptionCompareText = "option-compare-text";
+        public const string OutputKind = "output-kind";
     }
 }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -858,6 +858,7 @@ namespace Microsoft.Cci
 
                 WriteValue(CompilationOptionNames.Language, module.CommonCompilation.Options.Language);
                 WriteValue(CompilationOptionNames.SourceFileCount, module.CommonCompilation.SyntaxTrees.Count().ToString());
+                WriteValue(CompilationOptionNames.OutputKind, module.OutputKind.ToString());
 
                 if (module.EmitOptions.FallbackSourceFileEncoding != null)
                 {

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -950,7 +950,7 @@ namespace Microsoft.Cci
 
                     // Extern alias
                     if (pair.Aliases.Length > 0)
-                        builder.WriteUTF8(string.Join(",", pair.Aliases));
+                        builder.WriteUTF8(string.Join(",", pair.Aliases.OrderBy(StringComparer.Ordinal)));
 
                     // Always null terminate the extern alias list
                     builder.WriteByte(0);

--- a/src/Compilers/Core/Rebuild/CSharpCompilationFactory.cs
+++ b/src/Compilers/Core/Rebuild/CSharpCompilationFactory.cs
@@ -55,18 +55,18 @@ namespace Microsoft.CodeAnalysis.Rebuild
 
         private static (CSharpCompilationOptions, CSharpParseOptions) CreateCSharpCompilationOptions(string assemblyFileName, CompilationOptionsReader optionsReader)
         {
-            var pdbCompilationOptions = optionsReader.GetMetadataCompilationOptions();
+            var pdbOptions = optionsReader.GetMetadataCompilationOptions();
 
-            var langVersionString = pdbCompilationOptions.GetUniqueOption(CompilationOptionNames.LanguageVersion);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Optimization, out var optimization);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Platform, out var platform);
+            var langVersionString = pdbOptions.GetUniqueOption(CompilationOptionNames.LanguageVersion);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Optimization, out var optimization);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Platform, out var platform);
 
             // TODO: Check portability policy if needed
             // pdbCompilationOptions.TryGetValue("portability-policy", out var portabilityPolicyString);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Define, out var define);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Checked, out var checkedString);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Nullable, out var nullable);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Unsafe, out var unsafeString);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Define, out var define);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Checked, out var checkedString);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Nullable, out var nullable);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Unsafe, out var unsafeString);
 
             CS.LanguageVersionFacts.TryParse(langVersionString, out var langVersion);
 
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
                 : (NullableContextOptions)Enum.Parse(typeof(NullableContextOptions), nullable);
 
             var compilationOptions = new CSharpCompilationOptions(
-                optionsReader.GetOutputKind(),
+                pdbOptions.OptionToEnum<OutputKind>(CompilationOptionNames.OutputKind) ?? OutputKind.DynamicallyLinkedLibrary,
                 reportSuppressedDiagnostics: false,
 
                 moduleName: assemblyFileName,

--- a/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
+++ b/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
@@ -147,11 +147,6 @@ namespace Microsoft.CodeAnalysis.Rebuild
             return _metadataReferenceInfo;
         }
 
-        public OutputKind GetOutputKind() =>
-            (PdbReader.DebugMetadataHeader is { } header && !header.EntryPoint.IsNil)
-            ? OutputKind.ConsoleApplication
-            : OutputKind.DynamicallyLinkedLibrary;
-
         public string? GetMainTypeName() => GetMainMethodInfo()?.MainTypeName;
 
         public (string MainTypeName, string MainMethodName)? GetMainMethodInfo()
@@ -233,6 +228,11 @@ namespace Microsoft.CodeAnalysis.Rebuild
         public byte[]? GetPublicKey()
         {
             var metadataReader = PeReader.GetMetadataReader();
+            if (!metadataReader.IsAssembly)
+            {
+                return null;
+            }
+
             var blob = metadataReader.GetAssemblyDefinition().PublicKey;
             if (blob.IsNil)
             {

--- a/src/Compilers/Core/Rebuild/MetadataCompilationOptions.cs
+++ b/src/Compilers/Core/Rebuild/MetadataCompilationOptions.cs
@@ -56,5 +56,11 @@ namespace Microsoft.CodeAnalysis.Rebuild
 
             return optionValues[0].value;
         }
+
+        public string? OptionToString(string option) => TryGetUniqueOption(option, out var value) ? value : null;
+        public bool? OptionToBool(string option) => TryGetUniqueOption(option, out var value) ? ToBool(value) : null;
+        public T? OptionToEnum<T>(string option) where T : struct => TryGetUniqueOption(option, out var value) ? ToEnum<T>(value) : null;
+        public static bool? ToBool(string value) => bool.TryParse(value, out var boolValue) ? boolValue : null;
+        public static T? ToEnum<T>(string value) where T : struct => Enum.TryParse<T>(value, out var enumValue) ? enumValue : null;
     }
 }

--- a/src/Compilers/Core/Rebuild/Microsoft.CodeAnalysis.Rebuild.csproj
+++ b/src/Compilers/Core/Rebuild/Microsoft.CodeAnalysis.Rebuild.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Rebuild.UnitTests" />
+  </ItemGroup>
 </Project>

--- a/src/Compilers/Core/Rebuild/VisualBasicCompilationFactory.cs
+++ b/src/Compilers/Core/Rebuild/VisualBasicCompilationFactory.cs
@@ -55,12 +55,12 @@ namespace Microsoft.CodeAnalysis.Rebuild
 
         private static VisualBasicCompilationOptions CreateVisualBasicCompilationOptions(string assemblyFileName, CompilationOptionsReader optionsReader)
         {
-            var pdbCompilationOptions = optionsReader.GetMetadataCompilationOptions();
+            var pdbOptions = optionsReader.GetMetadataCompilationOptions();
 
-            var langVersionString = pdbCompilationOptions.GetUniqueOption(CompilationOptionNames.LanguageVersion);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Optimization, out var optimization);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Platform, out var platform);
-            pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.GlobalNamespaces, out var globalNamespacesString);
+            var langVersionString = pdbOptions.GetUniqueOption(CompilationOptionNames.LanguageVersion);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Optimization, out var optimization);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.Platform, out var platform);
+            pdbOptions.TryGetUniqueOption(CompilationOptionNames.GlobalNamespaces, out var globalNamespacesString);
 
             IEnumerable<GlobalImport>? globalImports = null;
             if (!string.IsNullOrEmpty(globalNamespacesString))
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
             VB.LanguageVersionFacts.TryParse(langVersionString, ref langVersion);
 
             IReadOnlyDictionary<string, object>? preprocessorSymbols = null;
-            if (OptionToString(CompilationOptionNames.Define) is string defineString)
+            if (pdbOptions.OptionToString(CompilationOptionNames.Define) is string defineString)
             {
                 preprocessorSymbols = VisualBasicCommandLineParser.ParseConditionalCompilationSymbols(defineString, out var diagnostics);
                 var diagnostic = diagnostics?.FirstOrDefault(x => x.IsUnsuppressedError);
@@ -88,21 +88,21 @@ namespace Microsoft.CodeAnalysis.Rebuild
                 .WithPreprocessorSymbols(preprocessorSymbols.ToImmutableArrayOrEmpty());
 
             var (optimizationLevel, plus) = GetOptimizationLevel(optimization);
-            var isChecked = OptionToBool(CompilationOptionNames.Checked) ?? true;
-            var embedVBRuntime = OptionToBool(CompilationOptionNames.EmbedRuntime) ?? false;
-            var rootNamespace = OptionToString(CompilationOptionNames.RootNamespace);
+            var isChecked = pdbOptions.OptionToBool(CompilationOptionNames.Checked) ?? true;
+            var embedVBRuntime = pdbOptions.OptionToBool(CompilationOptionNames.EmbedRuntime) ?? false;
+            var rootNamespace = pdbOptions.OptionToString(CompilationOptionNames.RootNamespace);
 
             var compilationOptions = new VisualBasicCompilationOptions(
-                optionsReader.GetOutputKind(),
+                pdbOptions.OptionToEnum<OutputKind>(CompilationOptionNames.OutputKind) ?? OutputKind.DynamicallyLinkedLibrary,
                 moduleName: assemblyFileName,
                 mainTypeName: optionsReader.GetMainTypeName(),
                 scriptClassName: "Script",
                 globalImports: globalImports,
                 rootNamespace: rootNamespace,
-                optionStrict: OptionToEnum<OptionStrict>(CompilationOptionNames.OptionStrict) ?? OptionStrict.Off,
-                optionInfer: OptionToBool(CompilationOptionNames.OptionInfer) ?? false,
-                optionExplicit: OptionToBool(CompilationOptionNames.OptionExplicit) ?? false,
-                optionCompareText: OptionToBool(CompilationOptionNames.OptionCompareText) ?? false,
+                optionStrict: pdbOptions.OptionToEnum<OptionStrict>(CompilationOptionNames.OptionStrict) ?? OptionStrict.Off,
+                optionInfer: pdbOptions.OptionToBool(CompilationOptionNames.OptionInfer) ?? false,
+                optionExplicit: pdbOptions.OptionToBool(CompilationOptionNames.OptionExplicit) ?? false,
+                optionCompareText: pdbOptions.OptionToBool(CompilationOptionNames.OptionCompareText) ?? false,
                 parseOptions: parseOptions,
                 embedVbCoreRuntime: embedVBRuntime,
                 optimizationLevel: optimizationLevel,
@@ -127,12 +127,6 @@ namespace Microsoft.CodeAnalysis.Rebuild
             compilationOptions.DebugPlusMode = plus;
 
             return compilationOptions;
-
-            string? OptionToString(string option) => pdbCompilationOptions.TryGetUniqueOption(option, out var value) ? value : null;
-            bool? OptionToBool(string option) => pdbCompilationOptions.TryGetUniqueOption(option, out var value) ? ToBool(value) : null;
-            T? OptionToEnum<T>(string option) where T : struct => pdbCompilationOptions.TryGetUniqueOption(option, out var value) ? ToEnum<T>(value) : null;
-            static bool? ToBool(string value) => bool.TryParse(value, out var boolValue) ? boolValue : null;
-            static T? ToEnum<T>(string value) where T : struct => Enum.TryParse<T>(value, out var enumValue) ? enumValue : null;
         }
     }
 }

--- a/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
+++ b/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Rebuild;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Microsoft.Cci;
+
+namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
+{
+    public class CompilationOptionsReaderTests : CSharpTestBase
+    {
+        private CompilationOptionsReader GetOptionsReader(Compilation compilation)
+        {
+            compilation.VerifyDiagnostics();
+            var peBytes = compilation.EmitToArray(new EmitOptions(debugInformationFormat: DebugInformationFormat.Embedded));
+            var originalReader = new PEReader(peBytes);
+            var originalPdbReader = originalReader.GetEmbeddedPdbMetadataReader();
+            var factory = LoggerFactory.Create(configure => { });
+            var logger = factory.CreateLogger("RoundTripVerification");
+            return new CompilationOptionsReader(logger, originalPdbReader, originalReader);
+        }
+
+        [Fact]
+        public void PublicKeyNetModule()
+        {
+            var compilation = CreateCompilation(
+                options: TestOptions.DebugModule,
+                source: @"
+class C { }
+");
+
+            var reader = GetOptionsReader(compilation);
+            Assert.Null(reader.GetPublicKey());
+        }
+
+        [Fact]
+        public void OutputKind()
+        {
+            foreach (OutputKind kind in Enum.GetValues(typeof(OutputKind)))
+            {
+                var compilation = CreateCompilation(
+                    options: new CSharpCompilationOptions(outputKind: kind),
+                    source: @"
+class Program {
+    public static void Main() { }
+}");
+                var reader = GetOptionsReader(compilation);
+                Assert.Equal(kind, reader.GetMetadataCompilationOptions().OptionToEnum<OutputKind>(CompilationOptionNames.OutputKind));
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
+++ b/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
@@ -51,20 +51,18 @@ class C { }
             Assert.Null(reader.GetPublicKey());
         }
 
-        [Fact]
-        public void OutputKind()
+        [Theory]
+        [CombinatorialData]
+        public void OutputKind(OutputKind kind)
         {
-            foreach (OutputKind kind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateCompilation(
-                    options: new CSharpCompilationOptions(outputKind: kind),
-                    source: @"
+            var compilation = CreateCompilation(
+                options: new CSharpCompilationOptions(outputKind: kind),
+                source: @"
 class Program {
-    public static void Main() { }
+public static void Main() { }
 }");
-                var reader = GetOptionsReader(compilation);
-                Assert.Equal(kind, reader.GetMetadataCompilationOptions().OptionToEnum<OutputKind>(CompilationOptionNames.OutputKind));
-            }
+            var reader = GetOptionsReader(compilation);
+            Assert.Equal(kind, reader.GetMetadataCompilationOptions().OptionToEnum<OutputKind>(CompilationOptionNames.OutputKind));
         }
     }
 }

--- a/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
+++ b/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Microsoft.Cci;
+using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
 {
@@ -31,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
             var peBytes = compilation.EmitToArray(new EmitOptions(debugInformationFormat: DebugInformationFormat.Embedded));
             var originalReader = new PEReader(peBytes);
             var originalPdbReader = originalReader.GetEmbeddedPdbMetadataReader();
+            AssertEx.NotNull(originalPdbReader);
             var factory = LoggerFactory.Create(configure => { });
             var logger = factory.CreateLogger("RoundTripVerification");
             return new CompilationOptionsReader(logger, originalPdbReader, originalReader);


### PR DESCRIPTION
The `OutputKind` value was not properly round tripping through the PDB. Instead
we were only distinguishing between roughly exe and dll outputs. The compiler 
though knows about six different output kinds and that both impacts the manner
in which compilation takes place as well as what values are encoded into the
PDB (impacts the `Subsystem` value for example). Properly round tripping the 
output kind here.

This builds off #52321 and will be kept in draft until that PR is complete. 