### PR TITLE
Suggest simplifying ToString with InvariantCulture inside FormattableString.Invariant

### DIFF
--- a/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -215,6 +215,74 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SimplifyInterpolation
         }
 
         [Fact]
+        public async Task ToStringWithInvariantCultureInsideFormattableStringInvariant()
+        {
+            // Invariance remains explicit, so this is okay.
+
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue[||]{|Unnecessary:.ToString(System.Globalization.CultureInfo.InvariantCulture)|}} suffix"");
+    }
+}",
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue} suffix"");
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ToStringWithInvariantCultureOutsideFormattableStringInvariant()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = $""prefix {someValue[||].ToString(System.Globalization.CultureInfo.InvariantCulture)} suffix"";
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ToStringWithFormatAndInvariantCultureInsideFormattableStringInvariant()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue[||]{|Unnecessary:.ToString(""|}some format code{|Unnecessary:"", System.Globalization.CultureInfo.InvariantCulture)|}} suffix"");
+    }
+}",
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue:some format code} suffix"");
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ToStringWithFormatAndInvariantCultureOutsideFormattableStringInvariant()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = $""prefix {someValue[||].ToString(""some format code"", System.Globalization.CultureInfo.InvariantCulture)} suffix"";
+    }
+}");
+        }
+
+        [Fact]
         public async Task PadLeftWithIntegerLiteral()
         {
             await TestInRegularAndScript1Async(

--- a/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
+++ b/src/Analyzers/CSharp/Tests/SimplifyInterpolation/SimplifyInterpolationTests.cs
@@ -237,6 +237,46 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SimplifyInterpolation
         }
 
         [Fact]
+        public async Task DateTimeFormatInfoInvariantInfoIsRecognized()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue[||]{|Unnecessary:.ToString(System.Globalization.DateTimeFormatInfo.InvariantInfo)|}} suffix"");
+    }
+}",
+@"class C
+{
+    void M(System.DateTime someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue} suffix"");
+    }
+}");
+        }
+
+        [Fact]
+        public async Task NumberFormatInfoInvariantInfoIsRecognized()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M(int someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue[||]{|Unnecessary:.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)|}} suffix"");
+    }
+}",
+@"class C
+{
+    void M(int someValue)
+    {
+        _ = System.FormattableString.Invariant($""prefix {someValue} suffix"");
+    }
+}");
+        }
+
+        [Fact]
         public async Task ToStringWithInvariantCultureOutsideFormattableStringInvariant()
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
@@ -161,19 +161,13 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
             {
                 if (member.Name == nameof(CultureInfo.InvariantCulture))
                 {
-                    return SymbolEqualityComparer.Default.Equals(
-                        member.ContainingType,
-                        operation.SemanticModel.Compilation.GetTypeByMetadataName(typeof(System.Globalization.CultureInfo).FullName!));
+                    return IsType<System.Globalization.CultureInfo>(member.ContainingType, operation.SemanticModel);
                 }
 
                 if (member.Name == "InvariantInfo")
                 {
-                    return SymbolEqualityComparer.Default.Equals(
-                            member.ContainingType,
-                            operation.SemanticModel.Compilation.GetTypeByMetadataName(typeof(System.Globalization.NumberFormatInfo).FullName!))
-                        || SymbolEqualityComparer.Default.Equals(
-                            member.ContainingType,
-                            operation.SemanticModel.Compilation.GetTypeByMetadataName(typeof(System.Globalization.DateTimeFormatInfo).FullName!));
+                    return IsType<System.Globalization.NumberFormatInfo>(member.ContainingType, operation.SemanticModel)
+                        || IsType<System.Globalization.DateTimeFormatInfo>(member.ContainingType, operation.SemanticModel);
                 }
             }
 
@@ -192,7 +186,12 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                 {
                     TargetMethod: { Name: nameof(FormattableString.Invariant), ContainingType: var containingType },
                 },
