### PR TITLE
Avoid LOH allocations in ObjectWriter and ObjectReader

### DIFF
--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis;
 
@@ -312,12 +313,12 @@ namespace Roslyn.Utilities
         private struct ReaderReferenceMap<T> : IDisposable
             where T : class
         {
-            private readonly List<T> _values;
+            private readonly SegmentedList<T> _values;
 
-            private static readonly ObjectPool<List<T>> s_objectListPool
-                = new(() => new List<T>(20));
+            private static readonly ObjectPool<SegmentedList<T>> s_objectListPool
+                = new(() => new SegmentedList<T>(20));
 
-            private ReaderReferenceMap(List<T> values)
+            private ReaderReferenceMap(SegmentedList<T> values)
                 => _values = values;
 
             public static ReaderReferenceMap<T> Create()

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis;
 
@@ -381,15 +382,17 @@ namespace Roslyn.Utilities
         /// </summary>
         private struct WriterReferenceMap
         {
-            private readonly Dictionary<object, int> _valueToIdMap;
+            // PERF: Use segmented collection to avoid Large Object Heap allocations during serialization.
+            // https://github.com/dotnet/roslyn/issues/43401
+            private readonly SegmentedDictionary<object, int> _valueToIdMap;
             private readonly bool _valueEquality;
             private int _nextId;
 
-            private static readonly ObjectPool<Dictionary<object, int>> s_referenceDictionaryPool =
-                new(() => new Dictionary<object, int>(128, ReferenceEqualityComparer.Instance));
+            private static readonly ObjectPool<SegmentedDictionary<object, int>> s_referenceDictionaryPool =
+                new(() => new SegmentedDictionary<object, int>(128, ReferenceEqualityComparer.Instance));
 
-            private static readonly ObjectPool<Dictionary<object, int>> s_valueDictionaryPool =
-                new(() => new Dictionary<object, int>(128));
+            private static readonly ObjectPool<SegmentedDictionary<object, int>> s_valueDictionaryPool =
+                new(() => new SegmentedDictionary<object, int>(128));
 
             public WriterReferenceMap(bool valueEquality)
             {
@@ -398,7 +401,7 @@ namespace Roslyn.Utilities
                 _nextId = 0;
             }
 
-            private static ObjectPool<Dictionary<object, int>> GetDictionaryPool(bool valueEquality)
+            private static ObjectPool<SegmentedDictionary<object, int>> GetDictionaryPool(bool valueEquality)
                 => valueEquality ? s_valueDictionaryPool : s_referenceDictionaryPool;
 
             public void Dispose()


### PR DESCRIPTION
For a 45 second trace locally (typing in SyntaxFactory.cs), this change avoids 1.75GB of Large Object Heap (LOH) allocations. GC pause times were not especially bad (200ms or lower), but excessive LOH allocations during background garbage collection was causing several instances of LOH allocations waiting for BGC to complete before allocating the large object (~600ms). Avoiding the LOH allocations on this path has two advantages:

1. This path is no longer subject to the 600ms pauses waiting for BGC to complete
2. Eliminating 75% of the observed LOH allocations reduces the number of _other_ cases that are subject to longer pause times

📝 The change in `ObjectWriter` produced all of the observed gain. The change in `ObjectReader` was implemented for parity.