### PR TITLE
Don't throw on cancellation in chained command handlers

### DIFF
--- a/src/EditorFeatures/CSharp/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
+++ b/src/EditorFeatures/CSharp/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
     internal partial class EventHookupCommandHandler : IChainedCommandHandler<TabKeyCommandArgs>
     {
-        public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler, CommandExecutionContext cotext)
+        public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (!args.SubjectBuffer.GetFeatureOnOffOption(InternalFeatureOnOffOptions.EventHookup))

--- a/src/EditorFeatures/CSharp/FixInterpolatedVerbatimString/FixInterpolatedVerbatimStringCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/FixInterpolatedVerbatimString/FixInterpolatedVerbatimStringCommandHandler.cs
@@ -36,6 +36,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.FixInterpolatedVerbatimString
 
         public void ExecuteCommand(TypeCharCommandArgs args, Action nextCommandHandler, CommandExecutionContext executionContext)
         {
+            try
+            {
+                ExecuteCommandWorker(args, nextCommandHandler, executionContext);
+            }
+            catch (OperationCanceledException)
+            {
+                // According to Editor command handler API guidelines, it's best if we return early if cancellation
+                // is requested instead of throwing. Otherwise, we could end up in an invalid state due to already
+                // calling nextCommandHandler().
+            }
+        }
+
+        private static void ExecuteCommandWorker(TypeCharCommandArgs args, Action nextCommandHandler, CommandExecutionContext executionContext)
+        {
             // We need to check for the token *after* the opening quote is typed, so defer to the editor first
             nextCommandHandler();
 

--- a/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
@@ -40,6 +40,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AddImports
 
         public void ExecuteCommand(PasteCommandArgs args, Action nextCommandHandler, CommandExecutionContext executionContext)
         {
+            try
+            {
+                ExecuteCommandWorker(args, nextCommandHandler, executionContext);
+            }
+            catch (OperationCanceledException)
+            {
+                // According to Editor command handler API guidelines, it's best if we return early if cancellation
+                // is requested instead of throwing. Otherwise, we could end up in an invalid state due to already
+                // calling nextCommandHandler().
+            }
+        }
+
+        private void ExecuteCommandWorker(PasteCommandArgs args, Action nextCommandHandler, CommandExecutionContext executionContext)
+        {
             // Check that the feature is enabled before doing any work
             var optionValue = args.SubjectBuffer.GetOptionalFeatureOnOffOption(FeatureOnOffOptions.AddImportsOnPaste);
 

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractXmlTagCompletionCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractXmlTagCompletionCommandHandler.cs
@@ -33,6 +33,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 
         public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
+            try
+            {
+                ExecuteCommandWorker(args, nextHandler, context);
+            }
+            catch (OperationCanceledException)
+            {
+                // According to Editor command handler API guidelines, it's best if we return early if cancellation
+                // is requested instead of throwing. Otherwise, we could end up in an invalid state due to already
+                // calling nextHandler().
+            }
+        }
+
+        private void ExecuteCommandWorker(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
+        {
             // Ensure completion and any other buffer edits happen first.
             nextHandler();
 

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractXmlTagCompletionCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractXmlTagCompletionCommandHandler.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
                 return;
             }
 
-            using var _ = context.OperationContext.AddScope(allowCancellation: true, EditorFeaturesResources.Completing_Tag);
+            using (context.OperationContext.AddScope(allowCancellation: true, EditorFeaturesResources.Completing_Tag))
             {
                 var buffer = args.SubjectBuffer;
 

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
@@ -23,19 +23,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 
         public void ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
+            using var _ = context.OperationContext.AddScope(allowCancellation: true, EditorFeaturesResources.Formatting_pasted_text);
+            var caretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer);
+
+            nextHandler();
+
+            var cancellationToken = context.OperationContext.UserCancellationToken;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             try
             {
-                using var _ = context.OperationContext.AddScope(allowCancellation: true, EditorFeaturesResources.Formatting_pasted_text);
-                var caretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer);
-
-                nextHandler();
-
-                var cancellationToken = context.OperationContext.UserCancellationToken;
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
-
                 ExecuteCommandWorker(args, caretPosition, cancellationToken);
             }
             catch (OperationCanceledException)

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
@@ -23,9 +23,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 
         public void ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
-            using (context.OperationContext.AddScope(allowCancellation: true, EditorFeaturesResources.Formatting_pasted_text))
+            try
             {
-                ExecuteCommandWorker(args, nextHandler, context.OperationContext.UserCancellationToken);
+                using (context.OperationContext.AddScope(allowCancellation: true, EditorFeaturesResources.Formatting_pasted_text))
+                {
+                    ExecuteCommandWorker(args, nextHandler, context.OperationContext.UserCancellationToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // According to Editor command handler API guidelines, it's best if we return early if cancellation
+                // is requested instead of throwing. Otherwise, we could end up in an invalid state due to already
+                // calling nextHandler().
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
@@ -99,6 +99,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 
         public void ExecuteReturnOrTypeCommand(EditorCommandArgs args, Action nextHandler, CancellationToken cancellationToken)
         {
+            try
+            {
+                ExecuteReturnOrTypeCommandWorker(args, nextHandler, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // According to Editor command handler API guidelines, it's best if we return early if cancellation
+                // is requested instead of throwing. Otherwise, we could end up in an invalid state due to already
+                // calling nextHandler().
+            }
+        }
+
+        private void ExecuteReturnOrTypeCommandWorker(EditorCommandArgs args, Action nextHandler, CancellationToken cancellationToken)
+        {
             // run next handler first so that editor has chance to put the return into the buffer first.
             nextHandler();
 

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
@@ -99,9 +99,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 
         public void ExecuteReturnOrTypeCommand(EditorCommandArgs args, Action nextHandler, CancellationToken cancellationToken)
         {
+            // run next handler first so that editor has chance to put the return into the buffer first.
+            nextHandler();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             try
             {
-                ExecuteReturnOrTypeCommandWorker(args, nextHandler, cancellationToken);
+                ExecuteReturnOrTypeCommandWorker(args, cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -111,11 +118,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
             }
         }
 
-        private void ExecuteReturnOrTypeCommandWorker(EditorCommandArgs args, Action nextHandler, CancellationToken cancellationToken)
+        private void ExecuteReturnOrTypeCommandWorker(EditorCommandArgs args, CancellationToken cancellationToken)
         {
-            // run next handler first so that editor has chance to put the return into the buffer first.
-            nextHandler();
-
             var textView = args.TextView;
             var subjectBuffer = args.SubjectBuffer;
             if (!CanExecuteCommand(subjectBuffer))


### PR DESCRIPTION
According to [these Editor API guidelines](https://github.com/Microsoft/vs-editor-api/wiki/Modern-Editor-Commanding-API-Revisited#command-handler-rules-of-handling-a-cancellation-request) for command handlers, we should return early when cancellation is requested instead of throwing an exception, specifically in handlers that may produce side effects upon cancellation.
For example, in Roslyn's format handler, `nextHandler()` is called which triggers the character insertion into the buffer. If cancellation is thrown later on in the format handler, these changes either need to reverted or we need to return early, otherwise the character might be inserted into the buffer twice.

I think I addressed most command handlers that were doing the wrong thing, but let me know if I missed any.
 
Fixes #52382.