### PR TITLE
Use CancellationSeries in ExternalErrorDiagnosticUpdateSource

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1400,6 +1400,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _textBufferFactoryService.TextBufferCreated -= AddTextBufferCloneServiceToBuffer;
                 _projectionBufferFactoryService.ProjectionBufferCreated -= AddTextBufferCloneServiceToBuffer;
                 FileWatchedReferenceFactory.ReferenceChanged -= RefreshMetadataReferencesForFile;
+
+                if (_lazyExternalErrorDiagnosticUpdateSource.IsValueCreated)
+                {
+                    _lazyExternalErrorDiagnosticUpdateSource.Value.Dispose();
+                }
             }
 
             base.Dispose(finalize);

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -334,7 +334,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         {
             var solution = inProgressState.Solution;
             var cancellationToken = inProgressState.CancellationToken;
-            var (allLiveErrors, pendingLiveErrorsToSync) = inProgressState.GetLiveErrors(cancellationToken);
+            var (allLiveErrors, pendingLiveErrorsToSync) = inProgressState.GetLiveErrors();
 
             // Raise events for build only errors
             var buildErrors = GetBuildErrors().Except(allLiveErrors).GroupBy(k => k.DocumentId);
@@ -694,13 +694,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             public ProjectId? TryGetLastProjectWithReportedErrors()
                 => _lastProjectWithReportedErrors;
 
-            public (ImmutableArray<DiagnosticData> allLiveErrors, ProjectErrorMap pendingLiveErrorsToSync) GetLiveErrors(CancellationToken cancellationToken)
+            public (ImmutableArray<DiagnosticData> allLiveErrors, ProjectErrorMap pendingLiveErrorsToSync) GetLiveErrors()
             {
                 var allLiveErrorsBuilder = ImmutableArray.CreateBuilder<DiagnosticData>();
                 var pendingLiveErrorsToSyncBuilder = ImmutableDictionary.CreateBuilder<ProjectId, ImmutableArray<DiagnosticData>>();
                 foreach (var projectId in GetProjectsWithErrors())
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    CancellationToken.ThrowIfCancellationRequested();
 
                     var errors = GetLiveErrorsForProject(projectId);
                     allLiveErrorsBuilder.AddRange(errors);

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
     /// Diagnostic source for warnings and errors reported from explicit build command invocations in Visual Studio.
     /// VS workspaces calls into us when a build is invoked or completed in Visual Studio.
     /// <see cref="ProjectExternalErrorReporter"/> calls into us to clear reported diagnostics or to report new diagnostics during the build.
-    /// For each of these callbacks, we create/capture the current <see cref="BuildInProgressState"/> and
+    /// For each of these callbacks, we create/capture the current <see cref="GetBuildInProgressState()"/> and
     /// schedule updating/processing this state on a serialized <see cref="_taskQueue"/> in the background.
     /// The processing phase de-dupes the diagnostics reported from build and intellisense to ensure that the error list does not contain duplicate diagnostics.
     /// It raises events about diagnostic updates, which eventually trigger the "Build + Intellisense" and "Build only" error list diagnostic
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         /// <summary>
         /// Task queue to serialize all the post-build and post error list refresh tasks.
         /// Error list refresh requires build/live diagnostics de-duping to complete, which happens during
-        /// <see cref="SyncBuildErrorsAndReportOnBuildCompletedAsync(DiagnosticAnalyzerService, InProgressState, CancellationToken)"/>.
+        /// <see cref="SyncBuildErrorsAndReportOnBuildCompletedAsync(DiagnosticAnalyzerService, InProgressState)"/>.
         /// Computationally expensive tasks such as writing build errors into persistent storage,
         /// invoking background analysis on open files/solution after build completes, etc.
         /// are added to this task queue to help ensure faster error list refresh.
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         /// <summary>
         /// Indicates if a build is currently in progress inside Visual Studio.
         /// </summary>
-        public bool IsInProgress => BuildInProgressState != null;
+        public bool IsInProgress => GetBuildInProgressState() != null;
 
         public void Dispose()
         {
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         /// This API is only intended to be invoked from <see cref="ProjectExternalErrorReporter"/> while a build is in progress.
         /// </summary>
         public bool IsSupportedDiagnosticId(ProjectId projectId, string id)
-            => BuildInProgressState?.IsSupportedDiagnosticId(projectId, id) ?? false;
+            => GetBuildInProgressState()?.IsSupportedDiagnosticId(projectId, id) ?? false;
 
         private void OnBuildProgressChanged(InProgressState? state, BuildProgress buildProgress)
         {
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         public void ClearErrors(ProjectId projectId)
         {
             // Capture state if it exists
-            var (state, cancellationToken) = GetBuildInProgressStateAndToken();
+            var state = GetBuildInProgressState();
 
             // Update the state to clear diagnostics and raise corresponding diagnostic updated events
             // on a serialized task queue.
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 {
                     // TODO: Is it possible that ClearErrors can be invoked while the build is not in progress?
                     // We fallback to current solution in the workspace and clear errors for the project.
-                    await ClearErrorsCoreAsync(projectId, _workspace.CurrentSolution, state, cancellationToken).ConfigureAwait(false);
+                    await ClearErrorsCoreAsync(projectId, _workspace.CurrentSolution, state).ConfigureAwait(false);
                 }
                 else
                 {
@@ -191,7 +191,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
                     var solution = state.Solution;
 
-                    await ClearErrorsCoreAsync(projectId, solution, state, cancellationToken).ConfigureAwait(false);
+                    await ClearErrorsCoreAsync(projectId, solution, state).ConfigureAwait(false);
 
                     var transitiveProjectIds = solution.GetProjectDependencyGraph().GetProjectsThatTransitivelyDependOnThisProject(projectId);
                     foreach (var projectId in transitiveProjectIds)
@@ -201,14 +201,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                             continue;
                         }
 
-                        await ClearErrorsCoreAsync(projectId, solution, state, cancellationToken).ConfigureAwait(false);
+                        await ClearErrorsCoreAsync(projectId, solution, state).ConfigureAwait(false);
                     }
                 }
-            }, cancellationToken);
+            }, GetApplicableCancellationToken(state));
 
             return;
 
