### PR TITLE
Fix race conditions in attribute asserts

### DIFF
--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -51,6 +51,7 @@ try {
 # Rebuilds with compilation errors
 # Rebuilds with missing references
 # Rebuilds with other issues
+  " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll" +
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude net45\Microsoft.CodeAnalysis.Debugging.Package.dll" +

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
@@ -68,6 +68,8 @@ namespace Microsoft.CodeAnalysis
         public bool SetEarlyDecodedWellKnownAttributeData(EarlyWellKnownAttributeData data)
         {
             WellKnownAttributeData.Seal(data);
+            // Early decode must complete before full decode
+            Debug.Assert(!IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData) || IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData));
             var setOnOurThread = Interlocked.CompareExchange(ref _earlyDecodedWellKnownAttributeData, data, null) == null;
             NotePartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData);
             return setOnOurThread;

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
@@ -68,8 +68,6 @@ namespace Microsoft.CodeAnalysis
         public bool SetEarlyDecodedWellKnownAttributeData(EarlyWellKnownAttributeData data)
         {
             WellKnownAttributeData.Seal(data);
-            // Early decode must complete before full decode
-            Debug.Assert(!IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData));
             var setOnOurThread = Interlocked.CompareExchange(ref _earlyDecodedWellKnownAttributeData, data, null) == null;
             NotePartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData);
             return setOnOurThread;

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CustomAttributesBag.cs
@@ -68,6 +68,8 @@ namespace Microsoft.CodeAnalysis
         public bool SetEarlyDecodedWellKnownAttributeData(EarlyWellKnownAttributeData data)
         {
             WellKnownAttributeData.Seal(data);
+            // Early decode must complete before full decode
+            Debug.Assert(!IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData));
             var setOnOurThread = Interlocked.CompareExchange(ref _earlyDecodedWellKnownAttributeData, data, null) == null;
             NotePartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData);
             return setOnOurThread;
@@ -81,6 +83,8 @@ namespace Microsoft.CodeAnalysis
         public bool SetDecodedWellKnownAttributeData(WellKnownAttributeData data)
         {
             WellKnownAttributeData.Seal(data);
+            // Early decode must complete before full decode
+            Debug.Assert(IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData));
             var setOnOurThread = Interlocked.CompareExchange(ref _decodedWellKnownAttributeData, data, null) == null;
             NotePartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData);
             return setOnOurThread;
@@ -172,13 +176,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal bool IsEarlyDecodedWellKnownAttributeDataComputed
         {
-            get
-            {
-                bool earlyComplete = IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData);
-                // If late attributes are complete, early attributes must also be complete
-                Debug.Assert(!IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData) || earlyComplete);
-                return earlyComplete;
-            }
+            get { return IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData); }
         }
 
         /// <summary>
@@ -187,13 +185,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal bool IsDecodedWellKnownAttributeDataComputed
         {
-            get
-            {
-                bool attributesComplete = IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData);
-                // If late attributes are complete, early attributes must also be complete
-                Debug.Assert(!attributesComplete || IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData));
-                return attributesComplete;
-            }
+            get { return IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData); }
         }
 
         /// <summary>


### PR DESCRIPTION
There are asserts in our `CustomAttributeBag` to verify we maintain the
invariant that early decoding occurs before the full decoding. The
asserts though done in the getters and take the following form:

```cs
bool earlyComplete = IsPartComplete(CustomAttributeBagCompletionPart.EarlyDecodedWellKnownAttributeData);
// If late attributes are complete, early attributes must also be complete
Debug.Assert(!IsPartComplete(CustomAttributeBagCompletionPart.DecodedWellKnownAttributeData) || earlyComplete);
return earlyComplete;
```

This pattern is subject to race conditions. Consider the case where the
`bool earlyComplete` statement runs to completion and returns `false`. Then
another thread swaps in and completes both early and full decoding. At
that point the original thread resumes and the `Debug.Assert` will fail
yet no invariant has been violated.

Moved the `Debug.Assert` into the setters where we can reliably test the
state invariants.

closes #52372
related to #52368