### PR TITLE
Implement binding and lowering for InterpolatedStringBuilder

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -144,6 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var unconvertedSource = (BoundUnconvertedInterpolatedString)source;
                 source = new BoundInterpolatedString(
                     unconvertedSource.Syntax,
+                    interpolationData: null,
                     unconvertedSource.Parts,
                     unconvertedSource.ConstantValue,
                     unconvertedSource.Type,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -376,14 +376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
                 case BoundUnconvertedInterpolatedString unconvertedInterpolatedString:
                     {
-                        // We determine the best method of emitting as a string (either via Concat, Format, or the builder pattern)
-                        // during lowering, and it's not part of the publicly-visible API, unlike conversion to a builder type.
-                        result = new BoundInterpolatedString(
-                            unconvertedInterpolatedString.Syntax,
-                            unconvertedInterpolatedString.Parts,
-                            unconvertedInterpolatedString.ConstantValue,
-                            unconvertedInterpolatedString.Type,
-                            unconvertedInterpolatedString.HasErrors);
+                        result = BindUnconvertedInterpolatedStringToString(unconvertedInterpolatedString, diagnostics);
                     }
                     break;
                 default:
@@ -2965,7 +2958,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return argument;
         }
 
-        private void CoerceArguments<TMember>(
+        internal void CoerceArguments<TMember>(
             MemberResolutionResult<TMember> methodResult,
             ArrayBuilder<BoundExpression> arguments,
             BindingDiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -25,7 +28,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                var objectType = GetSpecialType(SpecialType.System_Object, diagnostics, node);
                 var intType = GetSpecialType(SpecialType.System_Int32, diagnostics, node);
                 foreach (var content in node.Contents)
                 {
@@ -35,15 +37,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 var interpolation = (InterpolationSyntax)content;
                                 var value = BindValue(interpolation.Expression, diagnostics, BindValueKind.RValue);
-                                if (value.Type is null)
-                                {
-                                    value = GenerateConversionForAssignment(objectType, value, diagnostics);
-                                }
-                                else
-                                {
-                                    value = BindToNaturalType(value, diagnostics);
-                                    _ = GenerateConversionForAssignment(objectType, value, diagnostics);
-                                }
 
                                 // We need to ensure the argument is not a lambda, method group, etc. It isn't nice to wait until lowering,
                                 // when we perform overload resolution, to report a problem. So we do that check by calling
@@ -133,6 +126,274 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(isResultConstant == (resultConstant != null));
             return new BoundUnconvertedInterpolatedString(node, builder.ToImmutableAndFree(), resultConstant, stringType);
+        }
+
+        private BoundInterpolatedString BindUnconvertedInterpolatedStringToString(BoundUnconvertedInterpolatedString unconvertedInterpolatedString, BindingDiagnosticBag diagnostics)
+        {
+            // We have 4 possible lowering strategies, dependent on the contents of the string, in this order:
+            //  1. The string is a constant value. We can just use the final value.
+            //  2. The WellKnownType InterpolatedStringBuilder is available, and none of the interpolation holes contain an await expression.
+            //     The builder is a ref struct, and we can guarantee the lifetime won't outlive the stack if the string doesn't contain any
+            //     awaits, but if it does we cannot use it. This builder is the only way that ref structs can be directly used as interpolation
+            //     hole components, which means that ref structs components and await expressions cannot be combined. It is already illegal for
+            //     the user to use ref structs in an async method today, but if that were to ever change, this would still need to be respected.
+            //     We also cannot use this method if the interpolated string appears within a catch filter, as the builder is disposable and we
+            //     cannot put a try/finally inside a filter block.
+            //  3. The string is composed entirely of components that are strings themselves. We can turn this into a single call to string.Concat.
+            //     We prefer the builder over this because the builder can used pooling to avoid new allocations, while this call will potentially
+            //     need to allocate a param array.
+            //  4. The string has heterogeneous data and either InterpolatedStringBuilder is unavailable, or one of the holes contains an await
+            //     expression. This is turned into a call to string.Format.
+            //
+            // We need to do the determination of 1, 2, or 3/4 up front, rather than in lowering, as it affects diagnostics (ref structs not being
+            // able to be used, for example). However, between 3 and 4, we don't need to know at this point, so that logic is deferred for lowering.
+
+            if (unconvertedInterpolatedString.ConstantValue is not null)
+            {
+                // Case 1
+                Debug.Assert(unconvertedInterpolatedString.Parts.All(static part => part.Type is null or { SpecialType: SpecialType.System_String }));
+                return constructWithData(unconvertedInterpolatedString.Parts, data: null);
+            }
+
+            if (tryBindAsBuilderType(out var result))
+            {
+                // Case 2
+                return result;
+            }
+
+            // The specifics of 3 vs 4 aren't necessary for this stage of binding. The only thing that matters is that every part needs to be convertible
+            // object.
+            ArrayBuilder<BoundExpression>? partsBuilder = null;
+            var objectType = GetSpecialType(SpecialType.System_Object, diagnostics, unconvertedInterpolatedString.Syntax);
+            for (int i = 0; i < unconvertedInterpolatedString.Parts.Length; i++)
+            {
+                var part = unconvertedInterpolatedString.Parts[i];
+                if (part is BoundStringInsert insert)
+                {
+                    BoundExpression newValue;
+                    if (insert.Value.Type is null)
+                    {
+                        newValue = GenerateConversionForAssignment(objectType, insert.Value, diagnostics);
+                    }
+                    else
+                    {
+                        newValue = BindToNaturalType(insert.Value, diagnostics);
+                        _ = GenerateConversionForAssignment(objectType, insert.Value, diagnostics);
+                    }
+
+                    if (insert.Value != newValue)
+                    {
+                        if (partsBuilder is null)
+                        {
+                            partsBuilder = ArrayBuilder<BoundExpression>.GetInstance(unconvertedInterpolatedString.Parts.Length);
+                            partsBuilder.AddRange(unconvertedInterpolatedString.Parts, i);
+                        }
+
+                        partsBuilder.Add(insert.Update(newValue, insert.Alignment, insert.Format, insert.Type));
+                    }
+                    else
+                    {
+                        partsBuilder?.Add(part);
+                    }
+                }
+                else
+                {
+                    Debug.Assert(part is BoundLiteral { Type: { SpecialType: SpecialType.System_String } });
+                    partsBuilder?.Add(part);
+                }
+            }
+
+            return constructWithData(partsBuilder?.ToImmutableAndFree() ?? unconvertedInterpolatedString.Parts, data: null);
+
+            BoundInterpolatedString constructWithData(ImmutableArray<BoundExpression> parts, InterpolatedStringBuilderData? data)
+                => new BoundInterpolatedString(
+                    unconvertedInterpolatedString.Syntax,
+                    data,
+                    parts,
+                    unconvertedInterpolatedString.ConstantValue,
+                    unconvertedInterpolatedString.Type,
+                    unconvertedInterpolatedString.HasErrors);
+
+            bool tryBindAsBuilderType([NotNullWhen(true)] out BoundInterpolatedString? result)
+            {
+                if (this.Flags.Includes(BinderFlags.InCatchFilter))
+                {
+                    // CLI Spec does not permit nested tries inside a filter block, so we can't use the builder here, as it is disposable.
+                    // PROTOTYPE(interp-string): Should we try to collect errors if a type not otherwise usable in an interpolated string
+                    // is used in this case?
+                    result = null;
+                    return false;
+                }
+
+                result = null;
+                var interpolatedStringBuilderType = Compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder);
+                if (interpolatedStringBuilderType is MissingMetadataTypeSymbol)
+                {
+                    return false;
+                }
+
+                if (unconvertedInterpolatedString.Parts.ContainsAwaitExpression())
+                {
+                    return false;
+                }
+
+                BindingDiagnosticBag applicableDiagnostics = BindingDiagnosticBag.GetInstance(template: diagnostics);
+                if (!Conversions.IsApplicableInterpolatedStringBuilderType(unconvertedInterpolatedString, interpolatedStringBuilderType, applicableDiagnostics, out var builderArguments))
+                {
+                    applicableDiagnostics.Free();
+                    return false;
+                }
+
+                diagnostics.AddRangeAndFree(applicableDiagnostics);
+
+                // Prior to C# 10, all types in an interpolated string expression needed to be convertible to `object`. After 10, some types
+                // (such as Span<T>) that are not convertible to `object` are permissible as interpolated string components, provided there
+                // is an applicable TryFormatInterpolationHole that accepts them. To preserve langversion, we therefore make sure all components
+                // are convertible to object if the current langversion is lower than the interpolation feature
+                var needToCheckConversionToObject = !Compilation.IsFeatureEnabled(MessageID.IDS_FeatureImprovedInterpolatedStrings) && diagnostics.AccumulatesDiagnostics;
+                var (objectType, conversionDiagnostics) = needToCheckConversionToObject
+                    ? (GetSpecialType(SpecialType.System_Object, diagnostics, unconvertedInterpolatedString.Syntax), BindingDiagnosticBag.GetInstance())
+                    : (null, null);
+
+                // Swap out the first argument of the format calls, which is the (potentially converted) part from the original string with
+                // a placeholder, and put the part into the interpolated string's list of parts.
+                Debug.Assert(builderArguments.Length == unconvertedInterpolatedString.Parts.Length);
+                var interpolatedDataBuilder = ArrayBuilder<MethodArgumentInfo>.GetInstance(builderArguments.Length);
+                var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(3);
+                var partsBuilder = ArrayBuilder<BoundExpression>.GetInstance(builderArguments.Length);
+                int baseStringLength = 0;
+                int numFormatHoles = 0;
+
+                for (int i = 0; i < builderArguments.Length; i++)
+                {
+                    var currentFormatCall = builderArguments[i];
+                    Debug.Assert(currentFormatCall.Arguments.Length > 0);
+                    Debug.Assert(argumentsBuilder.Count == 0);
+
+                    var newPart = currentFormatCall.Arguments[0];
+                    argumentsBuilder.Add(new BoundInterpolatedStringElementPlaceholder(newPart.Syntax, i, newPart.Type));
+                    if (currentFormatCall.Arguments.Length > 1)
+                    {
+                        argumentsBuilder.AddRange(currentFormatCall.Arguments.AsSpan()[1..]);
+                    }
+
+                    interpolatedDataBuilder.Add(currentFormatCall with { Arguments = argumentsBuilder.ToImmutableAndClear() });
+
+                    var currentPart = unconvertedInterpolatedString.Parts[i];
+                    if (currentPart is BoundStringInsert insert)
+                    {
+                        numFormatHoles++;
+
+                        if (needToCheckConversionToObject)
+                        {
+                            Debug.Assert(conversionDiagnostics is not null);
+                            var value = insert.Value;
+                            bool reported = false;
+                            if (value.Type is not null)
+                            {
+                                value = BindToNaturalType(value, conversionDiagnostics);
+                                if (conversionDiagnostics.HasAnyErrors())
+                                {
+                                    CheckFeatureAvailability(value.Syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
+                                    conversionDiagnostics.Clear();
+                                    reported = true;
+                                }
+                            }
+
+                            if (!reported)
+                            {
+                                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(conversionDiagnostics);
+                                var conversion = Conversions.ClassifyConversionFromExpression(value, objectType, ref useSiteInfo);
+                                if (!conversion.Exists || !conversion.IsValid || useSiteInfo.HasErrors)
+                                {
+                                    CheckFeatureAvailability(value.Syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
+                                }
+                            }
+                        }
+
+                        newPart = insert.Update(newPart, insert.Alignment, insert.Format, newPart.Type);
+                    }
+                    else
+                    {
+                        Debug.Assert(newPart is BoundLiteral { ConstantValue: { IsString: true } });
+                        Debug.Assert(currentPart.ConstantValue is { IsString: true });
+                        baseStringLength += currentPart.ConstantValue.RopeValue!.Length;
+                    }
+
+                    partsBuilder.Add(newPart);
+
+                    ReportDiagnosticsIfObsolete(diagnostics, currentFormatCall.Method, currentPart.Syntax, hasBaseReceiver: false);
+                    ReportDiagnosticsIfUnmanagedCallersOnly(diagnostics, currentFormatCall.Method, currentPart.Syntax.Location, isDelegateConversion: false);
+                }
+
+                conversionDiagnostics?.Free();
+
+                var newParts = partsBuilder.ToImmutableAndFree();
+
+                var createMethod = (MethodSymbol)GetWellKnownTypeMember(
+                    WellKnownMember.System_Runtime_CompilerServices_InterpolatedStringBuilder__CreateInt32Int32,
+                    diagnostics,
+                    syntax: unconvertedInterpolatedString.Syntax);
+
+                MethodArgumentInfo? constructorInfo = null;
+
+                if (createMethod != null)
+                {
+                    var intType = GetSpecialType(SpecialType.System_Int32, diagnostics, unconvertedInterpolatedString.Syntax);
+                    var arguments = ImmutableArray.Create<BoundExpression>(
+                        new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(baseStringLength), intType) { WasCompilerGenerated = true },
+                        new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(numFormatHoles), intType) { WasCompilerGenerated = true });
+
+                    constructorInfo = new MethodArgumentInfo(createMethod, arguments, ArgsToParamsOpt: default, DefaultArguments: BitVector.Empty, Expanded: false);
+
+                    ReportDiagnosticsIfObsolete(diagnostics, createMethod, unconvertedInterpolatedString.Syntax, hasBaseReceiver: false);
+                    ReportDiagnosticsIfUnmanagedCallersOnly(diagnostics, createMethod, unconvertedInterpolatedString.Syntax.Location, isDelegateConversion: false);
+                }
+
+                // PROTOTYPE(interp-strings): Do we need to support versions of InterpolatedStringBuilder that do not have Dispose, or implement it
+                // with a different signature, or that are not a ref struct and explicitly implement IDisposable?
+                // PROTOTYPE(interp-string): Is the runtime going to expose this?
+
+                var disposeMethod = (MethodSymbol)GetWellKnownTypeMember(
+                    WellKnownMember.System_Runtime_CompilerServices_InterpolatedStringBuilder__Dispose,
+                    diagnostics,
+                    syntax: unconvertedInterpolatedString.Syntax);
+
+                MethodArgumentInfo? disposeInfo = null;
+
+                if (disposeMethod != null)
+                {
+                    var argsToParams = default(ImmutableArray<int>);
+                    var expanded = disposeMethod.HasParamsParameter();
+
+                    BindDefaultArguments(
+                        unconvertedInterpolatedString.Syntax,
+                        disposeMethod.Parameters,
+                        argumentsBuilder,
+                        argumentRefKindsBuilder: null,
+                        ref argsToParams,
+                        out BitVector defaultArguments,
+                        expanded,
+                        enableCallerInfo: true,
+                        diagnostics);
+
+                    disposeInfo = new MethodArgumentInfo(disposeMethod, argumentsBuilder.ToImmutable(), argsToParams, defaultArguments, expanded);
+
+                    ReportDiagnosticsIfObsolete(diagnostics, disposeMethod, unconvertedInterpolatedString.Syntax, hasBaseReceiver: false);
+                    ReportDiagnosticsIfUnmanagedCallersOnly(diagnostics, disposeMethod, unconvertedInterpolatedString.Syntax.Location, isDelegateConversion: false);
+                }
+
+                argumentsBuilder.Free();
+                result = constructWithData(
+                    newParts,
+                    new InterpolatedStringBuilderData(
+                        interpolatedStringBuilderType,
+                        constructorInfo,
+                        interpolatedDataBuilder.ToImmutableAndFree(),
+                        disposeInfo,
+                        LocalScopeDepth));
+                return true;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -4,11 +4,12 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -86,6 +87,234 @@ namespace Microsoft.CodeAnalysis.CSharp
                     TypeSymbol.Equals(destination, Compilation.GetWellKnownType(WellKnownType.System_FormattableString), TypeCompareKind.ConsiderEverything2))
                 ? Conversion.InterpolatedString : Conversion.NoConversion;
         }
+
+#nullable  enable
+        public override bool IsApplicableInterpolatedStringBuilderType(BoundUnconvertedInterpolatedString source, TypeSymbol builderType, BindingDiagnosticBag diagnostics, out ImmutableArray<MethodArgumentInfo> builderArguments)
+        {
+            // SPEC:
+            // A type is said to be an _applicable_interpolated_string_builder_type_ if, given an _interpolated_string_literal_ `S`, the following is true:
+            //  * Overload resolution with an identifier of `TryFormatBaseString` and a parameter type of `string` succeeds, and contains a single instance method that returns a `bool` or `void`.
+            //  * For every _regular_balanced_text_ component of `S` (`Si`) without an _interpolation_format_ component or _constant_expression_ (alignment) component, overload resolution
+            //    with an identifier of `TryFormatInterpolationHole` and parameter of the type of `Si` and succeeds, and contains a single instance method that returns a `bool` or `void`.
+            //  * For every _regular_balanced_text_ component of `S` (`Si`) with an _interpolation_format_ component and no _constant_expression_ (alignment) component, overload resolution
+            //    with an identifier of `TryFormatInterpolationHole` and parameter types of `Si` and `string` with name `format` (in that order) succeeds, and contains a single instance
+            //    method that returns a `bool` or `void`.
+            //  * For every _regular_balanced_text_ component of `S` (`Si`) with a _constant_expression_ (alignment) component and no _interpolation_format_ component, overload resolution
+            //    with an identifier of `TryFormatInterpolationHole and parameter types of `Si` and `int` with name `alignment` (in that order) succeeds, and contains a single instance
+            //    method that returns a `bool` or `void`.
+            //  * For every _regular_balanced_text_ component of `S` (`Si`) with an _interpolation_format_ component and a _constant_expression_ (alignment) component, overload resolution
+            //    with an identifier of `TryFormatInterpolationHole` and parameter types of `Si`, `int` with name `alignment`, and `string` with name `format` (in that order) succeeds, and
+            //    contains a single instance method that returns a `bool` or `void`.
+            // Additionally, all resolved method calls must return the same type. `TryFormat` calls that mix `bool` and `void` are not permitted.
+
+            // If the type is applicable, we'll add these to the given info at the end.
+            var useSiteInfo = _binder.GetNewCompoundUseSiteInfo(diagnostics);
+
+            // All builder types have to at least have a `TryFormatBaseString` that takes a single string argument and returns either bool or void.
+            if (!tryGetCandidateMethods("TryFormatBaseString", ref useSiteInfo, out ArrayBuilder<MethodSymbol>? baseStringCandidates))
+            {
+                // PROTOTYPE(interp-strings): We'll want to have a specific error for when we're converting to a non-string type
+                builderArguments = default;
+                diagnostics.AddDiagnostics(source.Syntax, useSiteInfo);
+                return false;
+            }
+
+            var typeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance();
+            var implicitBuilderReceiver = new BoundImplicitReceiver(source.Syntax, builderType);
+            var analyzedArguments = AnalyzedArguments.GetInstance();
+            var overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
+            var stringType = _binder.GetSpecialType(SpecialType.System_String, diagnostics, source.Syntax);
+            analyzedArguments.Arguments.Add(new BoundLiteral(CSharpSyntaxTree.Dummy.GetRoot(), constantValueOpt: null, stringType));
+            _binder.OverloadResolution.MethodInvocationOverloadResolution(
+                baseStringCandidates,
+                typeArguments,
+                implicitBuilderReceiver,
+                analyzedArguments,
+                overloadResolutionResult,
+                ref useSiteInfo);
+
+            if (!overloadResolutionResult.Succeeded || overloadResolutionResult.ValidResult.Member.CallsAreOmitted(source.SyntaxTree))
+            {
+                // PROTOTYPE(interp-strings): We'll want to have a specific error for when we're converting to a non-string type
+                free();
+                builderArguments = default;
+                return false;
+            }
+
+            Debug.Assert(!overloadResolutionResult.ValidResult.Member.IsStatic);
+
+            // All TryFormat... calls must have the same return type, and it must be either bool or void.
+            bool usesBoolReturn;
+            switch (overloadResolutionResult.ValidResult.Member.ReturnType.SpecialType)
+            {
+                case SpecialType.System_Void:
+                    usesBoolReturn = false;
+                    break;
+                case SpecialType.System_Boolean:
+                    usesBoolReturn = true;
+                    break;
+                default:
+                    free();
+                    builderArguments = default;
+                    return false;
+            }
+
+            // We at least have an invocable, applicable TryFormatBaseString method on the type. We can proceed with finding the correct overloads for
+            // each component.
+
+            if (source.Parts.Length == 0)
+            {
+                free();
+                diagnostics.AddDiagnostics(source.Syntax, useSiteInfo);
+                builderArguments = ImmutableArray<MethodArgumentInfo>.Empty;
+                return true;
+            }
+
+            ArrayBuilder<MethodSymbol>? interpolationHoleCandidates = null;
+            var builderFormatCalls = ArrayBuilder<MethodArgumentInfo>.GetInstance(source.Parts.Length);
+
+            foreach (var part in source.Parts)
+            {
+                Debug.Assert(typeArguments.IsEmpty());
+                Debug.Assert(part is BoundLiteral or BoundStringInsert);
+                analyzedArguments.Clear();
+                overloadResolutionResult.Clear();
+
+                ArrayBuilder<MethodSymbol> candidateMethods;
+                if (part is BoundStringInsert insert)
+                {
+                    if (interpolationHoleCandidates is null && !tryGetCandidateMethods("TryFormatInterpolationHole", ref useSiteInfo, out interpolationHoleCandidates))
+                    {
+                        // PROTOTYPE(interp-string): We'll likely want to continue attempting to bind for errors when we're not directly being converted to a string
+                        free();
+                        builderFormatCalls.Free();
+                        builderArguments = default;
+                        return false;
+                    }
+
+                    candidateMethods = interpolationHoleCandidates;
+                    analyzedArguments.Arguments.Add(insert.Value);
+                    analyzedArguments.Names.Add(null);
+
+                    if (insert.Alignment is not null)
+                    {
+                        analyzedArguments.Arguments.Add(insert.Alignment);
+                        analyzedArguments.Names.Add(SyntaxFactory.IdentifierName("alignment"));
+                    }
+                    if (insert.Format is not null)
+                    {
+                        analyzedArguments.Arguments.Add(insert.Format);
+                        analyzedArguments.Names.Add(SyntaxFactory.IdentifierName("format"));
+                    }
+                }
+                else
+                {
+                    candidateMethods = baseStringCandidates;
+                    analyzedArguments.Arguments.Add(part);
+                }
+
+                _binder.OverloadResolution.MethodInvocationOverloadResolution(
+                    candidateMethods,
+                    typeArguments,
+                    implicitBuilderReceiver,
+                    analyzedArguments,
+                    overloadResolutionResult,
+                    ref useSiteInfo);
+
+                if (!overloadResolutionResult.Succeeded
+                    || overloadResolutionResult.ValidResult.Member.CallsAreOmitted(source.SyntaxTree)
+                    || !returnTypeMatches(overloadResolutionResult.ValidResult.Member, usesBoolReturn))
+                {
+                    // PROTOTYPE(interp-string): We'll likely want to continue attempting to bind for errors when we're not directly being converted to a string
+                    free();
+                    builderFormatCalls.Free();
+                    interpolationHoleCandidates?.Free();
+                    builderArguments = default;
+                    return false;
+                }
+
+                var argsToParam = overloadResolutionResult.ValidResult.Result.ArgsToParamsOpt;
+
+                _binder.CoerceArguments(overloadResolutionResult.ValidResult, analyzedArguments.Arguments, diagnostics);
+
+                bool expanded = overloadResolutionResult.ValidResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
+                _binder.BindDefaultArguments(
+                    source.Syntax,
+                    overloadResolutionResult.ValidResult.Member.Parameters,
+                    analyzedArguments.Arguments,
+                    analyzedArguments.RefKinds,
+                    ref argsToParam,
+                    out BitVector defaultArguments,
+                    expanded,
+                    enableCallerInfo: true,
+                    diagnostics);
+
+                builderFormatCalls.Add(new MethodArgumentInfo(overloadResolutionResult.ValidResult.Member, analyzedArguments.Arguments.ToImmutable(), argsToParam, defaultArguments, expanded));
+            }
+
+            free();
+            diagnostics.AddDiagnostics(source.Syntax, useSiteInfo);
+            builderArguments = builderFormatCalls.ToImmutableAndFree();
+            interpolationHoleCandidates?.Free();
+            return true;
+
+            bool tryGetCandidateMethods(string methodName, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, [NotNullWhen(true)] out ArrayBuilder<MethodSymbol>? candidateMethods)
+            {
+                var lookupResult = LookupResult.GetInstance();
+                _binder.LookupSymbolsSimpleName(lookupResult,
+                    builderType,
+                    methodName,
+                    arity: 0,
+                    basesBeingResolved: null,
+                    options: LookupOptions.AllMethodsOnArityZero | LookupOptions.MustBeInstance | LookupOptions.MustBeInvocableIfMember,
+                    diagnose: true,
+                    ref useSiteInfo);
+
+                if (!lookupResult.IsMultiViable)
+                {
+                    candidateMethods = null;
+                    lookupResult.Free();
+                    return false;
+                }
+
+                Debug.Assert(lookupResult.Symbols.Count > 0);
+                candidateMethods = ArrayBuilder<MethodSymbol>.GetInstance(lookupResult.Symbols.Count);
+
+                foreach (var symbol in lookupResult.Symbols)
+                {
+                    if (symbol is not MethodSymbol method)
+                    {
+                        // PROTOTYPE(interp-strings): We'll want to have a specific error for when we're converting to a non-string type
+                        candidateMethods.Free();
+                        lookupResult.Free();
+                        candidateMethods = null;
+                        return false;
+                    }
+
+                    candidateMethods.Add(method);
+                }
+
+                lookupResult.Free();
+                return true;
+            }
+
+            void free()
+            {
+                typeArguments.Free();
+                analyzedArguments.Free();
+                overloadResolutionResult.Free();
+                baseStringCandidates.Free();
+            }
+
+            static bool returnTypeMatches(MethodSymbol symbol, bool expectedBoolReturn)
+                => symbol.ReturnType.SpecialType switch
+                {
+                    SpecialType.System_Boolean => expectedBoolReturn,
+                    SpecialType.System_Void => !expectedBoolReturn,
+                    _ => false
+                };
+        }
+#nullable disable
 
         /// <summary>
         /// Resolve method group based on the optional delegate invoke method.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -4,10 +4,9 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -73,6 +72,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected abstract ConversionsBase CreateInstance(int currentRecursionDepth);
 
         protected abstract Conversion GetInterpolatedStringConversion(BoundUnconvertedInterpolatedString source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo);
+
+#nullable  enable
+        public abstract bool IsApplicableInterpolatedStringBuilderType(BoundUnconvertedInterpolatedString source, TypeSymbol builderType, BindingDiagnosticBag diagnostics, [NotNullWhen(true)] out ImmutableArray<MethodArgumentInfo> builderArguments);
+#nullable disable
 
         internal AssemblySymbol CorLibrary { get { return corLibrary; } }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/TypeConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/TypeConversions.cs
@@ -6,9 +6,9 @@
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -56,6 +56,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override Conversion GetInterpolatedStringConversion(BoundUnconvertedInterpolatedString source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             // Conversions involving interpolated strings require a Binder.
+            throw ExceptionUtilities.Unreachable;
+        }
+
+#nullable  enable
+        public override bool IsApplicableInterpolatedStringBuilderType(BoundUnconvertedInterpolatedString source, TypeSymbol builderType,
+            BindingDiagnosticBag diagnostics,
+            [NotNullWhen(true)] out ImmutableArray<MethodArgumentInfo> builderArguments)
+        {
+            // Determining whether a builder type is applicable to an interpolated string requires a binder
             throw ExceptionUtilities.Unreachable;
         }
     }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodeExtensions.cs
