### PR TITLE
Show arrays as standard public classes.

### DIFF
--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return Glyph.Assembly;
 
                 case SymbolKind.ArrayType:
-                    return ((IArrayTypeSymbol)symbol).ElementType.GetGlyph();
+                    return Glyph.ClassPublic;
 
                 case SymbolKind.DynamicType:
                     return Glyph.ClassPublic;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/52439