### PR TITLE
Fix failure to process RoslynEventSource manifest

### DIFF
--- a/src/Workspaces/Core/Portable/Log/RoslynEventSource.cs
+++ b/src/Workspaces/Core/Portable/Log/RoslynEventSource.cs
@@ -74,11 +74,18 @@ namespace Microsoft.CodeAnalysis.Internal.Log
                 if (!_initialized)
                 {
                     // We're still in the constructor, need to defer sending until we've finished initializing
-                    Task.Yield().GetAwaiter().OnCompleted(() => Task.Run(SendFunctionDefinitions));
+                    Task.Yield().GetAwaiter().OnCompleted(FireAndForgetSendFunctionDefinitions);
                     return;
                 }
 
                 SendFunctionDefinitions();
+            }
+
+            // Cannot inline this local function as a lambda because we need NonEventAttribute applied.
+            [NonEvent]
+            void FireAndForgetSendFunctionDefinitions()
+            {
+                _ = Task.Run(SendFunctionDefinitions);
             }
         }
 


### PR DESCRIPTION
Due to a lack of `NonEventAttribute` on the compiler-generated method for a lambda function, the dynamic manifest treated a method named `<OnEventCommand>b__8_0` as an event and included the name in the manifest without escaping. The lack of escaping rendered the entire manifest invalid XML, so it could not be used for interpreting events in PerfView.