### PR TITLE
Workaround breaking change to allow LSP integration tests to run on 16.10p1

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -153,6 +154,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 logger);
         }
 
+        // Make sure this isn't inlined so these types are only loaded
+        // after the type check in CreateAsync.
+        // Removal tracked by https://github.com/dotnet/roslyn/issues/52454
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static async Task<LogHubLspLogger?> CreateLoggerAsync(
             VSShell.IAsyncServiceProvider? asyncServiceProvider,
             string serverTypeName,

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -133,6 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             // To allow LSP integration tests to run on 16.10 preview 1, we only setup the loghub
             // logger if the MS.VS.Utilities assembly contains the LogHub types.
             // FeatureFlags.IFeatureFlags is a known type in the MS.VS.Utilities assembly.
+            // Removal tracked by https://github.com/dotnet/roslyn/issues/52454
             var traceConfigurationType = typeof(FeatureFlags.IFeatureFlags).Assembly.GetType("Microsoft.VisualStudio.LogHub.TraceConfiguration", throwOnError: false);
             if (traceConfigurationType != null)
             {


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/issues/52454

The loghub types moved in 16.10p2 to different assemblies and namespaces (the old assembly was removed).  We reacted to this change in main-vs-deps, but this caused the LSP integration tests to fail server activation.  The main-vs-deps code could not find the new types in 16.10p1 since 16.10p1 is still on the old assembly.

Workaround by not creating the LSP logger when the new types are missing.  This should be removed when the integration test queue updates to 16.10p2.