### PR TITLE
Do not fire TagsChanged for the copy/paste classifier.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/CopyPasteAndPrintingClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/CopyPasteAndPrintingClassifierTests.cs
@@ -21,6 +21,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
 {
+    [UseExportProvider]
     [Trait(Traits.Feature, Traits.Features.Classification)]
     public class CopyPasteAndPrintingClassifierTests
     {

--- a/src/EditorFeatures/CSharpTest/Classification/CopyPasteAndPrintingClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/CopyPasteAndPrintingClassifierTests.cs
@@ -2,33 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Editor.Implementation.Classification;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Remote.Testing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
-using Microsoft.VisualStudio.Threading;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using static Microsoft.CodeAnalysis.Editor.UnitTests.Classification.FormattedClassifications;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
 {
@@ -50,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
                 workspace.ExportProvider.GetExportedValue<ClassificationTypeMap>(),
                 listenerProvider);
 
-            var tagger = provider.CreateTagger<IClassificationTag>(document.GetTextBuffer());
+            var tagger = provider.CreateTagger<IClassificationTag>(document.GetTextBuffer())!;
             using var disposable = (IDisposable)tagger;
             var waiter = listenerProvider.GetWaiter(FeatureAttribute.Classification);
             await waiter.ExpeditedWaitAsync();

--- a/src/EditorFeatures/CSharpTest/Classification/CopyPasteAndPrintingClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/CopyPasteAndPrintingClassifierTests.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Editor.Implementation.Classification;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Remote.Testing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Threading;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+using static Microsoft.CodeAnalysis.Editor.UnitTests.Classification.FormattedClassifications;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
+{
+    [Trait(Traits.Feature, Traits.Features.Classification)]
+    public class CopyPasteAndPrintingClassifierTests
+    {
+        [WpfFact]
+        public async Task TestGetTagsOnBufferTagger()
+        {
+            // don't crash
+            using var workspace = TestWorkspace.CreateCSharp("class C { C c; }");
+            var document = workspace.Documents.First();
+
+            var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
+
+            var provider = new CopyPasteAndPrintingClassificationBufferTaggerProvider(
+                workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
+                workspace.ExportProvider.GetExportedValue<IForegroundNotificationService>(),
+                workspace.ExportProvider.GetExportedValue<ClassificationTypeMap>(),
+                listenerProvider);
+
+            var tagger = provider.CreateTagger<IClassificationTag>(document.GetTextBuffer());
+            using var disposable = (IDisposable)tagger;
+            var waiter = listenerProvider.GetWaiter(FeatureAttribute.Classification);
+            await waiter.ExpeditedWaitAsync();
+
+            var tags = tagger.GetTags(document.GetTextBuffer().CurrentSnapshot.GetSnapshotSpanCollection());
+            var allTags = tagger.GetAllTags(document.GetTextBuffer().CurrentSnapshot.GetSnapshotSpanCollection(), CancellationToken.None);
+
+            Assert.Empty(tags);
+            Assert.NotEmpty(allTags);
+
+            Assert.Equal(1, allTags.Count());
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2627,35 +2627,6 @@ struct Type<T>
             await waiter.ExpeditedWaitAsync();
         }
 
-        [WpfFact]
-        public async Task TestGetTagsOnBufferTagger()
-        {
-            // don't crash
-            using var workspace = TestWorkspace.CreateCSharp("class C { C c; }");
-            var document = workspace.Documents.First();
-
-            var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
-
-            var provider = new SemanticClassificationBufferTaggerProvider(
-                workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
-                workspace.ExportProvider.GetExportedValue<IForegroundNotificationService>(),
-                workspace.ExportProvider.GetExportedValue<ClassificationTypeMap>(),
-                listenerProvider);
-
-            var tagger = provider.CreateTagger<IClassificationTag>(document.GetTextBuffer());
-            using var disposable = (IDisposable)tagger;
-            var waiter = listenerProvider.GetWaiter(FeatureAttribute.Classification);
-            await waiter.ExpeditedWaitAsync();
-
-            var tags = tagger.GetTags(document.GetTextBuffer().CurrentSnapshot.GetSnapshotSpanCollection());
-            var allTags = tagger.GetAllTags(document.GetTextBuffer().CurrentSnapshot.GetSnapshotSpanCollection(), CancellationToken.None);
-
-            Assert.Empty(tags);
-            Assert.NotEmpty(allTags);
-
-            Assert.Equal(1, allTags.Count());
-        }
-
         [Theory]
         [CombinatorialData]
         public async Task Tuples(TestHost testHost)

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -20,7 +19,6 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;

--- a/src/EditorFeatures/Core/Implementation/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -24,11 +24,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
-    internal partial class SemanticClassificationBufferTaggerProvider
+    internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider
     {
         private class Tagger : ForegroundThreadAffinitizedObject, IAccurateTagger<IClassificationTag>, IDisposable
         {
-            private readonly SemanticClassificationBufferTaggerProvider _owner;
+            private readonly CopyPasteAndPrintingClassificationBufferTaggerProvider _owner;
             private readonly ITextBuffer _subjectBuffer;
             private readonly ITaggerEventSource _eventSource;
             private readonly CancellationTokenSource _cancellationTokenSource = new();
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             private SnapshotSpan? _cachedTaggedSpan_doNotAccessDirectly;
 
             public Tagger(
-                SemanticClassificationBufferTaggerProvider owner,
+                CopyPasteAndPrintingClassificationBufferTaggerProvider owner,
                 ITextBuffer subjectBuffer,
                 IAsynchronousOperationListener asyncListener)
                 : base(owner.ThreadingContext)
@@ -59,6 +59,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
                 ConnectToEventSource();
             }
+
+            // Explicitly a no-op.  This classifier does not support change notifications. See comment in
+            // OnEventSourceChanged_OnForeground for more details.
+            public event EventHandler<SnapshotSpanEventArgs> TagsChanged { add { } remove { } }
 
             public void Dispose()
             {
@@ -130,8 +134,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 // It's important that we do not call TagsChanged here as the only thing we could do is notify that the
                 // entire doc is changed, and that incurs a heavy cost for the editor reacting to that notification.
             }
-
-            public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
 
             public IEnumerable<ITagSpan<IClassificationTag>> GetTags(NormalizedSnapshotSpanCollection spans)
             {

--- a/src/EditorFeatures/Core/Implementation/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
     [TagType(typeof(IClassificationTag))]
     [ContentType(ContentTypeNames.CSharpContentType)]
     [ContentType(ContentTypeNames.VisualBasicContentType)]
-    internal partial class SemanticClassificationBufferTaggerProvider : ForegroundThreadAffinitizedObject, ITaggerProvider
+    internal partial class CopyPasteAndPrintingClassificationBufferTaggerProvider : ForegroundThreadAffinitizedObject, ITaggerProvider
     {
         private readonly IAsynchronousOperationListener _asyncListener;
         private readonly IForegroundNotificationService _notificationService;
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-        public SemanticClassificationBufferTaggerProvider(
+        public CopyPasteAndPrintingClassificationBufferTaggerProvider(
             IThreadingContext threadingContext,
             IForegroundNotificationService notificationService,
             ClassificationTypeMap typeMap,

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
@@ -120,8 +120,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 this.CachedTags = null;
                 this.CachedTaggedSpan = null;
 
-                // And notify any concerned parties that we have new tags.
-                this.TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(_subjectBuffer.CurrentSnapshot.GetFullSpan()));
+                // Note: we explicitly do *not* call into TagsChanged here.  This type exists only for the copy/paste
+                // scenario, and in the case the editor always calls into us for the span in question, ignoring
+                // TagsChanged, as per DPugh:
+                //
+                //    For rich text copy, we always call the buffer classifier to get the classifications of the copied
+                //    text. It ignores any tags changed events.
+                //
+                // It's important that we do not call TagsChanged here as the only thing we could do is notify that the
+                // entire doc is changed, and that incurs a heavy cost for the editor reacting to that notification.
             }
 
             public event EventHandler<SnapshotSpanEventArgs> TagsChanged;


### PR DESCRIPTION
Caused by an internal discussion where an editor investigation found a high amount of work caused by these notifications we issue.