### PR TITLE
Improve Server Logging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,7 @@ jobs:
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
 
-    - script: eng/test-build-correctness.cmd -configuration Release
+    - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
       displayName: Build - Validate correctness
 
     - template: eng/pipelines/publish-logs.yml

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -33,8 +33,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
             ExitingTraceListener.Install();
 #endif
 
-            using var logger = new CompilerServerLogger();
-            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, logger);
+            var requestId = Guid.NewGuid();
+            using var logger = new CompilerServerLogger($"csc {requestId}");
+            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, logger, requestId);
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)

--- a/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
+++ b/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
@@ -102,16 +102,17 @@ namespace Microsoft.CodeAnalysis.CommandLine
         internal const string LoggingPrefix = "---";
 
         private Stream? _loggingStream;
-        private readonly int _processId;
+        private readonly string _identifier;
 
         public bool IsLogging => _loggingStream is object;
 
         /// <summary>
         /// Static class initializer that initializes logging.
         /// </summary>
-        public CompilerServerLogger()
+        public CompilerServerLogger(string identifier)
         {
-            _processId = Process.GetCurrentProcess().Id;
+            _identifier = identifier;
+            var processId = Process.GetCurrentProcess().Id;
 
             try
             {
@@ -123,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     // Otherwise, assume that the environment variable specifies the name of the log file.
                     if (Directory.Exists(loggingFileName))
                     {
-                        loggingFileName = Path.Combine(loggingFileName, $"server.{_processId}.log");
+                        loggingFileName = Path.Combine(loggingFileName, $"server.{processId}.log");
                     }
 
                     // Open allowing sharing. We allow multiple processes to log to the same file, so we use share mode to allow that.
@@ -147,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             if (_loggingStream is object)
             {
                 var threadId = Environment.CurrentManagedThreadId;
-                var prefix = $"PID={_processId} TID={threadId} Ticks={Environment.TickCount} ";
+                var prefix = $"ID={_identifier} TID={threadId}: ";
                 string output = prefix + message + Environment.NewLine;
                 byte[] bytes = Encoding.UTF8.GetBytes(output);
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -501,15 +502,16 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             try
             {
-                using var logger = new CompilerServerLogger();
+                using var logger = new CompilerServerLogger($"MSBuild {Process.GetCurrentProcess().Id}");
                 string workingDir = CurrentDirectoryToUse();
                 string? tempDir = BuildServerConnection.GetTempPath(workingDir);
+                var requestId = Guid.NewGuid();
 
                 if (!UseSharedCompilation ||
                     HasToolBeenOverridden ||
                     !BuildServerConnection.IsCompilerServerSupported)
                 {
-                    LogCompilationMessage(logger, CompilationKind.Tool, $"using command line tool by design '{pathToTool}'");
+                    LogCompilationMessage(logger, requestId, CompilationKind.Tool, $"using command line tool by design '{pathToTool}'");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 
@@ -520,7 +522,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 var clientDir = Path.GetDirectoryName(PathToManagedTool);
                 if (clientDir is null || tempDir is null)
                 {
-                    LogCompilationMessage(logger, CompilationKind.Tool, $"using command line tool because we could not find client directory '{PathToManagedTool}'");
+                    LogCompilationMessage(logger, requestId, CompilationKind.Tool, $"using command line tool because we could not find client directory '{PathToManagedTool}'");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 
@@ -535,6 +537,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 // commandLineCommands (the parameter) may have been mucked with
                 // (to support using the dotnet cli)
                 var responseTask = BuildServerConnection.RunServerCompilationAsync(
+                    requestId,
                     Language,
                     RoslynString.IsNullOrEmpty(SharedCompilationId) ? null : SharedCompilationId,
                     GetArguments(ToolArguments, responseFileCommands).ToList(),
@@ -546,7 +549,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                 responseTask.Wait(_sharedCompileCts.Token);
 
-                ExitCode = HandleResponse(responseTask.Result, pathToTool, responseFileCommands, commandLineCommands, logger);
+                ExitCode = HandleResponse(requestId, responseTask.Result, pathToTool, responseFileCommands, commandLineCommands, logger);
             }
             catch (OperationCanceledException)
             {
@@ -630,11 +633,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// Handle a response from the server, reporting messages and returning
         /// the appropriate exit code.
         /// </summary>
-        private int HandleResponse(BuildResponse? response, string pathToTool, string responseFileCommands, string commandLineCommands, ICompilerServerLogger logger)
+        private int HandleResponse(Guid requestId, BuildResponse? response, string pathToTool, string responseFileCommands, string commandLineCommands, ICompilerServerLogger logger)
         {
             if (response is null)
             {
-                LogCompilationMessage(logger, CompilationKind.ToolFallback, "could not launch server");
+                LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, "could not launch server");
                 return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
             }
 
@@ -648,30 +651,30 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 case BuildResponse.ResponseType.Completed:
                     var completedResponse = (CompletedBuildResponse)response;
                     LogCompilerOutput(completedResponse.Output, StandardOutputImportanceToUse);
-                    LogCompilationMessage(logger, CompilationKind.Server, "server processed compilation");
+                    LogCompilationMessage(logger, requestId, CompilationKind.Server, "server processed compilation");
                     return completedResponse.ReturnCode;
 
                 case BuildResponse.ResponseType.MismatchedVersion:
-                    LogCompilationMessage(logger, CompilationKind.FatalError, "server reports different protocol version than build task");
+                    LogCompilationMessage(logger, requestId, CompilationKind.FatalError, "server reports different protocol version than build task");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.IncorrectHash:
-                    LogCompilationMessage(logger, CompilationKind.FatalError, "server reports different hash version than build task");
+                    LogCompilationMessage(logger, requestId, CompilationKind.FatalError, "server reports different hash version than build task");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.Rejected:
                     var rejectedResponse = (RejectedBuildResponse)response;
-                    LogCompilationMessage(logger, CompilationKind.ToolFallback, $"server rejected the request '{rejectedResponse.Reason}'");
+                    LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"server rejected the request '{rejectedResponse.Reason}'");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 case BuildResponse.ResponseType.AnalyzerInconsistency:
                     var analyzerResponse = (AnalyzerInconsistencyBuildResponse)response;
                     var combinedMessage = string.Join(", ", analyzerResponse.ErrorMessages.ToArray());
-                    LogCompilationMessage(logger, CompilationKind.ToolFallback, $"server rejected the request due to analyzer / generator issues '{combinedMessage}'");
+                    LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"server rejected the request due to analyzer / generator issues '{combinedMessage}'");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
                 default:
-                    LogCompilationMessage(logger, CompilationKind.ToolFallback, $"server gave an unrecognized response");
+                    LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"server gave an unrecognized response");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
             }
         }
@@ -689,7 +692,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// These are intended to be processed by automation in the binlog hence do not change the structure of
         /// the messages here.
         /// </summary>
-        private void LogCompilationMessage(ICompilerServerLogger logger, CompilationKind kind, string diagnostic)
+        private void LogCompilationMessage(ICompilerServerLogger logger, Guid requestId, CompilationKind kind, string diagnostic)
         {
             var category = kind switch
             {
@@ -700,14 +703,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 _ => throw new Exception($"Unexpected value {kind}"),
             };
 
-            var message = $"CompilerServer: {category} - {diagnostic}";
-            logger.LogError(message);
+            var message = $"CompilerServer: {category} - {diagnostic} - {requestId}";
             if (kind == CompilationKind.FatalError)
             {
+                logger.LogError(message);
                 Log.LogError(message);
             }
             else
             {
+                logger.Log(message);
                 Log.LogMessage(message);
             }
         }

--- a/src/Compilers/Server/VBCSCompiler/BuildProtocolUtil.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildProtocolUtil.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     break;
             }
 
-            return new RunRequest(language, currentDirectory, tempDirectory, libDirectory, arguments);
+            return new RunRequest(req.RequestId, language, currentDirectory, tempDirectory, libDirectory, arguments);
         }
 
         internal static string[] GetCommandLineArguments(BuildRequest req, out string? currentDirectory, out string? tempDirectory, out string? libDirectory)