-            async Task ClearErrorsCoreAsync(ProjectId projectId, Solution solution, InProgressState? state, CancellationToken cancellationToken)
+            async Task ClearErrorsCoreAsync(ProjectId projectId, Solution solution, InProgressState? state)
             {
                 Debug.Assert(state == null || !state.WereProjectErrorsCleared(projectId));
 
@@ -220,7 +220,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
                 ClearBuildOnlyProjectErrors(solution, projectId);
 
-                await SetLiveErrorsForProjectAsync(projectId, ImmutableArray<DiagnosticData>.Empty, cancellationToken).ConfigureAwait(false);
+                await SetLiveErrorsForProjectAsync(projectId, ImmutableArray<DiagnosticData>.Empty, GetApplicableCancellationToken(state)).ConfigureAwait(false);
 
                 state?.MarkErrorsCleared(projectId);
 
@@ -277,14 +277,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         internal void OnSolutionBuildStarted()
         {
             // Build just started, create the state and fire build in progress event.
-            _ = GetOrCreateInProgressStateAndToken();
+            _ = GetOrCreateInProgressState();
         }
 
         internal void OnSolutionBuildCompleted()
         {
             // Building is done, so reset the state
             // and get local copy of in-progress state.
-            var (inProgressState, cancellationToken) = ClearInProgressState();
+            var inProgressState = ClearInProgressState();
 
             // Enqueue build/live sync in the queue.
             _taskQueue.ScheduleTask("OnSolutionBuild", async () =>
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     using var operation = _notificationService.Start("BuildDone");
                     if (_diagnosticService is DiagnosticAnalyzerService diagnosticService)
                     {
-                        await SyncBuildErrorsAndReportOnBuildCompletedAsync(diagnosticService, inProgressState, cancellationToken).ConfigureAwait(false);
+                        await SyncBuildErrorsAndReportOnBuildCompletedAsync(diagnosticService, inProgressState).ConfigureAwait(false);
                     }
 
                     // Mark build as complete.
@@ -322,7 +322,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 {
                     await _postBuildAndErrorListRefreshTaskQueue.LastScheduledTask.ConfigureAwait(false);
                 }
-            }, cancellationToken);
+            }, GetApplicableCancellationToken(inProgressState));
         }
 
         /// <summary>
@@ -330,9 +330,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         /// It raises diagnostic update events for both the Build-only diagnostics and Build + Intellisense diagnostics
         /// in the error list.
         /// </summary>
-        private async Task SyncBuildErrorsAndReportOnBuildCompletedAsync(DiagnosticAnalyzerService diagnosticService, InProgressState inProgressState, CancellationToken cancellationToken)
+        private async Task SyncBuildErrorsAndReportOnBuildCompletedAsync(DiagnosticAnalyzerService diagnosticService, InProgressState inProgressState)
         {
             var solution = inProgressState.Solution;
+            var cancellationToken = inProgressState.CancellationToken;
             var (allLiveErrors, pendingLiveErrorsToSync) = inProgressState.GetLiveErrors(cancellationToken);
 
             // Raise events for build only errors
@@ -396,36 +397,36 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         public void AddNewErrors(ProjectId projectId, DiagnosticData diagnostic)
         {
             // Capture state that will be processed in background thread.
-            var (state, cancellationToken) = GetOrCreateInProgressStateAndToken();
+            var state = GetOrCreateInProgressState();
 
             _taskQueue.ScheduleTask("Project New Errors", async () =>
             {
-                await ReportPreviousProjectErrorsIfRequiredAsync(projectId, state, cancellationToken).ConfigureAwait(false);
+                await ReportPreviousProjectErrorsIfRequiredAsync(projectId, state).ConfigureAwait(false);
                 state.AddError(projectId, diagnostic);
-            }, cancellationToken);
+            }, state.CancellationToken);
         }
 
         public void AddNewErrors(DocumentId documentId, DiagnosticData diagnostic)
         {
             // Capture state that will be processed in background thread.
-            var (state, cancellationToken) = GetOrCreateInProgressStateAndToken();
+            var state = GetOrCreateInProgressState();
 
             _taskQueue.ScheduleTask("Document New Errors", async () =>
             {
-                await ReportPreviousProjectErrorsIfRequiredAsync(documentId.ProjectId, state, cancellationToken).ConfigureAwait(false);
+                await ReportPreviousProjectErrorsIfRequiredAsync(documentId.ProjectId, state).ConfigureAwait(false);
                 state.AddError(documentId, diagnostic);
-            }, cancellationToken);
+            }, state.CancellationToken);
         }
 
         public void AddNewErrors(
             ProjectId projectId, HashSet<DiagnosticData> projectErrors, Dictionary<DocumentId, HashSet<DiagnosticData>> documentErrorMap)
         {
             // Capture state that will be processed in background thread
-            var (state, cancellationToken) = GetOrCreateInProgressStateAndToken();
+            var state = GetOrCreateInProgressState();
 
             _taskQueue.ScheduleTask("Project New Errors", async () =>
             {
-                await ReportPreviousProjectErrorsIfRequiredAsync(projectId, state, cancellationToken).ConfigureAwait(false);
+                await ReportPreviousProjectErrorsIfRequiredAsync(projectId, state).ConfigureAwait(false);
 
                 foreach (var kv in documentErrorMap)
                 {
@@ -433,7 +434,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 }
 
                 state.AddErrors(projectId, projectErrors);
-            }, cancellationToken);
+            }, state.CancellationToken);
         }
 
         /// <summary>
@@ -444,19 +445,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         /// This ensures that error list keeps getting refreshed while a build is in progress, as opposed to doing all the work
         /// and a single refresh when the build completes.
         /// </summary>
-        private async Task ReportPreviousProjectErrorsIfRequiredAsync(ProjectId projectId, InProgressState state, CancellationToken cancellationToken)
+        private async Task ReportPreviousProjectErrorsIfRequiredAsync(ProjectId projectId, InProgressState state)
         {
             if (state.TryGetLastProjectWithReportedErrors() is ProjectId lastProjectId &&
                 lastProjectId != projectId)
             {
-                await SetLiveErrorsForProjectAsync(lastProjectId, state, cancellationToken).ConfigureAwait(false);
+                await SetLiveErrorsForProjectAsync(lastProjectId, state).ConfigureAwait(false);
             }
         }
 
-        private async Task SetLiveErrorsForProjectAsync(ProjectId projectId, InProgressState state, CancellationToken cancellationToken)
+        private async Task SetLiveErrorsForProjectAsync(ProjectId projectId, InProgressState state)
         {
             var diagnostics = state.GetLiveErrorsForProject(projectId);
-            await SetLiveErrorsForProjectAsync(projectId, diagnostics, cancellationToken).ConfigureAwait(false);
+            await SetLiveErrorsForProjectAsync(projectId, diagnostics, state.CancellationToken).ConfigureAwait(false);
             state.MarkLiveErrorsReported(projectId);
         }
 
