### PR TITLE
Task 1285177: [LSP] Support Pull Diagnostics correctly for local client

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Features/Diagnostics/XamlDiagnosticSeverity.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Diagnostics/XamlDiagnosticSeverity.cs
@@ -24,6 +24,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Diagnostics
         /// <summary>
         /// Represents a hidden note.
         /// </summary>
-        Hidden
+        Hidden,
+
+        /// <summary>
+        /// Represents a hinted suggestion.
+        /// </summary>
+        HintedSuggestion
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -151,6 +151,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 // Hidden is translated in ConvertTags to pass along appropriate _ms tags
                 // that will hide the item in a client that knows about those tags.
                 XamlDiagnosticSeverity.Hidden => LSP.DiagnosticSeverity.Hint,
+                XamlDiagnosticSeverity.HintedSuggestion => LSP.DiagnosticSeverity.Hint,
                 XamlDiagnosticSeverity.Message => LSP.DiagnosticSeverity.Information,
                 XamlDiagnosticSeverity.Warning => LSP.DiagnosticSeverity.Warning,
                 XamlDiagnosticSeverity.Error => LSP.DiagnosticSeverity.Error,
@@ -172,6 +173,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 result.Add(VSDiagnosticTags.HiddenInEditor);
                 result.Add(VSDiagnosticTags.HiddenInErrorList);
                 result.Add(VSDiagnosticTags.SuppressEditorToolTip);
+            }
+            else if (diagnostic.Severity == XamlDiagnosticSeverity.HintedSuggestion)
+            {
+                result.Add(VSDiagnosticTags.HiddenInErrorList);
             }
             else
             {

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
@@ -56,6 +56,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             _threadingContext = threadingContext;
 
             AnalyzerService = analyzerService;
+
+            _workspace.DocumentClosed += OnDocumentClosed;
         }
 
         public static IXamlDocumentAnalyzerService? AnalyzerService { get; private set; }
@@ -184,6 +186,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             return null;
         }
 
+        private void OnDocumentClosed(object sender, DocumentEventArgs e)
+        {
+            this.OnDocumentClosed(e.Document.FilePath);
+        }
+
         private void OnProjectClosing(IVsHierarchy hierarchy)
         {
             if (_xamlProjects.TryGetValue(hierarchy, out var project))
@@ -232,8 +239,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             }
         }
 
-        private void OnDocumentClosed(string filePath)
+        private void OnDocumentClosed(string? filePath)
         {
+            if (filePath == null)
+            {
+                return;
+            }
+
             if (_documentIds.TryGetValue(filePath, out var documentId))
             {
                 var document = _workspace.CurrentSolution.GetDocument(documentId);

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService_IVsRunningDocTableEvents3.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService_IVsRunningDocTableEvents3.cs
@@ -4,9 +4,7 @@
 
 #nullable disable
 
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml
 {

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService_IVsRunningDocTableEvents3.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService_IVsRunningDocTableEvents3.cs
@@ -4,7 +4,9 @@
 
 #nullable disable
 
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml
 {
@@ -47,13 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
 
         public int OnBeforeLastDocumentUnlock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining)
         {
-            if (dwReadLocksRemaining == 0 && dwEditLocksRemaining == 0)
-            {
-                var docInfo = _rdt.GetDocumentInfo(docCookie);
-                OnDocumentClosed(docInfo.Moniker);
-            }
-
-            return VSConstants.S_OK;
+            return VSConstants.E_NOTIMPL;
         }
 
         public int OnBeforeSave(uint docCookie)


### PR DESCRIPTION
Changes in this PR:

1. Add HintedSuggestion to XamlDiagnosticSeverity and handle this new severity in AbstractPullDiagnosticHandler.

What is HintedSuggestion?
HintedSuggestion is a new error Severity XAML added lately to support errors that show the "..." marker in editor but don't show up in the error list.

2. Switch to listening to Workspace.DocumentClosed event instead of RDT OnBeforeLastDocumentUnlock in XamlProjectService.  RunningDocumentTableEventTracker is also listening to OnBeforeLastDocumentUnlock and will fire a DocumentClosed event for it. This OnBeforeLastDocumentUnlock inside RunningDocumentTableEventTracker is doing the same check as we have in XamlProjectService. There is no need for us to do duplicate work and meanwhile as we remove the XAML file when the file gets closed this will ensure the file only gets removed after the DocumentClosed event gets fired.