### PR TITLE
Use compile-time solution for solution crawler and EnC

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -9,6 +9,7 @@ using System.Composition;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -306,7 +307,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 ProgressReporter = progressReporter;
             }
 
-            public Solution CurrentSolution => Workspace.CurrentSolution;
+            public Solution GetCurrentCompileTimeSolution()
+                => Workspace.Services.GetRequiredService<ICompileTimeSolutionProvider>().GetCurrentCompileTimeSolution();
         }
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 ProgressReporter = progressReporter;
             }
 
-            public Solution GetCurrentCompileTimeSolution()
+            public Solution GetSolutionToAnalyze()
                 => Workspace.Services.GetRequiredService<ICompileTimeSolutionProvider>().GetCurrentCompileTimeSolution();
         }
     }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             // see whether we have work item for the document
                             Contract.ThrowIfFalse(GetNextWorkItem(out var workItem, out var documentCancellation));
 
-                            var solution = _processor.CurrentSolution;
+                            var solution = _processor._registration.GetCurrentCompileTimeSolution();
 
                             // okay now we have work to do
                             await ProcessDocumentAsync(solution, Analyzers, workItem, documentCancellation).ConfigureAwait(false);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             // see whether we have work item for the document
                             Contract.ThrowIfFalse(GetNextWorkItem(out var workItem, out var documentCancellation));
 
-                            var solution = _processor._registration.GetCurrentCompileTimeSolution();
+                            var solution = _processor._registration.GetSolutionToAnalyze();
 
                             // okay now we have work to do
                             await ProcessDocumentAsync(solution, Analyzers, workItem, documentCancellation).ConfigureAwait(false);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -204,8 +204,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 public ImmutableArray<IIncrementalAnalyzer> Analyzers => _normalPriorityProcessor.Analyzers;
 
-                private Solution CurrentSolution => _registration.CurrentSolution;
-                private ProjectDependencyGraph DependencyGraph => CurrentSolution.GetProjectDependencyGraph();
+                private ProjectDependencyGraph DependencyGraph => _registration.GetCurrentCompileTimeSolution().GetProjectDependencyGraph();
                 private IDiagnosticAnalyzerService? DiagnosticAnalyzerService => _lazyDiagnosticAnalyzerService?.Value;
 
                 public Task AsyncProcessorTask

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 public ImmutableArray<IIncrementalAnalyzer> Analyzers => _normalPriorityProcessor.Analyzers;
 
-                private ProjectDependencyGraph DependencyGraph => _registration.GetCurrentCompileTimeSolution().GetProjectDependencyGraph();
+                private ProjectDependencyGraph DependencyGraph => _registration.GetSolutionToAnalyze().GetProjectDependencyGraph();
                 private IDiagnosticAnalyzerService? DiagnosticAnalyzerService => _lazyDiagnosticAnalyzerService?.Value;
 
                 public Task AsyncProcessorTask

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // we do have work item for this project
                         var projectId = workItem.ProjectId;
                         var processedEverything = false;
-                        var processingSolution = Processor.CurrentSolution;
+                        var processingSolution = Processor._registration.GetCurrentCompileTimeSolution();
 
                         try
                         {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // we do have work item for this project
                         var projectId = workItem.ProjectId;
                         var processedEverything = false;
-                        var processingSolution = Processor._registration.GetCurrentCompileTimeSolution();
+                        var processingSolution = Processor._registration.GetSolutionToAnalyze();
 
                         try
                         {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // using later version of solution is always fine since, as long as there is new work item in the queue,
                         // solution crawler will eventually call the last workitem with the lastest solution
                         // making everything to catch up
-                        var solution = Processor.CurrentSolution;
+                        var solution = Processor._registration.GetCurrentCompileTimeSolution();
                         try
                         {
                             using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, w => w.ToString(), workItem, cancellationToken))
@@ -522,7 +522,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 return;
                             }
 
