### PR TITLE
Do not use the shallow checkout job during integration CI

### DIFF
--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -28,8 +28,6 @@ jobs:
   timeoutInMinutes: 40
 
   steps:
-    - template: checkout-unix-task.yml
-
     - script: ./eng/build.sh --ci --restore --prepareMachine --binaryLog --configuration ${{ parameters.configuration }}
       displayName: Restore
 

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -28,21 +28,19 @@ jobs:
   timeoutInMinutes: 40
 
   steps:
-    - template: checkout-windows-task.yml
-
     - task: PowerShell@2
       displayName: Restore
       inputs:
         filePath: eng/build.ps1
         arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog
 
-    - task: PowerShell@2 
+    - task: PowerShell@2
       displayName: Build
       inputs:
         filePath: eng/build.ps1
         arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -publish -binaryLog -skipDocumentation
 
-    - task: PowerShell@2 
+    - task: PowerShell@2
       displayName: Prepare Unit Tests
       inputs:
         filePath: eng/prepare-tests.ps1

--- a/eng/pipelines/checkout-unix-task.yml
+++ b/eng/pipelines/checkout-unix-task.yml
@@ -2,6 +2,10 @@
 steps:
   - checkout: none
 
+  # This script needs to be reevaluated. The Build.SourceVersion is the last
+  # commit SHA to the pull request and  does not include the merge commit.
+  # The equivalent of building `refs/pull/###/head` instead of `refs/pull/###/merge`.
+  # See https://github.com/dotnet/roslyn/issues/52444
   - script: |
       set -x
       git init

--- a/eng/pipelines/checkout-windows-task.yml
+++ b/eng/pipelines/checkout-windows-task.yml
@@ -2,6 +2,10 @@
 steps:
   - checkout: none
 
+  # This script needs to be reevaluated. The Build.SourceVersion is the last
+  # commit SHA to the pull request and  does not include the merge commit.
+  # The equivalent of building `refs/pull/###/head` instead of `refs/pull/###/merge`.
+  # See https://github.com/dotnet/roslyn/issues/52444
   - script: |
       @echo on
       git init


### PR DESCRIPTION
https://github.com/dotnet/roslyn/issues/52444

Disables the shallow checkout task.