### PR TITLE
Return cached results from nav to while we are loading the solution

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToSearcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToSearcherTests.cs
@@ -1,0 +1,207 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.NavigateTo;
+using Microsoft.CodeAnalysis.Navigation;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using Moq.Language.Flow;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
+{
+    [UseExportProvider]
+    [Trait(Traits.Feature, Traits.Features.NavigateTo)]
+    public class NavigateToSearcherTests
+    {
+        private static IReturnsResult<INavigateToSearchService> SetupSearchProject(
+            Mock<INavigateToSearchService> searchService,
+            string pattern,
+            bool isFullyLoaded,
+            INavigateToSearchResult? result)
+        {
+            var searchServiceSetup = searchService.Setup(ss => ss.SearchProjectAsync(
+                It.IsAny<Project>(),
+                It.IsAny<ImmutableArray<Document>>(),
+                pattern,
+                ImmutableHashSet<string>.Empty,
+                It.IsAny<Func<INavigateToSearchResult, Task>>(),
+                isFullyLoaded,
+                It.IsAny<CancellationToken>()));
+
+            var searchServiceCallback = searchServiceSetup.Callback(
+                (Project project,
+                 ImmutableArray<Document> priorityDocuments,
+                 string pattern2,
+                 IImmutableSet<string> kinds,
+                 Func<INavigateToSearchResult, Task> onResultFound2,
+                 bool isFullyLoaded2,
+                 CancellationToken cancellationToken) =>
+                {
+                    if (result != null)
+                        onResultFound2(result);
+                });
+
+            return searchServiceCallback.ReturnsAsync(isFullyLoaded ? NavigateToSearchLocation.Latest : NavigateToSearchLocation.Cache);
+        }
+
+        [Fact]
+        public async Task NotFullyLoadedOnlyMakesOneSearchProjectCallIfValueReturned()
+        {
+            using var workspace = TestWorkspace.CreateCSharp("");
+
+            var pattern = "irrelevant";
+
+            var result = new TestNavigateToSearchResult(workspace, new TextSpan(0, 0));
+
+            var searchService = new Mock<INavigateToSearchService>(MockBehavior.Strict);
+            SetupSearchProject(searchService, pattern, isFullyLoaded: false, result);
+
+            // Simulate a host that says the solution isn't fully loaded.
+            var hostMock = new Mock<INavigateToSearcherHost>(MockBehavior.Strict);
+            hostMock.Setup(h => h.IsFullyLoadedAsync(It.IsAny<CancellationToken>())).Returns(new ValueTask<bool>(false));
+            hostMock.Setup(h => h.GetNavigateToSearchService(It.IsAny<Project>())).Returns(searchService.Object);
+
+            var callbackMock = new Mock<INavigateToSearchCallback>(MockBehavior.Strict);
+            callbackMock.Setup(c => c.ReportProgress(It.IsAny<int>(), It.IsAny<int>()));
+            callbackMock.Setup(c => c.AddItemAsync(It.IsAny<Project>(), result, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            // Because we returned a result when not fully loaded, we should notify the user that data was not complete.
+            callbackMock.Setup(c => c.Done(false));
+
+            var searcher = NavigateToSearcher.Create(
+                workspace.CurrentSolution,
+                AsynchronousOperationListenerProvider.NullListener,
+                callbackMock.Object,
+                pattern,
+                searchCurrentDocument: false,
+                kinds: ImmutableHashSet<string>.Empty,
+                CancellationToken.None,
+                hostMock.Object);
+
+            await searcher.SearchAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NotFullyLoadedMakesTwoSearchProjectCallIfValueNotReturned()
+        {
+            using var workspace = TestWorkspace.CreateCSharp("");
+
+            var pattern = "irrelevant";
+
+            var result = new TestNavigateToSearchResult(workspace, new TextSpan(0, 0));
+
+            var searchService = new Mock<INavigateToSearchService>(MockBehavior.Strict);
+
+            // First call will pass in that we're not fully loaded.  If we return null, we should get
+            // another call with the request to search the fully loaded data.
+            SetupSearchProject(searchService, pattern, isFullyLoaded: false, result: null);
+            SetupSearchProject(searchService, pattern, isFullyLoaded: true, result);
+
+            // Simulate a host that says the solution isn't fully loaded.
+            var hostMock = new Mock<INavigateToSearcherHost>(MockBehavior.Strict);
+            hostMock.Setup(h => h.IsFullyLoadedAsync(It.IsAny<CancellationToken>())).Returns(new ValueTask<bool>(false));
+            hostMock.Setup(h => h.GetNavigateToSearchService(It.IsAny<Project>())).Returns(searchService.Object);
+
+            var callbackMock = new Mock<INavigateToSearchCallback>(MockBehavior.Strict);
+            callbackMock.Setup(c => c.ReportProgress(It.IsAny<int>(), It.IsAny<int>()));
+            callbackMock.Setup(c => c.AddItemAsync(It.IsAny<Project>(), result, It.IsAny<CancellationToken>()))
+                        .Returns(Task.CompletedTask);
+
+            // Becaue we did a ful search, we should let the user know it was totally accurate.
+            callbackMock.Setup(c => c.Done(true));
+
+            var searcher = NavigateToSearcher.Create(
+                workspace.CurrentSolution,
+                AsynchronousOperationListenerProvider.NullListener,
+                callbackMock.Object,
+                pattern,
+                searchCurrentDocument: false,
+                kinds: ImmutableHashSet<string>.Empty,
+                CancellationToken.None,
+                hostMock.Object);
+
+            await searcher.SearchAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task FullyLoadedMakesSingleSearchProjectCallIfValueNotReturned()
+        {
+            using var workspace = TestWorkspace.CreateCSharp("");
+
+            var pattern = "irrelevant";
+
+            var result = new TestNavigateToSearchResult(workspace, new TextSpan(0, 0));
+
+            var searchService = new Mock<INavigateToSearchService>(MockBehavior.Strict);
+
+            // First call will pass in that we're fully loaded.  If we return null, we should not get another call.
+            SetupSearchProject(searchService, pattern, isFullyLoaded: true, result: null);
+
+            // Simulate a host that says the solution is fully loaded.
+            var hostMock = new Mock<INavigateToSearcherHost>(MockBehavior.Strict);
+            hostMock.Setup(h => h.IsFullyLoadedAsync(It.IsAny<CancellationToken>())).Returns(new ValueTask<bool>(true));
+            hostMock.Setup(h => h.GetNavigateToSearchService(It.IsAny<Project>())).Returns(searchService.Object);
+
+            var callbackMock = new Mock<INavigateToSearchCallback>(MockBehavior.Strict);
+            callbackMock.Setup(c => c.ReportProgress(It.IsAny<int>(), It.IsAny<int>()));
+            callbackMock.Setup(c => c.AddItemAsync(It.IsAny<Project>(), result, It.IsAny<CancellationToken>()))
+                        .Returns(Task.CompletedTask);
+
+            // Because we did a full search, we should let the user know it was totally accurate.
+            callbackMock.Setup(c => c.Done(true));
+
+            var searcher = NavigateToSearcher.Create(
+                workspace.CurrentSolution,
+                AsynchronousOperationListenerProvider.NullListener,
+                callbackMock.Object,
+                pattern,
+                searchCurrentDocument: false,
+                kinds: ImmutableHashSet<string>.Empty,
+                CancellationToken.None,
+                hostMock.Object);
+
+            await searcher.SearchAsync(CancellationToken.None);
+        }
+
+        private class TestNavigateToSearchResult : INavigateToSearchResult, INavigableItem
+        {
+            private readonly TestWorkspace _workspace;
+            private readonly TextSpan _sourceSpan;
+
+            public TestNavigateToSearchResult(TestWorkspace workspace, TextSpan sourceSpan)
+            {
+                _workspace = workspace;
+                _sourceSpan = sourceSpan;
+            }
+
+            public Document Document => _workspace.CurrentSolution.Projects.Single().Documents.Single();
+            public TextSpan SourceSpan => _sourceSpan;
+
+            public string AdditionalInformation => throw new NotImplementedException();
+            public string Kind => throw new NotImplementedException();
+            public NavigateToMatchKind MatchKind => throw new NotImplementedException();
+            public bool IsCaseSensitive => throw new NotImplementedException();
+            public string Name => throw new NotImplementedException();
+            public ImmutableArray<TextSpan> NameMatchSpans => throw new NotImplementedException();
+            public string SecondarySort => throw new NotImplementedException();
+            public string Summary => throw new NotImplementedException();
+            public INavigableItem NavigableItem => this;
+            public Glyph Glyph => throw new NotImplementedException();
+            public ImmutableArray<TaggedText> DisplayTaggedParts => throw new NotImplementedException();
+            public bool DisplayFileLocation => throw new NotImplementedException();
+            public bool IsImplicitlyDeclared => throw new NotImplementedException();
+            public bool IsStale => throw new NotImplementedException();
+            public ImmutableArray<INavigableItem> ChildItems => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -1119,7 +1120,7 @@ class D
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             var items = await _aggregator.GetItemsAsync("VisibleMethod");
@@ -1192,7 +1193,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(
@@ -1226,7 +1227,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(
@@ -1259,7 +1260,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(
@@ -1289,7 +1290,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(
@@ -1324,7 +1325,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(
@@ -1351,7 +1352,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(
@@ -1378,7 +1379,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(
@@ -1404,7 +1405,7 @@ testHost, @"class C
 </Workspace>
 ", composition: EditorTestCompositions.EditorFeatures);
 
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
 
             VerifyNavigateToResultItems(

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -15,6 +15,7 @@ using System.Windows.Media.Imaging;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.Host;
@@ -114,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
 
         internal void InitializeWorkspace(TestWorkspace workspace)
         {
-            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener);
+            _provider = new NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService<IThreadingContext>());
             _aggregator = new NavigateToTestAggregator(_provider);
         }
 

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Remote.Testing
@@ -840,7 +841,7 @@ End Class
                     </Project>
                 </Workspace>, testHost, createTrackingService:=Nothing)
 
-                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener)
+                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService(Of IThreadingContext)())
                 _aggregator = New NavigateToTestAggregator(_provider)
 
                 VerifyNavigateToResultItems(
@@ -875,7 +876,7 @@ End Class
                     </Project>
                 </Workspace>, testHost, createTrackingService:=Nothing)
 
-                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener)
+                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService(Of IThreadingContext)())
                 _aggregator = New NavigateToTestAggregator(_provider)
 
                 VerifyNavigateToResultItems(
@@ -908,7 +909,7 @@ End Class
                     </Project>
                 </Workspace>, testHost, createTrackingService:=Nothing)
 
-                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener)
+                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService(Of IThreadingContext)())
                 _aggregator = New NavigateToTestAggregator(_provider)
 
                 VerifyNavigateToResultItems(
@@ -938,7 +939,7 @@ End Class
                     </Project>
                 </Workspace>, testHost, createTrackingService:=Nothing)
 
-                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener)
+                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService(Of IThreadingContext)())
                 _aggregator = New NavigateToTestAggregator(_provider)
 
                 VerifyNavigateToResultItems(
@@ -974,7 +975,7 @@ End Class
                     </Project>
                 </Workspace>, testHost, createTrackingService:=Nothing)
 
-                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener)
+                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService(Of IThreadingContext)())
                 _aggregator = New NavigateToTestAggregator(_provider)
 
                 VerifyNavigateToResultItems(
@@ -1000,7 +1001,7 @@ End Class
                     </Project>
                 </Workspace>, testHost, createTrackingService:=Nothing)
 
-                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener)
+                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService(Of IThreadingContext)())
                 _aggregator = New NavigateToTestAggregator(_provider)
 
                 VerifyNavigateToResultItems(
@@ -1027,7 +1028,7 @@ End Class
                     </Project>
                 </Workspace>, testHost, createTrackingService:=Nothing)
 
