### PR TITLE
Reset the interactive window using IInteractiveWindowOperations

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
@@ -37,7 +37,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public const string File_OpenFile = "File.OpenFile";
         public const string File_SaveAll = "File.SaveAll";
 
-        public const string InteractiveConsole_Reset = "InteractiveConsole.Reset";
         public const string InteractiveConsole_ClearScreen = "InteractiveConsole.ClearScreen";
         public const string InteractiveConsole_ExecuteInInteractive = "InteractiveConsole.ExecuteInInteractive";
 


### PR DESCRIPTION
The previous implementation relies on using DTE to execute a named command. However, since it is not the purpose of these tests to cover invoking this command by name (a dedicated test could be created if desired), we modify the code to instead directly invoke the backing API for this command. This change reduces the likelihood that a failure in the commanding infrastructure leads to an obscure test failure.

Closes #52409