-                            await Processor.RunAnalyzersAsync(Analyzers, Processor.CurrentSolution, workItem: new WorkItem(), (a, s, c) => a.NewSolutionSnapshotAsync(s, c), CancellationToken).ConfigureAwait(false);
+                            await Processor.RunAnalyzersAsync(
+                                Analyzers,
+                                Processor._registration.GetCurrentCompileTimeSolution(),
+                                workItem: new WorkItem(), (a, s, c) => a.NewSolutionSnapshotAsync(s, c), CancellationToken).ConfigureAwait(false);
 
                             foreach (var id in Processor.GetOpenDocumentIds())
                             {
@@ -538,7 +541,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         bool IsSolutionChanged()
                         {
-                            var currentSolution = Processor.CurrentSolution;
+                            var currentSolution = Processor._registration.GetCurrentCompileTimeSolution();
                             var oldSolution = _lastSolution;
 
                             if (currentSolution == oldSolution)
@@ -577,7 +580,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         base.Shutdown();
 
-                        SolutionCrawlerLogger.LogIncrementalAnalyzerProcessorStatistics(Processor._registration.CorrelationId, Processor.CurrentSolution, Processor._logAggregator, Analyzers);
+                        SolutionCrawlerLogger.LogIncrementalAnalyzerProcessorStatistics(Processor._registration.CorrelationId, Processor._registration.GetCurrentCompileTimeSolution(), Processor._logAggregator, Analyzers);
 
                         _workItemQueue.Dispose();
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // using later version of solution is always fine since, as long as there is new work item in the queue,
                         // solution crawler will eventually call the last workitem with the lastest solution
                         // making everything to catch up
-                        var solution = Processor._registration.GetCurrentCompileTimeSolution();
+                        var solution = Processor._registration.GetSolutionToAnalyze();
                         try
                         {
                             using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, w => w.ToString(), workItem, cancellationToken))
@@ -524,7 +524,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                             await Processor.RunAnalyzersAsync(
                                 Analyzers,
-                                Processor._registration.GetCurrentCompileTimeSolution(),
+                                Processor._registration.GetSolutionToAnalyze(),
                                 workItem: new WorkItem(), (a, s, c) => a.NewSolutionSnapshotAsync(s, c), CancellationToken).ConfigureAwait(false);
 
                             foreach (var id in Processor.GetOpenDocumentIds())
@@ -541,7 +541,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         bool IsSolutionChanged()
                         {
-                            var currentSolution = Processor._registration.GetCurrentCompileTimeSolution();
+                            var currentSolution = Processor._registration.GetSolutionToAnalyze();
                             var oldSolution = _lastSolution;
 
                             if (currentSolution == oldSolution)
@@ -580,7 +580,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         base.Shutdown();
 
-                        SolutionCrawlerLogger.LogIncrementalAnalyzerProcessorStatistics(Processor._registration.CorrelationId, Processor._registration.GetCurrentCompileTimeSolution(), Processor._logAggregator, Analyzers);
+                        SolutionCrawlerLogger.LogIncrementalAnalyzerProcessorStatistics(Processor._registration.CorrelationId, Processor._registration.GetSolutionToAnalyze(), Processor._logAggregator, Analyzers);
 
                         _workItemQueue.Dispose();
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         using (data.AsyncToken)
                         {
-                            var project = _registration.CurrentSolution.GetProject(data.ProjectId);
+                            var project = _registration.GetCurrentCompileTimeSolution().GetProject(data.ProjectId);
                             if (project == null)
                             {
                                 return;
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             }
 
                             // do dependency tracking here with current solution
-                            var solution = _registration.CurrentSolution;
+                            var solution = _registration.GetCurrentCompileTimeSolution();
                             foreach (var projectId in GetProjectsToAnalyze(solution, data.ProjectId))
                             {
                                 project = solution.GetProject(projectId);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         using (data.AsyncToken)
                         {
-                            var project = _registration.GetCurrentCompileTimeSolution().GetProject(data.ProjectId);
+                            var project = _registration.GetSolutionToAnalyze().GetProject(data.ProjectId);
                             if (project == null)
                             {
                                 return;
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             }
 
                             // do dependency tracking here with current solution
-                            var solution = _registration.GetCurrentCompileTimeSolution();
+                            var solution = _registration.GetSolutionToAnalyze();
                             foreach (var projectId in GetProjectsToAnalyze(solution, data.ProjectId))
                             {
                                 project = solution.GetProject(projectId);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 // subscribe to active document changed event for active file background analysis scope.
                 if (_documentTrackingService != null)
                 {
-                    _lastActiveDocument = _documentTrackingService.GetActiveDocument(_registration.Workspace.CurrentSolution);
+                    _lastActiveDocument = _documentTrackingService.GetActiveDocument(_registration.GetCurrentCompileTimeSolution());
                     _documentTrackingService.ActiveDocumentChanged += OnActiveDocumentChanged;
                 }
             }
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 _documentAndProjectWorkerProcessor.AddAnalyzer(analyzer, highPriorityForActiveFile);
 
                 // and ask to re-analyze whole solution for the given analyzer
-                var scope = new ReanalyzeScope(_registration.CurrentSolution.Id);
+                var scope = new ReanalyzeScope(_registration.GetCurrentCompileTimeSolution().Id);
                 Reanalyze(analyzer, scope);
             }
 
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         if (forceAnalyze || analyzer.NeedsReanalysisOnOptionChanged(sender, e))
                         {
-                            var scope = new ReanalyzeScope(_registration.CurrentSolution.Id);
+                            var scope = new ReanalyzeScope(_registration.GetCurrentCompileTimeSolution().Id);
                             Reanalyze(analyzer, scope);
                         }
                     }
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     // log big reanalysis request from things like fix all, suppress all or option changes
                     // we are not interested in 1 file re-analysis request which can happen from like venus typing
-                    var solution = _registration.CurrentSolution;
+                    var solution = _registration.GetCurrentCompileTimeSolution();
                     SolutionCrawlerLogger.LogReanalyze(
                         CorrelationId, analyzer, scope.GetDocumentCount(solution), scope.GetLanguagesStringForTelemetry(solution), highPriority);
                 }
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private void OnActiveDocumentChanged(object? sender, DocumentId activeDocumentId)
             {
-                var solution = _registration.Workspace.CurrentSolution;
+                var solution = _registration.GetCurrentCompileTimeSolution();
 
                 // Check if we are only performing backgroung analysis for active file.
                 if (activeDocumentId != null)
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private async Task EnqueueWorkItemAsync(IIncrementalAnalyzer analyzer, ReanalyzeScope scope, bool highPriority)
             {
-                var solution = _registration.CurrentSolution;
+                var solution = _registration.GetCurrentCompileTimeSolution();
                 var invocationReasons = highPriority ? InvocationReasons.ReanalyzeHighPriority : InvocationReasons.Reanalyze;
 
                 foreach (var document in scope.GetDocuments(solution))
@@ -683,7 +683,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 internal void WaitUntilCompletion(ImmutableArray<IIncrementalAnalyzer> workers)
                 {
-                    var solution = _workCoordinator._registration.CurrentSolution;
+                    var solution = _workCoordinator._registration.GetCurrentCompileTimeSolution();
                     var list = new List<WorkItem>();
 
                     foreach (var project in solution.Projects)

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 // subscribe to active document changed event for active file background analysis scope.
                 if (_documentTrackingService != null)
                 {
-                    _lastActiveDocument = _documentTrackingService.GetActiveDocument(_registration.GetCurrentCompileTimeSolution());
+                    _lastActiveDocument = _documentTrackingService.GetActiveDocument(_registration.GetSolutionToAnalyze());
                     _documentTrackingService.ActiveDocumentChanged += OnActiveDocumentChanged;
                 }
             }
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 _documentAndProjectWorkerProcessor.AddAnalyzer(analyzer, highPriorityForActiveFile);
 
                 // and ask to re-analyze whole solution for the given analyzer
-                var scope = new ReanalyzeScope(_registration.GetCurrentCompileTimeSolution().Id);
+                var scope = new ReanalyzeScope(_registration.GetSolutionToAnalyze().Id);
                 Reanalyze(analyzer, scope);
             }
 
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         if (forceAnalyze || analyzer.NeedsReanalysisOnOptionChanged(sender, e))
                         {
-                            var scope = new ReanalyzeScope(_registration.GetCurrentCompileTimeSolution().Id);
+                            var scope = new ReanalyzeScope(_registration.GetSolutionToAnalyze().Id);
                             Reanalyze(analyzer, scope);
                         }
                     }
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     // log big reanalysis request from things like fix all, suppress all or option changes
                     // we are not interested in 1 file re-analysis request which can happen from like venus typing
-                    var solution = _registration.GetCurrentCompileTimeSolution();
+                    var solution = _registration.GetSolutionToAnalyze();
                     SolutionCrawlerLogger.LogReanalyze(
                         CorrelationId, analyzer, scope.GetDocumentCount(solution), scope.GetLanguagesStringForTelemetry(solution), highPriority);
                 }
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private void OnActiveDocumentChanged(object? sender, DocumentId activeDocumentId)
             {
-                var solution = _registration.GetCurrentCompileTimeSolution();
+                var solution = _registration.GetSolutionToAnalyze();
 
                 // Check if we are only performing backgroung analysis for active file.
                 if (activeDocumentId != null)
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private async Task EnqueueWorkItemAsync(IIncrementalAnalyzer analyzer, ReanalyzeScope scope, bool highPriority)
             {
-                var solution = _registration.GetCurrentCompileTimeSolution();
+                var solution = _registration.GetSolutionToAnalyze();
                 var invocationReasons = highPriority ? InvocationReasons.ReanalyzeHighPriority : InvocationReasons.Reanalyze;
 
                 foreach (var document in scope.GetDocuments(solution))
@@ -683,7 +683,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 internal void WaitUntilCompletion(ImmutableArray<IIncrementalAnalyzer> workers)
                 {
-                    var solution = _workCoordinator._registration.GetCurrentCompileTimeSolution();
+                    var solution = _workCoordinator._registration.GetSolutionToAnalyze();
                     var list = new List<WorkItem>();
 
                     foreach (var project in solution.Projects)

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices
+{
+    /// <summary>
+    /// Provides a compile-time view of the current workspace solution.
+    /// Workaround for Razor projects which generate both design-time and compile-time source files.
+    /// TODO: remove https://github.com/dotnet/roslyn/issues/51678
+    /// </summary>
+    internal sealed class CompileTimeSolutionProvider : ICompileTimeSolutionProvider
+    {
+        [ExportWorkspaceServiceFactory(typeof(ICompileTimeSolutionProvider), WorkspaceKind.Host), Shared]
+        private sealed class Factory : IWorkspaceServiceFactory
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public Factory()
+            {
+            }
+
+            [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
+            public IWorkspaceService? CreateService(HostWorkspaceServices workspaceServices)
+                => new CompileTimeSolutionProvider(workspaceServices.Workspace);
+        }
+
+        private const string RazorEncConfigFileName = "RazorSourceGenerator.razorencconfig";
+
+        private readonly Workspace _workspace;
+        private readonly object _guard = new();
+
+        private Solution? _lazyCompileTimeSolution;
+        private int _correspondingDesignTimeSolutionVersion;
+
+        public CompileTimeSolutionProvider(Workspace workspace)
+        {
+            _workspace = workspace;
+        }
+
+        private static bool IsRazorAnalyzerConfig(TextDocumentState documentState)
+            => documentState.FilePath != null && documentState.FilePath.EndsWith(RazorEncConfigFileName, StringComparison.OrdinalIgnoreCase);
+
+        public Solution GetCurrentCompileTimeSolution()
+        {
+            lock (_guard)
+            {
+                var currentDesignTimeSolution = _workspace.CurrentSolution;
+
+                // Design time solution hasn't changed since we calculated the last compile-time solution:
+                if (currentDesignTimeSolution.WorkspaceVersion == _correspondingDesignTimeSolutionVersion)
+                {
+                    Contract.ThrowIfNull(_lazyCompileTimeSolution);
+                    return _lazyCompileTimeSolution;
+                }
+
+                using var _1 = ArrayBuilder<DocumentId>.GetInstance(out var configIdsToRemove);
+                using var _2 = ArrayBuilder<DocumentId>.GetInstance(out var documentIdsToRemove);
+
+                foreach (var (_, projectState) in currentDesignTimeSolution.State.ProjectStates)
+                {
+                    foreach (var configState in projectState.AnalyzerConfigDocumentStates.States)
+                    {
+                        if (IsRazorAnalyzerConfig(configState))
+                        {
+                            configIdsToRemove.Add(configState.Id);
+                        }
+                    }
+
+                    foreach (var documentState in projectState.DocumentStates.States)
+                    {
+                        if (documentState.Attributes.DesignTimeOnly)
+                        {
+                            documentIdsToRemove.Add(documentState.Id);
+                        }
+                    }
+                }
+
+                _lazyCompileTimeSolution = currentDesignTimeSolution
+                    .RemoveAnalyzerConfigDocuments(configIdsToRemove.ToImmutable())
+                    .RemoveDocuments(documentIdsToRemove.ToImmutable());
+
+                _correspondingDesignTimeSolutionVersion = currentDesignTimeSolution.WorkspaceVersion;
+                return _lazyCompileTimeSolution;
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         {
             _workspace = workspace;
             _correspondingDesignTimeSolutionVersion = -1;
-            _enabled = workspace.Services.GetRequiredService<IExperimentationService>().IsExperimentEnabled(WellKnownExperimentNames.RazorLspEditorFeatureFlag) == true;
+            _enabled = workspace.Services.GetRequiredService<IExperimentationService>().IsExperimentEnabled(WellKnownExperimentNames.RazorLspEditorFeatureFlag);
         }
 
         private static bool IsRazorAnalyzerConfig(TextDocumentState documentState)

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -68,19 +68,26 @@ namespace Microsoft.VisualStudio.LanguageServices
 
                 foreach (var (_, projectState) in currentDesignTimeSolution.State.ProjectStates)
                 {
+                    var anyConfigs = false;
+
                     foreach (var configState in projectState.AnalyzerConfigDocumentStates.States)
                     {
                         if (IsRazorAnalyzerConfig(configState))
                         {
                             configIdsToRemove.Add(configState.Id);
+                            anyConfigs = true;
                         }
                     }
 
-                    foreach (var documentState in projectState.DocumentStates.States)
+                    // only remove design-time only documents when source-generated ones replace them
+                    if (anyConfigs)
                     {
-                        if (documentState.Attributes.DesignTimeOnly)
+                        foreach (var documentState in projectState.DocumentStates.States)
                         {
-                            documentIdsToRemove.Add(documentState.Id);
+                            if (documentState.Attributes.DesignTimeOnly)
+                            {
+                                documentIdsToRemove.Add(documentState.Id);
+                            }
                         }
                     }
                 }

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         public CompileTimeSolutionProvider(Workspace workspace)
         {
             _workspace = workspace;
+            _correspondingDesignTimeSolutionVersion = -1;
         }
 
         private static bool IsRazorAnalyzerConfig(TextDocumentState documentState)

--- a/src/Features/Core/Portable/Workspace/ICompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/ICompileTimeSolutionProvider.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Host
+{
+    /// <summary>
+    /// Provides a compile-time view of the current workspace solution.
+    /// Workaround for Razor projects which generate both design-time and compile-time source files.
+    /// TODO: remove https://github.com/dotnet/roslyn/issues/51678
+    /// </summary>
+    internal interface ICompileTimeSolutionProvider : IWorkspaceService
+    {
+        Solution GetCurrentCompileTimeSolution();
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/ManagedEditAndContinueLanguageService.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
@@ -52,6 +53,9 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
             _diagnosticUpdateSource = diagnosticUpdateSource;
         }
 
+        private Solution GetCurrentCompileTimeSolution()
+            => _proxy.Workspace.Services.GetRequiredService<ICompileTimeSolutionProvider>().GetCurrentCompileTimeSolution();
+
         /// <summary>
         /// Called by the debugger when a debugging session starts and managed debugging is being used.
         /// </summary>
@@ -67,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
             try
             {
-                var solution = _proxy.Workspace.CurrentSolution;
+                var solution = GetCurrentCompileTimeSolution();
                 _debuggingSessionConnection = await _proxy.StartDebuggingSessionAsync(solution, _debuggerService, captureMatchingDocuments: false, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
@@ -85,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
                 return;
             }
 
-            var solution = _proxy.Workspace.CurrentSolution;
+            var solution = GetCurrentCompileTimeSolution();
 
             try
             {
@@ -175,7 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
         {
             try
             {
-                var solution = _proxy.Workspace.CurrentSolution;
+                var solution = GetCurrentCompileTimeSolution();
                 var activeStatementSpanProvider = GetActiveStatementSpanProvider(solution);
                 return await _proxy.HasChangesAsync(solution, activeStatementSpanProvider, sourceFilePath, cancellationToken).ConfigureAwait(false);
             }
@@ -189,7 +193,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
         {
             try
             {
-                var solution = _proxy.Workspace.CurrentSolution;
+                var solution = GetCurrentCompileTimeSolution();
                 var activeStatementSpanProvider = GetActiveStatementSpanProvider(solution);
                 return await _proxy.EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, _diagnosticService, _diagnosticUpdateSource, cancellationToken).ConfigureAwait(false);
             }
@@ -203,7 +207,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
         {
             try
             {
-                var solution = _proxy.Workspace.CurrentSolution;
+                var solution = GetCurrentCompileTimeSolution();
 
                 var activeStatementSpanProvider = new SolutionActiveStatementSpanProvider(async (documentId, cancellationToken) =>
                 {
@@ -224,7 +228,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
         {
             try
             {
-                var solution = _proxy.Workspace.CurrentSolution;
+                var solution = GetCurrentCompileTimeSolution();
                 return await _proxy.IsActiveStatementInExceptionRegionAsync(solution, instruction, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -38,5 +38,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string RemoveUnusedReferences = "Roslyn.RemoveUnusedReferences";
         public const string LSPCompletion = "Roslyn.LSP.Completion";
         public const string UnnamedSymbolCompletionDisabled = "Roslyn.UnnamedSymbolCompletionDisabled";
+        public const string RazorLspEditorFeatureFlag = "Razor.LSP.Editor";
     }
 }


### PR DESCRIPTION
Implements https://github.com/dotnet/roslyn/issues/51265

As a side effect Razor design-time documents are no longer used for reporting diagnostics.

Only impacts .NET 6 projects -- when source generators are used for Razor projects and when Razor LSP editor is enabled (`Razor.LSP.Editor` feature flag).

Validation build: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/317367

