### PR TITLE
Remove use of Editor.INavigationBarItemService in LSP

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.NavigationBar;
@@ -49,54 +46,65 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return Array.Empty<SymbolInformation>();
             }
 
-            var symbols = ArrayBuilder<object>.GetInstance();
-
-            var navBarService = document.Project.LanguageServices.GetRequiredService<Editor.INavigationBarItemService>();
-            var navBarItems = await navBarService.GetItemsAsync(document, cancellationToken).ConfigureAwait(false);
-            if (navBarItems.Count == 0)
+            var navBarService = document.Project.LanguageServices.GetRequiredService<INavigationBarItemService>();
+            var workspaceSupportsDocumentChanges = document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument);
+            var navBarItems = await navBarService.GetItemsAsync(document, workspaceSupportsDocumentChanges, cancellationToken).ConfigureAwait(false);
+            if (navBarItems.IsEmpty)
             {
-                return symbols.ToArrayAndFree();
+                return Array.Empty<object>();
             }
 
-            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             // TODO - Return more than 2 levels of symbols.
             // https://github.com/dotnet/roslyn/projects/45#card-20033869
+            using var _ = ArrayBuilder<object>.GetInstance(out var symbols);
             if (context.ClientCapabilities?.TextDocument?.DocumentSymbol?.HierarchicalDocumentSymbolSupport == true)
             {
                 foreach (var item in navBarItems)
                 {
                     // only top level ones
-                    symbols.Add(await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false));
+                    var symbol = await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false);
+                    if (symbol != null)
+                    {
+                        symbols.Add(symbol);
+                    }
                 }
             }
             else
             {
                 foreach (var item in navBarItems)
                 {
-                    symbols.Add(GetSymbolInformation(item, compilation, tree, document, text, cancellationToken, containerName: null));
+                    var symbol = GetSymbolInformation(item, compilation, tree, document, text, cancellationToken, containerName: null);
+                    if (symbol != null)
+                    {
+                        symbols.Add(symbol);
+                    }
 
                     foreach (var childItem in item.ChildItems)
                     {
-                        symbols.Add(GetSymbolInformation(childItem, compilation, tree, document, text, cancellationToken, item.Text));
+                        var childSymbol = GetSymbolInformation(childItem, compilation, tree, document, text, cancellationToken, item.Text);
+                        if (childSymbol != null)
+                        {
+                            symbols.Add(childSymbol);
+                        }
                     }
                 }
             }
 
-            var result = symbols.WhereNotNull().ToArray();
-            symbols.Free();
+            var result = symbols.ToArray();
             return result;
         }
 
         /// <summary>
         /// Get a symbol information from a specified nav bar item.
         /// </summary>