@@ -470,28 +471,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             }
         }
 
-        private InProgressState? BuildInProgressState => GetBuildInProgressStateAndToken().state;
+        private CancellationToken GetApplicableCancellationToken(InProgressState? state)
+            => state?.CancellationToken ?? _disposalToken;
 
-        private (InProgressState? state, CancellationToken cancellationToken) GetBuildInProgressStateAndToken()
+        private InProgressState? GetBuildInProgressState()
         {
             lock (_gate)
             {
-                return (_stateDoNotAccessDirectly, _stateDoNotAccessDirectly?.CancellationToken ?? _disposalToken);
+                return _stateDoNotAccessDirectly;
             }
         }
 
-        private (InProgressState? state, CancellationToken cancellationToken) ClearInProgressState()
+        private InProgressState? ClearInProgressState()
         {
             lock (_gate)
             {
                 var state = _stateDoNotAccessDirectly;
 
                 _stateDoNotAccessDirectly = null;
-                return (state, state?.CancellationToken ?? _disposalToken);
+                return state;
             }
         }
 
-        private (InProgressState state, CancellationToken cancellationToken) GetOrCreateInProgressStateAndToken()
+        private InProgressState GetOrCreateInProgressState()
         {
             lock (_gate)
             {
@@ -504,7 +506,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     OnBuildProgressChanged(_stateDoNotAccessDirectly, BuildProgress.Started);
                 }
 
-                return (_stateDoNotAccessDirectly, _stateDoNotAccessDirectly.CancellationToken);
+                return _stateDoNotAccessDirectly;
             }
         }
 

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -674,103 +674,104 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim service = Assert.IsType(Of DiagnosticService)(workspace.ExportProvider.GetExportedValue(Of IDiagnosticService)())
                 Dim analyzerService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.ExportProvider.GetExportedValue(Of IDiagnosticAnalyzerService)())
 
-                Dim updateSource = New ExternalErrorDiagnosticUpdateSource(workspace, analyzerService, listener, CancellationToken.None)
+                Using updateSource = New ExternalErrorDiagnosticUpdateSource(workspace, analyzerService, listener, CancellationToken.None)
 
-                Dim tableManagerProvider = New TestTableManagerProvider()
-                Dim table = New VisualStudioDiagnosticListTableWorkspaceEventListener.VisualStudioDiagnosticListTable(workspace, updateSource, tableManagerProvider)
+                    Dim tableManagerProvider = New TestTableManagerProvider()
+                    Dim table = New VisualStudioDiagnosticListTableWorkspaceEventListener.VisualStudioDiagnosticListTable(workspace, updateSource, tableManagerProvider)
 
-                Dim document1 = workspace.CurrentSolution.Projects.First(Function(p) p.Name = "Proj1").Documents.First()
-                Dim document2 = workspace.CurrentSolution.Projects.First(Function(p) p.Name = "Proj2").Documents.First()
+                    Dim document1 = workspace.CurrentSolution.Projects.First(Function(p) p.Name = "Proj1").Documents.First()
+                    Dim document2 = workspace.CurrentSolution.Projects.First(Function(p) p.Name = "Proj2").Documents.First()
 
-                Dim diagnostic1 = CreateItem(document1.Id)
-                Dim diagnostic2 = CreateItem(document2.Id)
+                    Dim diagnostic1 = CreateItem(document1.Id)
+                    Dim diagnostic2 = CreateItem(document2.Id)
 
-                updateSource.AddNewErrors(
-                    document1.Project.Id,
-                    New DiagnosticData(
-                        diagnostic1.Id,
-                        diagnostic1.Category,
-                        diagnostic1.Message,
-                        diagnostic1.ENUMessageForBingSearch,
-                        diagnostic1.Severity,
-                        diagnostic1.DefaultSeverity,
-                        diagnostic1.IsEnabledByDefault,
-                        diagnostic1.WarningLevel,
-                        diagnostic1.CustomTags,
-                        diagnostic1.Properties,
-                        diagnostic1.ProjectId,
-                        New DiagnosticDataLocation(
-                            Nothing,
-                            diagnostic1.DataLocation.SourceSpan,
-                            diagnostic1.DataLocation.OriginalFilePath,
-                            diagnostic1.DataLocation.OriginalStartLine,
-                            diagnostic1.DataLocation.OriginalStartColumn,
-                            diagnostic1.DataLocation.OriginalEndLine,
-                            diagnostic1.DataLocation.OriginalEndColumn,
-                            diagnostic1.DataLocation.MappedFilePath,
-                            diagnostic1.DataLocation.MappedStartLine,
-                            diagnostic1.DataLocation.MappedStartColumn,
-                            diagnostic1.DataLocation.MappedEndLine,
-                            diagnostic1.DataLocation.MappedEndColumn),
-                        diagnostic1.AdditionalLocations,
-                        diagnostic1.Language,
-                        diagnostic1.Title,
-                        diagnostic1.Description,
-                        diagnostic1.HelpLink,
-                        diagnostic1.IsSuppressed))
+                    updateSource.AddNewErrors(
+                        document1.Project.Id,
+                        New DiagnosticData(
+                            diagnostic1.Id,
+                            diagnostic1.Category,
+                            diagnostic1.Message,
+                            diagnostic1.ENUMessageForBingSearch,
+                            diagnostic1.Severity,
+                            diagnostic1.DefaultSeverity,
+                            diagnostic1.IsEnabledByDefault,
+                            diagnostic1.WarningLevel,
+                            diagnostic1.CustomTags,
+                            diagnostic1.Properties,
+                            diagnostic1.ProjectId,
+                            New DiagnosticDataLocation(
+                                Nothing,
+                                diagnostic1.DataLocation.SourceSpan,
+                                diagnostic1.DataLocation.OriginalFilePath,
+                                diagnostic1.DataLocation.OriginalStartLine,
+                                diagnostic1.DataLocation.OriginalStartColumn,
+                                diagnostic1.DataLocation.OriginalEndLine,
+                                diagnostic1.DataLocation.OriginalEndColumn,
+                                diagnostic1.DataLocation.MappedFilePath,
+                                diagnostic1.DataLocation.MappedStartLine,
+                                diagnostic1.DataLocation.MappedStartColumn,
+                                diagnostic1.DataLocation.MappedEndLine,
+                                diagnostic1.DataLocation.MappedEndColumn),
+                            diagnostic1.AdditionalLocations,
+                            diagnostic1.Language,
+                            diagnostic1.Title,
+                            diagnostic1.Description,
+                            diagnostic1.HelpLink,
+                            diagnostic1.IsSuppressed))
 
