### PR TITLE
Ignore razor virtual buffers as they cannot be ren…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -260,20 +260,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
         }
 
-        private const string ContainedLanguageMarker = nameof(ContainedLanguageMarker);
-
         private bool TryPopulateOpenTextBufferManagerForBuffer(ITextBuffer buffer)
         {
             AssertIsForeground();
             VerifyNotDismissed();
-
-            // TS creates generated documents to back script blocks in razor generated files.
-            // These files are opened in the roslyn workspace but are not valid to rename
-            // as they are not proper buffers.  So we exclude any buffer that is marked as a contained language.
-            if (buffer.Properties.TryGetProperty<bool>(ContainedLanguageMarker, out var markerValue) && markerValue)
-            {
-                return false;
-            }
 
             if (_workspace.Kind == WorkspaceKind.Interactive)
             {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -231,7 +231,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     }
                     Contract.ThrowIfNull(textSnapshot.TextBuffer);
 
-                    openBuffers.Add(textSnapshot.TextBuffer);
+                    // TS creates generated documents to back script blocks in razor generated files.
+                    // These files are opened in the roslyn workspace but are not valid to rename
+                    // as they do not have an undo history.  So we do not include any document that
+                    // we cannot find an undo history for.
+                    var textUndoHistoryService = _workspace.Services.GetService<ITextUndoHistoryWorkspaceService>();
+                    if (textUndoHistoryService.TryGetTextUndoHistory(_workspace, textSnapshot.TextBuffer, out var _))
+                    {
+                        openBuffers.Add(textSnapshot.TextBuffer);
+                    }
                 }
 
                 foreach (var buffer in openBuffers)

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -231,15 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     }
                     Contract.ThrowIfNull(textSnapshot.TextBuffer);
 
-                    // TS creates generated documents to back script blocks in razor generated files.
-                    // These files are opened in the roslyn workspace but are not valid to rename
-                    // as they do not have an undo history.  So we do not include any document that
-                    // we cannot find an undo history for.
-                    var textUndoHistoryService = _workspace.Services.GetService<ITextUndoHistoryWorkspaceService>();
-                    if (textUndoHistoryService.TryGetTextUndoHistory(_workspace, textSnapshot.TextBuffer, out var _))
-                    {
-                        openBuffers.Add(textSnapshot.TextBuffer);
-                    }
+                    openBuffers.Add(textSnapshot.TextBuffer);
                 }
 
                 foreach (var buffer in openBuffers)
@@ -268,10 +260,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
         }
 
+        private const string ContainedLanguageMarker = nameof(ContainedLanguageMarker);
+
         private bool TryPopulateOpenTextBufferManagerForBuffer(ITextBuffer buffer)
         {
             AssertIsForeground();
             VerifyNotDismissed();
+
+            // TS creates generated documents to back script blocks in razor generated files.
+            // These files are opened in the roslyn workspace but are not valid to rename
+            // as they are not proper buffers.  So we exclude any buffer that is marked as a contained language.
+            if (buffer.Properties.TryGetProperty<bool>(ContainedLanguageMarker, out var markerValue) && markerValue)
+            {
+                return false;
+            }
 
             if (_workspace.Kind == WorkspaceKind.Interactive)
             {


### PR DESCRIPTION
…amed.  Fixes an issue with generated TS documents without an undo history throwing during rename

Generated TS backing documents for razor are opened in the roslyn workspace but are missing an undo service.  They should not be renamed due to this (and LSP handles rename for these documents).  This check prevents us from throwing during a request to rename in a normal C# document.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1310317