### PR TITLE
"Add null check" inserts single line statements if preferred

### DIFF
--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -2273,7 +2273,7 @@ class C
     {
     }
 }",
-                FixedCode = @$"
+                FixedCode = $@"
 using System;
 
 class C

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -2046,5 +2046,219 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_NullCheck_BracesNone_SameLineFalse()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]object o)
+    {
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public C(object o)
+    {
+        if (o is null)
+            throw new ArgumentNullException(nameof(o));
+    }
+}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false, NotificationOption2.Silent },
+                }
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_NullCheck_BracesWhenMultiline_SameLineFalse()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]object o)
+    {
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public C(object o)
+    {
+        if (o is null)
+            throw new ArgumentNullException(nameof(o));
+    }
+}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false, NotificationOption2.Silent },
+                }
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_NullCheck_BracesAlways_SameLineFalse()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]object o)
+    {
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public C(object o)
+    {
+        if (o is null)
+        {
+            throw new ArgumentNullException(nameof(o));
+        }
+    }
+}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false, NotificationOption2.Silent },
+                }
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_NullCheck_BracesNone_SameLineTrue()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]object o)
+    {
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public C(object o)
+    {
+        if (o is null)
+            throw new ArgumentNullException(nameof(o));
+    }
+}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true, NotificationOption2.Silent },
+                }
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_NullCheck_BracesWhenMultiline_SameLineTrue()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]object o)
+    {
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public C(object o)
+    {
+        if (o is null)
+            throw new ArgumentNullException(nameof(o));
+    }
+}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true, NotificationOption2.Silent },
+                }
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_NullCheck_BracesAlways_SameLineTrue()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]object o)
+    {
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public C(object o)
+    {
+        if (o is null)
+        {
+            throw new ArgumentNullException(nameof(o));
+        }
+    }
+}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true, NotificationOption2.Silent },
+                }
+            }.RunAsync();
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -1748,7 +1748,8 @@ class C
 }",
                 Options =
                 {
-                    { CSharpCodeStyleOptions.PreferBraces, new CodeStyleOption2<PreferBracesPreference>((PreferBracesPreference)preferBraces, NotificationOption2.Silent) }
+                    { CSharpCodeStyleOptions.PreferBraces, new CodeStyleOption2<PreferBracesPreference>((PreferBracesPreference)preferBraces, NotificationOption2.Silent) },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
                 }
             }.RunAsync();
         }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -2075,9 +2075,9 @@ class C
 }",
                 Options =
                 {
-                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
                 }
             }.RunAsync();
         }
@@ -2110,9 +2110,9 @@ class C
 }",
                 Options =
                 {
-                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
                 }
             }.RunAsync();
         }
@@ -2147,9 +2147,9 @@ class C
 }",
                 Options =
                 {
-                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
                 }
             }.RunAsync();
         }
@@ -2176,15 +2176,14 @@ class C
 {
     public C(object o)
     {
-        if (o is null)
-            throw new ArgumentNullException(nameof(o));
+        if (o is null) throw new ArgumentNullException(nameof(o));
     }
 }",
                 Options =
                 {
-                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true },
                 }
             }.RunAsync();
         }
@@ -2211,15 +2210,14 @@ class C
 {
     public C(object o)
     {
-        if (o is null)
-            throw new ArgumentNullException(nameof(o));
+        if (o is null) throw new ArgumentNullException(nameof(o));
     }
 }",
                 Options =
                 {
-                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true },
                 }
             }.RunAsync();
         }