-                updateSource.AddNewErrors(
-                    document2.Project.Id,
-                    New DiagnosticData(
-                        diagnostic2.Id,
-                        diagnostic2.Category,
-                        diagnostic2.Message,
-                        diagnostic2.ENUMessageForBingSearch,
-                        diagnostic2.Severity,
-                        diagnostic2.Severity,
-                        diagnostic2.IsEnabledByDefault,
-                        diagnostic2.WarningLevel,
-                        diagnostic2.CustomTags,
-                        diagnostic2.Properties,
-                        diagnostic2.ProjectId,
-                        New DiagnosticDataLocation(
-                            Nothing,
-                            diagnostic2.DataLocation.SourceSpan,
-                            diagnostic2.DataLocation.OriginalFilePath,
-                            diagnostic2.DataLocation.OriginalStartLine,
-                            diagnostic2.DataLocation.OriginalStartColumn,
-                            diagnostic2.DataLocation.OriginalEndLine,
-                            diagnostic2.DataLocation.OriginalEndColumn,
-                            diagnostic2.DataLocation.MappedFilePath,
-                            diagnostic2.DataLocation.MappedStartLine,
-                            diagnostic2.DataLocation.MappedStartColumn,
-                            diagnostic2.DataLocation.MappedEndLine,
-                            diagnostic2.DataLocation.MappedEndColumn),
-                        diagnostic2.AdditionalLocations,
-                        diagnostic2.Language,
-                        diagnostic2.Title,
-                        diagnostic2.Description,
-                        diagnostic2.HelpLink,
-                        diagnostic2.IsSuppressed))
+                    updateSource.AddNewErrors(
+                        document2.Project.Id,
+                        New DiagnosticData(
+                            diagnostic2.Id,
+                            diagnostic2.Category,
+                            diagnostic2.Message,
+                            diagnostic2.ENUMessageForBingSearch,
+                            diagnostic2.Severity,
+                            diagnostic2.Severity,
+                            diagnostic2.IsEnabledByDefault,
+                            diagnostic2.WarningLevel,
+                            diagnostic2.CustomTags,
+                            diagnostic2.Properties,
+                            diagnostic2.ProjectId,
+                            New DiagnosticDataLocation(
+                                Nothing,
+                                diagnostic2.DataLocation.SourceSpan,
+                                diagnostic2.DataLocation.OriginalFilePath,
+                                diagnostic2.DataLocation.OriginalStartLine,
+                                diagnostic2.DataLocation.OriginalStartColumn,
+                                diagnostic2.DataLocation.OriginalEndLine,
+                                diagnostic2.DataLocation.OriginalEndColumn,
+                                diagnostic2.DataLocation.MappedFilePath,
+                                diagnostic2.DataLocation.MappedStartLine,
+                                diagnostic2.DataLocation.MappedStartColumn,
+                                diagnostic2.DataLocation.MappedEndLine,
+                                diagnostic2.DataLocation.MappedEndColumn),
+                            diagnostic2.AdditionalLocations,
+                            diagnostic2.Language,
+                            diagnostic2.Title,
+                            diagnostic2.Description,
+                            diagnostic2.HelpLink,
+                            diagnostic2.IsSuppressed))
 
-                updateSource.OnSolutionBuildCompleted()
+                    updateSource.OnSolutionBuildCompleted()
 
-                Await DirectCast(listener, IAsynchronousOperationWaiter).ExpeditedWaitAsync()
+                    Await DirectCast(listener, IAsynchronousOperationWaiter).ExpeditedWaitAsync()
 
-                Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
-                Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
+                    Dim manager = DirectCast(table.TableManager, TestTableManagerProvider.TestTableManager)
+                    Dim sinkAndSubscription = manager.Sinks_TestOnly.First()
 
-                Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
-                Dim snapshot = sink.Entries.First().GetCurrentSnapshot()
-                Assert.Equal(2, snapshot.Count)
+                    Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
+                    Dim snapshot = sink.Entries.First().GetCurrentSnapshot()
+                    Assert.Equal(2, snapshot.Count)
 
-                Dim filename As Object = Nothing
-                Assert.True(snapshot.TryGetValue(0, StandardTableKeyNames.DocumentName, filename))
-                Assert.Equal("test", filename)
+                    Dim filename As Object = Nothing
+                    Assert.True(snapshot.TryGetValue(0, StandardTableKeyNames.DocumentName, filename))
+                    Assert.Equal("test", filename)
 
-                Dim projectname As Object = Nothing
-                Assert.True(snapshot.TryGetValue(0, StandardTableKeyNames.ProjectName, projectname))
-                Assert.Equal("Proj1", projectname)
+                    Dim projectname As Object = Nothing
+                    Assert.True(snapshot.TryGetValue(0, StandardTableKeyNames.ProjectName, projectname))
+                    Assert.Equal("Proj1", projectname)
+                End Using
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -31,9 +31,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Using workspace = TestWorkspace.CreateCSharp(String.Empty)
                 Dim waiter = New AsynchronousOperationListener()
                 Dim service = New TestDiagnosticAnalyzerService()
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
-
-                Assert.False(source.SupportGetDiagnostics)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                    Assert.False(source.SupportGetDiagnostics)
+                End Using
             End Using
         End Sub
 
@@ -42,27 +42,28 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Using workspace = TestWorkspace.CreateCSharp(String.Empty)
                 Dim waiter = New AsynchronousOperationListener()
                 Dim service = New TestDiagnosticAnalyzerService()
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim project = workspace.CurrentSolution.Projects.First()
-                Dim diagnostic = GetDiagnosticData(project.Id)
+                    Dim project = workspace.CurrentSolution.Projects.First()
+                    Dim diagnostic = GetDiagnosticData(project.Id)
 
