### PR TITLE
Avoid telemetry overhead when opted out

### DIFF
--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
         }
 
         public bool IsEnabled(FunctionId functionId)
-            => true;
+            => _session.IsOptedIn;
 
         public void Log(FunctionId functionId, LogMessage logMessage)
         {


### PR DESCRIPTION
Eliminates 134MB allocations observed during a 45 second trace. The allocated data was never used because the session was not active.