### PR TITLE
Restore original OptionSet constructor

### DIFF
--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Options
 
         private readonly Func<OptionKey, object?> _getOptionCore;
 
-        public OptionSet()
+        protected OptionSet()
         {
             _getOptionCore = GetOptionCore;
         }


### PR DESCRIPTION
Reverts an unintentional change to the signature of this constructor which occurred in #51330.

Contributes to #52353.