-                Dim expected = 1
-                AddHandler source.DiagnosticsUpdated, Sub(o, a)
-                                                          Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
-                                                          Assert.Equal(expected, diagnostics.Length)
-                                                          If expected = 1 Then
-                                                              Assert.Equal(diagnostics(0), diagnostic)
-                                                          End If
-                                                      End Sub
+                    Dim expected = 1
+                    AddHandler source.DiagnosticsUpdated, Sub(o, a)
+                                                              Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
+                                                              Assert.Equal(expected, diagnostics.Length)
+                                                              If expected = 1 Then
+                                                                  Assert.Equal(diagnostics(0), diagnostic)
+                                                              End If
+                                                          End Sub
 
-                source.AddNewErrors(project.DocumentIds.First(), diagnostic)
-                source.OnSolutionBuildCompleted()
-                Await waiter.ExpeditedWaitAsync()
+                    source.AddNewErrors(project.DocumentIds.First(), diagnostic)
+                    source.OnSolutionBuildCompleted()
+                    Await waiter.ExpeditedWaitAsync()
 
-                expected = 0
-                source.ClearErrors(project.Id)
-                Await waiter.ExpeditedWaitAsync()
+                    expected = 0
+                    source.ClearErrors(project.Id)
+                    Await waiter.ExpeditedWaitAsync()
+                End Using
             End Using
         End Function
 
@@ -78,13 +79,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences({analyzerReference}))
 
                 Dim service = New TestDiagnosticAnalyzerService()
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim project = workspace.CurrentSolution.Projects.First()
-                source.OnSolutionBuildStarted()
+                    Dim project = workspace.CurrentSolution.Projects.First()
+                    source.OnSolutionBuildStarted()
 
-                Assert.True(source.IsSupportedDiagnosticId(project.Id, "ID1"))
-                Assert.False(source.IsSupportedDiagnosticId(project.Id, "CA1002"))
+                    Assert.True(source.IsSupportedDiagnosticId(project.Id, "ID1"))
+                    Assert.False(source.IsSupportedDiagnosticId(project.Id, "CA1002"))
+                End Using
             End Using
         End Sub
 
@@ -93,12 +95,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Using workspace = TestWorkspace.CreateCSharp(String.Empty)
                 Dim waiter = New AsynchronousOperationListener()
                 Dim service = New TestDiagnosticAnalyzerService()
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim project = workspace.CurrentSolution.Projects.First()
-                source.OnSolutionBuildStarted()
+                    Dim project = workspace.CurrentSolution.Projects.First()
+                    source.OnSolutionBuildStarted()
 
-                Parallel.For(0, 100, Sub(i As Integer) source.IsSupportedDiagnosticId(project.Id, "CS1002"))
+                    Parallel.For(0, 100, Sub(i As Integer) source.IsSupportedDiagnosticId(project.Id, "CS1002"))
+                End Using
             End Using
         End Sub
 