--- a/src/Compilers/Server/VBCSCompiler/ClientConnectionHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/ClientConnectionHandler.cs
@@ -51,20 +51,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             {
                 using var clientConnection = await clientConnectionTask.ConfigureAwait(false);
                 var request = await clientConnection.ReadBuildRequestAsync(cancellationToken).ConfigureAwait(false);
-
-                if (request.ProtocolVersion != BuildProtocolConstants.ProtocolVersion)
-                {
-                    return await WriteBuildResponseAsync(
-                        clientConnection,
-                        new MismatchedVersionBuildResponse(),
-                        CompletionData.RequestError,
-                        cancellationToken).ConfigureAwait(false);
-                }
+                Logger.Log($"Received request {request.RequestId} of type {request.GetType()}");
 
                 if (!string.Equals(request.CompilerHash, BuildProtocolConstants.GetCommitHash(), StringComparison.OrdinalIgnoreCase))
                 {
                     return await WriteBuildResponseAsync(
                         clientConnection,
+                        request.RequestId,
                         new IncorrectHashBuildResponse(),
                         CompletionData.RequestError,
                         cancellationToken).ConfigureAwait(false);
@@ -74,6 +67,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 {
                     return await WriteBuildResponseAsync(
                         clientConnection,
+                        request.RequestId,
                         new ShutdownBuildResponse(Process.GetCurrentProcess().Id),
                         new CompletionData(CompletionReason.RequestCompleted, shutdownRequested: true),
                         cancellationToken).ConfigureAwait(false);
@@ -83,6 +77,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 {
                     return await WriteBuildResponseAsync(
                         clientConnection,
+                        request.RequestId,
                         new RejectedBuildResponse("Compilation not allowed at this time"),
                         CompletionData.RequestCompleted,
                         cancellationToken).ConfigureAwait(false);
@@ -92,6 +87,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 {
                     return await WriteBuildResponseAsync(
                         clientConnection,
+                        request.RequestId,
                         new RejectedBuildResponse("Not enough resources to accept connection"),
                         CompletionData.RequestError,
                         cancellationToken).ConfigureAwait(false);
@@ -101,12 +97,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
         }
 
-        private async Task<CompletionData> WriteBuildResponseAsync(IClientConnection clientConnection, BuildResponse response, CompletionData completionData, CancellationToken cancellationToken)
+        private async Task<CompletionData> WriteBuildResponseAsync(IClientConnection clientConnection, Guid requestId, BuildResponse response, CompletionData completionData, CancellationToken cancellationToken)
         {
             var message = response switch
             {
-                RejectedBuildResponse r => $"Writing {r.Type} response '{r.Reason}' for {clientConnection.LoggingIdentifier}",
-                _ => $"Writing {response.Type} response for {clientConnection.LoggingIdentifier}"
+                RejectedBuildResponse r => $"Writing {r.Type} response '{r.Reason}' for {requestId}",
+                _ => $"Writing {response.Type} response for {requestId}"
             };
             Logger.Log(message);
             await clientConnection.WriteBuildResponseAsync(response, cancellationToken).ConfigureAwait(false);
@@ -143,13 +139,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     {
                         // The compilation task should never throw. If it does we need to assume that the compiler is
                         // in a bad state and need to issue a RequestError
-                        Logger.LogException(ex, $"Exception running compilation for {clientConnection.LoggingIdentifier}");
+                        Logger.LogException(ex, $"Exception running compilation for {request.RequestId}");
                         response = new RejectedBuildResponse($"Exception during compilation: {ex.Message}");
                         completionData = CompletionData.RequestError;
                     }
 
                     return await WriteBuildResponseAsync(
                         clientConnection,
+                        request.RequestId,
                         response,
                         completionData,
                         cancellationToken).ConfigureAwait(false);

--- a/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
@@ -142,14 +142,22 @@ Run Compilation for {request.RequestId}
             }
 
             Logger.Log($"Begin {request.RequestId} {request.Language} compiler run");
-            TextWriter output = new StringWriter(CultureInfo.InvariantCulture);
-            int returnCode = compiler.Run(output, cancellationToken);
-            var outputString = output.ToString();
-            Logger.Log(@$"End {request.RequestId} {request.Language} compiler run
+            try
+            {
+                TextWriter output = new StringWriter(CultureInfo.InvariantCulture);
+                int returnCode = compiler.Run(output, cancellationToken);
+                var outputString = output.ToString();
+                Logger.Log(@$"End {request.RequestId} {request.Language} compiler run
 Return code: {returnCode}
 Output:
 {outputString}");
-            return new CompletedBuildResponse(returnCode, utf8output, outputString);
+                return new CompletedBuildResponse(returnCode, utf8output, outputString);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException(ex, $"Running compilation for {request.RequestId}");
+                throw;
+            }
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
@@ -21,14 +21,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal readonly struct RunRequest
     {
+        public Guid RequestId { get; }
         public string Language { get; }
         public string? WorkingDirectory { get; }
         public string? TempDirectory { get; }
         public string? LibDirectory { get; }
         public string[] Arguments { get; }
 
-        public RunRequest(string language, string? workingDirectory, string? tempDirectory, string? libDirectory, string[] arguments)
+        public RunRequest(Guid requestId, string language, string? workingDirectory, string? tempDirectory, string? libDirectory, string[] arguments)
         {
+            RequestId = requestId;
             Language = language;
             WorkingDirectory = workingDirectory;
             TempDirectory = tempDirectory;
@@ -72,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             return AnalyzerConsistencyChecker.Check(baseDirectory, analyzers, AnalyzerAssemblyLoader, Logger, out errorMessages);
         }
 
-        public bool TryCreateCompiler(RunRequest request, BuildPaths buildPaths, [NotNullWhen(true)] out CommonCompiler? compiler)
+        public bool TryCreateCompiler(in RunRequest request, BuildPaths buildPaths, [NotNullWhen(true)] out CommonCompiler? compiler)
         {
             switch (request.Language)
             {
@@ -98,10 +100,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
         }
 
-        public BuildResponse RunCompilation(RunRequest request, CancellationToken cancellationToken)
+        public BuildResponse RunCompilation(in RunRequest request, CancellationToken cancellationToken)
         {
             Logger.Log($@"
-Run Compilation
+Run Compilation for {request.RequestId}
+  Language = {request.Language}
   CurrentDirectory = '{request.WorkingDirectory}
   LIB = '{request.LibDirectory}'");
 
@@ -109,35 +112,40 @@ Run Compilation
             // resolve files in the compilation
             if (string.IsNullOrEmpty(request.WorkingDirectory))
             {
-                return new RejectedBuildResponse("Missing temp directory");
+                var message = "Missing working directory";
+                Logger.Log($"Rejected: {request.RequestId}: {message}");
+                return new RejectedBuildResponse(message);
             }
 
             // Compiler server must be provided with a valid temporary directory in order to correctly
             // isolate signing between compilations.
             if (string.IsNullOrEmpty(request.TempDirectory))
             {
-                return new RejectedBuildResponse("Missing temp directory");
+                var message = "Missing temp directory";
+                Logger.Log($"Rejected: {request.RequestId}: {message}");
+                return new RejectedBuildResponse(message);
             }
 
             var buildPaths = new BuildPaths(ClientDirectory, request.WorkingDirectory, SdkDirectory, request.TempDirectory);
-            CommonCompiler? compiler;
-            if (!TryCreateCompiler(request, buildPaths, out compiler))
+            if (!TryCreateCompiler(request, buildPaths, out CommonCompiler? compiler))
             {
-                return new RejectedBuildResponse($"Cannot create compiler for language id {request.Language}");
+                var message = $"Cannot create compiler for language id {request.Language}";
+                Logger.Log($"Rejected: {request.RequestId}: {message}");
+                return new RejectedBuildResponse(message);
             }
 
             bool utf8output = compiler.Arguments.Utf8Output;
             if (!CheckAnalyzers(request.WorkingDirectory, compiler.Arguments.AnalyzerReferences, out List<string>? errorMessages))
             {
+                Logger.Log($"Rejected: {request.RequestId}: for analyer load issues {string.Join(";", errorMessages)}");
                 return new AnalyzerInconsistencyBuildResponse(new ReadOnlyCollection<string>(errorMessages));
             }
 
-            Logger.Log($"Begin {request.Language} compiler run");
+            Logger.Log($"Begin {request.RequestId} {request.Language} compiler run");
             TextWriter output = new StringWriter(CultureInfo.InvariantCulture);
             int returnCode = compiler.Run(output, cancellationToken);
             var outputString = output.ToString();
-            Logger.Log(@$"
-End {request.Language} Compilation complete.
+            Logger.Log(@$"End {request.RequestId} {request.Language} compiler run
 Return code: {returnCode}
 Output:
 {outputString}");

--- a/src/Compilers/Server/VBCSCompiler/IClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/IClientConnection.cs
@@ -15,12 +15,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     internal interface IClientConnection : IDisposable
     {
         /// <summary>
-        /// A value which can be used to identify this connection for logging purposes only.  It has 
-        /// no guarantee of uniqueness.  
-        /// </summary>
-        string LoggingIdentifier { get; }
-
-        /// <summary>
         /// This task resolves if the client disconnects from the server.
         /// </summary>
         Task DisconnectTask { get; }

--- a/src/Compilers/Server/VBCSCompiler/ICompilerServerHost.cs
+++ b/src/Compilers/Server/VBCSCompiler/ICompilerServerHost.cs
@@ -17,6 +17,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         ICompilerServerLogger Logger { get; }
 
-        BuildResponse RunCompilation(RunRequest request, CancellationToken cancellationToken);
+        BuildResponse RunCompilation(in RunRequest request, CancellationToken cancellationToken);
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -22,15 +22,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         public NamedPipeServerStream Stream { get; }
         public ICompilerServerLogger Logger { get; }
-        public string LoggingIdentifier { get; }
         public bool IsDisposed { get; private set; }
 
         public Task DisconnectTask => DisconnectTaskCompletionSource.Task;
 
-        internal NamedPipeClientConnection(NamedPipeServerStream stream, string loggingIdentifier, ICompilerServerLogger logger)
+        internal NamedPipeClientConnection(NamedPipeServerStream stream, ICompilerServerLogger logger)
         {
             Stream = stream;
-            LoggingIdentifier = loggingIdentifier;
             Logger = logger;
         }
 
@@ -46,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogException(ex, $"Error closing client connection {LoggingIdentifier}");
+                    Logger.LogException(ex, $"Error closing client connection");
                 }
 
                 IsDisposed = true;
@@ -73,11 +71,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             {
                 try
                 {
-                    await BuildServerConnection.MonitorDisconnectAsync(Stream, LoggingIdentifier, Logger, DisconnectCancellationTokenSource.Token).ConfigureAwait(false);
+                    await BuildServerConnection.MonitorDisconnectAsync(Stream, request.RequestId, Logger, DisconnectCancellationTokenSource.Token).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogException(ex, $"Error monitoring disconnect {LoggingIdentifier}");
+                    Logger.LogException(ex, $"Error monitoring disconnect {request.RequestId}");
                 }
                 finally
                 {

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         public static int Main(string[] args)
         {
-            using var logger = new CompilerServerLogger();
+            using var logger = new CompilerServerLogger("VCBCSCompiler");
 
             NameValueCollection appSettings;
             try

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         public static int Main(string[] args)
         {
-            using var logger = new CompilerServerLogger("VCBCSCompiler");
+            using var logger = new CompilerServerLogger("VBCSCompiler");
 
             NameValueCollection appSettings;
             try

--- a/src/Compilers/Server/VBCSCompilerTests/BuildProtocolTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildProtocolTest.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
@@ -44,7 +45,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public async Task ReadWriteRequest()
         {
             var request = new BuildRequest(
-                BuildProtocolConstants.ProtocolVersion,
                 RequestLanguage.VisualBasicCompile,
                 "HashValue",
                 ImmutableArray.Create(
@@ -55,7 +55,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             Assert.True(memoryStream.Position > 0);
             memoryStream.Position = 0;
             var read = await BuildRequest.ReadAsync(memoryStream, default(CancellationToken));
-            Assert.Equal(BuildProtocolConstants.ProtocolVersion, read.ProtocolVersion);
             Assert.Equal(RequestLanguage.VisualBasicCompile, read.Language);
             Assert.Equal("HashValue", read.CompilerHash);
             Assert.Equal(2, read.Arguments.Count);

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -70,7 +70,6 @@ class Hello
             builder.Add(new BuildRequest.Argument(BuildProtocolConstants.ArgumentId.CommandLineArgument, argumentIndex: 0, value: file.Path));
 
             return new BuildRequest(
-                BuildProtocolConstants.ProtocolVersion,
                 RequestLanguage.CSharpCompile,
                 BuildProtocolConstants.GetCommitHash(),
                 builder.ToImmutable());
@@ -183,18 +182,10 @@ class Hello
         }
 
         [Fact]
-        public async Task IncorrectProtocolReturnsMismatchedVersionResponse()
-        {
-            using var serverData = await ServerUtil.CreateServer(Logger);
-            var buildResponse = await serverData.SendAsync(new BuildRequest(1, RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
-            Assert.Equal(BuildResponse.ResponseType.MismatchedVersion, buildResponse.Type);
-        }
-
-        [Fact]
         public async Task IncorrectServerHashReturnsIncorrectHashResponse()
         {
             using var serverData = await ServerUtil.CreateServer(Logger);
-            var buildResponse = await serverData.SendAsync(new BuildRequest(BuildProtocolConstants.ProtocolVersion, RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
+            var buildResponse = await serverData.SendAsync(new BuildRequest(RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
             Assert.Equal(BuildResponse.ResponseType.IncorrectHash, buildResponse.Type);
         }
 

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -1495,7 +1495,7 @@ static void Main(string[] args)
             });
 
             using var serverData = await ServerUtil.CreateServer(_logger, compilerServerHost: host);
-            var request = new BuildRequest(1, RequestLanguage.CSharpCompile, string.Empty, new BuildRequest.Argument[0]);
+            var request = new BuildRequest(RequestLanguage.CSharpCompile, string.Empty, new BuildRequest.Argument[0]);
             var compileTask = serverData.SendAsync(request);
             var response = await compileTask;
             Assert.Equal(BuildResponse.ResponseType.Completed, response.Type);

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -24,13 +24,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     internal static class ProtocolUtil
     {
         internal static readonly BuildRequest EmptyCSharpBuildRequest = new BuildRequest(
-            BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.CSharpCompile,
             BuildProtocolConstants.GetCommitHash(),
             ImmutableArray<BuildRequest.Argument>.Empty);
 
         internal static readonly BuildRequest EmptyBasicBuildRequest = new BuildRequest(
-            BuildProtocolConstants.ProtocolVersion,
             RequestLanguage.VisualBasicCompile,
             BuildProtocolConstants.GetCommitHash(),
             ImmutableArray<BuildRequest.Argument>.Empty);
@@ -158,8 +156,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             TextWriter textWriter = null,
             int? timeoutOverride = null)
         {
-            compileFunc = compileFunc ?? GetCompileFunc(language);
-            textWriter = textWriter ?? new StringWriter();
+            compileFunc ??= GetCompileFunc(language);
+            textWriter ??= new StringWriter();
             return new BuildClient(language, compileFunc, logger, timeoutOverride: timeoutOverride);
         }
 

--- a/src/Compilers/Server/VBCSCompilerTests/TestableCompilerServerHost.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TestableCompilerServerHost.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             Logger = logger ?? EmptyCompilerServerLogger.Instance;
         }
 
-        BuildResponse ICompilerServerHost.RunCompilation(RunRequest request, CancellationToken cancellationToken)
+        BuildResponse ICompilerServerHost.RunCompilation(in RunRequest request, CancellationToken cancellationToken)
         {
             return RunCompilation(request, cancellationToken);
         }

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -260,26 +260,26 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 // Write the request
                 try
                 {
-                    logger.Log("Begin writing request");
+                    logger.Log($"Begin writing request for {request.RequestId}");
                     await request.WriteAsync(pipeStream, cancellationToken).ConfigureAwait(false);
-                    logger.Log("End writing request");
+                    logger.Log($"End writing request for {request.RequestId}");
                 }
                 catch (Exception e)
                 {
-                    logger.LogException(e, "Error writing build request.");
+                    logger.LogException(e, $"Error writing build request for {request.RequestId}");
                     return new RejectedBuildResponse($"Error writing build request: {e.Message}");
                 }
 
                 // Wait for the compilation and a monitor to detect if the server disconnects
                 var serverCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-                logger.Log("Begin reading response");
+                logger.Log($"Begin reading response for {request.RequestId}");
 
                 var responseTask = BuildResponse.ReadAsync(pipeStream, serverCts.Token);
                 var monitorTask = MonitorDisconnectAsync(pipeStream, request.RequestId, logger, serverCts.Token);
                 await Task.WhenAny(responseTask, monitorTask).ConfigureAwait(false);
 
-                logger.Log("End reading response");
+                logger.Log($"End reading response for {request.RequestId}");
 
                 if (responseTask.IsCompleted)
                 {
@@ -290,13 +290,13 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     }
                     catch (Exception e)
                     {
-                        logger.LogException(e, "Error reading response");
+                        logger.LogException(e, $"Reading response for {request.RequestId}");
                         response = new RejectedBuildResponse($"Error reading response: {e.Message}");
                     }
                 }
                 else
                 {
-                    logger.LogError("Client disconnect");
+                    logger.LogError($"Client disconnect for {request.RequestId}");
                     response = new RejectedBuildResponse($"Client disconnected");
                 }
 

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -33,8 +33,9 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
             ExitingTraceListener.Install();
 #endif
 
-            using var logger = new CompilerServerLogger();
-            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, logger);
+            var requestId = Guid.NewGuid();
+            using var logger = new CompilerServerLogger($"vbc {requestId}");
+            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, logger, requestId);
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)


### PR DESCRIPTION
The goal if this PR is to change the logging so that:

1. It's easier to identify the process writing the message. The prefix
for messages will be prefixed with either "VBCSCompiler" or "MSBuild
<process id>".
1. Add a `Guid` to a logical build request that is included in many
messages. This will make it easier to track requests as they travel
between the MSBuild and VBCSCompiler processes.
1. Ensure all failure states have an explicit log call

The motivation for this change is we are seeing the compiler server
crash in build correctness and source build legs. From the log it's hard
to see what is happening. The failure is essentially silent. This is an
attempt to get more data so we can see what is actually going on during
failure.