-                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener)
+                _provider = New NavigateToItemProvider(workspace, AsynchronousOperationListenerProvider.NullListener, workspace.GetService(Of IThreadingContext)())
                 _aggregator = New NavigateToTestAggregator(_provider)
 
                 VerifyNavigateToResultItems(

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigateToSearchService.cs
@@ -35,30 +35,34 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 
         public bool CanFilter => _searchService?.CanFilter ?? false;
 
-        public async Task SearchDocumentAsync(
+        public async Task<NavigateToSearchLocation> SearchDocumentAsync(
             Document document, string searchPattern, IImmutableSet<string> kinds,
             Func<INavigateToSearchResult, Task> onResultFound,
             bool isFullyLoaded, CancellationToken cancellationToken)
         {
-            if (_searchService == null)
-                return;
+            if (_searchService != null)
+            {
+                var results = await _searchService.SearchDocumentAsync(document, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
+                foreach (var result in results)
+                    await onResultFound(Convert(result)).ConfigureAwait(false);
+            }
 
-            var results = await _searchService.SearchDocumentAsync(document, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
-            foreach (var result in results)
-                await onResultFound(Convert(result)).ConfigureAwait(false);
+            return NavigateToSearchLocation.Latest;
         }
 
-        public async Task SearchProjectAsync(
+        public async Task<NavigateToSearchLocation> SearchProjectAsync(
             Project project, ImmutableArray<Document> priorityDocuments, string searchPattern,
             IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound,
             bool isFullyLoaded, CancellationToken cancellationToken)
         {
-            if (_searchService == null)
-                return;
+            if (_searchService != null)
+            {
+                var results = await _searchService.SearchProjectAsync(project, priorityDocuments, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
+                foreach (var result in results)
+                    await onResultFound(Convert(result)).ConfigureAwait(false);
+            }
 
-            var results = await _searchService.SearchProjectAsync(project, priorityDocuments, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
-            foreach (var result in results)
-                await onResultFound(Convert(result)).ConfigureAwait(false);
+            return NavigateToSearchLocation.Latest;
         }
 
         private static INavigateToSearchResult Convert(IVSTypeScriptNavigateToSearchResult result)

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -38,7 +38,8 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
         public static Task SearchFullyLoadedProjectInCurrentProcessAsync(
             Project project, ImmutableArray<Document> priorityDocuments, string searchPattern,
-            IImmutableSet<string> kinds, Func<RoslynNavigateToItem, Task> onResultFound, CancellationToken cancellationToken)
+            IImmutableSet<string> kinds, Func<RoslynNavigateToItem, Task> onResultFound,
+            CancellationToken cancellationToken)
         {
             return FindSearchResultsAsync(
                 project, priorityDocuments, searchDocument: null, pattern: searchPattern, kinds, onResultFound, cancellationToken);

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -38,8 +38,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
         public static Task SearchFullyLoadedProjectInCurrentProcessAsync(
             Project project, ImmutableArray<Document> priorityDocuments, string searchPattern,
-            IImmutableSet<string> kinds, Func<RoslynNavigateToItem, Task> onResultFound,
-            CancellationToken cancellationToken)
+            IImmutableSet<string> kinds, Func<RoslynNavigateToItem, Task> onResultFound, CancellationToken cancellationToken)
         {
             return FindSearchResultsAsync(
                 project, priorityDocuments, searchDocument: null, pattern: searchPattern, kinds, onResultFound, cancellationToken);

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.cs
@@ -42,11 +42,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             };
         }
 
-        public Task SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken)
+        public async Task<NavigateToSearchLocation> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken)
         {
-            return isFullyLoaded
-                ? SearchFullyLoadedDocumentAsync(document, searchPattern, kinds, onResultFound, cancellationToken)
-                : SearchCachedDocumentsAsync(ImmutableArray.Create(document), ImmutableArray<Document>.Empty, searchPattern, kinds, onResultFound, cancellationToken);
+            if (isFullyLoaded)
+            {
+                await SearchFullyLoadedDocumentAsync(document, searchPattern, kinds, onResultFound, cancellationToken).ConfigureAwait(false);
+                return NavigateToSearchLocation.Latest;
+            }
+            else
+            {
+                await SearchCachedDocumentsAsync(ImmutableArray.Create(document), ImmutableArray<Document>.Empty, searchPattern, kinds, onResultFound, cancellationToken).ConfigureAwait(false);
+                return NavigateToSearchLocation.Cache;
+            }
         }
 
         private static async Task SearchFullyLoadedDocumentAsync(
@@ -75,11 +82,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 document, searchPattern, kinds, onItemFound, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken)
+        public async Task<NavigateToSearchLocation> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken)
         {
-            return isFullyLoaded
-                ? SearchFullyLoadedProjectAsync(project, priorityDocuments, searchPattern, kinds, onResultFound, cancellationToken)
-                : SearchCachedDocumentsAsync(project.Documents.ToImmutableArray(), priorityDocuments, searchPattern, kinds, onResultFound, cancellationToken);
+            if (isFullyLoaded)
+            {
+                await SearchFullyLoadedProjectAsync(project, priorityDocuments, searchPattern, kinds, onResultFound, cancellationToken).ConfigureAwait(false);
+                return NavigateToSearchLocation.Latest;
+            }
+            else
+            {
+                await SearchCachedDocumentsAsync(project.Documents.ToImmutableArray(), priorityDocuments, searchPattern, kinds, onResultFound, cancellationToken).ConfigureAwait(false);
+                return NavigateToSearchLocation.Cache;
+            }
         }
 
         private static async Task SearchFullyLoadedProjectAsync(

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         /// subset of the documents from <paramref name="project"/> that can be used to prioritize
         /// work.
         /// </summary>
-        Task<NavigateToSearchLocation> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, bool allowCachedData, CancellationToken cancellationToken);
-        Task<NavigateToSearchLocation> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, bool allowCachedData, CancellationToken cancellationToken);
+        Task<NavigateToSearchLocation> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken);
+        Task<NavigateToSearchLocation> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken);
     }
 
     internal enum NavigateToSearchLocation

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -19,7 +19,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         /// Searches the document inside <paramref name="project"/> for symbols that matches <paramref name="searchPattern"/>.
         /// <paramref name="priorityDocuments"/> is an optional subset of the documents from <paramref name="project"/> that can be used to prioritize work.
         /// </summary>