@@ -2254,10 +2252,234 @@ class C
 }",
                 Options =
                 {
-                    { CSharpCodeStyleOptions.PreferThrowExpression, false, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always, NotificationOption2.Silent },
-                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true, NotificationOption2.Silent },
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true },
                 }
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_StringIsNullOrEmpty_BracesNone_SameLineFalse()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]string s)
+    {
+    }
+}",
+                FixedCode = @$"
+using System;
+
+class C
+{{
+    public C(string s)
+    {{
+        if (string.IsNullOrEmpty(s))
+            throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(s)}").Replace("\"", "\\\"")}"", nameof(s));
+    }}
+}}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
+                },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_string_IsNullOrEmpty_check)
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_StringIsNullOrEmpty_BracesWhenMultiline_SameLineFalse()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]string s)
+    {
+    }
+}",
+                FixedCode = @$"
+using System;
+
+class C
+{{
+    public C(string s)
+    {{
+        if (string.IsNullOrEmpty(s))
+            throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(s)}").Replace("\"", "\\\"")}"", nameof(s));
+    }}
+}}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline},
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
+                },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_string_IsNullOrEmpty_check)
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_StringIsNullOrEmpty_BracesAlways_SameLineFalse()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]string s)
+    {
+    }
+}",
+                FixedCode = @$"
+using System;
+
+class C
+{{
+    public C(string s)
+    {{
+        if (string.IsNullOrEmpty(s))
+        {{
+            throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(s)}").Replace("\"", "\\\"")}"", nameof(s));
+        }}
+    }}
+}}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
+                },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_string_IsNullOrEmpty_check)
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_StringIsNullOrEmpty_BracesNone_SameLineTrue()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]string s)
+    {
+    }
+}",
+                FixedCode = @$"
+using System;
+
+class C
+{{
+    public C(string s)
+    {{
+        if (string.IsNullOrEmpty(s)) throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(s)}").Replace("\"", "\\\"")}"", nameof(s));
+    }}
+}}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true },
+                },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_string_IsNullOrEmpty_check)
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_StringIsNullOrEmpty_BracesWhenMultiline_SameLineTrue()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]string s)
+    {
+    }
+}",
+                FixedCode = @$"
+using System;
+
+class C
+{{
+    public C(string s)
+    {{
+        if (string.IsNullOrEmpty(s)) throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(s)}").Replace("\"", "\\\"")}"", nameof(s));
+    }}
+}}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.WhenMultiline },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true },
+                },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_string_IsNullOrEmpty_check)
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_StringIsNullOrEmpty_BracesAlways_SameLineTrue()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]string s)
+    {
+    }
+}",
+                FixedCode = @$"
+using System;
+
+class C
+{{
+    public C(string s)
+    {{
+        if (string.IsNullOrEmpty(s))
+        {{
+            throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(s)}").Replace("\"", "\\\"")}"", nameof(s));
+        }}
+    }}
+}}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.Always },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true },
+                },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_string_IsNullOrEmpty_check)
             }.RunAsync();
         }
     }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -2481,5 +2481,43 @@ class C
                 CodeActionEquivalenceKey = nameof(FeaturesResources.Add_string_IsNullOrEmpty_check)
             }.RunAsync();
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        [WorkItem(52385, "https://github.com/dotnet/roslyn/issues/52385")]
+        public async Task SingleLineStatement_NullCheck_AllParameters()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public C([||]object a, object b, object c)
+    {
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public C(object a, object b, object c)
+    {
+        if (a is null) throw new ArgumentNullException(nameof(a));
+        if (b is null) throw new ArgumentNullException(nameof(b));
+        if (c is null) throw new ArgumentNullException(nameof(c));
+    }
+}",
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferThrowExpression, false },
+                    { CSharpCodeStyleOptions.PreferBraces, PreferBracesPreference.None },
+                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, true },
+                },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_null_checks_for_all_parameters)
+            }.RunAsync();
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -2059,7 +2059,7 @@ using System;
 
 class C
 {
-    public C([||]object o)
+    public C($$object o)
     {
     }
 }",
@@ -2094,7 +2094,7 @@ using System;
 
 class C
 {
-    public C([||]object o)
+    public C($$object o)
     {
     }
 }",
@@ -2129,7 +2129,7 @@ using System;
 
 class C
 {
-    public C([||]object o)
+    public C($$object o)
     {
     }
 }",
@@ -2166,7 +2166,7 @@ using System;
 
 class C
 {
-    public C([||]object o)
+    public C($$object o)
     {
     }
 }",
@@ -2200,7 +2200,7 @@ using System;
 
 class C
 {
-    public C([||]object o)
+    public C($$object o)
     {
     }
 }",
@@ -2234,7 +2234,7 @@ using System;
 
 class C
 {
-    public C([||]object o)
+    public C($$object o)
     {
     }
 }",
@@ -2271,7 +2271,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -2308,7 +2308,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -2345,7 +2345,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -2384,7 +2384,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -2420,7 +2420,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",
@@ -2456,7 +2456,7 @@ using System;
 
 class C
 {
-    public C([||]string s)
+    public C($$string s)
     {
     }
 }",

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -1742,14 +1742,12 @@ class C
 {
     public C(string s)
     {
-        if (s is null)
-            throw new ArgumentNullException(nameof(s));
+        if (s is null) throw new ArgumentNullException(nameof(s));
     }
 }",
                 Options =
                 {
                     { CSharpCodeStyleOptions.PreferBraces, new CodeStyleOption2<PreferBracesPreference>((PreferBracesPreference)preferBraces, NotificationOption2.Silent) },
-                    { CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine, false },
                 }
             }.RunAsync();
         }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
