### PR TITLE
Extract Method Highlight Part of Switch Expression Bug Fix

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -118,6 +118,31 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        public async Task TestSwitchExpression()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+{
+    int Foo(int x) => x switch
+    {
+        1 => 1,
+        _ => [|1 + x|]
+    };
+}",
+@"class Program
+{
+    int Foo(int x) => x switch
+    {
+        1 => 1,
+        _ => NewMethod(x)
+    };
+
+    private static int NewMethod(x) => 1 + x;
+}",
+new TestParameters(options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CSharpCodeStyleOptions.WhenPossibleWithSilentEnforcement)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public async Task TestUseExpressionBodyWhenPossible()
         {
             await TestInRegularAndScript1Async(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -523,6 +523,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 case SyntaxKind.RefExpression:
                 case SyntaxKind.LockStatement:
                 case SyntaxKind.ElementAccessExpression:
+                case SyntaxKind.SwitchExpressionArm:
                     // Direct parent kind checks.
                     return true;
             }


### PR DESCRIPTION
#39690 

The issue seemed to be that the "valid selection" was being retrieved as the containing method span rather than just the expression. Going down the calls, there is a check if the expression is part of a valid span. 
In ```CSharpSelectionValidator.Validator```, there is a call to ```CanReplaceWithRValue()```, which itself calls ```CanReplaceWithLValue()```. 

The highlighted selection's parent is a SwitchExpressionArmSyntax, which, I believe, should be able to have an Lvalue introduced for the expression. 
Please let me know if that is not the case or if there are specific cases in which that would not be okay. 