-        Task SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken);
-        Task SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, CancellationToken cancellationToken);
+        Task<NavigateToSearchLocation> SearchProjectAsync(Project project, ImmutableArray<Document> priorityDocuments, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, bool allowCachedData, CancellationToken cancellationToken);
+        Task<NavigateToSearchLocation> SearchDocumentAsync(Document document, string searchPattern, IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound, bool isFullyLoaded, bool allowCachedData, CancellationToken cancellationToken);
+    }
+
+    internal enum NavigateToSearchLocation
+    {
+        /// <summary>
+        /// If the search was performed against cached data from a previous run.
+        /// </summary>
+        Cache,
+
+        // If the search examined the latest data we have for the requested project or document.
+        Latest
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
@@ -19,7 +19,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     internal interface INavigateToSearcherHost
     {
         INavigateToSearchService? GetNavigateToSearchService(Project project);
-        ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns the fully loaded state for both the project system and the remote host.
+        /// </summary>
+        ValueTask<(bool projectSystem, bool remoteHost)> IsFullyLoadedAsync(CancellationToken cancellationToken);
     }
 
     internal class DefaultNavigateToSearchHost : INavigateToSearcherHost
@@ -50,7 +54,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         public INavigateToSearchService? GetNavigateToSearchService(Project project)
             => project.GetLanguageService<INavigateToSearchService>();
 
-        public async ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken)
+        public async ValueTask<(bool projectSystem, bool remoteHost)> IsFullyLoadedAsync(CancellationToken cancellationToken)
         {
             var service = _solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
 
@@ -59,10 +63,10 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             // return cached data from languages that support that.
             var isProjectSystemFullyLoaded = await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
             if (!isProjectSystemFullyLoaded)
-                return false;
+                return (false, false);
 
             var isRemoteHostFullyLoaded = GetRemoteHostHydrateTask().IsCompleted;
-            return isRemoteHostFullyLoaded;
+            return (isProjectSystemFullyLoaded, isRemoteHostFullyLoaded);
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
@@ -17,6 +18,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     /// </summary>
     internal interface INavigateToSearcherHost
     {
+        INavigateToSearchService? GetNavigateToSearchService(Project project);
         ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken);
     }
 
@@ -44,6 +46,9 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             _asyncListener = asyncListener;
             _disposalToken = disposalToken;
         }
+
+        public INavigateToSearchService? GetNavigateToSearchService(Project project)
+            => project.GetLanguageService<INavigateToSearchService>();
 
         public async ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+