-            } && SymbolEqualityComparer.Default.Equals(containingType, operation.SemanticModel.Compilation.GetTypeByMetadataName(typeof(System.FormattableString).FullName!));
+            } && IsType<System.FormattableString>(containingType, operation.SemanticModel);
+        }
+
+        private static bool IsType<T>(INamedTypeSymbol type, SemanticModel semanticModel)
+        {
+            return SymbolEqualityComparer.Default.Equals(type, semanticModel.Compilation.GetTypeByMetadataName(typeof(T).FullName!));
         }
 
         private static IEnumerable<IOperation> AncestorsAndSelf(IOperation operation)

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                     || (invocation.Arguments.Length == 2 && UsesInvariantCultureReferenceInsideFormattableStringInvariant(invocation, formatProviderArgumentIndex: 1)))
                 {
                     if (invocation.Arguments[0].Value is ILiteralOperation { ConstantValue: { HasValue: true, Value: string value } } literal &&
-                       expression.SemanticModel.Compilation.GetTypeByMetadataName(typeof(System.IFormattable).FullName!) is { } systemIFormattable &&
+                       FindType<System.IFormattable>(expression.SemanticModel) is { } systemIFormattable &&
                        invocation.Instance.Type.Implements(systemIFormattable))
                     {
                         unwrapped = invocation.Instance;
@@ -191,7 +191,12 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
 
         private static bool IsType<T>(INamedTypeSymbol type, SemanticModel semanticModel)
         {
-            return SymbolEqualityComparer.Default.Equals(type, semanticModel.Compilation.GetTypeByMetadataName(typeof(T).FullName!));
+            return SymbolEqualityComparer.Default.Equals(type, FindType<T>(semanticModel));
+        }
+
+        private static INamedTypeSymbol? FindType<T>(SemanticModel semanticModel)
+        {
+            return semanticModel.Compilation.GetTypeByMetadataName(typeof(T).FullName!);
         }
 
         private static IEnumerable<IOperation> AncestorsAndSelf(IOperation operation)

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
@@ -105,8 +105,8 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
                     || (invocation.Arguments.Length == 2 && UsesInvariantCultureReferenceInsideFormattableStringInvariant(invocation, formatProviderArgumentIndex: 1)))
                 {
                     if (invocation.Arguments[0].Value is ILiteralOperation { ConstantValue: { HasValue: true, Value: string value } } literal &&
-                       FindType<System.IFormattable>(expression.SemanticModel) is { } systemIFormattable &&
-                       invocation.Instance.Type.Implements(systemIFormattable))
+                        FindType<System.IFormattable>(expression.SemanticModel) is { } systemIFormattable &&
+                        invocation.Instance.Type.Implements(systemIFormattable))
                     {
                         unwrapped = invocation.Instance;
                         formatString = value;

--- a/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyInterpolation/Helpers.cs
@@ -153,25 +153,27 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
 
         private static bool IsInvariantCultureReference(IOperation operation)
         {
-            if (Unwrap(operation) is not IPropertyReferenceOperation { Member: { } member })
-                return false;
-
-            return member.Name switch
+            if (Unwrap(operation) is IPropertyReferenceOperation { Member: { } member })
             {
-                nameof(CultureInfo.InvariantCulture) => SymbolEqualityComparer.Default.Equals(
-                    member.ContainingType,
-                    operation.SemanticModel!.Compilation.GetTypeByMetadataName(typeof(System.Globalization.CultureInfo).FullName!)),
-
-                "InvariantInfo" =>
-                    SymbolEqualityComparer.Default.Equals(
+                if (member.Name == nameof(CultureInfo.InvariantCulture))
+                {
+                    return SymbolEqualityComparer.Default.Equals(
                         member.ContainingType,
-                        operation.SemanticModel!.Compilation.GetTypeByMetadataName(typeof(System.Globalization.NumberFormatInfo).FullName!))
-                    || SymbolEqualityComparer.Default.Equals(
-                        member.ContainingType,
-                        operation.SemanticModel!.Compilation.GetTypeByMetadataName(typeof(System.Globalization.DateTimeFormatInfo).FullName!)),
+                        operation.SemanticModel!.Compilation.GetTypeByMetadataName(typeof(System.Globalization.CultureInfo).FullName!));
+                }
 
-                _ => false,
-            };
+                if (member.Name == "InvariantInfo")
+                {
+                    return SymbolEqualityComparer.Default.Equals(
+                            member.ContainingType,
+                            operation.SemanticModel!.Compilation.GetTypeByMetadataName(typeof(System.Globalization.NumberFormatInfo).FullName!))
+                        || SymbolEqualityComparer.Default.Equals(
+                            member.ContainingType,
+                            operation.SemanticModel!.Compilation.GetTypeByMetadataName(typeof(System.Globalization.DateTimeFormatInfo).FullName!));
+                }
+            }
+
+            return false;
         }
 
         private static bool IsInsideFormattableStringInvariant(IOperation operation)


### PR DESCRIPTION
The result of following https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1310 or https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1307 is often that you end up with `.ToString(CultureInfo.InvariantCulture)` in your code. Last week I found myself wanting a quick way to simplify code like this:

```cs
first.ToString("0000", CultureInfo.InvariantCulture) + second.ToString("0000", CultureInfo.InvariantCulture) + third.ToString("0000", CultureInfo.InvariantCulture)
```

So I used the light bulb to convert concatenation to interpolation:
```cs
$"{first.ToString("0000", CultureInfo.InvariantCulture)}{second.ToString("0000", CultureInfo.InvariantCulture)}{third.ToString("0000", CultureInfo.InvariantCulture)}"
```

Then I manually added `FormattableString.Invariant(`...`)` around that:
```cs
FormattableString.Invariant($"{first.ToString("0000", CultureInfo.InvariantCulture)}{second.ToString("0000", CultureInfo.InvariantCulture)}{third.ToString("0000", CultureInfo.InvariantCulture)}")
```

At this point I thought it would be great if I could light-bulb fix the rest to end up with what I wanted:

```cs
FormattableString.Invariant($"{first:0000}{second:0000}{third:0000}")
```

This PR extends the existing 'Simplify interpolation' suggestion to cover this last step.

Nothing is added to help with the second-to-last step, inserting `FormattableString.Invariant` itself. I would like to maybe do that, but I went for a smaller PR.