-        private static SymbolInformation GetSymbolInformation(NavigationBarItem item, Compilation compilation, SyntaxTree tree, Document document,
-            SourceText text, CancellationToken cancellationToken, string containerName = null)
+        private static SymbolInformation? GetSymbolInformation(RoslynNavigationBarItem item, Compilation compilation, SyntaxTree tree, Document document,
+            SourceText text, CancellationToken cancellationToken, string? containerName = null)
         {
-            if (item.Spans.Count == 0)
+            if (item.Spans.IsEmpty)
             {
                 return null;
             }
@@ -110,7 +118,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             return Create(item, location.SourceSpan, containerName, document, text);
 
-            static VSSymbolInformation Create(NavigationBarItem item, TextSpan span, string containerName, Document document, SourceText text)
+            static VSSymbolInformation Create(RoslynNavigationBarItem item, TextSpan span, string? containerName, Document document, SourceText text)
             {
                 return new VSSymbolInformation
                 {
@@ -130,7 +138,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// <summary>
         /// Get a document symbol from a specified nav bar item.
         /// </summary>
-        private static async Task<DocumentSymbol> GetDocumentSymbolAsync(NavigationBarItem item, Compilation compilation, SyntaxTree tree,
+        private static async Task<DocumentSymbol?> GetDocumentSymbolAsync(RoslynNavigationBarItem item, Compilation compilation, SyntaxTree tree,
             SourceText text, CancellationToken cancellationToken)
         {
             // it is actually symbol location getter. but anyway.
@@ -157,19 +165,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 Children = await GetChildrenAsync(item.ChildItems, compilation, tree, text, cancellationToken).ConfigureAwait(false),
             };
 
-            static async Task<DocumentSymbol[]> GetChildrenAsync(IEnumerable<NavigationBarItem> items, Compilation compilation, SyntaxTree tree,
+            static async Task<DocumentSymbol[]> GetChildrenAsync(IEnumerable<RoslynNavigationBarItem> items, Compilation compilation, SyntaxTree tree,
                 SourceText text, CancellationToken cancellationToken)
             {
-                var list = new ArrayBuilder<DocumentSymbol>();
+                using var _ = ArrayBuilder<DocumentSymbol>.GetInstance(out var list);
                 foreach (var item in items)
                 {
-                    list.Add(await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false));
+                    var symbol = await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false);
+                    if (symbol != null)
+                    {
+                        list.Add(symbol);
+                    }
                 }
 
-                return list.ToArrayAndFree();
+                return list.ToArray();
             }
 
-            static async Task<ISymbol> GetSymbolAsync(Location location, Compilation compilation, CancellationToken cancellationToken)
+            static async Task<ISymbol?> GetSymbolAsync(Location location, Compilation compilation, CancellationToken cancellationToken)
             {
                 var model = compilation.GetSemanticModel(location.SourceTree);
                 var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
@@ -193,9 +205,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// <summary>
         /// Get a location for a particular nav bar item.
         /// </summary>
-        private static Location GetLocation(NavigationBarItem item, Compilation compilation, SyntaxTree tree, CancellationToken cancellationToken)
+        private static Location? GetLocation(RoslynNavigationBarItem item, Compilation compilation, SyntaxTree tree, CancellationToken cancellationToken)
         {
-            if (item is not WrappedNavigationBarItem { UnderlyingItem: RoslynNavigationBarItem.SymbolItem symbolItem })
+            if (item is not RoslynNavigationBarItem.SymbolItem symbolItem)
                 return null;
 
             var symbols = symbolItem.NavigationSymbolId.Resolve(compilation, cancellationToken: cancellationToken);
@@ -213,7 +225,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 }
             }
 
-            var location = symbol.Locations.FirstOrDefault(l => l.SourceTree.Equals(tree));
+            var location = symbol.Locations.FirstOrDefault(l => l.SourceTree?.Equals(tree) == true);
             return location ?? symbol.Locations.FirstOrDefault();
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -65,30 +65,18 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 foreach (var item in navBarItems)
                 {
                     // only top level ones
-                    var symbol = await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false);
-                    if (symbol != null)
-                    {
-                        symbols.Add(symbol);
-                    }
+                    symbols.AddIfNotNull(await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false));
                 }
             }
             else
             {
                 foreach (var item in navBarItems)
                 {
-                    var symbol = GetSymbolInformation(item, compilation, tree, document, text, cancellationToken, containerName: null);
-                    if (symbol != null)
-                    {
-                        symbols.Add(symbol);
-                    }
+                    symbols.AddIfNotNull(GetSymbolInformation(item, compilation, tree, document, text, cancellationToken, containerName: null));
 
                     foreach (var childItem in item.ChildItems)
                     {
-                        var childSymbol = GetSymbolInformation(childItem, compilation, tree, document, text, cancellationToken, item.Text);
-                        if (childSymbol != null)
-                        {
-                            symbols.Add(childSymbol);
-                        }
+                        symbols.AddIfNotNull(GetSymbolInformation(childItem, compilation, tree, document, text, cancellationToken, item.Text));
                     }
                 }
             }
@@ -170,11 +158,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 using var _ = ArrayBuilder<DocumentSymbol>.GetInstance(out var list);
                 foreach (var item in items)
                 {
-                    var symbol = await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false);
-                    if (symbol != null)
-                    {
-                        list.Add(symbol);
-                    }
+                    list.AddIfNotNull(await GetDocumentSymbolAsync(item, compilation, tree, text, cancellationToken).ConfigureAwait(false));
                 }
 
                 return list.ToArray();

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -47,8 +47,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             var navBarService = document.Project.LanguageServices.GetRequiredService<INavigationBarItemService>();
-            var workspaceSupportsDocumentChanges = document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument);
-            var navBarItems = await navBarService.GetItemsAsync(document, workspaceSupportsDocumentChanges, cancellationToken).ConfigureAwait(false);
+            var navBarItems = await navBarService.GetItemsAsync(document, supportsCodeGeneration: false, cancellationToken).ConfigureAwait(false);
             if (navBarItems.IsEmpty)
             {
                 return Array.Empty<object>();


### PR DESCRIPTION
Currently, the DocumentSymbolsHandler uses the editor version of INavigationBarItemService. Thanks to Cyrus's recent work around refactoring the nav bars for OOP, we now have a clean Features-layer API that we can seemlessly transition the handler to with minimal changes. I've done this, as well as a bit of general cleanup (enable nullable, fix a memory leak, a couple other things).
