### PR TITLE
Don't push diagnostics for LSP documents if Pull-diags are enabled.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -621,8 +621,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var document = solution.GetDocument(documentId);
+
                 if (document != null)
-                    await PublishDiagnosticsAsync(_diagnosticService, document, cancellationToken).ConfigureAwait(false);
+                {
+                    // If this is a `pull` client, and `pull` diagnostics is on, then we should not `publish` (push) the
+                    // diagnostics here. 
+                    var diagnosticMode = document.IsRazorDocument()
+                        ? InternalDiagnosticsOptions.RazorDiagnosticMode
+                        : InternalDiagnosticsOptions.NormalDiagnosticMode;
+                    if (_workspace.IsPushDiagnostics(diagnosticMode))
+                        await PublishDiagnosticsAsync(_diagnosticService, document, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             // Dedupe on DocumentId.  If we hear about the same document multiple times, we only need to process that id once.
             _diagnosticsWorkQueue = new AsyncBatchingWorkQueue<DocumentId>(
                 TimeSpan.FromMilliseconds(250),
-                ProcessDiagnosticUpdatedBatchAsync,
+                (ids, ct) => ProcessDiagnosticUpdatedBatchAsync(_diagnosticService, ids, ct),
                 EqualityComparer<DocumentId>.Default,
                 _listener,
                 _queue.CancellationToken);
@@ -592,8 +592,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         /// This dictionary stores the previously computed diagnostics for the published file so that we can
         /// union the currently computed diagnostics (e.g. for dA) with previously computed diagnostics (e.g. from dB).
         /// </summary>
-        private readonly Dictionary<Uri, Dictionary<DocumentId, ImmutableArray<LanguageServer.Protocol.Diagnostic>>> _publishedFileToDiagnostics =
-            new();
+        private readonly Dictionary<Uri, Dictionary<DocumentId, ImmutableArray<LSP.Diagnostic>>> _publishedFileToDiagnostics = new();
 
         /// <summary>
         /// Stores the mapping of a document to the uri(s) of diagnostics previously produced for this document.  When
@@ -611,9 +610,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         private static readonly Comparer<Uri> s_uriComparer = Comparer<Uri>.Create((uri1, uri2)
             => Uri.Compare(uri1, uri2, UriComponents.AbsoluteUri, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase));
 
-        private async Task ProcessDiagnosticUpdatedBatchAsync(ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)
+        // internal for testing purposes
+        internal async Task ProcessDiagnosticUpdatedBatchAsync(
+            IDiagnosticService? diagnosticService, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)
         {
-            if (_diagnosticService == null)
+            if (diagnosticService == null)
                 return;
 
             var solution = _workspace.CurrentSolution;
@@ -630,13 +631,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                         ? InternalDiagnosticsOptions.RazorDiagnosticMode
                         : InternalDiagnosticsOptions.NormalDiagnosticMode;
                     if (_workspace.IsPushDiagnostics(diagnosticMode))
-                        await PublishDiagnosticsAsync(_diagnosticService, document, cancellationToken).ConfigureAwait(false);
+                        await PublishDiagnosticsAsync(diagnosticService, document, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
 
-        // Internal for testing purposes.
-        internal async Task PublishDiagnosticsAsync(IDiagnosticService diagnosticService, Document document, CancellationToken cancellationToken)
+        private async Task PublishDiagnosticsAsync(IDiagnosticService diagnosticService, Document document, CancellationToken cancellationToken)
         {
             // Retrieve all diagnostics for the current document grouped by their actual file uri.
             var fileUriToDiagnostics = await GetDiagnosticsAsync(diagnosticService, document, cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
@@ -28,7 +28,6 @@ using Roslyn.Utilities;
 using StreamJsonRpc;
 using Xunit;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
-using Shell = Microsoft.VisualStudio.Shell;
 
 namespace Roslyn.VisualStudio.Next.UnitTests.Services
 {
@@ -55,6 +54,23 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
             var result = Assert.Single(results);
             Assert.Equal(new Uri(document.FilePath), result.Uri);
             Assert.Equal("id", result.Diagnostics.Single().Code);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticsWhenInPullMode()
+        {
+            using var workspace = CreateTestLspServer("", out _).TestWorkspace;
+            workspace.SetOptions(workspace.Options.WithChangedOption(
+                InternalDiagnosticsOptions.NormalDiagnosticMode, DiagnosticMode.Pull));
+
+            var document = workspace.CurrentSolution.Projects.First().Documents.First();
+
+            var diagnosticsMock = new Mock<IDiagnosticService>(MockBehavior.Strict);
+            // Create a mock that returns a diagnostic for the document.
+            SetupMockWithDiagnostics(diagnosticsMock, document.Id, await CreateMockDiagnosticDataAsync(document, "id").ConfigureAwait(false));
+
+            var (testAccessor, results) = await RunPublishDiagnosticsAsync(workspace, diagnosticsMock.Object, 0, document).ConfigureAwait(false);
+            Assert.Empty(results);
         }
 
         [Fact]
@@ -368,11 +384,11 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
             jsonRpc.StartListening();
 
             // Triggers language server to send notifications.
-            foreach (var document in documentsToPublish)
-                await languageServer.PublishDiagnosticsAsync(diagnosticService, document, CancellationToken.None).ConfigureAwait(false);
+            await languageServer.ProcessDiagnosticUpdatedBatchAsync(
+                diagnosticService, documentsToPublish.SelectAsArray(d => d.Id), CancellationToken.None);
 
             // Waits for all notifications to be received.
-            await callback.CallbackCompletedTask.Task.ConfigureAwait(false);
+            await callback.CallbackCompletedTask.ConfigureAwait(false);
 
             return (languageServer.GetTestAccessor(), callback.Results);
 
@@ -514,10 +530,11 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
 
         private class Callback
         {
+            private readonly TaskCompletionSource<object?> _callbackCompletedTaskSource = new();
             /// <summary>
             /// Task that can be awaited for the all callbacks to complete.
             /// </summary>
-            public TaskCompletionSource<object> CallbackCompletedTask { get; }
+            public Task CallbackCompletedTask => _callbackCompletedTaskSource.Task;
 
             /// <summary>
             /// Serialized results of all publish diagnostic notifications received by this callback.
@@ -527,7 +544,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
             /// <summary>
             /// Lock to guard concurrent callbacks.
             /// </summary>
-            private readonly object _lock = new object();
+            private readonly object _lock = new();
 
             /// <summary>
             /// The expected number of times this callback should be hit.
@@ -543,10 +560,12 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
 
             public Callback(int expectedNumberOfCallbacks)
             {
-                CallbackCompletedTask = new TaskCompletionSource<object>();
                 Results = new List<LSP.PublishDiagnosticParams>();
                 _expectedNumberOfCallbacks = expectedNumberOfCallbacks;
                 _currentNumberOfCallbacks = 0;
+
+                if (expectedNumberOfCallbacks == 0)
+                    _callbackCompletedTaskSource.SetResult(null);
             }
 
             [JsonRpcMethod(LSP.Methods.TextDocumentPublishDiagnosticsName)]
@@ -561,9 +580,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                     Results.Add(diagnosticParams);
 
                     if (_currentNumberOfCallbacks == _expectedNumberOfCallbacks)
-                    {
-                        CallbackCompletedTask.SetResult(new object());
-                    }
+                        _callbackCompletedTaskSource.SetResult(null);
 
                     return Task.CompletedTask;
                 }


### PR DESCRIPTION
Previous behavior was that we woudl push empty diags, as well as responding to pull diag requests.  Platform would like us to not report the empty push diags.

Working on a test now.