### PR TITLE
Escape special characters in section name of editor config

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -63,30 +63,30 @@ my_prop = my_val
         {
             var config = ParseConfigFile(@"is_global = true
 
-[c:/\{file1\}.cs]
+[c:/\{f\*i\?le1\}.cs]
 build_metadata.Compile.ToRetrieve = abc123
 
-[c:/file\#2.cs]
+[c:/f\,ile\#2.cs]
 build_metadata.Compile.ToRetrieve = def456
 
-[c:/file\[3\].cs]
+[c:/f\;i\!le\[3\].cs]
 build_metadata.Compile.ToRetrieve = ghi789
 ");
 
             var namedSections = config.NamedSections;
-            Assert.Equal("c:/\\{file1\\}.cs", namedSections[0].Name);
+            Assert.Equal("c:/\\{f\\*i\\?le1\\}.cs", namedSections[0].Name);
             AssertEx.Equal(
                 new[] { KeyValuePair.Create("build_metadata.compile.toretrieve", "abc123") },
                 namedSections[0].Properties
             );
 
-            Assert.Equal("c:/file\\#2.cs", namedSections[1].Name);
+            Assert.Equal("c:/f\\,ile\\#2.cs", namedSections[1].Name);
             AssertEx.Equal(
                 new[] { KeyValuePair.Create("build_metadata.compile.toretrieve", "def456") },
                 namedSections[1].Properties
             );
 
-            Assert.Equal("c:/file\\[3\\].cs", namedSections[2].Name);
+            Assert.Equal("c:/f\\;i\\!le\\[3\\].cs", namedSections[2].Name);
             AssertEx.Equal(
                 new[] { KeyValuePair.Create("build_metadata.compile.toretrieve", "ghi789") },
                 namedSections[2].Properties

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -58,6 +58,7 @@ my_prop = my_val
         }
 
         [Fact]
+        [WorkItem(52469, "https://github.com/dotnet/roslyn/issues/52469")]
         public void ConfigWithEscapedValues()
         {
             var config = ParseConfigFile(@"is_global = true

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -57,6 +57,41 @@ my_prop = my_val
             Assert.Equal("/bogus", config.NormalizedDirectory);
         }
 
+        [Fact]
+        public void ConfigWithEscapedValues()
+        {
+            var config = ParseConfigFile(@"is_global = true
+
+[c:/\{file1\}.cs]
+build_metadata.Compile.ToRetrieve = abc123
+
+[c:/file\#2.cs]
+build_metadata.Compile.ToRetrieve = def456
+
+[c:/file\[3\].cs]
+build_metadata.Compile.ToRetrieve = ghi789
+");
+
+            var namedSections = config.NamedSections;
+            Assert.Equal("c:/\\{file1\\}.cs", namedSections[0].Name);
+            AssertEx.Equal(
+                new[] { KeyValuePair.Create("build_metadata.compile.toretrieve", "abc123") },
+                namedSections[0].Properties
+            );
+
+            Assert.Equal("c:/file\\#2.cs", namedSections[1].Name);
+            AssertEx.Equal(
+                new[] { KeyValuePair.Create("build_metadata.compile.toretrieve", "def456") },
+                namedSections[1].Properties
+            );
+
+            Assert.Equal("c:/file\\[3\\].cs", namedSections[2].Name);
+            AssertEx.Equal(
+                new[] { KeyValuePair.Create("build_metadata.compile.toretrieve", "ghi789") },
+                namedSections[2].Properties
+            );
+        }
+
         [ConditionalFact(typeof(WindowsOnly))]
         public void WindowsPath()
         {

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -101,16 +101,18 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return true;
         }
 
-        // Filenames with special characters like '#' and'{' get written
-        // into the section names in the resulting .editorconfig file. Later,
-        // when the file is parsed in configuration options these special
-        // characters are interpretted as invalid values and ignored by the
-        // processor. We encode the special characters in these strings
-        // before writing them here.
+        /// <remarks>
+        /// Filenames with special characters like '#' and'{' get written
+        /// into the section names in the resulting .editorconfig file. Later,
+        /// when the file is parsed in configuration options these special
+        /// characters are interpretted as invalid values and ignored by the
+        /// processor. We encode the special characters in these strings
+        /// before writing them here.
+        /// </remarks>
 
-        private static void EncodeString(StringBuilder builder, string p)
+        private static void EncodeString(StringBuilder builder, string value)
         {
-            foreach (var c in p)
+            foreach (var c in value)
             {
                 if (c is '*' or '?' or '{' or ',' or ';' or '}' or '[' or ']' or '#')
                 {

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             foreach (var c in value)
             {
-                if (c is '*' or '?' or '{' or ',' or ';' or '}' or '[' or ']' or '#')
+                if (c is '*' or '?' or '{' or ',' or ';' or '}' or '[' or ']' or '#' or '!')
                 {
                     builder.Append("\\");
                 }

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -77,9 +77,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 // write the section for this item
                 builder.AppendLine()
-                       .Append("[")
-                       .Append(EncodeString(group.Key))
-                       .AppendLine("]");
+                       .Append("[");
+                EncodeString(builder, group.Key);
+                builder.AppendLine("]");
 
                 foreach (var item in group)
                 {
@@ -108,26 +108,16 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         // processor. We encode the special characters in these strings
         // before writing them here.
 
-        private static string EncodeString(string p)
+        private static void EncodeString(StringBuilder builder, string p)
         {
-            StringBuilder builder = new StringBuilder();
-            for (var i = 0; i < p.Length; i++)
+            foreach (var c in p)
             {
-                builder.Append(p[i] switch
+                if (c is '*' or '?' or '{' or ',' or ';' or '}' or '[' or ']' or '#')
                 {
-                    '*' => "\\*",
-                    '?' => "\\?",
-                    '{' => "\\{",
-                    ',' => "\\,",
-                    ';' => "\\;",
-                    '}' => "\\}",
-                    '[' => "\\[",
-                    ']' => "\\]",
-                    '#' => "\\#",
-                    var @default => @default
-                });
+                    builder.Append("\\");
+                }
+                builder.Append(c);
             }
-            return builder.ToString();
         }
 
         /// <remarks>

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 // write the section for this item
                 builder.AppendLine()
                        .Append("[")
-                       .Append(group.Key)
+                       .Append(EncodeString(group.Key))
                        .AppendLine("]");
 
                 foreach (var item in group)
@@ -99,6 +99,35 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             ConfigFileContents = builder.ToString();
             return true;
+        }
+
+        // Filenames with special characters like '#' and'{' get written
+        // into the section names in the resulting .editorconfig file. Later,
+        // when the file is parsed in configuration options these special
+        // characters are interpretted as invalid values and ignored by the
+        // processor. We encode the special characters in these strings
+        // before writing them here.
+
+        private static string EncodeString(string p)
+        {
+            StringBuilder builder = new StringBuilder();
+            for (var i = 0; i < p.Length; i++)
+            {
+                builder.Append(p[i] switch
+                {
+                    '*' => "\\*",
+                    '?' => "\\?",
+                    '{' => "\\{",
+                    ',' => "\\,",
+                    ';' => "\\;",
+                    '}' => "\\}",
+                    '[' => "\\[",
+                    ']' => "\\]",
+                    '#' => "\\#",
+                    var @default => @default
+                });
+            }
+            return builder.ToString();
         }
 
         /// <remarks>

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
@@ -101,9 +101,9 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
         [WorkItem(52469, "https://github.com/dotnet/roslyn/issues/52469")]
         public void MultipleSpecialCharacterItemMetaDataCreatesSections()
         {
-            ITaskItem item1 = MSBuildUtil.CreateTaskItem("c:/{file1}.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
-            ITaskItem item2 = MSBuildUtil.CreateTaskItem("c:/file#2.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
-            ITaskItem item3 = MSBuildUtil.CreateTaskItem("c:/file[3].cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "ghi789" } });
+            ITaskItem item1 = MSBuildUtil.CreateTaskItem("c:/{f*i?le1}.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
+            ITaskItem item2 = MSBuildUtil.CreateTaskItem("c:/f,ile#2.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
+            ITaskItem item3 = MSBuildUtil.CreateTaskItem("c:/f;i!le[3].cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "ghi789" } });
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
@@ -115,13 +115,13 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
 
             Assert.Equal(@"is_global = true
 
-[c:/\{file1\}.cs]
+[c:/\{f\*i\?le1\}.cs]
 build_metadata.Compile.ToRetrieve = abc123
 
-[c:/file\#2.cs]
+[c:/f\,ile\#2.cs]
 build_metadata.Compile.ToRetrieve = def456
 
-[c:/file\[3\].cs]
+[c:/f\;i\!le\[3\].cs]
 build_metadata.Compile.ToRetrieve = ghi789
 ", result);
         }

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
@@ -98,6 +98,34 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
         }
 
         [Fact]
+        public void MultipleSpecialCharacterItemMetaDataCreatesSections()
+        {
+            ITaskItem item1 = MSBuildUtil.CreateTaskItem("c:/{file1}.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });
+            ITaskItem item2 = MSBuildUtil.CreateTaskItem("c:/file#2.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "def456" } });
+            ITaskItem item3 = MSBuildUtil.CreateTaskItem("c:/file[3].cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "ghi789" } });
+
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
+            {
+                MetadataItems = new[] { item1, item2, item3 }
+            };
+            configTask.Execute();
+
+            var result = configTask.ConfigFileContents;
+
+            Assert.Equal(@"is_global = true
+
+[c:/\{file1\}.cs]
+build_metadata.Compile.ToRetrieve = abc123
+
+[c:/file\#2.cs]
+build_metadata.Compile.ToRetrieve = def456
+
+[c:/file\[3\].cs]
+build_metadata.Compile.ToRetrieve = ghi789
+", result);
+        }
+
+        [Fact]
         public void DuplicateItemSpecsAreCombinedInSections()
         {
             ITaskItem item1 = MSBuildUtil.CreateTaskItem("c:/file1.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
@@ -98,6 +98,7 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
         }
 
         [Fact]
+        [WorkItem(52469, "https://github.com/dotnet/roslyn/issues/52469")]
         public void MultipleSpecialCharacterItemMetaDataCreatesSections()
         {
             ITaskItem item1 = MSBuildUtil.CreateTaskItem("c:/{file1}.cs", new Dictionary<string, string> { { "ItemType", "Compile" }, { "MetadataName", "ToRetrieve" }, { "ToRetrieve", "abc123" } });


### PR DESCRIPTION
Addresses part of https://github.com/dotnet/roslyn/issues/52469.