+namespace Microsoft.CodeAnalysis.NavigateTo
+{
+    /// <summary>
+    /// Host interface abstracting over all the external functionality the <see cref="NavigateToSearcher"/> needs. This
+    /// provide an easy entry point for swapping out functionality of the host, including for testing purposes.
+    /// </summary>
+    internal interface INavigateToSearcherHost
+    {
+        ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken);
+    }
+
+    internal class DefaultNavigateToSearchHost : INavigateToSearcherHost
+    {
+        private readonly Solution _solution;
+        private readonly IAsynchronousOperationListener _asyncListener;
+        private readonly CancellationToken _disposalToken;
+
+        /// <summary>
+        /// Single task used to both hydrate the remote host with the initial workspace solution,
+        /// and track if that work completed.  Prior to it completing, we will try to get all
+        /// navigate-to requests from our caches.  Once it is populated though, we can attempt to
+        /// use the latest data instead.
+        /// </summary>
+        private static readonly object s_gate = new();
+        private static Task? s_remoteHostHydrateTask = null;
+
+        public DefaultNavigateToSearchHost(
+            Solution solution,
+            IAsynchronousOperationListener asyncListener,
+            CancellationToken disposalToken)
+        {
+            _solution = solution;
+            _asyncListener = asyncListener;
+            _disposalToken = disposalToken;
+        }
+
+        public async ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken)
+        {
+            var service = _solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
+
+            // We consider ourselves fully loaded when both the project system has completed loaded
+            // us, and we've totally hydrated the oop side.  Until that happens, we'll attempt to
+            // return cached data from languages that support that.
+            var isProjectSystemFullyLoaded = await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
+            if (!isProjectSystemFullyLoaded)
+                return false;
+
+            var isRemoteHostFullyLoaded = GetRemoteHostHydrateTask().IsCompleted;
+            return isRemoteHostFullyLoaded;
+        }
+
+        /// <summary>
+        /// If we're in a solution that is using OOP, this kicks off a task to get the oop side in
+        /// sync with us.  Until that happens, we'll continue to use the cached results from prior
+        /// sessions so that we can get results very quickly right after launch without forcing the
+        /// user to wait for OOP to hydrate the entire solution over.  This strikes a good balance
+        /// of speed and accuracy as most of the time cached results will be fast and good enough,
+        /// and eventually (usually within dozens of seconds, even for large projects) we will
+        /// switch over to full and accurate results which can also come back quickly.
+        /// </summary>
+        /// <remarks>
+        /// If we do report cached data, we inform the user of this so they know the results may be
+        /// incomplete or inaccurate and that they can try again later if necessary.
+        /// </remarks>
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
+        private Task GetRemoteHostHydrateTask()
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
+        {
+            lock (s_gate)
+            {
+                // Only need to do this once.
+                if (s_remoteHostHydrateTask == null)
+                {
+                    // If there are no projects in this solution that use OOP, then there's nothing we need to do.
+                    if (_solution.Projects.All(p => !RemoteSupportedLanguages.IsSupported(p.Language)))
+                    {
+                        s_remoteHostHydrateTask = Task.CompletedTask;
+                    }
+                    else
+                    {
+                        var asyncToken = _asyncListener.BeginAsyncOperation(nameof(GetRemoteHostHydrateTask));
+
+                        s_remoteHostHydrateTask = Task.Run(async () =>
+                        {
+                            var client = await RemoteHostClient.TryGetClientAsync(_solution.Workspace, _disposalToken).ConfigureAwait(false);
+                            if (client != null)
+                            {
+                                await client.TryInvokeAsync<IRemoteNavigateToSearchService>(
+                                    _solution,
+                                    (service, solutionInfo, cancellationToken) =>
+                                    service.HydrateAsync(solutionInfo, cancellationToken),
+                                    _disposalToken).ConfigureAwait(false);
+                            }
+                        }, _disposalToken);
+                        s_remoteHostHydrateTask.CompletesAsyncOperation(asyncToken);
+                    }
+                }
+
+                return s_remoteHostHydrateTask;
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         ValueTask SearchFullyLoadedDocumentAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, string searchPattern, ImmutableArray<string> kinds, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
         ValueTask SearchFullyLoadedProjectAsync(PinnedSolutionInfo solutionInfo, ProjectId projectId, ImmutableArray<DocumentId> priorityDocumentIds, string searchPattern, ImmutableArray<string> kinds, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
         ValueTask SearchCachedDocumentsAsync(ImmutableArray<DocumentKey> documentKeys, ImmutableArray<DocumentKey> priorityDocumentKeys, string searchPattern, ImmutableArray<string> kinds, RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
+        ValueTask HydrateAsync(PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken);
 
         public interface ICallback
         {

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -159,6 +159,9 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             // If we're only searching the current doc, we don't need to examine anything else but that.
             if (_searchCurrentDocument)
             {
+                // Note: _currentDocument may still be null.  Just because the user asked to search current document
+                // doesn't mean we were able to map the view to an active doc inside Roslyn.  In this case, we just
+                // don't search anything.
                 var project = _currentDocument?.Project;
                 return project == null
                     ? ImmutableArray<ImmutableArray<Project>>.Empty

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -29,6 +31,9 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private readonly Document? _currentDocument;
         private readonly IStreamingProgressTracker _progress;
         private readonly CancellationToken _cancellationToken;
+
+        private readonly Document? _activeDocument;
+        private readonly ImmutableArray<Document> _visibleDocuments;
 
         public NavigateToSearcher(
             Solution solution,
@@ -58,21 +63,27 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 var activeId = documentService.TryGetActiveDocument();
                 _currentDocument = activeId != null ? _solution.GetDocument(activeId) : null;
             }
+
+            var docTrackingService = _solution.Workspace.Services.GetService<IDocumentTrackingService>() ?? NoOpDocumentTrackingService.Instance;
+
+            // If the workspace is tracking documents, use that to prioritize our search
+            // order.  That way we provide results for the documents the user is working
+            // on faster than the rest of the solution.
+            _activeDocument = docTrackingService.GetActiveDocument(_solution);
+            _visibleDocuments = docTrackingService.GetVisibleDocuments(_solution)
+                                                  .WhereAsArray(d => d != _activeDocument);
         }
 
         internal async Task SearchAsync()
         {
-            var isFullyLoaded = true;
+            var searchWasComplete = true;
 
             try
             {
-                var service = _solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
-                isFullyLoaded = await service.IsFullyLoadedAsync(_cancellationToken).ConfigureAwait(false);
-
                 using var navigateToSearch = Logger.LogBlock(FunctionId.NavigateTo_Search, KeyValueLogMessage.Create(LogType.UserAction), _cancellationToken);
                 using var asyncToken = _asyncListener.BeginAsyncOperation(GetType() + ".Search");
-                await _progress.AddItemsAsync(_solution.Projects.Count()).ConfigureAwait(false);
-                await SearchAllProjectsAsync(isFullyLoaded).ConfigureAwait(false);
+
+                searchWasComplete = await SearchAllProjectsAsync().ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -81,72 +92,150 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             {
                 // providing this extra information will make UI to show indication to users
                 // that result might not contain full data
-                _callback.Done(isFullyLoaded);
+                _callback.Done(searchWasComplete);
             }
         }
 
-        private async Task SearchAllProjectsAsync(bool isFullyLoaded)
+        /// <summary>
+        /// Returns <see langword="true"/> if all searches were performed against the latest data
+        /// and represent the complete set of results. Or <see langword="false"/> if any searches
+        /// were performed against cached data.
+        /// </summary>
+        private async Task<bool> SearchAllProjectsAsync()
         {
-            var seenItems = new HashSet<INavigateToSearchResult>(NavigateToSearchResultComparer.Instance);
-            var processedProjects = new HashSet<Project>();
+            var service = _solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
+            var isFullyLoaded = await service.IsFullyLoadedAsync(_cancellationToken).ConfigureAwait(false);
 
-            // If the workspace is tracking documents, use that to prioritize our search
-            // order.  That way we provide results for the documents the user is working
-            // on faster than the rest of the solution.
-            var docTrackingService = _solution.Workspace.Services.GetService<IDocumentTrackingService>() ?? NoOpDocumentTrackingService.Instance;
+            var orderedProjects = GetOrderedProjectsToProcess();
+            var (itemsReported, projectResults) = await ProcessProjectsAsync(
+                orderedProjects, isFullyLoaded, allowCachedData: true).ConfigureAwait(false);
 
-            var activeDocument = docTrackingService.GetActiveDocument(_solution);
-            var visibleDocs = docTrackingService.GetVisibleDocuments(_solution)
-                                                .WhereAsArray(d => d != activeDocument);
-
-            // First, if there's an active document, search that project first, prioritizing
-            // that active document and all visible documents from it.
-            if (activeDocument != null)
+            // If we're not fully loaded yet, this is the best we could do in terms of getting
+            // results.  Nothing we can do at this point until we reach the fully loaded state.
+            if (!isFullyLoaded)
             {
-                var activeProject = activeDocument.Project;
-                processedProjects.Add(activeProject);
-
-                var visibleDocsFromProject = visibleDocs.Where(d => d.Project == activeProject);
-                var priorityDocs = ImmutableArray.Create(activeDocument).AddRange(visibleDocsFromProject);
-
-                // Search the active project first.  That way we can deliver results that are
-                // closer in scope to the user quicker without forcing them to do something like
-                // NavToInCurrentDoc
-                await Task.Run(() => SearchAsync(activeProject, priorityDocs, seenItems, isFullyLoaded), _cancellationToken).ConfigureAwait(false);
+                // We weren't fully loaded, so definitely let the user know the results are
+                // incomplete in the UI.
+                return false;
             }
 
-            // Now, process all visible docs that were not from the active project.
-            var tasks = new List<Task>();
-            foreach (var (currentProject, priorityDocs) in visibleDocs.GroupBy(d => d.Project))
+            // We were fully loaded *and* we reported some items to the user.
+            var anyCached = projectResults.Any(t => t.cached);
+            if (itemsReported > 0)
             {
-                // make sure we only process this project if we didn't already process it above.
-                if (processedProjects.Add(currentProject))
-                    tasks.Add(Task.Run(() => SearchAsync(currentProject, priorityDocs.Where(d => d.Project == currentProject).ToImmutableArray(), seenItems, isFullyLoaded), _cancellationToken));
+                // Let our caller know if any of these results came from cached data.  If so, we'll
+                // put a header on the nav-to window letting the user know that results may be stale.
+                return !anyCached;
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            // We didn't have any items reported.  If it turns out that some of our projects were
+            // using cached data, try searching them again, but this time disallow checking them for
+            // cached results.
+            var projectsUsingCache = projectResults.Where(t => t.cached).SelectAsArray(t => t.project);
+            Contract.ThrowIfFalse(isFullyLoaded);
+            await ProcessProjectsAsync(
+                ImmutableArray.Create(projectsUsingCache), isFullyLoaded: true, allowCachedData: false).ConfigureAwait(false);
 
-            // Now, process the remainder of projects
-            tasks.Clear();
-            foreach (var currentProject in _solution.Projects)
-            {
-                // make sure we only process this project if we didn't already process it above.
-                if (processedProjects.Add(currentProject))
-                    tasks.Add(Task.Run(() => SearchAsync(currentProject, ImmutableArray<Document>.Empty, seenItems, isFullyLoaded), _cancellationToken));
-            }
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            // we did a full uncached search.  return true to indicate that no message should be
+            // shown to the user.
+            return true;
         }
 
-        private async Task SearchAsync(
-            Project project,
-            ImmutableArray<Document> priorityDocuments,
-            HashSet<INavigateToSearchResult> seenItems,
-            bool isFullyLoaded)
+        private ImmutableArray<ImmutableArray<Project>> GetOrderedProjectsToProcess()
+        {
+            // If we're only searching the current doc, we don't need to examine anything else but that.
+            if (_searchCurrentDocument)
+            {
+                var project = _currentDocument?.Project;
+                return project == null
+                    ? ImmutableArray<ImmutableArray<Project>>.Empty
+                    : ImmutableArray.Create(ImmutableArray.Create(project));
+            }
+
+            using var result = TemporaryArray<ImmutableArray<Project>>.Empty;
+
+            using var _ = PooledHashSet<Project>.GetInstance(out var processedProjects);
+
+            // First, if there's an active document, search that project first, prioritizing that
+            // active document and all visible documents from it.
+            if (_activeDocument != null)
+            {
+                processedProjects.Add(_activeDocument.Project);
+                result.Add(ImmutableArray.Create(_activeDocument.Project));
+            }
+
+            // Next process all visible docs that were not from the active project.
+            using var buffer = TemporaryArray<Project>.Empty;
+            foreach (var doc in _visibleDocuments)
+            {
+                if (processedProjects.Add(doc.Project))
+                    buffer.Add(doc.Project);
+            }
+
+            if (buffer.Count > 0)
+                result.Add(buffer.ToImmutableAndClear());
+
+            // Finally, process the remainder of projects
+            foreach (var project in _solution.Projects)
+            {
+                if (processedProjects.Add(project))
+                    buffer.Add(project);
+            }
+
+            if (buffer.Count > 0)
+                result.Add(buffer.ToImmutableAndClear());
+
+            return result.ToImmutableAndClear();
+        }
+
+        private ImmutableArray<Document> GetPriorityDocuments(Project project)
+        {
+            using var result = TemporaryArray<Document>.Empty;
+            if (_activeDocument?.Project == project)
+                result.Add(_activeDocument);
+
+            foreach (var doc in _visibleDocuments)
+            {
+                if (doc.Project == project)
+                    result.Add(doc);
+            }
+
+            return result.ToImmutableAndClear();
+        }
+
+        private async Task<(int itemsReported, ImmutableArray<(Project project, bool cached)>)> ProcessProjectsAsync(
+            ImmutableArray<ImmutableArray<Project>> orderedProjects,
+            bool isFullyLoaded,
+            bool allowCachedData)
+        {
+            var projectCount = orderedProjects.Sum(p => p.Length);
+            await _progress.AddItemsAsync(projectCount).ConfigureAwait(false);
+
+            using var _ = ArrayBuilder<(Project project, bool cached)>.GetInstance(out var result);
+
+            var seenItems = new HashSet<INavigateToSearchResult>(NavigateToSearchResultComparer.Instance);
+            foreach (var projectGroup in orderedProjects)
+            {
+                var tasks = projectGroup.SelectAsArray(p => Task.Run(() => SearchAsync(p, isFullyLoaded, allowCachedData, seenItems)));
+                var taskResults = await Task.WhenAll(tasks).ConfigureAwait(false);
+                foreach (var taskResult in taskResults)
+                    result.AddIfNotNull(taskResult);
+            }
+
+            return (seenItems.Count, result.ToImmutable());
+        }
+
+        private async Task<(Project project, bool cached)?> SearchAsync(
+            Project project, bool isFullyLoaded, bool allowCachedData,
+            HashSet<INavigateToSearchResult> seenItems)
         {
             try
             {
-                await SearchCoreAsync(project, priorityDocuments, seenItems, isFullyLoaded).ConfigureAwait(false);
+                var location = await SearchCoreAsync(project, allowCachedData, isFullyLoaded, seenItems).ConfigureAwait(false);
+                if (location == null)
+                    return null;
+
+                return (project, cached: location == NavigateToSearchLocation.Cache);
             }
             finally
             {
@@ -154,25 +243,24 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
         }
 
-        private async Task SearchCoreAsync(
-            Project project,
-            ImmutableArray<Document> priorityDocuments,
-            HashSet<INavigateToSearchResult> seenItems,
-            bool isFullyLoaded)
+        private async Task<NavigateToSearchLocation?> SearchCoreAsync(
+            Project project, bool isFullyLoaded, bool allowCachedData,
+            HashSet<INavigateToSearchResult> seenItems)
         {
-            if (_searchCurrentDocument && _currentDocument?.Project != project)
-                return;
-
             var service = project.GetLanguageService<INavigateToSearchService>();
             if (service == null)
-                return;
+                return null;
 
-            var task = _currentDocument != null
-                ? service.SearchDocumentAsync(_currentDocument, _searchPattern, _kinds, OnResultFound, isFullyLoaded, _cancellationToken)
-                : service.SearchProjectAsync(project, priorityDocuments, _searchPattern, _kinds, OnResultFound, isFullyLoaded, _cancellationToken);
+            if (_searchCurrentDocument)
+            {
+                Contract.ThrowIfNull(_currentDocument);
+                return await service.SearchDocumentAsync(
+                    _currentDocument, _searchPattern, _kinds, OnResultFound, isFullyLoaded, allowCachedData, _cancellationToken).ConfigureAwait(false);
+            }
 
-            await task.ConfigureAwait(false);
-            return;
+            var priorityDocuments = GetPriorityDocuments(project);
+            return await service.SearchProjectAsync(
+                project, priorityDocuments, _searchPattern, _kinds, OnResultFound, isFullyLoaded, allowCachedData, _cancellationToken).ConfigureAwait(false);
 
             async Task OnResultFound(INavigateToSearchResult result)
             {

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         /// sync with us.  Until that happens, we'll continue to use the cached results from prior
         /// sessions so that we can get results very quickly right after launch without forcing the
         /// user to wait for OOP to hydrate the entire solution over.  This strikes a good balance
-        /// of speed an accuracy as most of the time cached results will be fast and good enough,
+        /// of speed and accuracy as most of the time cached results will be fast and good enough,
         /// and eventually (usually within dozens of seconds, even for large projects) we will
         /// switch over to full and accurate results which can also come back quickly.
         /// </summary>

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -5,17 +5,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Collections;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
@@ -261,7 +257,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         {
             // If they don't even support the service, then always show them as having done the
             // complete search.  That way we don't call back into this project ever.
-            var service = project.GetLanguageService<INavigateToSearchService>();
+            var service = _host.GetNavigateToSearchService(project);
             if (service == null)
                 return NavigateToSearchLocation.Latest;
 

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                     project, GetPriorityDocuments(project), _searchPattern, _kinds, OnResultFound, isFullyLoaded, cancellationToken).ConfigureAwait(false);
             }
 
-            async Task OnResultFound(INavigateToSearchResult result)
+            Task OnResultFound(INavigateToSearchResult result)
             {
                 // If we're seeing a dupe in another project, then filter it out here.  The results from
                 // the individual projects will already contain the information about all the projects
@@ -281,10 +281,10 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 lock (seenItems)
                 {
                     if (!seenItems.Add(result))
-                        return;
+                        return Task.CompletedTask;
                 }
 
-                await _callback.AddItemAsync(project, result, cancellationToken).ConfigureAwait(false);
+                return _callback.AddItemAsync(project, result, cancellationToken);
             }
         }
     }

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -95,11 +95,25 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             return new NavigateToSearcher(solution, asyncListener, callback, searchPattern, searchCurrentDocument, kinds);
         }
 
+        /// <summary>
+        /// If we're in a solution that is using OOP, this kicks off a task to get the oop side in
+        /// sync with us.  Until that happens, we'll continue to use the cached results from prior
+        /// sessions so that we can get results very quickly right after launch without forcing the
+        /// user to wait for OOP to hydrate the entire solution over.  This strikes a good balance
+        /// of speed an accuracy as most of the time cached results will be fast and good enough,
+        /// and eventually (usually within dozens of seconds, even for large projects) we will
+        /// switch over to full and accurate results which can also come back quickly.
+        /// </summary>
+        /// <remarks>
+        /// If we do report cached data, we inform the user of this so they know the results may be
+        /// incomplete or inaccurate and that they can try again later if necessary.
+        /// </remarks>
         private static void InitializeRemoteHostIfNecessary(
             Solution solution, IAsynchronousOperationListener asyncListener, CancellationToken disposalToken)
         {
             lock (s_gate)
             {
+                // Only need to do this once.
                 if (s_remoteHostHydrateTask != null)
                     return;
 
@@ -153,11 +167,15 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         /// <summary>
         /// Returns <see langword="true"/> if all searches were performed against the latest data
         /// and represent the complete set of results. Or <see langword="false"/> if any searches
-        /// were performed against cached data.
+        /// were performed against cached data and could be incomplete or inaccurate.
         /// </summary>
         private async Task<bool> SearchAllProjectsAsync(CancellationToken cancellationToken)
         {
             var service = _solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
+
+            // We consider ourselves fully loaded when both the project system has completed loaded
+            // us, and we've totally hydrated the oop side.  Until that happens, we'll attempt to
+            // return cached data from languages that support that.
             var isProjectSystemFullyLoaded = await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
             var isRemoteHostFullyLoaded = s_remoteHostHydrateTask.IsCompleted;
 
@@ -167,28 +185,25 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             var (itemsReported, projectResults) = await ProcessProjectsAsync(
                 orderedProjects, isFullyLoaded, cancellationToken).ConfigureAwait(false);
 
-            // If we're not fully loaded yet, this is the best we could do in terms of getting
-            // results.  Nothing we can do at this point until we reach the fully loaded state.
+            // If we're fully loaded then we're done at this point.  All the searchs would have been against the latest
+            // computed data and we don't need to do anything else.
             if (isFullyLoaded)
-            {
-                // We were fully loaded, so definitely let the user know the results are complete in the UI.
                 return true;
-            }
 
-            // We were fully loaded *and* we reported some items to the user.
-            var anyCached = projectResults.Any(t => t.cached);
+            // We weren't fully loaded *but* we reported some items to the user, then consider that
+            // good enough for now.  The user will have some results they can use, and (in the case
+            // that we actually examined the cache for data) we will tell the user that hte results
+            // may be incomplete/inacurate and they should try again soon.
             if (itemsReported > 0)
             {
-                // Let our caller know if any of these results came from cached data.  If so, we'll
-                // put a header on the nav-to window letting the user know that results may be stale.
-                return !anyCached;
+                return projectResults.All(t => t.location == NavigateToSearchLocation.Latest);
             }
 
-            // We didn't have any items reported and we weren't fully loaded.  If it turns out that
-            // some of our projects were using cached data then we can try searching them again, but
-            // this tell them to use the latest data.  The ensures the user at least gets some
-            // result instead of nothing.
-            var projectsUsingCache = projectResults.Where(t => t.cached).SelectAsArray(t => t.project);
+            // We didn't have any items reported *and* we weren't fully loaded.  If it turns out
+            // that some of our projects were using cached data then we can try searching them
+            // again, but this tell them to use the latest data.  The ensures the user at least gets
+            // some result instead of nothing.
+            var projectsUsingCache = projectResults.Where(t => t.location == NavigateToSearchLocation.Cache).SelectAsArray(t => t.project);
             await ProcessProjectsAsync(ImmutableArray.Create(projectsUsingCache), isFullyLoaded: true, cancellationToken).ConfigureAwait(false);
 
             // we did a full uncached search.  return true to indicate that no message should be
@@ -196,6 +211,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             return true;
         }
 
+        /// <summary>
+        /// Returns a sequence of groups of projects to process.  The sequence is in priority order,
+        /// and all projects in a particular group should be processed before the next group.  This
+        /// allows us to associate cpu resources in likely areas the user wants, while also still
+        /// allowing for good parallelization.
+        /// </summary>
         private ImmutableArray<ImmutableArray<Project>> GetOrderedProjectsToProcess()
         {
             // If we're only searching the current doc, we don't need to examine anything else but that.
@@ -243,9 +264,15 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             return result.ToImmutableAndClear();
         }
 
+        /// <summary>
+        /// Given a search within a particular project, this returns any documents within that
+        /// project that should take precedence when searching.  This allows results to get to the
+        /// user more quickly for common cases (like using nav-to to find results in the file you
+        /// currently have open
+        /// </summary>
         private ImmutableArray<Document> GetPriorityDocuments(Project project)
         {
-            using var result = TemporaryArray<Document>.Empty;
+            using var _ = ArrayBuilder<Document>.GetInstance(out var result);
             if (_activeDocument?.Project == project)
                 result.Add(_activeDocument);
 
@@ -255,16 +282,16 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                     result.Add(doc);
             }
 
-            return result.ToImmutableAndClear();
+            result.RemoveDuplicates();
+            return result.ToImmutable();
         }
 
-        private async Task<(int itemsReported, ImmutableArray<(Project project, bool cached)>)> ProcessProjectsAsync(
+        private async Task<(int itemsReported, ImmutableArray<(Project project, NavigateToSearchLocation location)>)> ProcessProjectsAsync(
             ImmutableArray<ImmutableArray<Project>> orderedProjects, bool isFullyLoaded, CancellationToken cancellationToken)
         {
-            var projectCount = orderedProjects.Sum(p => p.Length);
-            await _progress.AddItemsAsync(projectCount).ConfigureAwait(false);
+            await _progress.AddItemsAsync(orderedProjects.Sum(p => p.Length)).ConfigureAwait(false);
 
-            using var _ = ArrayBuilder<(Project project, bool cached)>.GetInstance(out var result);
+            using var _ = ArrayBuilder<(Project project, NavigateToSearchLocation location)>.GetInstance(out var result);
 
             var seenItems = new HashSet<INavigateToSearchResult>(NavigateToSearchResultComparer.Instance);
             foreach (var projectGroup in orderedProjects)
@@ -272,22 +299,19 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 var tasks = projectGroup.SelectAsArray(p => Task.Run(() => SearchAsync(p, isFullyLoaded, seenItems, cancellationToken)));
                 var taskResults = await Task.WhenAll(tasks).ConfigureAwait(false);
                 foreach (var taskResult in taskResults)
-                    result.AddIfNotNull(taskResult);
+                    result.Add(taskResult);
             }
 
             return (seenItems.Count, result.ToImmutable());
         }
 
-        private async Task<(Project project, bool cached)?> SearchAsync(
+        private async Task<(Project project, NavigateToSearchLocation location)> SearchAsync(
             Project project, bool isFullyLoaded, HashSet<INavigateToSearchResult> seenItems, CancellationToken cancellationToken)
         {
             try
             {
                 var location = await SearchCoreAsync(project, isFullyLoaded, seenItems, cancellationToken).ConfigureAwait(false);
-                if (location == null)
-                    return null;
-
-                return (project, cached: location == NavigateToSearchLocation.Cache);
+                return (project, location);
             }
             finally
             {
@@ -295,12 +319,14 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
         }
 
-        private async Task<NavigateToSearchLocation?> SearchCoreAsync(
+        private async Task<NavigateToSearchLocation> SearchCoreAsync(
             Project project, bool isFullyLoaded, HashSet<INavigateToSearchResult> seenItems, CancellationToken cancellationToken)
         {
+            // If they don't even support the service, then always show them as having done the
+            // complete search.  That way we don't call back into this project ever.
             var service = project.GetLanguageService<INavigateToSearchService>();
             if (service == null)
-                return null;
+                return NavigateToSearchLocation.Latest;
 
             if (_searchCurrentDocument)
             {
@@ -308,10 +334,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 return await service.SearchDocumentAsync(
                     _currentDocument, _searchPattern, _kinds, OnResultFound, isFullyLoaded, cancellationToken).ConfigureAwait(false);
             }
-
-            var priorityDocuments = GetPriorityDocuments(project);
-            return await service.SearchProjectAsync(
-                project, priorityDocuments, _searchPattern, _kinds, OnResultFound, isFullyLoaded, cancellationToken).ConfigureAwait(false);
+            else
+            {
+                return await service.SearchProjectAsync(
+                    project, GetPriorityDocuments(project), _searchPattern, _kinds, OnResultFound, isFullyLoaded, cancellationToken).ConfigureAwait(false);
+            }
 
             async Task OnResultFound(INavigateToSearchResult result)
             {

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal partial class NavigateToSearcher
     {
+        private readonly INavigateToSearcherHost _host;
         private readonly Solution _solution;
         private readonly IAsynchronousOperationListener _asyncListener;
         private readonly INavigateToSearchCallback _callback;
@@ -36,16 +37,8 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private readonly Document? _activeDocument;
         private readonly ImmutableArray<Document> _visibleDocuments;
 
-        /// <summary>
-        /// Single task used to both hydrate the remote host with the initial workspace solution,
-        /// and track if that work completed.  Prior to it completing, we will try to get all
-        /// navigate-to requests from our caches.  Once it is populated though, we can attempt to
-        /// use the latest data instead.
-        /// </summary>
-        private static readonly object s_gate = new();
-        private static Task s_remoteHostHydrateTask = null!;
-
         private NavigateToSearcher(
+            INavigateToSearcherHost host,
             Solution solution,
             IAsynchronousOperationListener asyncListener,
             INavigateToSearchCallback callback,
@@ -53,6 +46,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             bool searchCurrentDocument,
             IImmutableSet<string> kinds)
         {
+            _host = host;
             _solution = solution;
             _asyncListener = asyncListener;
             _callback = callback;
@@ -83,6 +77,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         }
 
         public static NavigateToSearcher Create(
+            INavigateToSearcherHost? host,
             Solution solution,
             IAsynchronousOperationListener asyncListener,
             INavigateToSearchCallback callback,
@@ -91,55 +86,8 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             IImmutableSet<string> kinds,
             CancellationToken disposalToken)
         {
-            InitializeRemoteHostIfNecessary(solution, asyncListener, disposalToken);
-            return new NavigateToSearcher(solution, asyncListener, callback, searchPattern, searchCurrentDocument, kinds);
-        }
-
-        /// <summary>
-        /// If we're in a solution that is using OOP, this kicks off a task to get the oop side in
-        /// sync with us.  Until that happens, we'll continue to use the cached results from prior
-        /// sessions so that we can get results very quickly right after launch without forcing the
-        /// user to wait for OOP to hydrate the entire solution over.  This strikes a good balance
-        /// of speed and accuracy as most of the time cached results will be fast and good enough,
-        /// and eventually (usually within dozens of seconds, even for large projects) we will
-        /// switch over to full and accurate results which can also come back quickly.
-        /// </summary>
-        /// <remarks>
-        /// If we do report cached data, we inform the user of this so they know the results may be
-        /// incomplete or inaccurate and that they can try again later if necessary.
-        /// </remarks>
-        private static void InitializeRemoteHostIfNecessary(
-            Solution solution, IAsynchronousOperationListener asyncListener, CancellationToken disposalToken)
-        {
-            lock (s_gate)
-            {
-                // Only need to do this once.
-                if (s_remoteHostHydrateTask != null)
-                    return;
-
-                // If there are no projects in this solution that use OOP, then there's nothing we need to do.
-                if (solution.Projects.All(p => !RemoteSupportedLanguages.IsSupported(p.Language)))
-                {
-                    s_remoteHostHydrateTask = Task.CompletedTask;
-                    return;
-                }
-
-                var asyncToken = asyncListener.BeginAsyncOperation(nameof(InitializeRemoteHostIfNecessary));
-
-                s_remoteHostHydrateTask = Task.Run(async () =>
-                {
-                    var client = await RemoteHostClient.TryGetClientAsync(solution.Workspace, disposalToken).ConfigureAwait(false);
-                    if (client != null)
-                    {
-                        await client.TryInvokeAsync<IRemoteNavigateToSearchService>(
-                            solution,
-                            (service, solutionInfo, cancellationToken) =>
-                            service.HydrateAsync(solutionInfo, cancellationToken),
-                            disposalToken).ConfigureAwait(false);
-                    }
-                }, disposalToken);
-                s_remoteHostHydrateTask.CompletesAsyncOperation(asyncToken);
-            }
+            host ??= new DefaultNavigateToSearchHost(solution, asyncListener, disposalToken);
+            return new NavigateToSearcher(host, solution, asyncListener, callback, searchPattern, searchCurrentDocument, kinds);
         }
 
         internal async Task SearchAsync(CancellationToken cancellationToken)
@@ -171,15 +119,10 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         /// </summary>
         private async Task<bool> SearchAllProjectsAsync(CancellationToken cancellationToken)
         {
-            var service = _solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
-
             // We consider ourselves fully loaded when both the project system has completed loaded
             // us, and we've totally hydrated the oop side.  Until that happens, we'll attempt to
             // return cached data from languages that support that.
-            var isProjectSystemFullyLoaded = await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
-            var isRemoteHostFullyLoaded = s_remoteHostHydrateTask.IsCompleted;
-
-            var isFullyLoaded = isProjectSystemFullyLoaded && isRemoteHostFullyLoaded;
+            var isFullyLoaded = await _host.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
 
             var orderedProjects = GetOrderedProjectsToProcess();
             var (itemsReported, projectResults) = await ProcessProjectsAsync(orderedProjects, isFullyLoaded, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -294,12 +294,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
             var seenItems = new HashSet<INavigateToSearchResult>(NavigateToSearchResultComparer.Instance);
             foreach (var projectGroup in orderedProjects)
-            {
-                var tasks = projectGroup.SelectAsArray(p => Task.Run(() => SearchAsync(p, isFullyLoaded, seenItems, cancellationToken)));
-                var taskResults = await Task.WhenAll(tasks).ConfigureAwait(false);
-                foreach (var taskResult in taskResults)
-                    result.Add(taskResult);
-            }
+                result.AddRange(await Task.WhenAll(projectGroup.Select(p => Task.Run(() => SearchAsync(p, isFullyLoaded, seenItems, cancellationToken)))).ConfigureAwait(false));
 
             return (seenItems.Count, result.ToImmutable());
         }

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -182,8 +182,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             var isFullyLoaded = isProjectSystemFullyLoaded && isRemoteHostFullyLoaded;
 
             var orderedProjects = GetOrderedProjectsToProcess();
-            var (itemsReported, projectResults) = await ProcessProjectsAsync(
-                orderedProjects, isFullyLoaded, cancellationToken).ConfigureAwait(false);
+            var (itemsReported, projectResults) = await ProcessProjectsAsync(orderedProjects, isFullyLoaded, cancellationToken).ConfigureAwait(false);
 
             // If we're fully loaded then we're done at this point.  All the searchs would have been against the latest
             // computed data and we don't need to do anything else.

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -8,6 +8,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -37,12 +38,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 NavigateToItemKind.Structure);
 
         private readonly IAsynchronousOperationListener _asyncListener;
+        private readonly IThreadingContext _threadingContext;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public WorkspaceSymbolsHandler(IAsynchronousOperationListenerProvider listenerProvider)
+        public WorkspaceSymbolsHandler(
+            IAsynchronousOperationListenerProvider listenerProvider,
+            IThreadingContext threadingContext)
         {
             _asyncListener = listenerProvider.GetListener(FeatureAttribute.NavigateTo);
+            _threadingContext = threadingContext;
         }
 
         public override string Method => Methods.WorkspaceSymbolName;
@@ -59,17 +64,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var solution = context.Solution;
 
             using var progress = BufferedProgress.Create(request.PartialResultToken);
-            var searcher = new NavigateToSearcher(
+            var searcher = NavigateToSearcher.Create(
                 solution,
                 _asyncListener,
                 new LSPNavigateToCallback(progress),
                 request.Query,
                 searchCurrentDocument: false,
                 s_supportedKinds,
-                cancellationToken);
+                _threadingContext.DisposalToken);
 
-            await searcher.SearchAsync().ConfigureAwait(false);
-
+            await searcher.SearchAsync(cancellationToken).ConfigureAwait(false);
             return progress.GetValues();
         }
 

--- a/src/Tools/ExternalAccess/FSharp/Internal/NavigateTo/FSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/NavigateTo/FSharpNavigateToSearchService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.NavigateTo
 
         public bool CanFilter => _service.CanFilter;
 
-        public async Task SearchDocumentAsync(
+        public async Task<NavigateToSearchLocation> SearchDocumentAsync(
             Document document, string searchPattern, IImmutableSet<string> kinds,
             Func<INavigateToSearchResult, Task> onResultFound,
             bool isFullyLoaded, CancellationToken cancellationToken)
@@ -38,9 +38,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.NavigateTo
             var results = await _service.SearchDocumentAsync(document, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
             foreach (var result in results)
                 await onResultFound(new InternalFSharpNavigateToSearchResult(result)).ConfigureAwait(false);
+
+            return NavigateToSearchLocation.Latest;
         }
 
-        public async Task SearchProjectAsync(
+        public async Task<NavigateToSearchLocation> SearchProjectAsync(
             Project project, ImmutableArray<Document> priorityDocuments, string searchPattern,
             IImmutableSet<string> kinds, Func<INavigateToSearchResult, Task> onResultFound,
             bool isFullyLoaded, CancellationToken cancellationToken)
@@ -48,6 +50,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.NavigateTo
             var results = await _service.SearchProjectAsync(project, priorityDocuments, searchPattern, kinds, cancellationToken).ConfigureAwait(false);
             foreach (var result in results)
                 await onResultFound(new InternalFSharpNavigateToSearchResult(result)).ConfigureAwait(false);
+
+            return NavigateToSearchLocation.Latest;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/NavigateTo/VisualStudioNavigateToItemProviderFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/NavigateTo/VisualStudioNavigateToItemProviderFactory.cs
@@ -17,13 +17,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigateTo
     {
         private readonly IAsynchronousOperationListener _asyncListener;
         private readonly VisualStudioWorkspace _workspace;
+        private readonly IThreadingContext _threadingContext;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualStudioNavigateToItemProviderFactory(VisualStudioWorkspace workspace, IAsynchronousOperationListenerProvider listenerProvider)
+        public VisualStudioNavigateToItemProviderFactory(
+            VisualStudioWorkspace workspace,
+            IAsynchronousOperationListenerProvider listenerProvider,
+            IThreadingContext threadingContext)
         {
             _asyncListener = listenerProvider.GetListener(FeatureAttribute.NavigateTo);
             _workspace = workspace;
+            _threadingContext = threadingContext;
         }
 
         public bool TryCreateNavigateToItemProvider(IServiceProvider serviceProvider, out INavigateToItemProvider? provider)
@@ -35,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigateTo
                 return false;
             }
 
-            provider = new NavigateToItemProvider(_workspace, _asyncListener);
+            provider = new NavigateToItemProvider(_workspace, _asyncListener, _threadingContext);
             return true;
         }
     }

--- a/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/TypeScriptHandlerShims.cs
@@ -173,8 +173,11 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public TypeScriptWorkspaceSymbolsHandlerShim(ILspWorkspaceRegistrationService workspaceRegistrationService, IAsynchronousOperationListenerProvider listenerProvider)
-            : base(listenerProvider)
+        public TypeScriptWorkspaceSymbolsHandlerShim(
+            ILspWorkspaceRegistrationService workspaceRegistrationService,
+            IAsynchronousOperationListenerProvider listenerProvider,
+            IThreadingContext threadingContext)
+            : base(listenerProvider, threadingContext)
         {
             _workspaceRegistrationService = workspaceRegistrationService;
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
@@ -37,6 +37,14 @@ namespace Microsoft.CodeAnalysis.Remote
                 cancellationToken).ConfigureAwait(false);
         }
 
+        public ValueTask HydrateAsync(PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
+        {
+            return RunServiceAsync(async cancellationToken =>
+            {
+                await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
+            }, cancellationToken);
+        }
+
         public ValueTask SearchFullyLoadedDocumentAsync(
             PinnedSolutionInfo solutionInfo,
             DocumentId documentId,

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
@@ -41,6 +41,10 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             return RunServiceAsync(async cancellationToken =>
             {
+                // All we need to do is request the solution.  This will ensure that all assets are
+                // pulled over from the host side to the remote side.  Once this completes, the next
+                // call to SearchFullyLoadedDocumentAsync or SearchFullyLoadedProjectAsync will be
+                // quick as very little will need to by sync'ed over.
                 await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }


### PR DESCRIPTION
Continued followup to https://github.com/dotnet/roslyn/pull/52351.  Includes cleanup for clarity, as well as new logic so that if we find *nothing* in teh search of hte cache, we fallback to still hydrating and searching OOP fully.  This has the benefit that if you loaded a solution fresh, and you search, that you will get some results, and not nothing when searching.  This also means that you shoudl always end up either getting:

1. Some results, but a message saying they could be incomplete.
2. Some results, with no message.
3. No results, with no mesage.

You should never end up with no results, and a message saying thigns are incomplete.  We definitely want to avoid this case as the user won't really have an idea about when that state will be over and when they can search again.  Ideally, the 'some results' they get back are enough to accomplish at least some of the task they want until they end up searching again.

--

Needs some testing here.  My initial approach on testing this didn't pan out given that we mock out storage during most of our normal tests.  SO this will actually have to create a real storage subsystem to validate the behavior with/without data in it.