### PR TITLE
Remove reliance on "questionable" UpdateFile operation

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
@@ -33,10 +33,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             var project = new Project(ProjectName);
             VisualStudio.SolutionExplorer.AddProject(project, WellKnownProjectTemplates.ConsoleApplication, Microsoft.CodeAnalysis.LanguageNames.CSharp);
 
-            VisualStudio.SolutionExplorer.UpdateFile(
-                ProjectName,
-                FileName,
-                @"using System;
+            VisualStudio.Editor.SetText(@"using System;
 
  namespace TestProj
  {
@@ -64,8 +61,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
          }
      }
  }
-",
-                open: true);
+");
+            VisualStudio.Editor.Activate();
 
             VisualStudio.InteractiveWindow.SubmitText("using System;");
         }


### PR DESCRIPTION
During investigation of #52409, logs were observed where the editor text did not appear to match the text set up by `InitializeAsync` (e.g. https://github.com/dotnet/roslyn/pull/52441#issuecomment-814457780 below). Since the `InitializeAsync` method set the text using a somewhat unique method, and other tests aren't showing signs of incorrect values, we modify the problematic test to set the editor text using the same coding pattern that other non-problematic tests are using.

The failure has not been locally reproducible, so it's not clear why (or to some degree if) the `UpdateFile` call is failing in this scenario.

The new code follows the approach of `AbstractEditorTest.SetUpEditor`.