### PR TITLE
UsePatternCombinator: Fix wrong target equivalence comparison.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/AnalyzedPattern.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/AnalyzedPattern.cs
@@ -113,7 +113,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternCombinators
                 if (target is null)
                     return null;
 
-                if (!SyntaxFactory.AreEquivalent(target.Syntax, rightPattern.Target.Syntax))
+                var compareTarget = target == leftTarget ? rightTarget : leftTarget;
+                if (!SyntaxFactory.AreEquivalent(target.Syntax, compareTarget.Syntax))
                     return null;
 
                 return new Binary(leftPattern, rightPattern, isDisjunctive, token, target);

--- a/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
@@ -360,5 +360,23 @@ public class C
     }}
 }}");
         }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
+        [WorkItem(52573, "https://github.com/dotnet/roslyn/issues/52573")]
+        [InlineData("&&")]
+        [InlineData("||")]
+        public async Task TestMissingIntegerAndStringIndex(string logicalOperator)
+        {
+            await TestMissingAsync(
+$@"using System;
+
+public class C
+{{
+    private static bool IsS(char[] ch, int count)
+    {{
+        return count == 1 [|{logicalOperator}|] ch[0] == 'S';
+    }}
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
@@ -297,5 +297,68 @@ public class C
     }
 }");
         }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
+        [WorkItem(51691, "https://github.com/dotnet/roslyn/issues/51691")]
+        [InlineData("&&")]
+        [InlineData("||")]
+        public async Task TestMissingInPropertyAccess_EnumCheckAndNullCheck(string logicalOperator)
+        {
+            await TestMissingAsync(
+$@"using System.Diagnostics;
+
+public class C
+{{
+    public void M()
+    {{
+            var p = default(Process);
+            if (p.StartInfo.WindowStyle == ProcessWindowStyle.Hidden [|{logicalOperator}|] p.StartInfo != null)
+            {{
+            }}
+    }}
+}}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
+        [WorkItem(51691, "https://github.com/dotnet/roslyn/issues/51691")]
+        [InlineData("&&")]
+        [InlineData("||")]
+        public async Task TestMissingInPropertyAccess_EnumCheckAndNullCheckOnOtherType(string logicalOperator)
+        {
+            await TestMissingAsync(
+$@"using System.Diagnostics;
+
+public class C
+{{
+    public void M()
+    {{
+            var p = default(Process);
+            if (p.StartInfo.WindowStyle == ProcessWindowStyle.Hidden [|{logicalOperator}|] this != null)
+            {{
+            }}
+    }}
+}}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
+        [WorkItem(51693, "https://github.com/dotnet/roslyn/issues/51693")]
+        [InlineData("&&")]
+        [InlineData("||")]
+        public async Task TestMissingInPropertyAccess_IsCheckAndNullCheck(string logicalOperator)
+        {
+            await TestMissingAsync(
+$@"using System;
+
+public class C
+{{
+    public void M()
+    {{
+            var o1 = new object();
+            if (o1 is IAsyncResult ar [|{logicalOperator}|] ar.AsyncWaitHandle != null)
+            {{
+            }}
+    }}
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -249,6 +250,50 @@ class C
     void M0(IQueryable<int> q)
     {
         q.Where(item => item == 1 [||]|| item == 2);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
+        [WorkItem(52397, "https://github.com/dotnet/roslyn/issues/52397")]
+        public async Task TestMissingInPropertyAccess_NullCheckOnLeftSide()
+        {
+            await TestMissingAsync(
+@"using System;
+
+public class C
+{
+    public int I { get; }
+    
+    public EventArgs Property { get; } 
+
+    public void M()
+    {
+        if (Property != null [|&&|] I == 1)
+        {
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
+        [WorkItem(52397, "https://github.com/dotnet/roslyn/issues/52397")]
+        public async Task TestMissingInPropertyAccess_NullCheckOnRightSide()
+        {
+            await TestMissingAsync(
+@"using System;
+
+public class C
+{
+    public int I { get; }
+    
+    public EventArgs Property { get; } 
+
+    public void M()
+    {
+        if (I == 1 [|&&|] Property != null)
+        {
+        }
     }
 }");
         }


### PR DESCRIPTION
Fixes #52397
Fixes #51691 
Fixes  #51693 
Fixes #52573

~Also resolves #51693, but @alrz mentioned another solution in https://github.com/dotnet/roslyn/issues/51693#issuecomment-803296746, so I would not close it until a new issue is created.~