@@ -66,5 +66,31 @@ namespace Microsoft.CodeAnalysis.CSharp
             node.WasCompilerGenerated = true;
             return node;
         }
+
+        public static bool ContainsAwaitExpression(this ImmutableArray<BoundExpression> expressions)
+        {
+            var visitor = new ContainsAwaitVisitor();
+            foreach (var expression in expressions)
+            {
+                visitor.Visit(expression);
+                if (visitor.ContainsAwait)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private class ContainsAwaitVisitor : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+        {
+            public bool ContainsAwait = false;
+
+            public override BoundNode? VisitAwaitExpression(BoundAwaitExpression node)
+            {
+                ContainsAwait = true;
+                return null;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2014,6 +2014,11 @@
   </Node>
 
   <Node Name="BoundInterpolatedString" Base="BoundInterpolatedStringBase">
+      <Field Name="InterpolationData" Type="InterpolatedStringBuilderData?"/>
+  </Node>
+    
+  <Node Name="BoundInterpolatedStringElementPlaceholder" Base="BoundExpression">
+      <Field Name="Index" Type="int"/>
   </Node>
 
   <Node Name="BoundStringInsert" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringBuilderData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringBuilderData.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed record InterpolatedStringBuilderData(
+        TypeSymbol BuilderType,
+        MethodArgumentInfo? Construction,
+        ImmutableArray<MethodArgumentInfo> BuilderFormatCalls,
+        MethodArgumentInfo? DisposeInfo,
+        uint ScopeOfContainingExpression);
+}

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6600,4 +6600,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_FunctionPointerTypesInAttributeNotSupported" xml:space="preserve">
     <value>Using a function pointer type in a 'typeof' in an attribute is not supported.</value>
   </data>
+  <data name="IDS_FeatureImprovedInterpolatedStrings" xml:space="preserve">
+    <value>improved interpolated strings</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -216,6 +216,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureVarianceSafetyForStaticInterfaceMembers = MessageBase + 12791,
         IDS_FeatureConstantInterpolatedStrings = MessageBase + 12792,
         IDS_FeatureMixedDeclarationsAndExpressionsInDeconstruction = MessageBase + 12793,
+
+
+        IDS_FeatureImprovedInterpolatedStrings = MessageBase + 13000, // PROTOTYPE(interp-string): condense
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -324,7 +327,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# preview features.
                 case MessageID.IDS_FeatureMixedDeclarationsAndExpressionsInDeconstruction:
+                case MessageID.IDS_FeatureImprovedInterpolatedStrings: // semantic check
                     return LanguageVersion.Preview;
+
                 // C# 9.0 features.
                 case MessageID.IDS_FeatureLambdaDiscardParameters: // semantic check
                 case MessageID.IDS_FeatureFunctionPointers:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -32,6 +32,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    // PROTOTYPE(interp-strings): Adjust for bool-returning holes
     /// <summary>
     /// Implement C# definite assignment.
     /// </summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -17,6 +17,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    // PROTOTYPE(interp-string): Implement TryFormat and Create method analysis.
     /// <summary>
     /// Nullability flow analysis.
     /// </summary>

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -194,7 +194,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             var type = (variable.Kind == SymbolKind.Local) ? ((LocalSymbol)variable).Type : ((ParameterSymbol)variable).Type;
             if (type.IsRestrictedType())
             {
-                (_lazyDisallowedCaptures ??= new MultiDictionary<Symbol, SyntaxNode>()).Add(variable, syntax);
+                // Interpolated string builder variables are limited in lifetime, and will not be used in a context that
+                // actually needs to be saved to the closure.
+                if (variable is not SynthesizedLocal { SynthesizedKind: SynthesizedLocalKind.InterpolatedStringBuilder })
+                {
+                    (_lazyDisallowedCaptures ??= new MultiDictionary<Symbol, SyntaxNode>()).Add(variable, syntax);
+                }
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -529,7 +529,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
             )
         {
-            return new SynthesizedLocal(CurrentFunction, TypeWithAnnotations.Create(type), kind, syntax, isPinned, refKind
+            return new SynthesizedLocal(CurrentFunction, TypeWithAnnotations.Create(type), kind, syntax, isPinned, refKind, valEscapeScope: null
+#if DEBUG
+                , createdAtLineNumber, createdAtFilePath
+#endif
+                );
+        }
+
+        public LocalSymbol InterpolatedStringBuilderLocal(
+            TypeSymbol type,
+            uint valEscapeScope,
+            SyntaxNode syntax
+#if DEBUG
+            ,
+            [CallerLineNumber] int createdAtLineNumber = 0,
+            [CallerFilePath] string? createdAtFilePath = null
+#endif
+            )
+        {
+            return new SynthesizedLocal(CurrentFunction, TypeWithAnnotations.Create(type), SynthesizedLocalKind.InterpolatedStringBuilder, syntax, isPinned: false, RefKind.None, valEscapeScope
 #if DEBUG
                 , createdAtLineNumber, createdAtFilePath
 #endif

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -972,6 +972,11 @@
         <target state="translated">Vytvoření objektu s cílovým typem</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Sestavení {0}, které obsahuje typ {1}, se odkazuje na architekturu .NET Framework, což se nepodporuje.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -972,6 +972,11 @@
         <target state="translated">Objekterstellung mit Zieltyp</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Die Assembly "{0}" mit dem Typ "{1}" verweist auf das .NET Framework. Dies wird nicht unterstützt.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -972,6 +972,11 @@
         <target state="translated">creación de objetos con tipo de destino</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">El ensamblado "{0}" que contiene el tipo "{1}" hace referencia a .NET Framework, lo cual no se admite.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -972,6 +972,11 @@
         <target state="translated">création d'un objet typé cible</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">L'assembly '{0}' contenant le type '{1}' référence le .NET Framework, ce qui n'est pas pris en charge.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -972,6 +972,11 @@
         <target state="translated">creazione di oggetti con tipo di destinazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">L'assembly '{0}' che contiene il tipo '{1}' fa riferimento a .NET Framework, che non è supportato.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -972,6 +972,11 @@
         <target state="translated">target-typed オブジェクトの作成</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">型 '{1}' を含むアセンブリ '{0}' が .NET Framework を参照しています。これはサポートされていません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -972,6 +972,11 @@
         <target state="translated">대상으로 형식화된 개체 만들기</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">'{1}' 형식을 포함하는 '{0}' 어셈블리가 지원되지 않는 .NET Framework를 참조합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -972,6 +972,11 @@
         <target state="translated">tworzenie obiektu z typem docelowym</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Zestaw „{0}” zawierający typ „{1}” odwołuje się do platformy .NET Framework, co nie jest obsługiwane.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -972,6 +972,11 @@
         <target state="translated">criação de objeto de tipo de destino</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">O assembly '{0}' contendo o tipo '{1}' referencia o .NET Framework, mas não há suporte para isso.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -972,6 +972,11 @@
         <target state="translated">создание объекта с типом целевого объекта</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">Сборка "{0}", содержащая тип "{1}", ссылается на платформу .NET Framework, которая не поддерживается.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -972,6 +972,11 @@
         <target state="translated">hedeflenen türde nesne oluşturma</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">'{1}' türünü içeren '{0}' bütünleştirilmiş kodu, desteklenmeyen .NET Framework'e başvuruyor.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -972,6 +972,11 @@
         <target state="translated">创建目标类型对象</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">包含类型“{1}”的程序集“{0}”引用了 .NET Framework，而此操作不受支持。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -972,6 +972,11 @@
         <target state="translated">建立具目標類型的物件</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
+        <source>improved interpolated strings</source>
+        <target state="new">improved interpolated strings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_AnalyzerReferencesFramework">
         <source>The assembly '{0}' containing type '{1}' references .NET Framework, which is not supported.</source>
         <target state="translated">包含類型 '{1}' 的組件 '{0}' 參考了 .NET Framework，此情形不受支援。</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -7,7 +7,9 @@
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -1194,6 +1196,2147 @@ static class C
                 //         System.IFormattable i = $"{""}";
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, @"$""{""""}""").WithArguments("System.FormattableString", "System.IFormattable").WithLocation(23, 33)
                 );
+        }
+
+        private string GetInterpolatedStringBuilderDefinition(bool includeSpanOverloads, bool useDefaultParameters, bool useBoolReturns, string returnExpression = null)
+        {
+            Debug.Assert(returnExpression == null || useBoolReturns);
+
+            var builder = new StringBuilder();
+            builder.AppendLine(@"
+namespace System.Runtime.CompilerServices
+{
+    using System.Text;
+    public ref struct InterpolatedStringBuilder
+    {
+        public static InterpolatedStringBuilder Create(int baseLength, int holeCount) => new InterpolatedStringBuilder(baseLength);
+        private readonly StringBuilder _builder;
+        public InterpolatedStringBuilder(int baseLength)
+        {
+            _builder = new StringBuilder();
+        }
+        public override string ToString() => _builder.ToString();
+        public void Dispose() => Console.WriteLine(""Disposed"");");
+
+            appendSignature("TryFormatBaseString(string s)");
+            appendBody(includeValue: false, includeAlignment: false, includeFormat: false);
+
+            if (useDefaultParameters)
+            {
+                appendSignature("TryFormatInterpolationHole<T>(T value, int alignment = 0, string format = null)");
+                appendBody(includeValue: true, includeAlignment: true, includeFormat: true);
+                appendSignature("TryFormatInterpolationHole(object value, int alignment = 0, string format = null)");
+                appendBody(includeValue: true, includeAlignment: true, includeFormat: true);
+            }
+            else
+            {
+                appendSignature("TryFormatInterpolationHole<T>(T value)");
+                appendBody(includeValue: true, includeAlignment: false, includeFormat: false);
+                appendSignature("TryFormatInterpolationHole<T>(T value, int alignment)");
+                appendBody(includeValue: true, includeAlignment: true, includeFormat: false);
+                appendSignature("TryFormatInterpolationHole<T>(T value, string format)");
+                appendBody(includeValue: true, includeAlignment: false, includeFormat: true);
+                appendSignature("TryFormatInterpolationHole<T>(T value, int alignment, string format)");
+                appendBody(includeValue: true, includeAlignment: true, includeFormat: true);
+                appendSignature("TryFormatInterpolationHole(object value)");
+                appendBody(includeValue: true, includeAlignment: false, includeFormat: false);
+                appendSignature("TryFormatInterpolationHole(object value, int alignment)");
+                appendBody(includeValue: true, includeAlignment: true, includeFormat: false);
+                appendSignature("TryFormatInterpolationHole(object value, string format)");
+                appendBody(includeValue: true, includeAlignment: false, includeFormat: true);
+                appendSignature("TryFormatInterpolationHole(object value, int alignment, string format)");
+                appendBody(includeValue: true, includeAlignment: true, includeFormat: true);
+            }
+
+            if (includeSpanOverloads)
+            {
+                if (useDefaultParameters)
+                {
+                    appendSignature("TryFormatInterpolationHole(ReadOnlySpan<char> value, int alignment = 0, string format = null)");
+                    appendBody(includeValue: true, includeAlignment: true, includeFormat: true, isSpan: true);
+                }
+                else
+                {
+                    appendSignature("TryFormatInterpolationHole(ReadOnlySpan<char> value)");
+                    appendBody(includeValue: true, includeAlignment: false, includeFormat: false, isSpan: true);
+                    appendSignature("TryFormatInterpolationHole(ReadOnlySpan<char> value, int alignment)");
+                    appendBody(includeValue: true, includeAlignment: true, includeFormat: false, isSpan: true);
+                    appendSignature("TryFormatInterpolationHole(ReadOnlySpan<char> value, string format)");
+                    appendBody(includeValue: true, includeAlignment: false, includeFormat: true, isSpan: true);
+                    appendSignature("TryFormatInterpolationHole(ReadOnlySpan<char> value, int alignment, string format)");
+                    appendBody(includeValue: true, includeAlignment: true, includeFormat: true, isSpan: true);
+                }
+            }
+
+            builder.Append(@"
+    }
+}");
+            return builder.ToString();
+
+            void appendBody(bool includeValue, bool includeAlignment, bool includeFormat, bool isSpan = false)
+            {
+                if (includeValue)
+                {
+                    builder.Append($@"
+        {{
+            _builder.Append(""value:"");
+            _builder.Append(value{(isSpan ? "" : "?")}.ToString());");
+                }
+                else
+                {
+                    builder.Append(@"
+        {
+            _builder.Append(s);");
+                }
+
+                if (includeAlignment)
+                {
+                    builder.Append(@"
+            _builder.Append("",alignment:"");
+            _builder.Append(alignment);");
+                }
+
+                if (includeFormat)
+                {
+                    builder.Append(@"
+            _builder.Append("":format:"");
+            _builder.Append(format);");
+                }
+
+                builder.Append(@"
+            _builder.AppendLine();");
+
+                if (useBoolReturns)
+                {
+                    builder.Append($@"
+            return {returnExpression ?? "true"};");
+                }
+
+                builder.AppendLine(@"
+        }");
+            }
+
+            void appendSignature(string nameAndParams)
+            {
+                builder.Append(@$"
+        public {(useBoolReturns ? "bool" : "void")} {nameAndParams}");
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringBuilder_OverloadsAndBoolReturns(bool useDefaultParameters, bool useBoolReturns)
+        {
+            var source =
+@"int a = 1;
+System.Console.WriteLine($""base{a}{a,1}{a:X}{a,2:Y}"");";
+
+            string interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters, useBoolReturns);
+
+            string expectedOutput = useDefaultParameters ?
+@"Disposed
+base
+value:1,alignment:0:format:
+value:1,alignment:1:format:
+value:1,alignment:0:format:X
+value:1,alignment:2:format:Y" :
+@"Disposed
+base
+value:1
+value:1,alignment:1
+value:1:format:X
+value:1,alignment:2:format:Y";
+
+            string expectedIl = getIl();
+
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: expectedOutput);
+            verifier.VerifyIL("<top-level-statements-entry-point>", expectedIl);
+
+            var comp1 = CreateCompilation(interpolatedStringBuilder);
+
+            foreach (var reference in new[] { comp1.EmitToImageReference(), comp1.EmitToPortableExecutableReference() })
+            {
+                var comp2 = CreateCompilation(source, new[] { reference });
+                verifier = CompileAndVerify(comp2, expectedOutput: expectedOutput);
+                verifier.VerifyIL("<top-level-statements-entry-point>", expectedIl);
+            }
+
+            string getIl() => (useDefaultParameters, useBoolReturns) switch
+            {
+                (useDefaultParameters: false, useBoolReturns: false) => @"
+{
+  // Code size       97 (0x61)
+  .maxstack  4
+  .locals init (int V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  .try
+  {
+    IL_0002:  ldc.i4.4
+    IL_0003:  ldc.i4.4
+    IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0009:  stloc.2
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  ldstr      ""base""
+    IL_0011:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_0016:  ldloca.s   V_2
+    IL_0018:  ldloc.0
+    IL_0019:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int)""
+    IL_001e:  ldloca.s   V_2
+    IL_0020:  ldloc.0
+    IL_0021:  ldc.i4.1
+    IL_0022:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int)""
+    IL_0027:  ldloca.s   V_2
+    IL_0029:  ldloc.0
+    IL_002a:  ldstr      ""X""
+    IL_002f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, string)""
+    IL_0034:  ldloca.s   V_2
+    IL_0036:  ldloc.0
+    IL_0037:  ldc.i4.2
+    IL_0038:  ldstr      ""Y""
+    IL_003d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_0042:  ldloca.s   V_2
+    IL_0044:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_004a:  callvirt   ""string object.ToString()""
+    IL_004f:  stloc.1
+    IL_0050:  leave.s    IL_005a
+  }
+  finally
+  {
+    IL_0052:  ldloca.s   V_2
+    IL_0054:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0059:  endfinally
+  }
+  IL_005a:  ldloc.1
+  IL_005b:  call       ""void System.Console.WriteLine(string)""
+  IL_0060:  ret
+}
+",
+                (useDefaultParameters: true, useBoolReturns: false) => @"
+{
+  // Code size      101 (0x65)
+  .maxstack  4
+  .locals init (int V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  .try
+  {
+    IL_0002:  ldc.i4.4
+    IL_0003:  ldc.i4.4
+    IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0009:  stloc.2
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  ldstr      ""base""
+    IL_0011:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_0016:  ldloca.s   V_2
+    IL_0018:  ldloc.0
+    IL_0019:  ldc.i4.0
+    IL_001a:  ldnull
+    IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_0020:  ldloca.s   V_2
+    IL_0022:  ldloc.0
+    IL_0023:  ldc.i4.1
+    IL_0024:  ldnull
+    IL_0025:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_002a:  ldloca.s   V_2
+    IL_002c:  ldloc.0
+    IL_002d:  ldc.i4.0
+    IL_002e:  ldstr      ""X""
+    IL_0033:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_0038:  ldloca.s   V_2
+    IL_003a:  ldloc.0
+    IL_003b:  ldc.i4.2
+    IL_003c:  ldstr      ""Y""
+    IL_0041:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_0046:  ldloca.s   V_2
+    IL_0048:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_004e:  callvirt   ""string object.ToString()""
+    IL_0053:  stloc.1
+    IL_0054:  leave.s    IL_005e
+  }
+  finally
+  {
+    IL_0056:  ldloca.s   V_2
+    IL_0058:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_005d:  endfinally
+  }
+  IL_005e:  ldloc.1
+  IL_005f:  call       ""void System.Console.WriteLine(string)""
+  IL_0064:  ret
+}",
+                (useDefaultParameters: false, useBoolReturns: true) => @"
+{
+  // Code size      109 (0x6d)
+  .maxstack  4
+  .locals init (int V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  .try
+  {
+    IL_0002:  ldc.i4.4
+    IL_0003:  ldc.i4.4
+    IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0009:  stloc.2
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  ldstr      ""base""
+    IL_0011:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_0016:  brfalse.s  IL_004c
+    IL_0018:  ldloca.s   V_2
+    IL_001a:  ldloc.0
+    IL_001b:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int)""
+    IL_0020:  brfalse.s  IL_004c
+    IL_0022:  ldloca.s   V_2
+    IL_0024:  ldloc.0
+    IL_0025:  ldc.i4.1
+    IL_0026:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int)""
+    IL_002b:  brfalse.s  IL_004c
+    IL_002d:  ldloca.s   V_2
+    IL_002f:  ldloc.0
+    IL_0030:  ldstr      ""X""
+    IL_0035:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, string)""
+    IL_003a:  brfalse.s  IL_004c
+    IL_003c:  ldloca.s   V_2
+    IL_003e:  ldloc.0
+    IL_003f:  ldc.i4.2
+    IL_0040:  ldstr      ""Y""
+    IL_0045:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_004a:  br.s       IL_004d
+    IL_004c:  ldc.i4.0
+    IL_004d:  pop
+    IL_004e:  ldloca.s   V_2
+    IL_0050:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_0056:  callvirt   ""string object.ToString()""
+    IL_005b:  stloc.1
+    IL_005c:  leave.s    IL_0066
+  }
+  finally
+  {
+    IL_005e:  ldloca.s   V_2
+    IL_0060:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0065:  endfinally
+  }
+  IL_0066:  ldloc.1
+  IL_0067:  call       ""void System.Console.WriteLine(string)""
+  IL_006c:  ret
+}",
+                (useDefaultParameters: true, useBoolReturns: true) => @"
+{
+  // Code size      113 (0x71)
+  .maxstack  4
+  .locals init (int V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  .try
+  {
+    IL_0002:  ldc.i4.4
+    IL_0003:  ldc.i4.4
+    IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0009:  stloc.2
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  ldstr      ""base""
+    IL_0011:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_0016:  brfalse.s  IL_0050
+    IL_0018:  ldloca.s   V_2
+    IL_001a:  ldloc.0
+    IL_001b:  ldc.i4.0
+    IL_001c:  ldnull
+    IL_001d:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_0022:  brfalse.s  IL_0050
+    IL_0024:  ldloca.s   V_2
+    IL_0026:  ldloc.0
+    IL_0027:  ldc.i4.1
+    IL_0028:  ldnull
+    IL_0029:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_002e:  brfalse.s  IL_0050
+    IL_0030:  ldloca.s   V_2
+    IL_0032:  ldloc.0
+    IL_0033:  ldc.i4.0
+    IL_0034:  ldstr      ""X""
+    IL_0039:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_003e:  brfalse.s  IL_0050
+    IL_0040:  ldloca.s   V_2
+    IL_0042:  ldloc.0
+    IL_0043:  ldc.i4.2
+    IL_0044:  ldstr      ""Y""
+    IL_0049:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int, int, string)""
+    IL_004e:  br.s       IL_0051
+    IL_0050:  ldc.i4.0
+    IL_0051:  pop
+    IL_0052:  ldloca.s   V_2
+    IL_0054:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_005a:  callvirt   ""string object.ToString()""
+    IL_005f:  stloc.1
+    IL_0060:  leave.s    IL_006a
+  }
+  finally
+  {
+    IL_0062:  ldloca.s   V_2
+    IL_0064:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0069:  endfinally
+  }
+  IL_006a:  ldloc.1
+  IL_006b:  call       ""void System.Console.WriteLine(string)""
+  IL_0070:  ret
+}",
+            };
+        }
+
+        [Fact]
+        public void UseOfSpanInInterpolationHole_CSharp9()
+        {
+            var source = @"
+using System;
+ReadOnlySpan<char> span = stackalloc char[1];
+Console.WriteLine($""{span}"");";
+
+            var comp = CreateCompilation(new[] { source, GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false) }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (4,22): error CS8652: The feature 'improved interpolated strings' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // Console.WriteLine($"{span}");
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "span").WithArguments("improved interpolated strings").WithLocation(4, 22)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void UseOfSpanInInterpolationHole(bool useDefaultParameters, bool useBoolReturns)
+        {
+            var source =
+@"
+using System;
+ReadOnlySpan<char> a = ""1"";
+System.Console.WriteLine($""base{a}{a,1}{a:X}{a,2:Y}"");";
+
+            string interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters, useBoolReturns);
+
+            string expectedOutput = useDefaultParameters ?
+@"Disposed
+base
+value:1,alignment:0:format:
+value:1,alignment:1:format:
+value:1,alignment:0:format:X
+value:1,alignment:2:format:Y" :
+@"Disposed
+base
+value:1
+value:1,alignment:1
+value:1:format:X
+value:1,alignment:2:format:Y";
+
+            string expectedIl = getIl();
+
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: expectedOutput, targetFramework: TargetFramework.NetCoreApp, parseOptions: TestOptions.RegularPreview);
+            verifier.VerifyIL("<top-level-statements-entry-point>", expectedIl);
+
+            var comp1 = CreateCompilation(interpolatedStringBuilder, targetFramework: TargetFramework.NetCoreApp);
+
+            foreach (var reference in new[] { comp1.EmitToImageReference(), comp1.EmitToPortableExecutableReference() })
+            {
+                var comp2 = CreateCompilation(source, new[] { reference }, targetFramework: TargetFramework.NetCoreApp, parseOptions: TestOptions.RegularPreview);
+                verifier = CompileAndVerify(comp2, expectedOutput: expectedOutput);
+                verifier.VerifyIL("<top-level-statements-entry-point>", expectedIl);
+            }
+
+            string getIl() => (useDefaultParameters, useBoolReturns) switch
+            {
+                (useDefaultParameters: false, useBoolReturns: false) => @"
+{
+  // Code size      106 (0x6a)
+  .maxstack  4
+  .locals init (System.ReadOnlySpan<char> V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldstr      ""1""
+  IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
+  IL_000a:  stloc.0
+  .try
+  {
+    IL_000b:  ldc.i4.4
+    IL_000c:  ldc.i4.4
+    IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0012:  stloc.2
+    IL_0013:  ldloca.s   V_2
+    IL_0015:  ldstr      ""base""
+    IL_001a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_001f:  ldloca.s   V_2
+    IL_0021:  ldloc.0
+    IL_0022:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>)""
+    IL_0027:  ldloca.s   V_2
+    IL_0029:  ldloc.0
+    IL_002a:  ldc.i4.1
+    IL_002b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int)""
+    IL_0030:  ldloca.s   V_2
+    IL_0032:  ldloc.0
+    IL_0033:  ldstr      ""X""
+    IL_0038:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, string)""
+    IL_003d:  ldloca.s   V_2
+    IL_003f:  ldloc.0
+    IL_0040:  ldc.i4.2
+    IL_0041:  ldstr      ""Y""
+    IL_0046:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_004b:  ldloca.s   V_2
+    IL_004d:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_0053:  callvirt   ""string object.ToString()""
+    IL_0058:  stloc.1
+    IL_0059:  leave.s    IL_0063
+  }
+  finally
+  {
+    IL_005b:  ldloca.s   V_2
+    IL_005d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0062:  endfinally
+  }
+  IL_0063:  ldloc.1
+  IL_0064:  call       ""void System.Console.WriteLine(string)""
+  IL_0069:  ret
+}
+",
+                (useDefaultParameters: true, useBoolReturns: false) => @"
+{
+  // Code size      110 (0x6e)
+  .maxstack  4
+  .locals init (System.ReadOnlySpan<char> V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldstr      ""1""
+  IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
+  IL_000a:  stloc.0
+  .try
+  {
+    IL_000b:  ldc.i4.4
+    IL_000c:  ldc.i4.4
+    IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0012:  stloc.2
+    IL_0013:  ldloca.s   V_2
+    IL_0015:  ldstr      ""base""
+    IL_001a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_001f:  ldloca.s   V_2
+    IL_0021:  ldloc.0
+    IL_0022:  ldc.i4.0
+    IL_0023:  ldnull
+    IL_0024:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_0029:  ldloca.s   V_2
+    IL_002b:  ldloc.0
+    IL_002c:  ldc.i4.1
+    IL_002d:  ldnull
+    IL_002e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_0033:  ldloca.s   V_2
+    IL_0035:  ldloc.0
+    IL_0036:  ldc.i4.0
+    IL_0037:  ldstr      ""X""
+    IL_003c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_0041:  ldloca.s   V_2
+    IL_0043:  ldloc.0
+    IL_0044:  ldc.i4.2
+    IL_0045:  ldstr      ""Y""
+    IL_004a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_004f:  ldloca.s   V_2
+    IL_0051:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_0057:  callvirt   ""string object.ToString()""
+    IL_005c:  stloc.1
+    IL_005d:  leave.s    IL_0067
+  }
+  finally
+  {
+    IL_005f:  ldloca.s   V_2
+    IL_0061:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0066:  endfinally
+  }
+  IL_0067:  ldloc.1
+  IL_0068:  call       ""void System.Console.WriteLine(string)""
+  IL_006d:  ret
+}",
+                (useDefaultParameters: false, useBoolReturns: true) => @"
+{
+  // Code size      118 (0x76)
+  .maxstack  4
+  .locals init (System.ReadOnlySpan<char> V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldstr      ""1""
+  IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
+  IL_000a:  stloc.0
+  .try
+  {
+    IL_000b:  ldc.i4.4
+    IL_000c:  ldc.i4.4
+    IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0012:  stloc.2
+    IL_0013:  ldloca.s   V_2
+    IL_0015:  ldstr      ""base""
+    IL_001a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_001f:  brfalse.s  IL_0055
+    IL_0021:  ldloca.s   V_2
+    IL_0023:  ldloc.0
+    IL_0024:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>)""
+    IL_0029:  brfalse.s  IL_0055
+    IL_002b:  ldloca.s   V_2
+    IL_002d:  ldloc.0
+    IL_002e:  ldc.i4.1
+    IL_002f:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int)""
+    IL_0034:  brfalse.s  IL_0055
+    IL_0036:  ldloca.s   V_2
+    IL_0038:  ldloc.0
+    IL_0039:  ldstr      ""X""
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, string)""
+    IL_0043:  brfalse.s  IL_0055
+    IL_0045:  ldloca.s   V_2
+    IL_0047:  ldloc.0
+    IL_0048:  ldc.i4.2
+    IL_0049:  ldstr      ""Y""
+    IL_004e:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_0053:  br.s       IL_0056
+    IL_0055:  ldc.i4.0
+    IL_0056:  pop
+    IL_0057:  ldloca.s   V_2
+    IL_0059:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_005f:  callvirt   ""string object.ToString()""
+    IL_0064:  stloc.1
+    IL_0065:  leave.s    IL_006f
+  }
+  finally
+  {
+    IL_0067:  ldloca.s   V_2
+    IL_0069:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_006e:  endfinally
+  }
+  IL_006f:  ldloc.1
+  IL_0070:  call       ""void System.Console.WriteLine(string)""
+  IL_0075:  ret
+}
+",
+                (useDefaultParameters: true, useBoolReturns: true) => @"
+{
+  // Code size      122 (0x7a)
+  .maxstack  4
+  .locals init (System.ReadOnlySpan<char> V_0, //a
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+  IL_0000:  ldstr      ""1""
+  IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
+  IL_000a:  stloc.0
+  .try
+  {
+    IL_000b:  ldc.i4.4
+    IL_000c:  ldc.i4.4
+    IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0012:  stloc.2
+    IL_0013:  ldloca.s   V_2
+    IL_0015:  ldstr      ""base""
+    IL_001a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+    IL_001f:  brfalse.s  IL_0059
+    IL_0021:  ldloca.s   V_2
+    IL_0023:  ldloc.0
+    IL_0024:  ldc.i4.0
+    IL_0025:  ldnull
+    IL_0026:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_002b:  brfalse.s  IL_0059
+    IL_002d:  ldloca.s   V_2
+    IL_002f:  ldloc.0
+    IL_0030:  ldc.i4.1
+    IL_0031:  ldnull
+    IL_0032:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_0037:  brfalse.s  IL_0059
+    IL_0039:  ldloca.s   V_2
+    IL_003b:  ldloc.0
+    IL_003c:  ldc.i4.0
+    IL_003d:  ldstr      ""X""
+    IL_0042:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_0047:  brfalse.s  IL_0059
+    IL_0049:  ldloca.s   V_2
+    IL_004b:  ldloc.0
+    IL_004c:  ldc.i4.2
+    IL_004d:  ldstr      ""Y""
+    IL_0052:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>, int, string)""
+    IL_0057:  br.s       IL_005a
+    IL_0059:  ldc.i4.0
+    IL_005a:  pop
+    IL_005b:  ldloca.s   V_2
+    IL_005d:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_0063:  callvirt   ""string object.ToString()""
+    IL_0068:  stloc.1
+    IL_0069:  leave.s    IL_0073
+  }
+  finally
+  {
+    IL_006b:  ldloca.s   V_2
+    IL_006d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0072:  endfinally
+  }
+  IL_0073:  ldloc.1
+  IL_0074:  call       ""void System.Console.WriteLine(string)""
+  IL_0079:  ret
+}",
+            };
+        }
+
+        [Fact]
+        public void BoolReturns_ShortCircuit()
+        {
+            var source = @"
+using System;
+int a = 1;
+Console.Write($""base{Throw()}{a = 2}"");
+Console.WriteLine(a);
+string Throw() => throw new Exception();";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: true, returnExpression: "false");
+
+            CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
+Disposed
+base
+1");
+        }
+
+        [Fact]
+        public void AwaitInHoles_UsesFormat()
+        {
+            // PROTOTYPE(interp-string): We could make this case use the builder as well by evaluating the holes ahead of time. For InterpolatedStringBuilder,
+            // we know that the framework is never going to ship a version that short circuits, so it would be a valid optimization for us to make.
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+Console.WriteLine($""base{await Hole()}"");
+Task<int> Hole() => Task.FromResult(1);";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"base1");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       47 (0x2f)
+  .maxstack  2
+  .locals init (<Program>$.<<Main>$>d__0 V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  call       ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Create()""
+  IL_0007:  stfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  ldc.i4.m1
+  IL_000f:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start<<Program>$.<<Main>$>d__0>(ref <Program>$.<<Main>$>d__0)""
+  IL_0022:  ldloca.s   V_0
+  IL_0024:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+  IL_0029:  call       ""System.Threading.Tasks.Task System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Task.get""
+  IL_002e:  ret
+}
+");
+        }
+
+        [Fact]
+        public void NoAwaitInHoles_UsesBuilder()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+var hole = await Hole();
+Console.WriteLine($""base{hole}"");
+Task<int> Hole() => Task.FromResult(1);";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
+Disposed
+base
+value:1");
+
+            verifier.VerifyIL("<Program>$.<<Main>$>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      211 (0xd3)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1, //hole
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
+                string V_3,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0041
+    IL_000a:  call       ""System.Threading.Tasks.Task<int> <Program>$.<<Main>$>g__Hole|0_0()""
+    IL_000f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0014:  stloc.2
+    IL_0015:  ldloca.s   V_2
+    IL_0017:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_001c:  brtrue.s   IL_005d
+    IL_001e:  ldarg.0
+    IL_001f:  ldc.i4.0
+    IL_0020:  dup
+    IL_0021:  stloc.0
+    IL_0022:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_0027:  ldarg.0
+    IL_0028:  ldloc.2
+    IL_0029:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_002e:  ldarg.0
+    IL_002f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+    IL_0034:  ldloca.s   V_2
+    IL_0036:  ldarg.0
+    IL_0037:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, <Program>$.<<Main>$>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref <Program>$.<<Main>$>d__0)""
+    IL_003c:  leave      IL_00d2
+    IL_0041:  ldarg.0
+    IL_0042:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_0047:  stloc.2
+    IL_0048:  ldarg.0
+    IL_0049:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_004e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0054:  ldarg.0
+    IL_0055:  ldc.i4.m1
+    IL_0056:  dup
+    IL_0057:  stloc.0
+    IL_0058:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_005d:  ldloca.s   V_2
+    IL_005f:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0064:  stloc.1
+    .try
+    {
+      IL_0065:  ldc.i4.4
+      IL_0066:  ldc.i4.1
+      IL_0067:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+      IL_006c:  stloc.s    V_4
+      IL_006e:  ldloca.s   V_4
+      IL_0070:  ldstr      ""base""
+      IL_0075:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+      IL_007a:  ldloca.s   V_4
+      IL_007c:  ldloc.1
+      IL_007d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int)""
+      IL_0082:  ldloca.s   V_4
+      IL_0084:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+      IL_008a:  callvirt   ""string object.ToString()""
+      IL_008f:  stloc.3
+      IL_0090:  leave.s    IL_009e
+    }
+    finally
+    {
+      IL_0092:  ldloc.0
+      IL_0093:  ldc.i4.0
+      IL_0094:  bge.s      IL_009d
+      IL_0096:  ldloca.s   V_4
+      IL_0098:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+      IL_009d:  endfinally
+    }
+    IL_009e:  ldloc.3
+    IL_009f:  call       ""void System.Console.WriteLine(string)""
+    IL_00a4:  leave.s    IL_00bf
+  }
+  catch System.Exception
+  {
+    IL_00a6:  stloc.s    V_5
+    IL_00a8:  ldarg.0
+    IL_00a9:  ldc.i4.s   -2
+    IL_00ab:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_00b0:  ldarg.0
+    IL_00b1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+    IL_00b6:  ldloc.s    V_5
+    IL_00b8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00bd:  leave.s    IL_00d2
+  }
+  IL_00bf:  ldarg.0
+  IL_00c0:  ldc.i4.s   -2
+  IL_00c2:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+  IL_00c7:  ldarg.0
+  IL_00c8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+  IL_00cd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00d2:  ret
+}
+");
+        }
+
+        [Fact]
+        public void NoAwaitInHoles_AwaitInExpression_UsesBuilder()
+        {
+
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+var hole = 2;
+Test(await M(1), $""base{hole}"", await M(3));
+void Test(int i1, string s, int i2) => Console.WriteLine(s);
+Task<int> M(int i) 
+{
+    Console.WriteLine(i);
+    return Task.FromResult(1);
+}";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
+1
+Disposed
+3
+base
+value:2");
+
+            verifier.VerifyIL("<Program>$.<<Main>$>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      356 (0x164)
+  .maxstack  3
+  .locals init (int V_0,
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2,
+                int V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0052
+    IL_000a:  ldloc.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  beq        IL_00f7
+    IL_0011:  ldarg.0
+    IL_0012:  ldc.i4.2
+    IL_0013:  stfld      ""int <Program>$.<<Main>$>d__0.<hole>5__2""
+    IL_0018:  ldc.i4.1
+    IL_0019:  call       ""System.Threading.Tasks.Task<int> <Program>$.<<Main>$>g__M|0_1(int)""
+    IL_001e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0023:  stloc.s    V_4
+    IL_0025:  ldloca.s   V_4
+    IL_0027:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_002c:  brtrue.s   IL_006f
+    IL_002e:  ldarg.0
+    IL_002f:  ldc.i4.0
+    IL_0030:  dup
+    IL_0031:  stloc.0
+    IL_0032:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_0037:  ldarg.0
+    IL_0038:  ldloc.s    V_4
+    IL_003a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_003f:  ldarg.0
+    IL_0040:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+    IL_0045:  ldloca.s   V_4
+    IL_0047:  ldarg.0
+    IL_0048:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, <Program>$.<<Main>$>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref <Program>$.<<Main>$>d__0)""
+    IL_004d:  leave      IL_0163
+    IL_0052:  ldarg.0
+    IL_0053:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_0058:  stloc.s    V_4
+    IL_005a:  ldarg.0
+    IL_005b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_0060:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0066:  ldarg.0
+    IL_0067:  ldc.i4.m1
+    IL_0068:  dup
+    IL_0069:  stloc.0
+    IL_006a:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_006f:  ldarg.0
+    IL_0070:  ldloca.s   V_4
+    IL_0072:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0077:  stfld      ""int <Program>$.<<Main>$>d__0.<>7__wrap2""
+    .try
+    {
+      IL_007c:  ldc.i4.4
+      IL_007d:  ldc.i4.1
+      IL_007e:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+      IL_0083:  stloc.2
+      IL_0084:  ldloca.s   V_2
+      IL_0086:  ldstr      ""base""
+      IL_008b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)""
+      IL_0090:  ldloca.s   V_2
+      IL_0092:  ldarg.0
+      IL_0093:  ldfld      ""int <Program>$.<<Main>$>d__0.<hole>5__2""
+      IL_0098:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int)""
+      IL_009d:  ldloca.s   V_2
+      IL_009f:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+      IL_00a5:  callvirt   ""string object.ToString()""
+      IL_00aa:  stloc.1
+      IL_00ab:  leave.s    IL_00b9
+    }
+    finally
+    {
+      IL_00ad:  ldloc.0
+      IL_00ae:  ldc.i4.0
+      IL_00af:  bge.s      IL_00b8
+      IL_00b1:  ldloca.s   V_2
+      IL_00b3:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+      IL_00b8:  endfinally
+    }
+    IL_00b9:  ldarg.0
+    IL_00ba:  ldloc.1
+    IL_00bb:  stfld      ""string <Program>$.<<Main>$>d__0.<>7__wrap3""
+    IL_00c0:  ldc.i4.3
+    IL_00c1:  call       ""System.Threading.Tasks.Task<int> <Program>$.<<Main>$>g__M|0_1(int)""
+    IL_00c6:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_00cb:  stloc.s    V_4
+    IL_00cd:  ldloca.s   V_4
+    IL_00cf:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_00d4:  brtrue.s   IL_0114
+    IL_00d6:  ldarg.0
+    IL_00d7:  ldc.i4.1
+    IL_00d8:  dup
+    IL_00d9:  stloc.0
+    IL_00da:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_00df:  ldarg.0
+    IL_00e0:  ldloc.s    V_4
+    IL_00e2:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_00e7:  ldarg.0
+    IL_00e8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+    IL_00ed:  ldloca.s   V_4
+    IL_00ef:  ldarg.0
+    IL_00f0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, <Program>$.<<Main>$>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref <Program>$.<<Main>$>d__0)""
+    IL_00f5:  leave.s    IL_0163
+    IL_00f7:  ldarg.0
+    IL_00f8:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_00fd:  stloc.s    V_4
+    IL_00ff:  ldarg.0
+    IL_0100:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_0105:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_010b:  ldarg.0
+    IL_010c:  ldc.i4.m1
+    IL_010d:  dup
+    IL_010e:  stloc.0
+    IL_010f:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_0114:  ldloca.s   V_4
+    IL_0116:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_011b:  stloc.3
+    IL_011c:  ldarg.0
+    IL_011d:  ldfld      ""int <Program>$.<<Main>$>d__0.<>7__wrap2""
+    IL_0122:  ldarg.0
+    IL_0123:  ldfld      ""string <Program>$.<<Main>$>d__0.<>7__wrap3""
+    IL_0128:  ldloc.3
+    IL_0129:  call       ""void <Program>$.<<Main>$>g__Test|0_0(int, string, int)""
+    IL_012e:  ldarg.0
+    IL_012f:  ldnull
+    IL_0130:  stfld      ""string <Program>$.<<Main>$>d__0.<>7__wrap3""
+    IL_0135:  leave.s    IL_0150
+  }
+  catch System.Exception
+  {
+    IL_0137:  stloc.s    V_5
+    IL_0139:  ldarg.0
+    IL_013a:  ldc.i4.s   -2
+    IL_013c:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_0141:  ldarg.0
+    IL_0142:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+    IL_0147:  ldloc.s    V_5
+    IL_0149:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_014e:  leave.s    IL_0163
+  }
+  IL_0150:  ldarg.0
+  IL_0151:  ldc.i4.s   -2
+  IL_0153:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+  IL_0158:  ldarg.0
+  IL_0159:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+  IL_015e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0163:  ret
+}
+");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("public static InterpolatedStringBuilder Create(int baseLength) => throw null;")]
+        [InlineData("public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles, object otherParam = null) => throw null;")]
+        [InlineData("public static void Create(int baseLength) => throw null;")]
+        [InlineData("public InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;")]
+        public void MissingWellKnownMethod_Create(string createSignature)
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        " + createSignature + @"
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        public override string ToString() => throw null;
+        public void Dispose() => throw null;
+        public void TryFormatBaseString(string value) => throw null;
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            comp.VerifyDiagnostics(
+                // (1,5): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.InterpolatedStringBuilder.Create'
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "Create").WithLocation(1, 5)
+            );
+
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("public void Dispose(int baseLength) => throw null;")]
+        [InlineData("public bool Dispose() => throw null;")]
+        [InlineData("public static void Dispose() => throw null;")]
+        public void MissingWellKnownMethod_Dispose(string disposeMethod)
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        " + disposeMethod + @"
+        public override string ToString() => throw null;
+        public void TryFormatBaseString(string value) => throw null;
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            comp.VerifyDiagnostics(
+                // (1,5): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose'
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "Dispose").WithLocation(1, 5)
+            );
+        }
+
+        // PROTOTYPE(interp-string): Should we hard error on malformed TryFormat... methods in the well-known InterpolatedStringBuilder as well?
+
+        [Fact]
+        public void ObsoleteCreateMethod()
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        [System.Obsolete(""Create is obsolete"", error: true)]
+        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        public void Dispose() => throw null;
+        public override string ToString() => throw null;
+        public void TryFormatBaseString(string value) => throw null;
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            comp.VerifyDiagnostics(
+                // (1,5): error CS0619: 'InterpolatedStringBuilder.Create(int, int)' is obsolete: 'Create is obsolete'
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)", "Create is obsolete").WithLocation(1, 5)
+            );
+        }
+
+        [Fact]
+        public void ObsoleteDisposeMethod()
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        [System.Obsolete(""Dispose is obsolete"", error: true)]
+        public void Dispose() => throw null;
+        public override string ToString() => throw null;
+        public void TryFormatBaseString(string value) => throw null;
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            comp.VerifyDiagnostics(
+                // (1,5): error CS0619: 'InterpolatedStringBuilder.Dispose()' is obsolete: 'Dispose is obsolete'
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()", "Dispose is obsolete").WithLocation(1, 5)
+            );
+        }
+
+        [Fact]
+        public void ObsoleteTryFormatBaseStringMethod()
+        {
+            var code = @"_ = $""base{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        public void Dispose() => throw null;
+        public override string ToString() => throw null;
+        [System.Obsolete(""TryFormatBaseString is obsolete"", error: true)]
+        public void TryFormatBaseString(string value) => throw null;
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            comp.VerifyDiagnostics(
+                // (1,7): error CS0619: 'InterpolatedStringBuilder.TryFormatBaseString(string)' is obsolete: 'TryFormatBaseString is obsolete'
+                // _ = $"base{(object)1}";
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "base").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatBaseString(string)", "TryFormatBaseString is obsolete").WithLocation(1, 7)
+            );
+        }
+
+        [Fact]
+        public void ObsoleteTryFormatInterpolationHoleMethod()
+        {
+            var code = @"_ = $""base{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        public void Dispose() => throw null;
+        public override string ToString() => throw null;
+        public void TryFormatBaseString(string value) => throw null;
+        [System.Obsolete(""TryFormatFormatHole is obsolete"", error: true)]
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            comp.VerifyDiagnostics(
+                // (1,11): error CS0619: 'InterpolatedStringBuilder.TryFormatInterpolationHole<T>(T, int, string)' is obsolete: 'TryFormatFormatHole is obsolete'
+                // _ = $"base{(object)1}";
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "{(object)1}").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<T>(T, int, string)", "TryFormatFormatHole is obsolete").WithLocation(1, 11)
+            );
+        }
+
+        [Fact]
+        public void ObsoleteToStringMethod()
+        {
+            var code = @"_ = $""base{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        public void Dispose() => throw null;
+        [System.Obsolete(""ToString is obsolete"", error: true)]
+        public override string ToString() => throw null;
+        public void TryFormatBaseString(string value) => throw null;
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+";
+
+            // Note: We report obsolete on the base method, ie object.ToString(), which is not obsolete. So no diagnostics are reported here.
+            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            comp.VerifyEmitDiagnostics(
+                // (10,32): warning CS0809: Obsolete member 'InterpolatedStringBuilder.ToString()' overrides non-obsolete member 'object.ToString()'
+                //         public override string ToString() => throw null;
+                Diagnostic(ErrorCode.WRN_ObsoleteOverridingNonObsolete, "ToString").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.ToString()", "object.ToString()").WithLocation(10, 32)
+            );
+        }
+
+        [Fact]
+        public void UnmanagedCallersOnlyCreateMethod()
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+namespace System.Runtime.CompilerServices
+{
+    public ref struct InterpolatedStringBuilder
+    {
+        [System.Runtime.InteropServices.UnmanagedCallersOnly]
+        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
+        public InterpolatedStringBuilder(int baseLength) => throw null;
+        public void Dispose() => throw null;
+        public override string ToString() => throw null;
+        public void TryFormatBaseString(string value) => throw null;
+        public void TryFormatInterpolationHole<T>(T hole, int alignment = 0, string format = null) => throw null;
+    }
+}
+namespace System.Runtime.InteropServices
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class UnmanagedCallersOnlyAttribute : Attribute
+    {
+        public UnmanagedCallersOnlyAttribute()
+        {
+        }
+
+        public Type[] CallConvs;
+        public string EntryPoint;
+    }
+}
+";
+
+            var comp1 = CreateCompilation(interpolatedStringBuilder, targetFramework: TargetFramework.NetCoreApp);
+
+            var comp = CreateCompilation(new[] { code }, references: new[] { comp1.EmitToImageReference() });
+            comp.VerifyDiagnostics(
+                // (1,5): error CS8901: 'InterpolatedStringBuilder.Create(int, int)' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)").WithLocation(1, 5)
+            );
+        }
+
+        private const string UnmanagedCallersOnlyIl = @"
+.class public auto ansi sealed beforefieldinit System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute extends [mscorlib]System.Attribute
+{
+    .custom instance void [mscorlib]System.AttributeUsageAttribute::.ctor(valuetype [mscorlib]System.AttributeTargets) = (
+        01 00 40 00 00 00 01 00 54 02 09 49 6e 68 65 72
+        69 74 65 64 00
+    )
+    .field public class [mscorlib]System.Type[] CallConvs
+    .field public string EntryPoint
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor () cil managed 
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Attribute::.ctor()
+        ret
+    }
+}";
+
+        [Fact]
+        public void UnmanagedCallersOnlyDisposeMethod()
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+
+.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.InterpolatedStringBuilder
+    extends [mscorlib]System.ValueType
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [mscorlib]System.ObsoleteAttribute::.ctor(string, bool) = (
+        01 00 52 54 79 70 65 73 20 77 69 74 68 20 65 6d
+        62 65 64 64 65 64 20 72 65 66 65 72 65 6e 63 65
+        73 20 61 72 65 20 6e 6f 74 20 73 75 70 70 6f 72
+        74 65 64 20 69 6e 20 74 68 69 73 20 76 65 72 73
+        69 6f 6e 20 6f 66 20 79 6f 75 72 20 63 6f 6d 70
+        69 6c 65 72 2e 01 00 00
+    )
+    .pack 0
+    .size 1
+
+    // Methods
+    .method public hidebysig static 
+        valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder Create (
+            int32 baseLength,
+            int32 numFormatHoles
+        ) cil managed 
+    {
+        .locals init (
+            [0] valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder
+        )
+
+        ldnull
+        throw
+    }
+
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor (
+            int32 baseLength
+        ) cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void Dispose () cil managed 
+    {
+        .custom instance void System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute::.ctor() = (
+            01 00 00 00
+        )
+        ldnull
+        throw
+    }
+
+    .method public hidebysig virtual 
+        instance string ToString () cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatBaseString (
+            string 'value'
+        ) cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatInterpolationHole<T> (
+            !!T hole,
+            [opt] int32 'alignment',
+            [opt] string format
+        ) cil managed 
+    {
+        .param [2] = int32(0)
+        .param [3] = nullref
+        ldnull
+        throw
+    }
+}
+";
+
+            var comp = CreateCompilationWithIL(code, ilSource: interpolatedStringBuilder + UnmanagedCallersOnlyIl);
+            comp.VerifyDiagnostics(
+                // (1,5): error CS0570: 'InterpolatedStringBuilder.Dispose()' is not supported by the language
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_BindToBogus, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()").WithLocation(1, 5),
+                // (1,5): error CS8901: 'InterpolatedStringBuilder.Dispose()' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()").WithLocation(1, 5)
+            );
+        }
+
+        [Fact]
+        public void UnmanagedCallersOnlyTryFormatBaseStringMethod()
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+
+.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.InterpolatedStringBuilder
+    extends [mscorlib]System.ValueType
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [mscorlib]System.ObsoleteAttribute::.ctor(string, bool) = (
+        01 00 52 54 79 70 65 73 20 77 69 74 68 20 65 6d
+        62 65 64 64 65 64 20 72 65 66 65 72 65 6e 63 65
+        73 20 61 72 65 20 6e 6f 74 20 73 75 70 70 6f 72
+        74 65 64 20 69 6e 20 74 68 69 73 20 76 65 72 73
+        69 6f 6e 20 6f 66 20 79 6f 75 72 20 63 6f 6d 70
+        69 6c 65 72 2e 01 00 00
+    )
+    .pack 0
+    .size 1
+
+    // Methods
+    .method public hidebysig static 
+        valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder Create (
+            int32 baseLength,
+            int32 numFormatHoles
+        ) cil managed 
+    {
+        .locals init (
+            [0] valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder
+        )
+
+        ldnull
+        throw
+    }
+
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor (
+            int32 baseLength
+        ) cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void Dispose () cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig virtual 
+        instance string ToString () cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatBaseString (
+            string 'value'
+        ) cil managed 
+    {
+        .custom instance void System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute::.ctor() = (
+            01 00 00 00
+        )
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatInterpolationHole<T> (
+            !!T hole,
+            [opt] int32 'alignment',
+            [opt] string format
+        ) cil managed 
+    {
+        .param [2] = int32(0)
+        .param [3] = nullref
+        ldnull
+        throw
+    }
+}
+";
+
+            var comp = CreateCompilationWithIL(code, ilSource: interpolatedStringBuilder + UnmanagedCallersOnlyIl);
+            var verifier = CompileAndVerify(comp);
+
+            // PROTOTYPE(interp-string): Do we want to hard error in this case, instead of falling back to string.Format?
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  ldstr      ""{0}""
+  IL_0005:  ldc.i4.1
+  IL_0006:  box        ""int""
+  IL_000b:  call       ""string string.Format(string, object)""
+  IL_0010:  pop
+  IL_0011:  ret
+}
+");
+        }
+
+        [Fact]
+        public void UnmanagedCallersOnlyTryFormatInterpolationHoleMethod()
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+
+.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.InterpolatedStringBuilder
+    extends [mscorlib]System.ValueType
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [mscorlib]System.ObsoleteAttribute::.ctor(string, bool) = (
+        01 00 52 54 79 70 65 73 20 77 69 74 68 20 65 6d
+        62 65 64 64 65 64 20 72 65 66 65 72 65 6e 63 65
+        73 20 61 72 65 20 6e 6f 74 20 73 75 70 70 6f 72
+        74 65 64 20 69 6e 20 74 68 69 73 20 76 65 72 73
+        69 6f 6e 20 6f 66 20 79 6f 75 72 20 63 6f 6d 70
+        69 6c 65 72 2e 01 00 00
+    )
+    .pack 0
+    .size 1
+
+    // Methods
+    .method public hidebysig static 
+        valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder Create (
+            int32 baseLength,
+            int32 numFormatHoles
+        ) cil managed 
+    {
+        .locals init (
+            [0] valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder
+        )
+
+        ldnull
+        throw
+    }
+
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor (
+            int32 baseLength
+        ) cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void Dispose () cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig virtual 
+        instance string ToString () cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatBaseString (
+            string 'value'
+        ) cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatInterpolationHole<T> (
+            !!T hole,
+            [opt] int32 'alignment',
+            [opt] string format
+        ) cil managed 
+    {
+        .custom instance void System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute::.ctor() = (
+            01 00 00 00
+        )
+        .param [2] = int32(0)
+        .param [3] = nullref
+        ldnull
+        throw
+    }
+}
+";
+
+            var comp = CreateCompilationWithIL(code, ilSource: interpolatedStringBuilder + UnmanagedCallersOnlyIl);
+            var verifier = CompileAndVerify(comp);
+
+            // PROTOTYPE(interp-string): Do we want to hard error in this case, instead of falling back to string.Format?
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  ldstr      ""{0}""
+  IL_0005:  ldc.i4.1
+  IL_0006:  box        ""int""
+  IL_000b:  call       ""string string.Format(string, object)""
+  IL_0010:  pop
+  IL_0011:  ret
+}
+");
+        }
+
+        [Fact]
+        public void UnmanagedCallersOnlyToStringMethod()
+        {
+            var code = @"_ = $""{(object)1}"";";
+
+            var interpolatedStringBuilder = @"
+
+.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.InterpolatedStringBuilder
+    extends [mscorlib]System.ValueType
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [mscorlib]System.ObsoleteAttribute::.ctor(string, bool) = (
+        01 00 52 54 79 70 65 73 20 77 69 74 68 20 65 6d
+        62 65 64 64 65 64 20 72 65 66 65 72 65 6e 63 65
+        73 20 61 72 65 20 6e 6f 74 20 73 75 70 70 6f 72
+        74 65 64 20 69 6e 20 74 68 69 73 20 76 65 72 73
+        69 6f 6e 20 6f 66 20 79 6f 75 72 20 63 6f 6d 70
+        69 6c 65 72 2e 01 00 00
+    )
+    .pack 0
+    .size 1
+
+    // Methods
+    .method public hidebysig static 
+        valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder Create (
+            int32 baseLength,
+            int32 numFormatHoles
+        ) cil managed 
+    {
+        .locals init (
+            [0] valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder
+        )
+
+        ldnull
+        throw
+    }
+
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor (
+            int32 baseLength
+        ) cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void Dispose () cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig virtual 
+        instance string ToString () cil managed 
+    {
+        .custom instance void System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute::.ctor() = (
+            01 00 00 00
+        )
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatBaseString (
+            string 'value'
+        ) cil managed 
+    {
+        ldnull
+        throw
+    }
+
+    .method public hidebysig 
+        instance void TryFormatInterpolationHole<T> (
+            !!T hole,
+            [opt] int32 'alignment',
+            [opt] string format
+        ) cil managed 
+    {
+        .param [2] = int32(0)
+        .param [3] = nullref
+        ldnull
+        throw
+    }
+}
+";
+
+            var comp = CreateCompilationWithIL(code, ilSource: interpolatedStringBuilder + UnmanagedCallersOnlyIl);
+            comp.VerifyDiagnostics();
+            comp.VerifyEmitDiagnostics(
+                // (1,1): error CS0570: 'InterpolatedStringBuilder.ToString()' is not supported by the language
+                // _ = $"{(object)1}";
+                Diagnostic(ErrorCode.ERR_BindToBogus, @"_ = $""{(object)1}"";").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.ToString()").WithLocation(1, 1)
+            );
+        }
+
+        [Fact]
+        public void UnsupportedArgumentType()
+        {
+            var source = @"
+unsafe
+{
+    int* i = null;
+    var s = new S();
+    _ = $""{i}{s}"";
+}
+ref struct S
+{
+}";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: true, useBoolReturns: false);
+
+            var comp = CreateCompilation(new[] { source, interpolatedStringBuilder }, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseExe, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (6,12): error CS0029: Cannot implicitly convert type 'int*' to 'object'
+                //     _ = $"{i}{s}";
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "i").WithArguments("int*", "object").WithLocation(6, 12),
+                // (6,15): error CS0029: Cannot implicitly convert type 'S' to 'object'
+                //     _ = $"{i}{s}";
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("S", "object").WithLocation(6, 15)
+            );
+        }
+
+        [Fact]
+        public void TargetTypedInterpolationHoles()
+        {
+            var source = @"
+bool b = true;
+System.Console.WriteLine($""{b switch { true => 1, false => null }}{(!b ? null : 2)}{new()}{default}{null}"");";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
+Disposed
+value:1
+value:2
+value:System.Object
+value:
+value:");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size      110 (0x6e)
+  .maxstack  2
+  .locals init (bool V_0, //b
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2,
+                object V_3)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  .try
+  {
+    IL_0002:  ldc.i4.0
+    IL_0003:  ldc.i4.5
+    IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0009:  stloc.2
+    IL_000a:  ldloc.0
+    IL_000b:  brfalse.s  IL_0016
+    IL_000d:  ldc.i4.1
+    IL_000e:  box        ""int""
+    IL_0013:  stloc.3
+    IL_0014:  br.s       IL_0018
+    IL_0016:  ldnull
+    IL_0017:  stloc.3
+    IL_0018:  ldloca.s   V_2
+    IL_001a:  ldloc.3
+    IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(object)""
+    IL_0020:  ldloca.s   V_2
+    IL_0022:  ldloc.0
+    IL_0023:  brfalse.s  IL_002d
+    IL_0025:  ldc.i4.2
+    IL_0026:  box        ""int""
+    IL_002b:  br.s       IL_002e
+    IL_002d:  ldnull
+    IL_002e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(object)""
+    IL_0033:  ldloca.s   V_2
+    IL_0035:  newobj     ""object..ctor()""
+    IL_003a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(object)""
+    IL_003f:  ldloca.s   V_2
+    IL_0041:  ldnull
+    IL_0042:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(object)""
+    IL_0047:  ldloca.s   V_2
+    IL_0049:  ldnull
+    IL_004a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(object)""
+    IL_004f:  ldloca.s   V_2
+    IL_0051:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_0057:  callvirt   ""string object.ToString()""
+    IL_005c:  stloc.1
+    IL_005d:  leave.s    IL_0067
+  }
+  finally
+  {
+    IL_005f:  ldloca.s   V_2
+    IL_0061:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0066:  endfinally
+  }
+  IL_0067:  ldloc.1
+  IL_0068:  call       ""void System.Console.WriteLine(string)""
+  IL_006d:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TargetTypedInterpolationHoles_Errors()
+        {
+            var source = @"System.Console.WriteLine($""{(null, default)}"");";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var comp = CreateCompilation(new[] { source, interpolatedStringBuilder });
+            comp.VerifyDiagnostics(
+                // (1,29): error CS8135: Tuple with 2 elements cannot be converted to type 'object'.
+                // System.Console.WriteLine($"{(null, default)}");
+                Diagnostic(ErrorCode.ERR_ConversionNotTupleCompatible, "(null, default)").WithArguments("2", "object").WithLocation(1, 29)
+            );
+        }
+
+        [Fact]
+        public void RefTernary()
+        {
+            var source = @"
+bool b = true;
+int i = 1;
+System.Console.WriteLine($""{(!b ? ref i : ref i)}"");";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
+Disposed
+value:1");
+        }
+
+        [Fact]
+        public void NestedInterpolatedStrings()
+        {
+            var source = @"
+int i = 1;
+System.Console.WriteLine($""{$""{i}""}"");";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
+Disposed
+Disposed
+value:value:1");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       90 (0x5a)
+  .maxstack  2
+  .locals init (int V_0, //i
+                string V_1,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2,
+                string V_3,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_4)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  .try
+  {
+    IL_0002:  ldc.i4.0
+    IL_0003:  ldc.i4.1
+    IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0009:  stloc.2
+    .try
+    {
+      IL_000a:  ldc.i4.0
+      IL_000b:  ldc.i4.1
+      IL_000c:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+      IL_0011:  stloc.s    V_4
+      IL_0013:  ldloca.s   V_4
+      IL_0015:  ldloc.0
+      IL_0016:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<int>(int)""
+      IL_001b:  ldloca.s   V_4
+      IL_001d:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+      IL_0023:  callvirt   ""string object.ToString()""
+      IL_0028:  stloc.3
+      IL_0029:  leave.s    IL_0033
+    }
+    finally
+    {
+      IL_002b:  ldloca.s   V_4
+      IL_002d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+      IL_0032:  endfinally
+    }
+    IL_0033:  ldloca.s   V_2
+    IL_0035:  ldloc.3
+    IL_0036:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<string>(string)""
+    IL_003b:  ldloca.s   V_2
+    IL_003d:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_0043:  callvirt   ""string object.ToString()""
+    IL_0048:  stloc.1
+    IL_0049:  leave.s    IL_0053
+  }
+  finally
+  {
+    IL_004b:  ldloca.s   V_2
+    IL_004d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0052:  endfinally
+  }
+  IL_0053:  ldloc.1
+  IL_0054:  call       ""void System.Console.WriteLine(string)""
+  IL_0059:  ret
+}
+");
+        }
+
+        [Fact]
+        public void ExceptionFilter_01()
+        {
+            var source = @"
+using System;
+
+int i = 1;
+try
+{
+    Console.WriteLine(""Starting try"");
+    throw new MyException { Prop = i };
+}
+catch (MyException e) when (e.ToString() == $""{i}"")
+{
+    Console.WriteLine(""Caught"");
+}
+
+class MyException : Exception
+{
+    public int Prop { get; set; }
+    public override string ToString() => Prop.ToString();
+}";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            // Note the lack of "Disposed" in the output
+            var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
+Starting try
+Caught");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       82 (0x52)
+  .maxstack  3
+  .locals init (int V_0) //i
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  .try
+  {
+    IL_0002:  ldstr      ""Starting try""
+    IL_0007:  call       ""void System.Console.WriteLine(string)""
+    IL_000c:  newobj     ""MyException..ctor()""
+    IL_0011:  dup
+    IL_0012:  ldloc.0
+    IL_0013:  callvirt   ""void MyException.Prop.set""
+    IL_0018:  throw
+  }
+  filter
+  {
+    IL_0019:  isinst     ""MyException""
+    IL_001e:  dup
+    IL_001f:  brtrue.s   IL_0025
+    IL_0021:  pop
+    IL_0022:  ldc.i4.0
+    IL_0023:  br.s       IL_0042
+    IL_0025:  callvirt   ""string object.ToString()""
+    IL_002a:  ldstr      ""{0}""
+    IL_002f:  ldloc.0
+    IL_0030:  box        ""int""
+    IL_0035:  call       ""string string.Format(string, object)""
+    IL_003a:  call       ""bool string.op_Equality(string, string)""
+    IL_003f:  ldc.i4.0
+    IL_0040:  cgt.un
+    IL_0042:  endfilter
+  }  // end filter
+  {  // handler
+    IL_0044:  pop
+    IL_0045:  ldstr      ""Caught""
+    IL_004a:  call       ""void System.Console.WriteLine(string)""
+    IL_004f:  leave.s    IL_0051
+  }
+  IL_0051:  ret
+}
+");
+        }
+
+        [Fact]
+        public void ExceptionFilter_02()
+        {
+            var source = @"
+using System;
+
+try
+{
+}
+catch (Exception e) when (e.ToString() == $""{(ReadOnlySpan<char>)""""}"")
+{
+}
+";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
+
+            var comp = CreateCompilation(new[] { source, interpolatedStringBuilder }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            // PROTOTYPE(interp-string): Can we get a better error message for this?
+            comp.VerifyDiagnostics(
+                // (7,46): error CS0029: Cannot implicitly convert type 'System.ReadOnlySpan<char>' to 'object'
+                // catch (Exception e) when (e.ToString() == $"{(ReadOnlySpan<char>)""}")
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"(ReadOnlySpan<char>)""""").WithArguments("System.ReadOnlySpan<char>", "object").WithLocation(7, 46)
+            );
+        }
+
+        [Fact]
+        public void ImplicitUserDefinedConversionInHole()
+        {
+            var source = @"
+using System;
+
+S s = default;
+C c = new C();
+Console.WriteLine($""{s}{c}"");
+
+ref struct S
+{
+    public static implicit operator ReadOnlySpan<char>(S s) => ""S converted"";
+}
+class C
+{
+    public static implicit operator ReadOnlySpan<char>(C s) => ""C converted"";
+}";
+
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
+
+            var comp = CreateCompilation(new[] { source, interpolatedStringBuilder }, targetFramework: TargetFramework.NetCoreApp, parseOptions: TestOptions.RegularPreview);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+Disposed
+value:S converted
+value:C");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       74 (0x4a)
+  .maxstack  2
+  .locals init (S V_0, //s
+                C V_1, //c
+                string V_2,
+                System.Runtime.CompilerServices.InterpolatedStringBuilder V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  newobj     ""C..ctor()""
+  IL_000d:  stloc.1
+  .try
+  {
+    IL_000e:  ldc.i4.0
+    IL_000f:  ldc.i4.2
+    IL_0010:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0015:  stloc.3
+    IL_0016:  ldloca.s   V_3
+    IL_0018:  ldloc.0
+    IL_0019:  call       ""System.ReadOnlySpan<char> S.op_Implicit(S)""
+    IL_001e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole(System.ReadOnlySpan<char>)""
+    IL_0023:  ldloca.s   V_3
+    IL_0025:  ldloc.1
+    IL_0026:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.TryFormatInterpolationHole<C>(C)""
+    IL_002b:  ldloca.s   V_3
+    IL_002d:  constrained. ""System.Runtime.CompilerServices.InterpolatedStringBuilder""
+    IL_0033:  callvirt   ""string object.ToString()""
+    IL_0038:  stloc.2
+    IL_0039:  leave.s    IL_0043
+  }
+  finally
+  {
+    IL_003b:  ldloca.s   V_3
+    IL_003d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.Dispose()""
+    IL_0042:  endfinally
+  }
+  IL_0043:  ldloc.2
+  IL_0044:  call       ""void System.Console.WriteLine(string)""
+  IL_0049:  ret
+}
+");
+        }
+
+
+        [Fact]
+        public void ExplicitUserDefinedConversionInHole()
+        {
+            var source = @"
+using System;
+
+S s = default;
+Console.WriteLine($""{s}"");
+
+ref struct S
+{
+    public static explicit operator ReadOnlySpan<char>(S s) => ""S converted"";
+}
+";
+            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
+
+            var comp = CreateCompilation(new[] { source, interpolatedStringBuilder }, targetFramework: TargetFramework.NetCoreApp, parseOptions: TestOptions.RegularPreview);
+            // PROTOTYPE(interp-string): Can we make a better error here?
+            comp.VerifyDiagnostics(
+                // (5,22): error CS0029: Cannot implicitly convert type 'S' to 'object'
+                // Console.WriteLine($"{s}");
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("S", "object").WithLocation(5, 22)
+            );
         }
     }
 }

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -232,6 +232,12 @@ namespace Microsoft.CodeAnalysis
         /// TODO: Avoid using lambdas and display classes for implementation of relaxation stubs and remove this kind.
         /// </summary>
         DelegateRelaxationReceiver = 0x101,