@@ -70,13 +70,14 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             var withBlock = options.GetOption(CSharpCodeStyleOptions.PreferBraces).Value == CodeAnalysis.CodeStyle.PreferBracesPreference.Always;
             var singleLine = options.GetOption(CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine).Value;
             var ifTruePart = withBlock
-                ? Block(ifTrueStatement)
+                ? Block(ifTrueStatement) // wrap the if-true part in braces
                 : singleLine
-                    ? ifTrueStatement.WithoutLeadingTrivia()
+                    ? ifTrueStatement.WithoutLeadingTrivia() // if single line is allowed, any elastic trivia between the closing brace of if and the statement must be removed
                     : ifTrueStatement;
             var closeParenTrailingTrivia = singleLine && !withBlock
-                ? Space
+                ? Space // Remove any elastic marker and replace it with a space
                 : ElasticMarker;
+
             return IfStatement(
                 attributeLists: default,
                 ifKeyword: Token(SyntaxKind.IfKeyword),

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
@@ -76,7 +76,9 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             }
             else if (singleLine)
             {
-                // if single line is allowed, any elastic trivia between the closing brace of if and the statement must be removed
+                // Any elastic trivia between the closing parenthesis of if and the statement must be removed
+                // to convince the formatter to keep everything on a single line.
+                // Note: ifTrueStatement and closeParenToken are generated, so there is no need to deal with any existing trivia.
                 closeParenToken = closeParenToken.WithTrailingTrivia(Space);
                 ifTrueStatement = ifTrueStatement.WithoutLeadingTrivia();
             }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
@@ -69,22 +69,25 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
         {
             var withBlock = options.GetOption(CSharpCodeStyleOptions.PreferBraces).Value == CodeAnalysis.CodeStyle.PreferBracesPreference.Always;
             var singleLine = options.GetOption(CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine).Value;
-            var ifTruePart = withBlock
-                ? Block(ifTrueStatement) // wrap the if-true part in braces
-                : singleLine
-                    ? ifTrueStatement.WithoutLeadingTrivia() // if single line is allowed, any elastic trivia between the closing brace of if and the statement must be removed
-                    : ifTrueStatement;
-            var closeParenTrailingTrivia = singleLine && !withBlock
-                ? Space // Remove any elastic marker and replace it with a space
-                : ElasticMarker;
+            var closeParenToken = Token(SyntaxKind.CloseParenToken);
+            if (withBlock)
+            {
+                ifTrueStatement = Block(ifTrueStatement);
+            }
+            else if (singleLine)
+            {
+                // if single line is allowed, any elastic trivia between the closing brace of if and the statement must be removed
+                closeParenToken = closeParenToken.WithTrailingTrivia(Space);
+                ifTrueStatement = ifTrueStatement.WithoutLeadingTrivia();
+            }
 
             return IfStatement(
                 attributeLists: default,
                 ifKeyword: Token(SyntaxKind.IfKeyword),
                 openParenToken: Token(SyntaxKind.OpenParenToken),
                 condition: condition,
-                closeParenToken: Token(SyntaxKind.CloseParenToken).WithTrailingTrivia(closeParenTrailingTrivia),
-                statement: ifTruePart,
+                closeParenToken: closeParenToken,
+                statement: ifTrueStatement,
                 @else: null);
         }
     }

