### PR TITLE
Fix handling of out/ref params

### DIFF
--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.Visitor.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.Visitor.cs
@@ -1,0 +1,151 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using static Microsoft.CodeAnalysis.EditAndContinue.TraceLog;
+using Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection;
+
+namespace Microsoft.CodeAnalysis.ValueTracking
+{
+    internal partial class ValueTrackingService
+    {
+        private class OperationCollector
+        {
+            public ValueTrackingProgressCollector ProgressCollector { get; }
+            public Solution Solution { get; }
+
+            public OperationCollector(ValueTrackingProgressCollector progressCollector, Solution solution)
+            {
+                ProgressCollector = progressCollector;
+                Solution = solution;
+            }
+
+            public Task VisitAsync(IOperation operation, CancellationToken cancellationToken)
+                => operation switch
+                {
+                    IObjectCreationOperation objectCreationOperation => VisitObjectCreationAsync(objectCreationOperation, cancellationToken),
+                    IInvocationOperation invocationOperation => VisitInvocationAsync(invocationOperation, cancellationToken),
+                    ILiteralOperation literalOperation => VisitLiteralAsync(literalOperation, cancellationToken),
+                    IReturnOperation returnOperation => VisitReturnAsync(returnOperation, cancellationToken),
+                    IFieldReferenceOperation fieldReferenceOperation => VisitFieldReferenceAsync(fieldReferenceOperation, cancellationToken),
+                    _ => VisitDefaultAsync(operation, cancellationToken)
+                };
+
+            private async Task VisitDefaultAsync(IOperation operation, CancellationToken cancellationToken)
+            {
+                // If the operation has children, always visit the children instead of the root 
+                // operation. They are the interesting bits for ValueTracking
+                if (operation.Children.Any())
+                {
+                    foreach (var childOperation in operation.Children)
+                    {
+                        await VisitAsync(childOperation, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    return;
+                }
+
+                var semanticModel = operation.SemanticModel;
+                if (semanticModel is null)
+                {
+                    return;
+                }
+
+                var symbolInfo = semanticModel.GetSymbolInfo(operation.Syntax, cancellationToken);
+                if (symbolInfo.Symbol is null)
+                {
+                    return;
+                }
+
+                await AddOperationAsync(operation, symbolInfo.Symbol, cancellationToken).ConfigureAwait(false);
+            }
+
+            private Task VisitFieldReferenceAsync(IFieldReferenceOperation fieldReferenceOperation, CancellationToken cancellationToken)
+               => AddOperationAsync(fieldReferenceOperation, fieldReferenceOperation.Member, cancellationToken);
+
+            private Task VisitObjectCreationAsync(IObjectCreationOperation objectCreationOperation, CancellationToken cancellationToken)
+                => TrackArgumentsAsync(objectCreationOperation.Arguments, cancellationToken);
+
+            private async Task VisitInvocationAsync(IInvocationOperation invocationOperation, CancellationToken cancellationToken)
+            {
+                await AddOperationAsync(invocationOperation, invocationOperation.TargetMethod, cancellationToken).ConfigureAwait(false);
+                await TrackArgumentsAsync(invocationOperation.Arguments, cancellationToken).ConfigureAwait(false);
+            }
+
+            private async Task VisitLiteralAsync(ILiteralOperation literalOperation, CancellationToken cancellationToken)
+            {
+                if (literalOperation.Type is null)
+                {
+                    return;
+                }
+
+                await AddOperationAsync(literalOperation, literalOperation.Type, cancellationToken).ConfigureAwait(false);
+            }
+
+            private async Task VisitReturnAsync(IReturnOperation returnOperation, CancellationToken cancellationToken)
+            {
+                if (returnOperation.ReturnedValue is null)
+                {
+                    return;
+                }
+
+                await VisitAsync(returnOperation.ReturnedValue, cancellationToken).ConfigureAwait(false);
+            }
+
+            private async Task AddOperationAsync(IOperation operation, ISymbol symbol, CancellationToken cancellationToken)
+            {
+                _ = await ProgressCollector.TryReportAsync(
+                        Solution,
+                        operation.Syntax.GetLocation(),
+                        symbol,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            private async Task TrackArgumentsAsync(ImmutableArray<IArgumentOperation> argumentOperations, CancellationToken cancellationToken)
+            {
+                var collectorsAndArgumentMap = argumentOperations
+                    .Where(ShouldTrack)
+                    .Select(argument => (collector: Clone(), argument))
+                    .ToImmutableArray();
+
+                var tasks = collectorsAndArgumentMap
+                    .Select(pair => pair.collector.VisitAsync(pair.argument.Value, cancellationToken));
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                var items = collectorsAndArgumentMap
+                    .Select(pair => pair.collector.ProgressCollector)
+                    .SelectMany(collector => collector.GetItems())
+                    .Reverse(); // ProgressCollector uses a Stack, and we want to maintain the order by arguments, so reverse
+
+                foreach (var item in items)
+                {
+                    ProgressCollector.Report(item);
+                }
+
+                static bool ShouldTrack(IArgumentOperation argumentOperation)
+                {
+                    return argumentOperation.Parameter.IsRefOrOut()
+                        || argumentOperation.Value is IExpressionStatementOperation
+                            or IBinaryOperation
+                            or IInvocationOperation
+                            or IParameterReferenceOperation
+                            or ILiteralOperation;
+                }
+            }
+
+            private OperationCollector Clone()
+            {
+                var collector = new ValueTrackingProgressCollector();
+                collector.Parent = ProgressCollector.Parent;
+                return new OperationCollector(collector, Solution);
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.Visitor.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.Visitor.cs
@@ -201,8 +201,10 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             /// </remarks>
             private OperationCollector Clone()
             {
-                var collector = new ValueTrackingProgressCollector();
-                collector.Parent = ProgressCollector.Parent;
+                var collector = new ValueTrackingProgressCollector
+                {
+                    Parent = ProgressCollector.Parent
+                };
                 return new OperationCollector(collector, Solution);
             }
 
@@ -219,24 +221,24 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                         or IBinaryOperation
                         or IInvocationOperation
 
-                    // If the argument value is a parameter reference, then the method calls
-                    // leading to that parameter value should be tracked as well.
-                    // Ex:
-                    // string Prepend(string s1) => "pre" + s1;
-                    // string CallPrepend(string [|s2|]) => Prepend(s2);
-                    // Tracking [|s2|] into calls as an argument means that we 
-                    // need to know where [|s2|] comes from and how it contributes
-                    // to the value s1
+                        // If the argument value is a parameter reference, then the method calls
+                        // leading to that parameter value should be tracked as well.
+                        // Ex:
+                        // string Prepend(string s1) => "pre" + s1;
+                        // string CallPrepend(string [|s2|]) => Prepend(s2);
+                        // Tracking [|s2|] into calls as an argument means that we 
+                        // need to know where [|s2|] comes from and how it contributes
+                        // to the value s1
                         or IParameterReferenceOperation
 
-                    // A literal value as an argument is a dead end for data, but still contributes
-                    // to a value and should be shown in value tracking. It should never expand
-                    // further though. 
-                    // Ex:
-                    // string Prepend(string [|s|]) => "pre" + s;
-                    // string DefaultPrepend() => Prepend("default");
-                    // [|s|] is the parameter we need to track values for, which 
-                    // is assigned to "default" in DefaultPrepend
+                        // A literal value as an argument is a dead end for data, but still contributes
+                        // to a value and should be shown in value tracking. It should never expand
+                        // further though. 
+                        // Ex:
+                        // string Prepend(string [|s|]) => "pre" + s;
+                        // string DefaultPrepend() => Prepend("default");
+                        // [|s|] is the parameter we need to track values for, which 
+                        // is assigned to "default" in DefaultPrepend
                         or ILiteralOperation;
             }
 
@@ -247,9 +249,9 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             {
                 while (operation is not null)
                 {
-                    if (operation is TContainingOperation)
+                    if (operation is TContainingOperation tmpOperation)
                     {
-                        containingOperation = (TContainingOperation)operation;
+                        containingOperation = tmpOperation;
                         return true;
                     }
 

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.Visitor.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.Visitor.cs
@@ -212,34 +212,48 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             {
                 // Ref or Out arguments always contribute data as "assignments"
                 // across method calls
-                return argumentOperation.Parameter?.IsRefOrOut() == true
+                if (argumentOperation.Parameter?.IsRefOrOut() == true)
+                {
+                    return true;
+                }
 
-                    // If the argument value is an expression, binary operation, or
-                    // invocation then parts of the operation need to be evaluated
-                    // to see if they contribute data for value tracking
-                    || argumentOperation.Value is IExpressionStatementOperation
+                // If the argument value is an expression, binary operation, or
+                // invocation then parts of the operation need to be evaluated
+                // to see if they contribute data for value tracking
+                if (argumentOperation.Value is IExpressionStatementOperation
                         or IBinaryOperation
-                        or IInvocationOperation
+                        or IInvocationOperation)
+                {
+                    return true;
+                }
 
-                        // If the argument value is a parameter reference, then the method calls
-                        // leading to that parameter value should be tracked as well.
-                        // Ex:
-                        // string Prepend(string s1) => "pre" + s1;
-                        // string CallPrepend(string [|s2|]) => Prepend(s2);
-                        // Tracking [|s2|] into calls as an argument means that we 
-                        // need to know where [|s2|] comes from and how it contributes
-                        // to the value s1
-                        or IParameterReferenceOperation
+                // If the argument value is a parameter reference, then the method calls
+                // leading to that parameter value should be tracked as well.
+                // Ex:
+                // string Prepend(string s1) => "pre" + s1;
+                // string CallPrepend(string [|s2|]) => Prepend(s2);
+                // Tracking [|s2|] into calls as an argument means that we 
+                // need to know where [|s2|] comes from and how it contributes
+                // to the value s1
+                if (argumentOperation.Value is IParameterReferenceOperation)
+                {
+                    return true;
+                }
 
-                        // A literal value as an argument is a dead end for data, but still contributes
-                        // to a value and should be shown in value tracking. It should never expand
-                        // further though. 
-                        // Ex:
-                        // string Prepend(string [|s|]) => "pre" + s;
-                        // string DefaultPrepend() => Prepend("default");
-                        // [|s|] is the parameter we need to track values for, which 
-                        // is assigned to "default" in DefaultPrepend
-                        or ILiteralOperation;
+                // A literal value as an argument is a dead end for data, but still contributes
+                // to a value and should be shown in value tracking. It should never expand
+                // further though. 
+                // Ex:
+                // string Prepend(string [|s|]) => "pre" + s;
+                // string DefaultPrepend() => Prepend("default");
+                // [|s|] is the parameter we need to track values for, which 
+                // is assigned to "default" in DefaultPrepend
+                if (argumentOperation.Value is ILiteralOperation)
+                {
+                    return true;
+                }
+
+                return false;
             }
 
             private static bool IsContainedIn<TContainingOperation>(IOperation? operation) where TContainingOperation : IOperation

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
@@ -8,7 +8,6 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -19,13 +18,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ValueTracking
 {
-    internal class BaseTrackingService
-    {
-
-    }
-
     [ExportWorkspaceService(typeof(IValueTrackingService)), Shared]
-    internal partial class ValueTrackingService : BaseTrackingService, IValueTrackingService
+    internal partial class ValueTrackingService : IValueTrackingService
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
@@ -89,20 +89,6 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                     await progressCollector.TryReportAsync(document.Project.Solution, node.GetLocation(), symbol, cancellationToken).ConfigureAwait(false);
                 }
             }
-            else if (node is not null && symbol is null)
-            {
-                // If the correct symbol couldn't be determined but a node is available, try to let
-                // the operation collector handle the operation and report as needed
-                var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var operation = semanticModel.GetOperation(node, cancellationToken);
-
-                if (operation is null)
-                {
-                    return;
-                }
-
-                await operationCollector.VisitAsync(operation, cancellationToken).ConfigureAwait(false);
-            }
         }
 
         public async Task<ImmutableArray<ValueTrackedItem>> TrackValueSourceAsync(

--- a/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
+++ b/src/EditorFeatures/Core/ValueTracking/ValueTrackingService.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                         // In this case, s is being tracked because it contributed to the return of the method. We only
                         // want to track assignments to s that could impact the return rather than tracking the same method
                         // twice.
-                        var isParameterForPreviousTrackedMethod = previousSymbol == parameterSymbol.ContainingSymbol;
+                        var isParameterForPreviousTrackedMethod = previousSymbol?.Equals(parameterSymbol.ContainingSymbol) == true;
 
                         // For Ref or Out parameters, they contribute data across method calls through assignments
                         // within the method. No need to track returns

--- a/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ValueTracking;
@@ -32,25 +33,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ValueTracking
             return await service.TrackValueSourceAsync(item, cancellationToken);
         }
 
-        internal static async Task<ImmutableArray<ValueTrackedItem>> ValidateChildrenAsync(TestWorkspace testWorkspace, ValueTrackedItem item, int[] lines, CancellationToken cancellationToken = default)
-        {
-            var children = await GetTrackedItemsAsync(testWorkspace, item, cancellationToken);
-
-            Assert.Equal(lines.Length, children.Length);
-
-            for (var i = 0; i < lines.Length; i++)
-            {
-                ValidateItem(children[i], lines[i]);
-            }
-
-            return children;
-        }
-
         internal static async Task<ImmutableArray<ValueTrackedItem>> ValidateChildrenAsync(TestWorkspace testWorkspace, ValueTrackedItem item, (int line, string text)[] childInfo, CancellationToken cancellationToken = default)
         {
             var children = await GetTrackedItemsAsync(testWorkspace, item, cancellationToken);
-
-            Assert.Equal(childInfo.Length, children.Length);
+            Assert.True(childInfo.Length == children.Length, $"GetTrackedItemsAsync on [{item}]\n\texpected: [{string.Join(",", childInfo.Select(p => p.text))}]\n\t  actual: [{string.Join(",", children)}]");
 
             for (var i = 0; i < childInfo.Length; i++)
             {

--- a/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/AbstractBaseValueTrackingTests.cs
@@ -33,6 +33,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ValueTracking
             return await service.TrackValueSourceAsync(item, cancellationToken);
         }
 
+        internal static async Task<ImmutableArray<ValueTrackedItem>> ValidateItemsAsync(TestWorkspace testWorkspace, (int line, string text)[] itemInfo, CancellationToken cancellationToken = default)
+        {
+            var items = await GetTrackedItemsAsync(testWorkspace, cancellationToken);
+            Assert.True(itemInfo.Length == items.Length, $"GetTrackedItemsAsync\n\texpected: [{string.Join(",", itemInfo.Select(p => p.text))}]\n\t  actual: [{string.Join(",", items)}]");
+
+            for (var i = 0; i < items.Length; i++)
+            {
+                ValidateItem(items[i], itemInfo[i].line, itemInfo[i].text);
+            }
+
+            return items;
+        }
+
         internal static async Task<ImmutableArray<ValueTrackedItem>> ValidateChildrenAsync(TestWorkspace testWorkspace, ValueTrackedItem item, (int line, string text)[] childInfo, CancellationToken cancellationToken = default)
         {
             var children = await GetTrackedItemsAsync(testWorkspace, item, cancellationToken);

--- a/src/EditorFeatures/Test/ValueTracking/CSharpValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/CSharpValueTrackingTests.cs
@@ -205,9 +205,9 @@ class C
 
 class Other
 {
-    public void CallS(C c, string s)
+    public void CallS(C c, string str)
     {
-        c.SetS(s);
+        c.SetS(str);
     }
 
     public void CallS(C c)
@@ -237,8 +237,8 @@ class Other
             //
             // S = s; [Code.cs:7]
             //  |> S = [|s|] [Code.cs:7]
-            //    |> [|c.SetS(s)|]; [Code.cs:17]
-            //    |> c.SetS([|s|]); [Code.cs:17]
+            //    |> [|c.SetS(str)|]; [Code.cs:17]
+            //    |> c.SetS([|str|]); [Code.cs:17]
             //      |> CallS([|c|], CalculateDefault(c)) [Code.cs:22]
             //      |> CallS(c, [|CalculateDefault(c)|]) [Code.cs:22]
             //         |>  return "" [Code.cs:37]
@@ -253,8 +253,8 @@ class Other
                 initialItems.Single(),
                 childInfo: new[]
                 {
-                    (17, "s"), // |> c.SetS([|s|]); [Code.cs:17]
-                    (17, "c.SetS(s)"), // |> [|c.SetS(s)|]; [Code.cs:17]
+                    (17, "str"), // |> c.SetS([|str|]); [Code.cs:17]
+                    (17, "c.SetS(str)"), // |> [|c.SetS(str)|]; [Code.cs:17]
                 });
 
             // |> [|c.SetS(s)|]; [Code.cs:17]
@@ -587,21 +587,18 @@ class C
                 initialItems.Single(),
                 childInfo: new[]
                 {
-                    (24, "2"), // |> i = [|2|] [Code.cs:24]
                     (18, "i"), // |> if (TryConvertInt(o, out [|i|])) [Code.cs:18]
                 });
 
-            await ValidateChildrenEmptyAsync(workspace, children[0]);
-
             children = await ValidateChildrenAsync(
                 workspace,
-                children[1],
+                children.Single(),
                 childInfo: new[]
                 {
                     (5, "i") // |> if (int.TryParse(o.ToString(), out [|i|])) [Code.cs:5]
                 });
 
-            await ValidateChildrenEmptyAsync(workspace, children[0]);
+            await ValidateChildrenEmptyAsync(workspace, children.Single());
         }
     }
 }

--- a/src/EditorFeatures/Test/ValueTracking/VisualBasicValueTrackingTests.cs
+++ b/src/EditorFeatures/Test/ValueTracking/VisualBasicValueTrackingTests.cs
@@ -78,9 +78,13 @@ End Class
             //  |> Me._s = s [Code.vb:4]
             //  |> Private _s As String = "" [Code.vb:2]
             //
-            Assert.Equal(2, initialItems.Length);
-            ValidateItem(initialItems[0], 5);
-            ValidateItem(initialItems[1], 2);
+            await ValidateItemsAsync(
+                workspace,
+                itemInfo: new[]
+                {
+                    (5, "s"),
+                    (2, "_s")
+                });
         }
 
         [Fact]


### PR DESCRIPTION
Fix handling of out/ref params. 

Split complex operation logic into a "visitor" to make it easier to understand what is going on and simplify information being passed around. 