@@ -111,22 +114,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim diagnostic = GetDiagnosticData(project.Id)
 
                 Dim service = New TestDiagnosticAnalyzerService(ImmutableArray.Create(diagnostic))
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim map = New Dictionary(Of DocumentId, HashSet(Of DiagnosticData))()
-                map.Add(project.DocumentIds.First(), New HashSet(Of DiagnosticData)(
+                    Dim map = New Dictionary(Of DocumentId, HashSet(Of DiagnosticData))()
+                    map.Add(project.DocumentIds.First(), New HashSet(Of DiagnosticData)(
                         SpecializedCollections.SingletonEnumerable(GetDiagnosticData(project.Id))))
 
-                source.AddNewErrors(project.Id, New HashSet(Of DiagnosticData)(SpecializedCollections.SingletonEnumerable(diagnostic)), map)
+                    source.AddNewErrors(project.Id, New HashSet(Of DiagnosticData)(SpecializedCollections.SingletonEnumerable(diagnostic)), map)
 
-                AddHandler source.DiagnosticsUpdated, Sub(o, a)
-                                                          Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
-                                                          Assert.Equal(1, diagnostics.Length)
-                                                      End Sub
+                    AddHandler source.DiagnosticsUpdated, Sub(o, a)
+                                                              Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
+                                                              Assert.Equal(1, diagnostics.Length)
+                                                          End Sub
 
-                source.OnSolutionBuildCompleted()
+                    source.OnSolutionBuildCompleted()
 
-                Await waiter.ExpeditedWaitAsync()
+                    Await waiter.ExpeditedWaitAsync()
+                End Using
             End Using
         End Function
 
@@ -139,22 +143,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim diagnostic = GetDiagnosticData(project.Id)
 
                 Dim service = New TestDiagnosticAnalyzerService()
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
-                AddHandler source.BuildProgressChanged, Sub(o, progress)
-                                                            If progress = ExternalErrorDiagnosticUpdateSource.BuildProgress.Done Then
-                                                                Assert.Equal(2, source.GetBuildErrors().Length)
-                                                            End If
-                                                        End Sub
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                    AddHandler source.BuildProgressChanged, Sub(o, progress)
+                                                                If progress = ExternalErrorDiagnosticUpdateSource.BuildProgress.Done Then
+                                                                    Assert.Equal(2, source.GetBuildErrors().Length)
+                                                                End If
+                                                            End Sub
 
-                Dim map = New Dictionary(Of DocumentId, HashSet(Of DiagnosticData))()
-                map.Add(project.DocumentIds.First(), New HashSet(Of DiagnosticData)(
+                    Dim map = New Dictionary(Of DocumentId, HashSet(Of DiagnosticData))()
+                    map.Add(project.DocumentIds.First(), New HashSet(Of DiagnosticData)(
                         SpecializedCollections.SingletonEnumerable(GetDiagnosticData(project.Id))))
 
-                source.AddNewErrors(project.Id, New HashSet(Of DiagnosticData)(SpecializedCollections.SingletonEnumerable(diagnostic)), map)
-                Await waiter.ExpeditedWaitAsync()
+                    source.AddNewErrors(project.Id, New HashSet(Of DiagnosticData)(SpecializedCollections.SingletonEnumerable(diagnostic)), map)
+                    Await waiter.ExpeditedWaitAsync()
 
-                source.OnSolutionBuildCompleted()
-                Await waiter.ExpeditedWaitAsync()
+                    source.OnSolutionBuildCompleted()
+                    Await waiter.ExpeditedWaitAsync()
+                End Using
             End Using
         End Function
 
@@ -192,20 +197,21 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim diagnostic = GetDiagnosticData(project.Id)
 
                 Dim service = New TestDiagnosticAnalyzerService()
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                ' we shouldn't crash here
-                source.AddNewErrors(project.Id, diagnostic)
-                source.AddNewErrors(project.Id, diagnostic)
+                    ' we shouldn't crash here
+                    source.AddNewErrors(project.Id, diagnostic)
+                    source.AddNewErrors(project.Id, diagnostic)
 
-                AddHandler source.DiagnosticsUpdated, Sub(o, a)
-                                                          Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
-                                                          Assert.Equal(1, diagnostics.Length)
-                                                      End Sub
+                    AddHandler source.DiagnosticsUpdated, Sub(o, a)
+                                                              Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
+                                                              Assert.Equal(1, diagnostics.Length)
+                                                          End Sub
 
-                source.OnSolutionBuildCompleted()
+                    source.OnSolutionBuildCompleted()
 
-                Await waiter.ExpeditedWaitAsync()
+                    Await waiter.ExpeditedWaitAsync()
+                End Using
             End Using
         End Function
 
@@ -227,24 +233,25 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim service = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
                 Dim registation = service.CreateIncrementalAnalyzer(workspace)
 
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
-                source.AddNewErrors(project.Id, diagnostic)
+                    Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
+                    source.AddNewErrors(project.Id, diagnostic)
 
-                Dim buildDiagnosticCallbackSeen = False
-                AddHandler source.DiagnosticsUpdated, Sub(o, a)
-                                                          buildDiagnosticCallbackSeen = True
+                    Dim buildDiagnosticCallbackSeen = False
+                    AddHandler source.DiagnosticsUpdated, Sub(o, a)
+                                                              buildDiagnosticCallbackSeen = True
 
-                                                          Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
-                                                          Assert.Equal(1, diagnostics.Length)
-                                                          Assert.Equal(diagnostics(0).Properties(WellKnownDiagnosticPropertyNames.Origin), WellKnownDiagnosticTags.Build)
-                                                      End Sub
-                source.OnSolutionBuildCompleted()
+                                                              Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
+                                                              Assert.Equal(1, diagnostics.Length)
+                                                              Assert.Equal(diagnostics(0).Properties(WellKnownDiagnosticPropertyNames.Origin), WellKnownDiagnosticTags.Build)
+                                                          End Sub
+                    source.OnSolutionBuildCompleted()
 
-                Await waiter.ExpeditedWaitAsync()
+                    Await waiter.ExpeditedWaitAsync()
 
-                Assert.Equal(hasCompilationEndTag, buildDiagnosticCallbackSeen)
+                    Assert.Equal(hasCompilationEndTag, buildDiagnosticCallbackSeen)
+                End Using
             End Using
         End Function
 
@@ -265,21 +272,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim service = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
                 Dim registation = service.CreateIncrementalAnalyzer(workspace)
 
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
-                source.AddNewErrors(project.Id, diagnostic)
+                    Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
+                    source.AddNewErrors(project.Id, diagnostic)
 
-                AddHandler source.DiagnosticsUpdated, Sub(o, a)
-                                                          Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
+                    AddHandler source.DiagnosticsUpdated, Sub(o, a)
+                                                              Dim diagnostics = a.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
 
-                                                          Assert.Equal(1, diagnostics.Length)
-                                                          Assert.Equal(diagnostics(0).Properties(WellKnownDiagnosticPropertyNames.Origin), WellKnownDiagnosticTags.Build)
-                                                      End Sub
+                                                              Assert.Equal(1, diagnostics.Length)
+                                                              Assert.Equal(diagnostics(0).Properties(WellKnownDiagnosticPropertyNames.Origin), WellKnownDiagnosticTags.Build)
+                                                          End Sub
 
-                source.OnSolutionBuildCompleted()
+                    source.OnSolutionBuildCompleted()
 
-                Await waiter.ExpeditedWaitAsync()
+                    Await waiter.ExpeditedWaitAsync()
+                End Using
             End Using
         End Function
 
@@ -303,22 +311,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim service = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
                 Dim registation = service.CreateIncrementalAnalyzer(workspace)
 
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
-                source.AddNewErrors(project.Id, diagnostic)
+                    Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
+                    source.AddNewErrors(project.Id, diagnostic)
 
-                Dim called = False
-                AddHandler source.DiagnosticsUpdated, Sub(o, a)
-                                                          called = True
-                                                      End Sub
+                    Dim called = False
+                    AddHandler source.DiagnosticsUpdated, Sub(o, a)
+                                                              called = True
+                                                          End Sub
 
-                source.OnSolutionBuildCompleted()
+                    source.OnSolutionBuildCompleted()
 
-                Await waiter.ExpeditedWaitAsync()
+                    Await waiter.ExpeditedWaitAsync()
 
-                ' error is considered live error, so event shouldn't be raised
-                Assert.False(called)
+                    ' error is considered live error, so event shouldn't be raised
+                    Assert.False(called)
+                End Using
             End Using
         End Function
 
@@ -333,26 +342,27 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim projectId2 = workspace.CurrentSolution.ProjectIds(1)
 
                 Dim service = New TestDiagnosticAnalyzerService()
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                source.AddNewErrors(projectId1, GetDiagnosticData(projectId1))
-                Await waiter.ExpeditedWaitAsync()
+                    source.AddNewErrors(projectId1, GetDiagnosticData(projectId1))
+                    Await waiter.ExpeditedWaitAsync()
 
-                Dim numberOfUpdateCalls = 0
-                AddHandler source.BuildProgressChanged, Sub(o, progress)
-                                                            If progress = ExternalErrorDiagnosticUpdateSource.BuildProgress.Updated Then
-                                                                numberOfUpdateCalls += 1
-                                                                Assert.Equal(numberOfUpdateCalls, source.GetBuildErrors().Length)
-                                                            ElseIf progress = ExternalErrorDiagnosticUpdateSource.BuildProgress.Done Then
-                                                                Assert.Equal(2, source.GetBuildErrors().Length)
-                                                            End If
-                                                        End Sub
+                    Dim numberOfUpdateCalls = 0
+                    AddHandler source.BuildProgressChanged, Sub(o, progress)
+                                                                If progress = ExternalErrorDiagnosticUpdateSource.BuildProgress.Updated Then
+                                                                    numberOfUpdateCalls += 1
+                                                                    Assert.Equal(numberOfUpdateCalls, source.GetBuildErrors().Length)
+                                                                ElseIf progress = ExternalErrorDiagnosticUpdateSource.BuildProgress.Done Then
+                                                                    Assert.Equal(2, source.GetBuildErrors().Length)
+                                                                End If
+                                                            End Sub
 
-                source.AddNewErrors(projectId2, GetDiagnosticData(projectId2))
-                Await waiter.ExpeditedWaitAsync()
+                    source.AddNewErrors(projectId2, GetDiagnosticData(projectId2))
+                    Await waiter.ExpeditedWaitAsync()
 
-                source.OnSolutionBuildCompleted()
-                Await waiter.ExpeditedWaitAsync()
+                    source.OnSolutionBuildCompleted()
+                    Await waiter.ExpeditedWaitAsync()
+                End Using
             End Using
         End Function
 
@@ -373,9 +383,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
                 Dim service = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
                 Dim registation = service.CreateIncrementalAnalyzer(workspace)
-                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
+                Using source = New ExternalErrorDiagnosticUpdateSource(workspace, service, waiter, CancellationToken.None)
 
-                Dim diagnostic = New DiagnosticData(
+                    Dim diagnostic = New DiagnosticData(
                     id:="CS1002",
                     category:="Test",
                     message:="Test Message",
@@ -390,21 +400,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                     location:=New DiagnosticDataLocation(documentId:=Nothing, sourceSpan:=Nothing, "Test.txt", 4, 4),
                     language:=project.Language)
 
-                AddHandler service.DiagnosticsUpdated, Sub(o, args)
-                                                           Dim diagnostics = args.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
+                    AddHandler service.DiagnosticsUpdated, Sub(o, args)
+                                                               Dim diagnostics = args.GetPushDiagnostics(workspace, InternalDiagnosticsOptions.NormalDiagnosticMode)
 
-                                                           Assert.Single(diagnostics)
-                                                           Assert.Equal(diagnostics(0).Id, diagnostic.Id)
-                                                       End Sub
+                                                               Assert.Single(diagnostics)
+                                                               Assert.Equal(diagnostics(0).Id, diagnostic.Id)
+                                                           End Sub
 
-                source.AddNewErrors(project.Id, diagnostic)
-                Await waiter.ExpeditedWaitAsync()
+                    source.AddNewErrors(project.Id, diagnostic)
+                    Await waiter.ExpeditedWaitAsync()
 
-                source.OnSolutionBuildCompleted()
-                Await waiter.ExpeditedWaitAsync()
+                    source.OnSolutionBuildCompleted()
+                    Await waiter.ExpeditedWaitAsync()
 
-                Dim diagnosticServiceWaiter = TryCast(listenerProvider.GetListener(FeatureAttribute.DiagnosticService), AsynchronousOperationListener)
-                Await diagnosticServiceWaiter.ExpeditedWaitAsync()
+                    Dim diagnosticServiceWaiter = TryCast(listenerProvider.GetListener(FeatureAttribute.DiagnosticService), AsynchronousOperationListener)
+                    Await diagnosticServiceWaiter.ExpeditedWaitAsync()
+                End Using
             End Using
         End Function
 

--- a/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+#if DEBUG
+using System.Diagnostics;
+#endif
+using System.Threading;
+
+namespace Microsoft.VisualStudio.Threading.Tasks
+{
+    /// <summary>
+    /// Produces a series of <see cref="CancellationToken"/> objects such that requesting a new token
+    /// causes the previously issued token to be cancelled.
+    /// </summary>
+    /// <remarks>
+    /// <para>Consuming code is responsible for managing overlapping asynchronous operations.</para>
+    /// <para>This class has a lock-free implementation to minimise latency and contention.</para>
+    /// </remarks>
+    internal sealed class CancellationSeries : IDisposable
+    {
+        private CancellationTokenSource? _cts = new();
+
+        private readonly CancellationToken _superToken;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CancellationSeries"/>.
+        /// </summary>
+        /// <param name="token">An optional cancellation token that, when cancelled, cancels the last
+        /// issued token and causes any subsequent tokens to be issued in a cancelled state.</param>
+        public CancellationSeries(CancellationToken token = default)
+        {
+            _superToken = token;
+
+#if DEBUG
+            _ctorStack = new StackTrace();
+#endif
+        }
+
+#if DEBUG
+        private readonly StackTrace _ctorStack;
+
+        ~CancellationSeries()
+        {
+            Debug.Assert(
+                Environment.HasShutdownStarted || _cts == null,
+                "Instance of CancellationSeries not disposed before being finalized",
+                "Stack at construction:{0}{1}",
+                Environment.NewLine,
+                _ctorStack);
+        }
+#endif
+
+        /// <summary>
+        /// Creates the next <see cref="CancellationToken"/> in the series, ensuring the last issued
+        /// token (if any) is cancelled first.
+        /// </summary>
+        /// <param name="token">An optional cancellation token that, when cancelled, cancels the
+        /// returned token.</param>
+        /// <returns>
+        /// A cancellation token that will be cancelled when either:
+        /// <list type="bullet">
+        /// <item><see cref="CreateNext"/> is called again</item>
+        /// <item>The token passed to this method (if any) is cancelled</item>
+        /// <item>The token passed to the constructor (if any) is cancelled</item>
+        /// <item><see cref="Dispose"/> is called</item>
+        /// </list>
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">This object has been disposed.</exception>
+        public CancellationToken CreateNext(CancellationToken token = default)
+        {
+            var nextSource = CancellationTokenSource.CreateLinkedTokenSource(token, _superToken);
+
+            // Obtain the token before exchange, as otherwise the CTS may be cancelled before
+            // we request the Token, which will result in an ObjectDisposedException.
+            // This way we would return a cancelled token, which is reasonable.
+            CancellationToken nextToken = nextSource.Token;
+
+            CancellationTokenSource? priorSource = Interlocked.Exchange(ref _cts, nextSource);
+
+            if (priorSource == null)
+            {
+                nextSource.Dispose();
+
+                throw new ObjectDisposedException(nameof(CancellationSeries));
+            }
+
+            try
+            {
+                priorSource.Cancel();
+            }
+            finally
+            {
+                // A registered action on the token may throw, which would surface here.
+                // Ensure we always dispose the prior CTS.
+                priorSource.Dispose();
+            }
+
+            return nextToken;
+        }
+
+        public void Dispose()
+        {
+#if DEBUG
+            GC.SuppressFinalize(this);
+#endif
+
+            CancellationTokenSource? source = Interlocked.Exchange(ref _cts, null);
+
+            if (source == null)
+            {
+                // Already disposed
+                return;
+            }
+
+            try
+            {
+                source.Cancel();
+            }
+            finally
+            {
+                source.Dispose();
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
@@ -1,5 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+// NOTE: This code is derived from an implementation originally in dotnet/project-system:
+// https://github.com/dotnet/project-system/blob/bdf69d5420ec8d894f5bf4c3d4692900b7f2479c/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System;
 #if DEBUG
 using System.Diagnostics;

--- a/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
@@ -1,4 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/project-system:
 // https://github.com/dotnet/project-system/blob/bdf69d5420ec8d894f5bf4c3d4692900b7f2479c/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
@@ -12,7 +14,7 @@ using System.Diagnostics;
 #endif
 using System.Threading;
 
-namespace Microsoft.VisualStudio.Threading.Tasks
+namespace Roslyn.Utilities
 {
     /// <summary>
     /// Produces a series of <see cref="CancellationToken"/> objects such that requesting a new token
@@ -47,12 +49,9 @@ namespace Microsoft.VisualStudio.Threading.Tasks
 
         ~CancellationSeries()
         {
-            Debug.Assert(
+            Contract.ThrowIfFalse(
                 Environment.HasShutdownStarted || _cts == null,
-                "Instance of CancellationSeries not disposed before being finalized",
-                "Stack at construction:{0}{1}",
-                Environment.NewLine,
-                _ctorStack);
+                $"Instance of CancellationSeries not disposed before being finalized{Environment.NewLine}Stack at construction:{Environment.NewLine}{_ctorStack}");
         }
 #endif
 
@@ -79,9 +78,9 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             // Obtain the token before exchange, as otherwise the CTS may be cancelled before
             // we request the Token, which will result in an ObjectDisposedException.
             // This way we would return a cancelled token, which is reasonable.
-            CancellationToken nextToken = nextSource.Token;
+            var nextToken = nextSource.Token;
 
-            CancellationTokenSource? priorSource = Interlocked.Exchange(ref _cts, nextSource);
+            var priorSource = Interlocked.Exchange(ref _cts, nextSource);
 
             if (priorSource == null)
             {
@@ -110,7 +109,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             GC.SuppressFinalize(this);
 #endif
 
-            CancellationTokenSource? source = Interlocked.Exchange(ref _cts, null);
+            var source = Interlocked.Exchange(ref _cts, null);
 
             if (source == null)
             {

--- a/src/Workspaces/CoreTest/UtilityTest/CancellationSeriesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/CancellationSeriesTests.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Threading.Tasks
+{
+    public sealed class CancellationSeriesTests
+    {
+        [Fact]
+        public void CreateNext_ReturnsNonCancelledToken()
+        {
+            using var series = new CancellationSeries();
+            var token = series.CreateNext();
+
+            Assert.False(token.IsCancellationRequested);
+            Assert.True(token.CanBeCanceled);
+        }
+
+        [Fact]
+        public void CreateNext_CancelsPreviousToken()
+        {
+            using var series = new CancellationSeries();
+            var token1 = series.CreateNext();
+
+            Assert.False(token1.IsCancellationRequested);
+
+            var token2 = series.CreateNext();
+
+            Assert.True(token1.IsCancellationRequested);
+            Assert.False(token2.IsCancellationRequested);
+
+            var token3 = series.CreateNext();
+
+            Assert.True(token2.IsCancellationRequested);
+            Assert.False(token3.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CreateNext_ThrowsIfDisposed()
+        {
+            var series = new CancellationSeries();
+
+            series.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => series.CreateNext());
+        }
+
+        [Fact]
+        public void CreateNext_ReturnsCancelledTokenIfSuperTokenAlreadyCancelled()
+        {
+            var cts = new CancellationTokenSource();
+
+            using var series = new CancellationSeries(cts.Token);
+            cts.Cancel();
+
+            var token = series.CreateNext();
+
+            Assert.True(token.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CreateNext_ReturnsCancelledTokenIfInputTokenAlreadyCancelled()
+        {
+            var cts = new CancellationTokenSource();
+
+            using var series = new CancellationSeries();
+            cts.Cancel();
+
+            var token = series.CreateNext(cts.Token);
+
+            Assert.True(token.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CancellingSuperTokenCancelsIssuedToken()
+        {
+            var cts = new CancellationTokenSource();
+
+            using var series = new CancellationSeries(cts.Token);
+            var token = series.CreateNext();
+
+            Assert.False(token.IsCancellationRequested);
+
+            cts.Cancel();
+
+            Assert.True(token.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CancellingInputTokenCancelsIssuedToken()
+        {
+            var cts = new CancellationTokenSource();
+
+            using var series = new CancellationSeries();
+            var token = series.CreateNext(cts.Token);
+
+            Assert.False(token.IsCancellationRequested);
+
+            cts.Cancel();
+
+            Assert.True(token.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CreateNext_HandlesExceptionsFromPreviousTokenRegistration()
+        {
+            using var series = new CancellationSeries();
+            var token1 = series.CreateNext();
+
+            var exception = new Exception();
+
+            token1.Register(() => throw exception);
+
+            var aggregateException = Assert.Throws<AggregateException>(() => series.CreateNext());
+
+            Assert.Same(exception, aggregateException.InnerExceptions.Single());
+            Assert.True(token1.IsCancellationRequested);
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/UtilityTest/CancellationSeriesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/CancellationSeriesTests.cs
@@ -1,4 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/project-system:
 // https://github.com/dotnet/project-system/blob/bdf69d5420ec8d894f5bf4c3d4692900b7f2479c/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/CancellationSeriesTests.cs
@@ -11,7 +13,7 @@ using System.Linq;
 using System.Threading;
 using Xunit;
 
-namespace Microsoft.VisualStudio.Threading.Tasks
+namespace Roslyn.Utilities
 {
     public sealed class CancellationSeriesTests
     {

--- a/src/Workspaces/CoreTest/UtilityTest/CancellationSeriesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/CancellationSeriesTests.cs
@@ -1,5 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+// NOTE: This code is derived from an implementation originally in dotnet/project-system:
+// https://github.com/dotnet/project-system/blob/bdf69d5420ec8d894f5bf4c3d4692900b7f2479c/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/CancellationSeriesTests.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System;
 using System.Linq;
 using System.Threading;


### PR DESCRIPTION
Review commit-by-commit highly recommended. Due to limitations in VB, it is recommended that the test classes in acfee1f be reviewed with whitespace ignored.

Fixes [AB#1265306](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1265306)

Supersedes #50409