+
+        /// <summary>
+        /// The builder type of an interpolated string, when using the interpolated string builder pattern.
+        /// This synthesized local is allowed to have a val escape
+        /// </summary>
+        InterpolatedStringBuilder = 0x102,
     }
 
     internal static class SynthesizedLocalKindExtensions

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -511,6 +511,9 @@ namespace Microsoft.CodeAnalysis
         System_Text_StringBuilder__AppendObject,
         System_Text_StringBuilder__ctor,
 
+        System_Runtime_CompilerServices_InterpolatedStringBuilder__CreateInt32Int32,
+        System_Runtime_CompilerServices_InterpolatedStringBuilder__Dispose,
+
         Count
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3504,6 +3504,22 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    
+                // System_Runtime_CompilerServices_InterpolatedStringBuilder__CreateInt32Int32
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder - WellKnownType.ExtSentinel), // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    
+                // System_Runtime_CompilerServices_InterpolatedStringBuilder__Dispose
+                (byte)MemberFlags.Method,                                                                                   // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3944,6 +3960,8 @@ namespace Microsoft.CodeAnalysis
                 "Append",                                   // System_Text_StringBuilder__AppendString
                 "Append",                                   // System_Text_StringBuilder__AppendObject
                 ".ctor",                                    // System_Text_StringBuilder__ctor