--- a/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicAddParameterCheckCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicAddParameterCheckCodeRefactoringProvider.vb
@@ -54,5 +54,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
         Protected Overrides Function EscapeResourceString(input As String) As String
             Return input.Replace("""", """""")
         End Function
+
+        Protected Overrides Function CreateParameterCheckIfStatement(options As DocumentOptionSet, condition As ExpressionSyntax, ifTrueStatement As StatementSyntax) As StatementSyntax
+            Return SyntaxFactory.MultiLineIfBlock(SyntaxFactory.IfStatement(condition), New SyntaxList(Of StatementSyntax)(ifTrueStatement), Nothing, Nothing)
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicAddParameterCheckCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicAddParameterCheckCodeRefactoringProvider.vb
@@ -57,10 +57,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
 
         Protected Overrides Function CreateParameterCheckIfStatement(options As DocumentOptionSet, condition As ExpressionSyntax, ifTrueStatement As StatementSyntax) As StatementSyntax
             Return SyntaxFactory.MultiLineIfBlock(
-                SyntaxFactory.IfStatement(SyntaxFactory.Token(SyntaxKind.IfKeyword), condition, SyntaxFactory.Token(SyntaxKind.ThenKeyword)),
-                New SyntaxList(Of StatementSyntax)(ifTrueStatement),
-                Nothing,
-                Nothing)
+                ifStatement:=SyntaxFactory.IfStatement(SyntaxFactory.Token(SyntaxKind.IfKeyword), condition, SyntaxFactory.Token(SyntaxKind.ThenKeyword)),
+                statements:=New SyntaxList(Of StatementSyntax)(ifTrueStatement),
+                elseIfBlocks:=Nothing,
+                elseBlock:=Nothing)
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicAddParameterCheckCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/InitializeParameter/VisualBasicAddParameterCheckCodeRefactoringProvider.vb
@@ -56,7 +56,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InitializeParameter
         End Function
 
         Protected Overrides Function CreateParameterCheckIfStatement(options As DocumentOptionSet, condition As ExpressionSyntax, ifTrueStatement As StatementSyntax) As StatementSyntax
-            Return SyntaxFactory.MultiLineIfBlock(SyntaxFactory.IfStatement(condition), New SyntaxList(Of StatementSyntax)(ifTrueStatement), Nothing, Nothing)
+            Return SyntaxFactory.MultiLineIfBlock(
+                SyntaxFactory.IfStatement(SyntaxFactory.Token(SyntaxKind.IfKeyword), condition, SyntaxFactory.Token(SyntaxKind.ThenKeyword)),
+                New SyntaxList(Of StatementSyntax)(ifTrueStatement),
+                Nothing,
+                Nothing)
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -183,27 +183,26 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             SemanticModel semanticModel,
             IParameterSymbol parameter)
         {
-            var identifier = factory.IdentifierName(parameter.Name);
+            var condition = factory.CreateNullCheckExpression(semanticModel, parameter.Name);
+            var throwStatement = factory.CreateThrowArgumentNullExceptionStatement(semanticModel.Compilation, parameter);
+
+            // generates: if (s is null) { throw new ArgumentNullException(nameof(s)); }
+            return factory.IfStatement(
+                condition,
+                SpecializedCollections.SingletonEnumerable(throwStatement));
+        }
+
+        public static SyntaxNode CreateThrowArgumentNullExceptionStatement(this SyntaxGenerator factory, Compilation compilation, IParameterSymbol parameter)
+            => factory.ThrowStatement(CreateNewArgumentNullException(factory, compilation, parameter));
+
+        public static SyntaxNode CreateNullCheckExpression(this SyntaxGenerator factory, SemanticModel semanticModel, string identifierName)
+        {
+            var identifier = factory.IdentifierName(identifierName);
             var nullExpr = factory.NullLiteralExpression();
             var condition = factory.SyntaxGeneratorInternal.SupportsPatterns(semanticModel.SyntaxTree.Options)
                 ? factory.SyntaxGeneratorInternal.IsPatternExpression(identifier, factory.SyntaxGeneratorInternal.ConstantPattern(nullExpr))
                 : factory.ReferenceEqualsExpression(identifier, nullExpr);
-
-            // generates: if (s == null) throw new ArgumentNullException(nameof(s))
-            var throwStatement = factory.ThrowStatement(CreateNewArgumentNullException(
-                                    factory, semanticModel.Compilation, parameter));
-            throwStatement = throwStatement.WithLeadingTrivia(factory.Whitespace(" ")).WithoutAnnotations(SyntaxAnnotation.ElasticAnnotation);
-
-            var ifStatement = factory.IfStatement(
-               condition,
-                SpecializedCollections.SingletonEnumerable(
-                    throwStatement));
-
-            var close = ifStatement.FindToken(10);
-            var newClose = close.WithoutTrailingTrivia();
-            ifStatement = ifStatement.ReplaceToken(close, newClose);
-
-            return ifStatement;
+            return condition;
         }
 
         public static ImmutableArray<SyntaxNode> CreateAssignmentStatements(


### PR DESCRIPTION
Fixes #52385

* [x] Respect `csharp_prefer_braces`
* [x] Respect `csharp_style_allow_embedded_statements_on_same_line_experimental`
* [x] string.IsNullOrEmpty is handled also
* [ ] What about https://github.com/dotnet/roslyn/issues/52385#issuecomment-812893055