+                "Create",                                   // System_Runtime_CompilerServices_InterpolatedStringBuilder__CreateInt32Int32
+                "Dispose",                                  // System_Runtime_CompilerServices_InterpolatedStringBuilder__Dispose
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -313,6 +313,8 @@ namespace Microsoft.CodeAnalysis
 
         System_Text_StringBuilder,
 
+        System_Runtime_CompilerServices_InterpolatedStringBuilder,
+
         NextAvailable,
 
         // Remember to update the AllWellKnownTypes tests when making changes here
@@ -620,6 +622,7 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.InteropServices.OutAttribute",
 
             "System.Text.StringBuilder",
+            "System.Runtime.CompilerServices.InterpolatedStringBuilder",
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -2602,7 +2602,7 @@ End Class
             Dim c = str(i)
             If (c = vbLf(0)) AndAlso
                 ((i = str.Length - 1) OrElse (str(i + 1) <> vbCr(0))) Then
-                builder.AddRange(vbCrLf)
+                builder.AddRange(DirectCast(vbCrLf, IEnumerable(Of Char)))
             Else
                 builder.Add(c)
             End If

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -496,6 +496,14 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             }
         }
 
+        public void AddRange(ReadOnlySpan<T> items)
+        {
+            foreach (var i in items)
+            {
+                _builder.Add(i);
+            }
+        }
+
         public void AddRange<S>(ImmutableArray<S> items) where S : class, T
         {
             AddRange(ImmutableArray<T>.CastUp(items));

--- a/src/Test/PdbUtilities/Reader/MockSymUnmanagedReader.cs
+++ b/src/Test/PdbUtilities/Reader/MockSymUnmanagedReader.cs
@@ -321,7 +321,7 @@ namespace Roslyn.Test.Utilities
             if (name != null)
             {
                 var builder = ArrayBuilder<char>.GetInstance();
-                builder.AddRange(name);
+                builder.AddRange(name.AsSpan());
                 builder.AddRange('\0');
                 _nameChars = builder.ToImmutableAndFree();
             }


### PR DESCRIPTION
This implements initial binding and lowering for the InterpolatedStringBuilder, used when an interpolated string is converted directly to a `string`, and not to some other builder type. I've written it in such a way as to make future refactorings to support general builder types simple, but some of the steps (particularly lowering) are more simplistic for now. I did _not_ implement nullable analysis or definite assignment in this PR, prototype comments have been left to make sure that those are handled later. The spec for this feature is located at https://github.com/dotnet/csharplang/blob/main/proposals/improved-interpolated-strings.md, I will have a PR out later today or tomorrow to reflect the changes from LDM earlier today.
