### PR TITLE
State tables for Source Generators

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1124,9 +1124,9 @@ class C { }
         [Fact]
         public void User_WrappedFunc_Throw_Exceptions()
         {
-            var func = makeFunc(throwEx: false);
-            var throwsFunc = makeFunc(throwEx: true);
-            var timeoutFunc = makeFunc(throwCanceled: true);
+            Func<int, int> func = (input) => input;
+            Func<int, int> throwsFunc = (input) => throw new InvalidOperationException("user code exception");
+            Func<int, int> timeoutFunc = (input) => throw new OperationCanceledException();
 
             var userFunc = func.WrapUserFunction();
             var userThrowsFunc = throwsFunc.WrapUserFunction();
@@ -1154,25 +1154,6 @@ class C { }
             // cancellation is not wrapped, and is bubbled up
             Assert.Throws<OperationCanceledException>(() => timeoutFunc(30));
             Assert.Throws<OperationCanceledException>(() => userTimeoutFunc(30));
-
-            Func<int, int> makeFunc(bool throwEx = false, bool throwCanceled = false)
-            {
-                return (input) =>
-                {
-                    if (throwEx)
-                    {
-                        throw new InvalidOperationException("User code did something");
-                    }
-                    else if (throwCanceled)
-                    {
-                        throw new OperationCanceledException();
-                    }
-                    else
-                    {
-                        return input;
-                    }
-                };
-            }
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -18,9 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         public void Node_Table_Entries_Can_Be_Enumerated()
         {
             var builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added)));
-            builder.AddEntries(ImmutableArray.Create((2, EntryState.Added)));
-            builder.AddEntries(ImmutableArray.Create((3, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create(1), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(2), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(3), EntryState.Added);
             var table = builder.ToImmutableAndFree();
 
             var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added));
@@ -31,34 +31,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         public void Node_Table_Entries_Are_Flattend_When_Enumerated()
         {
             var builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added)));
-            builder.AddEntries(ImmutableArray.Create((4, EntryState.Added), (5, EntryState.Added), (6, EntryState.Added)));
-            builder.AddEntries(ImmutableArray.Create((7, EntryState.Added), (8, EntryState.Added), (9, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
             var table = builder.ToImmutableAndFree();
 
             var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added), (4, EntryState.Added), (5, EntryState.Added), (6, EntryState.Added), (7, EntryState.Added), (8, EntryState.Added), (9, EntryState.Added));
             AssertTableEntries(table, expected);
         }
 
-        [Fact]
-        public void Node_Table_Entries_Can_Have_Different_States()
-        {
-            var builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified)));
-            var table = builder.ToImmutableAndFree();
+        //[Fact]
+        //public void Node_Table_Entries_Can_Have_Different_States()
+        //{
+        //    var builder = new NodeStateTable<int>.Builder();
+        //    builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified)));
+        //    var table = builder.ToImmutableAndFree();
 
-            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified));
-            AssertTableEntries(table, expected);
-        }
+        //    var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified));
+        //    AssertTableEntries(table, expected);
+        //}
 
         [Fact]
         public void Node_Table_Entries_Can_Be_The_Same()
         {
             var builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (1, EntryState.Added), (1, EntryState.Modified)));
+            builder.AddEntries(ImmutableArray.Create(1, 1, 1), EntryState.Added);
             var table = builder.ToImmutableAndFree();
 
-            var expected = ImmutableArray.Create((1, EntryState.Added), (1, EntryState.Added), (1, EntryState.Modified));
+            var expected = ImmutableArray.Create((1, EntryState.Added), (1, EntryState.Added), (1, EntryState.Added));
             AssertTableEntries(table, expected);
         }
 
@@ -66,21 +66,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         public void Node_Builder_Can_Add_Entries_From_Previous_Table()
         {
             var builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added)));
-            builder.AddEntries(ImmutableArray.Create((2, EntryState.Cached), (3, EntryState.Removed)));
-            builder.AddEntries(ImmutableArray.Create((4, EntryState.Added), (5, EntryState.Modified)));
-            builder.AddEntries(ImmutableArray.Create((6, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create(1), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(2, 3), EntryState.Cached);
+            builder.AddEntries(ImmutableArray.Create(4, 5), EntryState.Modified);
+            builder.AddEntries(ImmutableArray.Create(6), EntryState.Added);
             var previousTable = builder.ToImmutableAndFree();
 
             builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Cached)));
-            builder.AddEntriesFromPreviousTable(previousTable); // ((2, EntryState.Cached), (3, EntryState.Removed))
-            builder.AddEntries(ImmutableArray.Create((20, EntryState.Added), (21, EntryState.Modified), (22, EntryState.Removed)));
-            builder.AddEntriesFromPreviousTable(previousTable); //((6, EntryState.Added))); 
+            builder.AddEntries(ImmutableArray.Create(10, 11), EntryState.Added);
+            builder.AddEntriesFromPreviousTable(previousTable, EntryState.Cached); // ((2, EntryState.Cached), (3, EntryState.Cached))
+            builder.AddEntries(ImmutableArray.Create(20, 21, 22), EntryState.Modified);
+            builder.AddEntriesFromPreviousTable(previousTable, EntryState.Removed); //((6, EntryState.Removed))); 
             var newTable = builder.ToImmutableAndFree();
 
 
-            var expected = ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Removed), (20, EntryState.Added), (21, EntryState.Modified), (22, EntryState.Removed), (6, EntryState.Added));
+            var expected = ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Cached), (20, EntryState.Modified), (21, EntryState.Modified), (22, EntryState.Modified), (6, EntryState.Removed));
             AssertTableEntries(newTable, expected);
         }
 
@@ -88,16 +88,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         public void Node_Table_Entries_Are_Cached_Or_Removed_When_Compacted()
         {
             var builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Removed), (3, EntryState.Cached)));
-            builder.AddEntries(ImmutableArray.Create((4, EntryState.Removed), (5, EntryState.Modified), (6, EntryState.Added)));
-            builder.AddEntries(ImmutableArray.Create((7, EntryState.Modified), (8, EntryState.Added), (9, EntryState.Removed)));
+            builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Removed);
+            builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
             var table = builder.ToImmutableAndFree();
 
-            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Removed), (3, EntryState.Cached), (4, EntryState.Removed), (5, EntryState.Modified), (6, EntryState.Added), (7, EntryState.Modified), (8, EntryState.Added), (9, EntryState.Removed));
+            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added), (4, EntryState.Removed), (5, EntryState.Removed), (6, EntryState.Removed), (7, EntryState.Added), (8, EntryState.Added), (9, EntryState.Added));
             AssertTableEntries(table, expected);
 
             var compactedTable = (NodeStateTable<int>)table.Compact();
-            expected = ImmutableArray.Create((1, EntryState.Cached), (3, EntryState.Cached), (5, EntryState.Cached), (6, EntryState.Cached), (7, EntryState.Cached), (8, EntryState.Cached));
+            expected = ImmutableArray.Create((1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached), (7, EntryState.Cached), (8, EntryState.Cached), (9, EntryState.Cached));
             AssertTableEntries(compactedTable, expected);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -40,25 +40,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             AssertTableEntries(table, expected);
         }
 
-        //[Fact]
-        //public void Node_Table_Entries_Can_Have_Different_States()
-        //{
-        //    var builder = new NodeStateTable<int>.Builder();
-        //    builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified)));
-        //    var table = builder.ToImmutableAndFree();
-
-        //    var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified));
-        //    AssertTableEntries(table, expected);
-        //}
-
         [Fact]
-        public void Node_Table_Entries_Can_Be_The_Same()
+        public void Node_Table_Entries_Can_Be_The_Same_Object()
         {
-            var builder = new NodeStateTable<int>.Builder();
-            builder.AddEntries(ImmutableArray.Create(1, 1, 1), EntryState.Added);
+            var o = new object();
+
+            var builder = new NodeStateTable<object>.Builder();
+            builder.AddEntries(ImmutableArray.Create(o, o, o), EntryState.Added);
             var table = builder.ToImmutableAndFree();
 
-            var expected = ImmutableArray.Create((1, EntryState.Added), (1, EntryState.Added), (1, EntryState.Added));
+            var expected = ImmutableArray.Create((o, EntryState.Added), (o, EntryState.Added), (o, EntryState.Added));
             AssertTableEntries(table, expected);
         }
 
@@ -101,6 +92,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             AssertTableEntries(compactedTable, expected);
         }
 
+        [Fact]
+        public void Driver_Table_Entries_Can_Be_Looked_Up()
+        {
+
+        }
 
         private void AssertTableEntries<T>(NodeStateTable<T> table, IList<(T item, EntryState state)> expected)
         {

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
@@ -26,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         }
 
         [Fact]
-        public void Node_Table_Entries_Are_Flattend_When_Enumerated()
+        public void Node_Table_Entries_Are_Flattened_When_Enumerated()
         {
             var builder = new NodeStateTable<int>.Builder();
             builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
@@ -67,7 +66,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             builder.AddEntries(ImmutableArray.Create(20, 21, 22), EntryState.Modified);
             builder.AddEntriesFromPreviousTable(previousTable, EntryState.Removed); //((6, EntryState.Removed))); 
             var newTable = builder.ToImmutableAndFree();
-
 
             var expected = ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Cached), (20, EntryState.Modified), (21, EntryState.Modified), (22, EntryState.Modified), (6, EntryState.Removed));
             AssertTableEntries(newTable, expected);
@@ -167,8 +165,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             DriverStateTable.Builder builder2 = new DriverStateTable.Builder(builder.ToImmutable());
             builder2.GetLatestStateTableForNode(callbackNode);
 
-            Debug.Assert(passedIn is object);
-            AssertTableEntries(passedIn, new[] { (1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached) });
+            Assert.NotNull(passedIn);
+            AssertTableEntries(passedIn!, new[] { (1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached) });
         }
 
         [Fact]
@@ -198,8 +196,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             builder2.GetLatestStateTableForNode(callbackNode);
 
             // table returned from the first instance was compacted by the builder
-            Debug.Assert(passedIn is object);
-            AssertTableEntries(passedIn, new[] { (1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached), (5, EntryState.Cached), (6, EntryState.Cached) });
+            Assert.NotNull(passedIn);
+            AssertTableEntries(passedIn!, new[] { (1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached), (5, EntryState.Cached), (6, EntryState.Cached) });
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added), (4, EntryState.Removed), (5, EntryState.Removed), (6, EntryState.Removed), (7, EntryState.Added), (8, EntryState.Added), (9, EntryState.Added));
             AssertTableEntries(table, expected);
 
-            var compactedTable = (NodeStateTable<int>)table.Compact();
+            var compactedTable = table.Compact();
             expected = ImmutableArray.Create((1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached), (7, EntryState.Cached), (8, EntryState.Cached), (9, EntryState.Cached));
             AssertTableEntries(compactedTable, expected);
         }
@@ -100,12 +100,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added), (4, EntryState.Removed), (5, EntryState.Removed), (6, EntryState.Removed), (7, EntryState.Added), (8, EntryState.Added), (9, EntryState.Added));
             AssertTableEntries(table, expected);
 
-            var compactedTable = (NodeStateTable<int>)table.Compact();
+            var compactedTable = table.Compact();
             expected = ImmutableArray.Create((1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached), (7, EntryState.Cached), (8, EntryState.Cached), (9, EntryState.Cached));
             AssertTableEntries(compactedTable, expected);
 
             // calling compact a second time just returns the same instance
-            var compactedTable2 = (NodeStateTable<int>)compactedTable.Compact();
+            var compactedTable2 = compactedTable.Compact();
             Assert.Same(compactedTable, compactedTable2);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
+{
+    public class StateTableTests
+    {
+        [Fact]
+        public void Node_Table_Entries_Can_Be_Enumerated()
+        {
+            var builder = new NodeStateTable<int>.Builder();
+            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create((2, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create((3, EntryState.Added)));
+            var table = builder.ToImmutableAndFree();
+
+            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added));
+            AssertTableEntries(table, expected);
+        }
+
+        [Fact]
+        public void Node_Table_Entries_Are_Flattend_When_Enumerated()
+        {
+            var builder = new NodeStateTable<int>.Builder();
+            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create((4, EntryState.Added), (5, EntryState.Added), (6, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create((7, EntryState.Added), (8, EntryState.Added), (9, EntryState.Added)));
+            var table = builder.ToImmutableAndFree();
+
+            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added), (4, EntryState.Added), (5, EntryState.Added), (6, EntryState.Added), (7, EntryState.Added), (8, EntryState.Added), (9, EntryState.Added));
+            AssertTableEntries(table, expected);
+        }
+
+        [Fact]
+        public void Node_Table_Entries_Can_Have_Different_States()
+        {
+            var builder = new NodeStateTable<int>.Builder();
+            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified)));
+            var table = builder.ToImmutableAndFree();
+
+            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Modified));
+            AssertTableEntries(table, expected);
+        }
+
+        [Fact]
+        public void Node_Table_Entries_Can_Be_The_Same()
+        {
+            var builder = new NodeStateTable<int>.Builder();
+            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (1, EntryState.Added), (1, EntryState.Modified)));
+            var table = builder.ToImmutableAndFree();
+
+            var expected = ImmutableArray.Create((1, EntryState.Added), (1, EntryState.Added), (1, EntryState.Modified));
+            AssertTableEntries(table, expected);
+        }
+
+        [Fact]
+        public void Node_Builder_Can_Add_Entries_From_Previous_Table()
+        {
+            var builder = new NodeStateTable<int>.Builder();
+            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create((2, EntryState.Cached), (3, EntryState.Removed)));
+            builder.AddEntries(ImmutableArray.Create((4, EntryState.Added), (5, EntryState.Modified)));
+            builder.AddEntries(ImmutableArray.Create((6, EntryState.Added)));
+            var previousTable = builder.ToImmutableAndFree();
+
+            builder = new NodeStateTable<int>.Builder();
+            builder.AddEntries(ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Cached)));
+            builder.AddEntriesFromPreviousTable(previousTable); // ((2, EntryState.Cached), (3, EntryState.Removed))
+            builder.AddEntries(ImmutableArray.Create((20, EntryState.Added), (21, EntryState.Modified), (22, EntryState.Removed)));
+            builder.AddEntriesFromPreviousTable(previousTable); //((6, EntryState.Added))); 
+            var newTable = builder.ToImmutableAndFree();
+
+
+            var expected = ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Removed), (20, EntryState.Added), (21, EntryState.Modified), (22, EntryState.Removed), (6, EntryState.Added));
+            AssertTableEntries(newTable, expected);
+        }
+
+        [Fact]
+        public void Node_Table_Entries_Are_Cached_Or_Removed_When_Compacted()
+        {
+            var builder = new NodeStateTable<int>.Builder();
+            builder.AddEntries(ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Removed), (3, EntryState.Cached)));
+            builder.AddEntries(ImmutableArray.Create((4, EntryState.Removed), (5, EntryState.Modified), (6, EntryState.Added)));
+            builder.AddEntries(ImmutableArray.Create((7, EntryState.Modified), (8, EntryState.Added), (9, EntryState.Removed)));
+            var table = builder.ToImmutableAndFree();
+
+            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Removed), (3, EntryState.Cached), (4, EntryState.Removed), (5, EntryState.Modified), (6, EntryState.Added), (7, EntryState.Modified), (8, EntryState.Added), (9, EntryState.Removed));
+            AssertTableEntries(table, expected);
+
+            var compactedTable = (NodeStateTable<int>)table.Compact();
+            expected = ImmutableArray.Create((1, EntryState.Cached), (3, EntryState.Cached), (5, EntryState.Cached), (6, EntryState.Cached), (7, EntryState.Cached), (8, EntryState.Cached));
+            AssertTableEntries(compactedTable, expected);
+        }
+
+
+        private void AssertTableEntries<T>(NodeStateTable<T> table, IList<(T item, EntryState state)> expected)
+        {
+            int index = 0;
+            foreach (var entry in table)
+            {
+                Assert.Equal(expected[index].item, entry.item);
+                Assert.Equal(expected[index].state, entry.state);
+                index++;
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -20,6 +20,8 @@ Microsoft.CodeAnalysis.IncrementalGeneratorOutput.IncrementalGeneratorOutput() -
 Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext
 Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.IncrementalGeneratorPipelineContext() -> void
 Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.RegisterOutput(Microsoft.CodeAnalysis.IncrementalGeneratorOutput output) -> void
+Microsoft.CodeAnalysis.IncrementalValueSource<T>
+Microsoft.CodeAnalysis.IncrementalValueSource<T>.IncrementalValueSource() -> void
 Microsoft.CodeAnalysis.ISyntaxContextReceiver
 Microsoft.CodeAnalysis.ISyntaxContextReceiver.OnVisitSyntaxNode(Microsoft.CodeAnalysis.GeneratorSyntaxContext context) -> void
 Microsoft.CodeAnalysis.GeneratorInitializationContext.RegisterForPostInitialization(System.Action<Microsoft.CodeAnalysis.GeneratorPostInitializationContext>! callback) -> void
@@ -32,6 +34,11 @@ Microsoft.CodeAnalysis.IMethodSymbol.MethodImplementationFlags.get -> System.Ref
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
+Microsoft.CodeAnalysis.SourceGeneration.IncrementalValueSource<T>
+Microsoft.CodeAnalysis.SourceGeneration.IncrementalValueSource<T>.IncrementalValueSource() -> void
+Microsoft.CodeAnalysis.SourceProductionContext
+Microsoft.CodeAnalysis.SourceProductionContext.AddSource(string! name, string! content) -> void
+Microsoft.CodeAnalysis.SourceProductionContext.SourceProductionContext() -> void
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.RecordClassName = 31 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 const Microsoft.CodeAnalysis.WellKnownDiagnosticTags.CompilationEnd = "CompilationEnd" -> string!
 Microsoft.CodeAnalysis.SyntaxContextReceiverCreator

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -34,8 +34,6 @@ Microsoft.CodeAnalysis.IMethodSymbol.MethodImplementationFlags.get -> System.Ref
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
-Microsoft.CodeAnalysis.SourceGeneration.IncrementalValueSource<T>
-Microsoft.CodeAnalysis.SourceGeneration.IncrementalValueSource<T>.IncrementalValueSource() -> void
 Microsoft.CodeAnalysis.SourceProductionContext
 Microsoft.CodeAnalysis.SourceProductionContext.AddSource(string! name, string! content) -> void
 Microsoft.CodeAnalysis.SourceProductionContext.SourceProductionContext() -> void

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
     /// Adapts an ISourceGenerator to an incremental generator that
     /// by providng an execution environment that matches the old one
     /// </summary>
-    internal class SourceGeneratorAdaptor : IIncrementalGenerator
+    internal sealed class SourceGeneratorAdaptor : IIncrementalGenerator
     {
         internal ISourceGenerator SourceGenerator { get; }
 
@@ -29,16 +29,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
             // executes the old generator in the new framework
 
             GeneratorInitializationContext oldContext = new GeneratorInitializationContext(context.CancellationToken);
-            try
-            {
-                SourceGenerator.Initialize(oldContext);
-            }
-            catch (Exception)
-            {
-                // PROTOTYPE(source-generators):
-                // wrap in a user func exception?
-                throw;
-            }
+            SourceGenerator.Initialize(oldContext);
 
             if (oldContext.InfoBuilder.PostInitCallback is object)
             {
@@ -47,7 +38,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
 
             context.RegisterExecutionPipeline((ctx) =>
             {
-
+                // PROTOTYPE: this is where we'll build the actual emulation pipeline
             });
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
@@ -23,9 +23,10 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            // PROTOTYPE: we'll call initialize on the underlying generator and pull out any info that is needed
-            //            then we'll set PostInit etc on our context and register a pipleine that
-            //            executes the old generator in the new framework
+            // PROTOTYPE(source-generators):
+            // we'll call initialize on the underlying generator and pull out any info that is needed
+            // then we'll set PostInit etc on our context and register a pipleine that
+            // executes the old generator in the new framework
 
             GeneratorInitializationContext oldContext = new GeneratorInitializationContext(context.CancellationToken);
             try
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
             }
             catch (Exception)
             {
-                // PROTOTYPE 
+                // PROTOTYPE(source-generators):
                 // wrap in a user func exception?
                 throw;
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.SourceGeneration
+{
+    /// <summary>
+    /// Adapts an ISourceGenerator to an incremental generator that
+    /// by providng an execution environment that matches the old one
+    /// </summary>
+    internal class SourceGeneratorAdaptor : IIncrementalGenerator
+    {
+        internal ISourceGenerator SourceGenerator { get; }
+
+        public SourceGeneratorAdaptor(ISourceGenerator generator)
+        {
+            SourceGenerator = generator;
+        }
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            // PROTOTYPE: we'll call initialize on the underlying generator and pull out any info that is needed
+            //            then we'll set PostInit etc on our context and register a pipleine that
+            //            executes the old generator in the new framework
+
+            GeneratorInitializationContext oldContext = new GeneratorInitializationContext(context.CancellationToken);
+            try
+            {
+                SourceGenerator.Initialize(oldContext);
+            }
+            catch (Exception)
+            {
+                // PROTOTYPE 
+                // wrap in a user func exception?
+                throw;
+            }
+
+            if (oldContext.InfoBuilder.PostInitCallback is object)
+            {
+                context.RegisterForPostInitialization(oldContext.InfoBuilder.PostInitCallback);
+            }
+
+            context.RegisterExecutionPipeline((ctx) =>
+            {
+
+            });
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
 {
     /// <summary>
     /// Adapts an ISourceGenerator to an incremental generator that
-    /// by providng an execution environment that matches the old one
+    /// by providing an execution environment that matches the old one
     /// </summary>
     internal sealed class SourceGeneratorAdaptor : IIncrementalGenerator
     {
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
 
             context.RegisterExecutionPipeline((ctx) =>
             {
-                // PROTOTYPE: this is where we'll build the actual emulation pipeline
+                // PROTOTYPE(source-generators): this is where we'll build the actual emulation pipeline
             });
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -51,4 +51,12 @@ namespace Microsoft.CodeAnalysis
             // PROTOTYPE(source-generators): public api stub
         }
     }
+
+    /// <summary>
+    /// Context passed to the callback provided as part of <see cref="IncrementalValueSourceExtensions.GenerateSource{T}(IncrementalValueSource{T}, Action{SourceProductionContext, T})"/>
+    /// </summary>
+    public readonly struct SourceProductionContext
+    {
+        public void AddSource(string name, string content) { }
+    }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
     }
 
     /// <summary>
-    /// Context passed to the callback provided as part of <see cref="ValueSourceExtensions.GenerateSource{T}(IncrementalValueSource{T}, Action{SourceProductionContext, T})"/>
+    /// Context passed to the callback provided as part of producing sources
     /// </summary>
     public readonly struct SourceProductionContext
     {

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
     }
 
     /// <summary>
-    /// Context passed to the callback provided as part of <see cref="IncrementalValueSourceExtensions.GenerateSource{T}(IncrementalValueSource{T}, Action{SourceProductionContext, T})"/>
+    /// Context passed to the callback provided as part of <see cref="ValueSourceExtensions.GenerateSource{T}(IncrementalValueSource{T}, Action{SourceProductionContext, T})"/>
     /// </summary>
     public readonly struct SourceProductionContext
     {

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
@@ -26,37 +26,4 @@ namespace Microsoft.CodeAnalysis
             this.node = node;
         }
     }
-
-    // PROTOTYPE(source-generators): these are just internal stubs for now, that let us build the API surface up
-    static class IncrementalValueSourceExtensions
-    {
-        // 1 => 1 transform 
-        internal static IncrementalValueSource<U> Transform<T, U>(this IncrementalValueSource<T> source, Func<T, U> func) => default;
-
-        // 1 => many (or none) transform
-        internal static IncrementalValueSource<U> TransformMany<T, U>(this IncrementalValueSource<T> source, Func<T, IEnumerable<U>> func) => default;
-
-        // collection => collection
-        internal static IncrementalValueSource<U> BatchTransform<T, U>(this IncrementalValueSource<T> source, Func<IEnumerable<T>, U> func) => default;
-
-        // single
-        internal static IncrementalValueSource<U> BatchTransformMany<T, U>(this IncrementalValueSource<T> source, Func<IEnumerable<T>, IEnumerable<U>> func) => default;
-
-        // join many => many ((source1[0], source2), (source1[1], source2) ...)
-        internal static IncrementalValueSource<(T, U)> Join<T, U>(this IncrementalValueSource<T> source1, IncrementalValueSource<U> source2) => default;
-
-        // helper for filtering
-        internal static IncrementalValueSource<T> Filter<T>(this IncrementalValueSource<T> source, Func<T, bool> filter)
-        {
-            return source.TransformMany((item) => (IEnumerable<T>)(filter(item) ? new[] { item } : Array.Empty<T>()));
-        }
-
-        // PROTOTYPE: naming. Does GenerateSource make it sound like you can't have multiple IncrementalGeneratorOutputs?
-
-        // 1 => 1 production
-        internal static IncrementalGeneratorOutput GenerateSource<T>(this IncrementalValueSource<T> source, Action<SourceProductionContext, T> action) => default;
-
-        // single => 1 production
-        internal static IncrementalGeneratorOutput GenerateSourceBatch<T>(this IncrementalValueSource<T> source, Action<SourceProductionContext, IEnumerable<T>> action) => default;
-    }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     /// <remarks>
     /// This is an opaque type that cannot be used directly. Instead an <see cref="IIncrementalGenerator" />
-    /// will receive a set of value sources when constructing it's execution pipeline. A set of extension methods
+    /// will receive a set of value sources when constructing its execution pipeline. A set of extension methods
     /// are then used to create transforms over the data that creates the actual pipeline.
     /// </remarks>
     /// <typeparam name="T">The type of value that this source provides access to</typeparam>

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Represents a value that can have transforms applied to it to construct an execution pipeline
+    /// </summary>
+    /// <remarks>
+    /// This is an opaque type that cannot be used directly. Instead an <see cref="IIncrementalGenerator" />
+    /// will receive a set of value sources when constructing it's execution pipeline. A set of extension methods
+    /// are then used to create transforms over the data that creates the actual pipeline.
+    /// </remarks>
+    /// <typeparam name="T">The type of value that this source provides access to</typeparam>
+    public struct IncrementalValueSource<T>
+    {
+        internal readonly IIncrementalGeneratorNode<T> node;
+
+        internal IncrementalValueSource(IIncrementalGeneratorNode<T> node)
+        {
+            this.node = node;
+        }
+    }
+
+    // PROTOTYPE(source-generators): these are just internal stubs for now, that let us build the API surface up
+    static class IncrementalValueSourceExtensions
+    {
+        // 1 => 1 transform 
+        internal static IncrementalValueSource<U> Transform<T, U>(this IncrementalValueSource<T> source, Func<T, U> func) => default;
+
+        // 1 => many (or none) transform
+        internal static IncrementalValueSource<U> TransformMany<T, U>(this IncrementalValueSource<T> source, Func<T, IEnumerable<U>> func) => default;
+
+        // collection => collection
+        internal static IncrementalValueSource<U> BatchTransform<T, U>(this IncrementalValueSource<T> source, Func<IEnumerable<T>, U> func) => default;
+
+        // single
+        internal static IncrementalValueSource<U> BatchTransformMany<T, U>(this IncrementalValueSource<T> source, Func<IEnumerable<T>, IEnumerable<U>> func) => default;
+
+        // join many => many ((source1[0], source2), (source1[1], source2) ...)
+        internal static IncrementalValueSource<(T, U)> Join<T, U>(this IncrementalValueSource<T> source1, IncrementalValueSource<U> source2) => default;
+
+        // helper for filtering
+        internal static IncrementalValueSource<T> Filter<T>(this IncrementalValueSource<T> source, Func<T, bool> filter)
+        {
+            return source.TransformMany((item) => (IEnumerable<T>)(filter(item) ? new[] { item } : Array.Empty<T>()));
+        }
+
+        // PROTOTYPE: naming. Does GenerateSource make it sound like you can't have multiple IncrementalGeneratorOutputs?
+
+        // 1 => 1 production
+        internal static IncrementalGeneratorOutput GenerateSource<T>(this IncrementalValueSource<T> source, Action<SourceProductionContext, T> action) => default;
+
+        // single => 1 production
+        internal static IncrementalGeneratorOutput GenerateSourceBatch<T>(this IncrementalValueSource<T> source, Action<SourceProductionContext, IEnumerable<T>> action) => default;
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalValueSource.cs
@@ -17,13 +17,13 @@ namespace Microsoft.CodeAnalysis
     /// are then used to create transforms over the data that creates the actual pipeline.
     /// </remarks>
     /// <typeparam name="T">The type of value that this source provides access to</typeparam>
-    public struct IncrementalValueSource<T>
+    public readonly struct IncrementalValueSource<T>
     {
-        internal readonly IIncrementalGeneratorNode<T> node;
+        internal readonly IIncrementalGeneratorNode<T> Node;
 
         internal IncrementalValueSource(IIncrementalGeneratorNode<T> node)
         {
-            this.node = node;
+            this.Node = node;
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -10,15 +10,18 @@ using System.Text;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal sealed class PipelineStateTable
+    // PROTOTYPE: the builder seems useful as a type, but the actual table is just a wrapper around a dict
+    //            do we actually need the type itself, or should we just store the dict directly as
+    //            part of the driver state?
+    internal sealed class DriverStateTable
     {
         // PROTOTYPE(source-generators): should we make a non generic node interface that we can use as the key
         //                               instead of just object?
         private readonly ImmutableDictionary<object, IStateTable> _tables;
 
-        internal static PipelineStateTable Empty { get; } = new PipelineStateTable(ImmutableDictionary<object, IStateTable>.Empty);
+        internal static DriverStateTable Empty { get; } = new DriverStateTable(ImmutableDictionary<object, IStateTable>.Empty);
 
-        private PipelineStateTable(ImmutableDictionary<object, IStateTable> tables)
+        private DriverStateTable(ImmutableDictionary<object, IStateTable> tables)
         {
             _tables = tables;
         }
@@ -27,16 +30,16 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly ImmutableDictionary<object, IStateTable>.Builder _tableBuilder = ImmutableDictionary<object, IStateTable>.Empty.ToBuilder();
 
-            private readonly PipelineStateTable _previousTable;
+            private readonly DriverStateTable _previousTable;
 
-            public Builder(PipelineStateTable previousTable)
+            public Builder(DriverStateTable previousTable)
             {
                 _previousTable = previousTable;
             }
 
             public NodeStateTable<T> GetLatestStateTableForNode<T>(IIncrementalGeneratorNode<T> source)
             {
-                // if we've already evaluated node during this build, we can just return the existing result
+                // if we've already evaluated a node during this build, we can just return the existing result
                 if (_tableBuilder.ContainsKey(source))
                 {
                     return (NodeStateTable<T>)_tableBuilder[source];
@@ -53,7 +56,7 @@ namespace Microsoft.CodeAnalysis
                 return newTable;
             }
 
-            public PipelineStateTable ToImmutable()
+            public DriverStateTable ToImmutable()
             {
                 // we can compact the tables at this point, as we'll no longer be using them to determine current state
                 var keys = _tableBuilder.Keys.ToArray();
@@ -62,7 +65,7 @@ namespace Microsoft.CodeAnalysis
                     _tableBuilder[keys[i]] = _tableBuilder[keys[i]].Compact();
                 }
 
-                return new PipelineStateTable(_tableBuilder.ToImmutable());
+                return new DriverStateTable(_tableBuilder.ToImmutable());
             }
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -10,9 +10,10 @@ using System.Text;
 
 namespace Microsoft.CodeAnalysis
 {
-    // PROTOTYPE: the builder seems useful as a type, but the actual table is just a wrapper around a dict
-    //            do we actually need the type itself, or should we just store the dict directly as
-    //            part of the driver state?
+    // PROTOTYPE(source-generators):
+    // the builder seems useful as a type, but the actual table is just a wrapper around a dict
+    // do we actually need the type itself, or should we just store the dict directly as
+    // part of the driver state?
     internal sealed class DriverStateTable
     {
         // PROTOTYPE(source-generators): should we make a non generic node interface that we can use as the key

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
@@ -6,9 +6,13 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis
 {
+    /// <summary>
+    /// Represents a step in the execution piepline of an incremental generator
+    /// </summary>
+    /// <typeparam name="T">The type of value this step operates on</typeparam>
     internal interface IIncrementalGeneratorNode<T>
     {
-        // StateTable<T> UpdateStateTable(GraphStateTable.Builder graphState, StateTable<T> previousTable);
+        NodeStateTable<T> UpdateStateTable(PipelineStateTable.Builder graphState, NodeStateTable<T> previousTable);
 
         IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer);
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
     /// <typeparam name="T">The type of value this step operates on</typeparam>
     internal interface IIncrementalGeneratorNode<T>
     {
-        NodeStateTable<T> UpdateStateTable(PipelineStateTable.Builder graphState, NodeStateTable<T> previousTable);
+        NodeStateTable<T> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<T> previousTable);
 
         IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer);
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis
     {
         NodeStateTable<T> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<T> previousTable);
 
+        // PROTOTYPE: will allow for custom comparison of values stored in statetables
         IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer);
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorNode.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal interface IIncrementalGeneratorNode<T>
+    {
+        // StateTable<T> UpdateStateTable(GraphStateTable.Builder graphState, StateTable<T> previousTable);
+
+        IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer);
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -11,6 +11,37 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {
+    // NOTE:
+    /* A node table is the fundamental structure we use to track changes through the incremental 
+    generator api. It can be thought of as a series of slots that take their input from an
+    upstate table and produce 0-or-more outputs. When viewed from a downstream table the outputs
+    are presented as a single unified list, with each output forming the new input to the downstream
+    table.
+
+    Each slot has an associated state which is used to inform the operation that should be performed
+    to create or update the outputs. States generally flow through from upstream to downstream tables.
+    For instance an Added state implies that the upstream table produced a value that was not seen 
+    in the previous iteration, and the table should run whatever transform it tracks on the input 
+    to produce the outputs. These new outputs will also have a state of Added. A cached input specifies
+    that the input has not changed, and thus the outputs will be the same as the previous run. Added,
+    and Modified inputs will always run a transform to produce new outputs. Cached and Removed
+    entries will always use the previous entries and perform no work.
+
+    It is important to track Removed entries while updating the downstream tables, as an upstream 
+    remove can result in multiple downstream entries being removed. However, once all tables are up 
+    to date, the removed entries are no longer needed, and the remaining entries can be considered to
+    be cached. This process is called 'compaction' and results in the actual tables which are stored
+    between runs, as opposed to the 'live' tables that exist during an update.
+
+    Modified entries are similar to added inputs, but with a subtle difference. When an input is Added
+    all outputs are unconditionally added too. However when an input is modified, the outputs may still
+    be the same (for instance something changed elsewhere in a file that had no bearing on the produced
+    output). In this case, the state table checks the results against the previously produced values,
+    and any that are found to be the same instead get a cached state, meaning no new downstream work 
+    will be produced for them. Thus a modified input is the only slot that can have differing output 
+    states.
+    */
+
     internal enum EntryState { Added, Removed, Modified, Cached };
 
     internal interface IStateTable

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
             return _states.SelectMany(s => s).GetEnumerator();
         }
 
-        public IStateTable Compact()
+        public NodeStateTable<T> Compact()
         {
             if (_isCompacted)
                 return this;
@@ -95,6 +95,8 @@ namespace Microsoft.CodeAnalysis
             }
             return new NodeStateTable<T>(compacted.ToImmutableAndFree(), isCompacted: true, _exception);
         }
+
+        IStateTable IStateTable.Compact() => Compact();
 
         // PROTOTYPE: this will be called to allow exceptions to flow through the graph
         public static NodeStateTable<T> FromFaultedTable<U>(NodeStateTable<U> table)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -88,6 +88,7 @@ namespace Microsoft.CodeAnalysis
             {
                 // we have to keep empty entries
                 // we only remove all entries at once, so only need to check the first item
+                // PROTOTYPE(source-generators): doc/assert invariants required for this to be true
                 if (entry.Length == 0 || entry[0].state != EntryState.Removed)
                 {
                     compacted.Add(entry.SelectAsArray(e => (e.item, EntryState.Cached)));
@@ -118,6 +119,9 @@ namespace Microsoft.CodeAnalysis
 
             public void AddEntriesFromPreviousTable(NodeStateTable<T> previousTable, EntryState newState)
             {
+                // PROTOTYPE(source-generators): this doens't hold true if the node is added after an initial run. That 
+                //                               will occur in the IDE, so we'll need to make sure we support empty tables
+                //                               that see cached/removed entries upstream.
                 Debug.Assert(previousTable._states.Length > _states.Count);
                 var previousEntries = previousTable._states[_states.Count].SelectAsArray(s => (s.item, newState));
                 _states.Add(previousEntries);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -40,9 +40,7 @@ namespace Microsoft.CodeAnalysis
 
         public IEnumerator<(T item, EntryState state)> GetEnumerator()
         {
-            foreach (var entry in _states)
-                foreach (var item in entry)
-                    yield return (item.item, item.state);
+            return _states.SelectMany(s => s).GetEnumerator();
         }
 
         public IStateTable Compact()
@@ -72,15 +70,15 @@ namespace Microsoft.CodeAnalysis
 
             private Exception? _exception = null;
 
-            public void AddEntries(ImmutableArray<(T, EntryState)> values)
+            public void AddEntries(ImmutableArray<T> values, EntryState state)
             {
-                _states.Add(values);
+                _states.Add(values.SelectAsArray(v => (v, state)));
             }
 
-            public void AddEntriesFromPreviousTable(NodeStateTable<T> previousTable)
+            public void AddEntriesFromPreviousTable(NodeStateTable<T> previousTable, EntryState newState)
             {
                 Debug.Assert(previousTable._states.Length > _states.Count);
-                var previousEntries = previousTable._states[_states.Count];
+                var previousEntries = previousTable._states[_states.Count].SelectAsArray(s => (s.item, newState));
                 _states.Add(previousEntries);
             }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -24,88 +24,64 @@ namespace Microsoft.CodeAnalysis
     /// <typeparam name="T"></typeparam>
     internal sealed class NodeStateTable<T> : IStateTable
     {
-        internal static NodeStateTable<T> Empty { get; } = new NodeStateTable<T>(ImmutableArray<ImmutableArray<(T, EntryState)>>.Empty, 0, exception: null);
+        internal static NodeStateTable<T> Empty { get; } = new NodeStateTable<T>(ImmutableArray<ImmutableArray<(T, EntryState)>>.Empty, exception: null);
 
-        readonly ImmutableArray<ImmutableArray<(T, EntryState)>> _states;
-
-        readonly int _removedCount;
+        readonly ImmutableArray<ImmutableArray<(T item, EntryState state)>> _states;
 
         readonly Exception? _exception;
 
-        private NodeStateTable(ImmutableArray<ImmutableArray<(T, EntryState)>> states, int removedCount, Exception? exception)
+        private NodeStateTable(ImmutableArray<ImmutableArray<(T, EntryState)>> states, Exception? exception)
         {
             _states = states;
-            _removedCount = removedCount;
             _exception = exception;
         }
 
         public bool IsFaulted { get => _exception is not null; }
 
-        //PROTOTYPE: should this just be an indexer?
-        public ImmutableArray<T> GetEntries(int inputIndex)
+        public IEnumerator<(T item, EntryState state)> GetEnumerator()
         {
-            Debug.Assert(inputIndex < _states.Length);
-            return _states[inputIndex].SelectAsArray(e => e.Item1);
-        }
-
-        public IEnumerator<(int index, T item, EntryState state)> GetEnumerator()
-        {
-            int index = 0;
             foreach (var entry in _states)
                 foreach (var item in entry)
-                    yield return (index++, item.Item1, item.Item2);
+                    yield return (item.item, item.state);
         }
 
         public IStateTable Compact()
         {
-            var compacted = ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance(_states.Length - _removedCount);
+            var compacted = ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance();
             foreach (var entry in _states)
             {
                 // we have to keep empty entries
                 // we only remove all entries at once, so only need to check the first item
-                if (entry.Length == 0 || entry[0].Item2 != EntryState.Removed)
+                if (entry.Length == 0 || entry[0].state != EntryState.Removed)
                 {
-                    compacted.Add(entry.SelectAsArray(e => (e.Item1, EntryState.Cached)));
+                    compacted.Add(entry.SelectAsArray(e => (e.item, EntryState.Cached)));
                 }
             }
-            return new NodeStateTable<T>(compacted.ToImmutableAndFree(), 0, _exception);
+            return new NodeStateTable<T>(compacted.ToImmutableAndFree(), _exception);
         }
 
         public static NodeStateTable<T> FromFaultedTable<U>(NodeStateTable<U> table)
         {
             Debug.Assert(table.IsFaulted);
-            return new NodeStateTable<T>(Empty._states, 0, table._exception);
+            return new NodeStateTable<T>(Empty._states, table._exception);
         }
 
         public class Builder
         {
             private readonly ArrayBuilder<ImmutableArray<(T, EntryState)>> _states = ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance();
 
-            private int _removedCount = 0;
-
             private Exception? _exception = null;
-
-            public void AddEntries(ImmutableArray<T> values, EntryState state)
-            {
-                _states.Add(values.Select(v => (v, state)).ToImmutableArray());
-            }
 
             public void AddEntries(ImmutableArray<(T, EntryState)> values)
             {
                 _states.Add(values);
             }
 
-            public void RemoveEntries(int inputIndex)
+            public void AddEntriesFromPreviousTable(NodeStateTable<T> previousTable)
             {
-                Debug.Assert(inputIndex < _states.Count);
-                _removedCount++;
-                _states[inputIndex] = _states[inputIndex].Select((t) => (t.Item1, EntryState.Removed)).ToImmutableArray();
-            }
-
-            public void SetEntries(int inputIndex, IEnumerable<(T, EntryState)> values)
-            {
-                Debug.Assert(inputIndex < _states.Count);
-                _states[inputIndex] = values.ToImmutableArray();
+                Debug.Assert(previousTable._states.Length > _states.Count);
+                var previousEntries = previousTable._states[_states.Count];
+                _states.Add(previousEntries);
             }
 
             public void SetFaulted(Exception e)
@@ -113,7 +89,7 @@ namespace Microsoft.CodeAnalysis
                 _exception = e;
             }
 
-            public NodeStateTable<T> ToImmutableAndFree() => new NodeStateTable<T>(_states.ToImmutableAndFree(), _removedCount, exception: _exception);
+            public NodeStateTable<T> ToImmutableAndFree() => new NodeStateTable<T>(_states.ToImmutableAndFree(), exception: _exception);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -11,36 +11,34 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {
-    // NOTE:
-    /* A node table is the fundamental structure we use to track changes through the incremental 
-    generator api. It can be thought of as a series of slots that take their input from an
-    upstate table and produce 0-or-more outputs. When viewed from a downstream table the outputs
-    are presented as a single unified list, with each output forming the new input to the downstream
-    table.
-
-    Each slot has an associated state which is used to inform the operation that should be performed
-    to create or update the outputs. States generally flow through from upstream to downstream tables.
-    For instance an Added state implies that the upstream table produced a value that was not seen 
-    in the previous iteration, and the table should run whatever transform it tracks on the input 
-    to produce the outputs. These new outputs will also have a state of Added. A cached input specifies
-    that the input has not changed, and thus the outputs will be the same as the previous run. Added,
-    and Modified inputs will always run a transform to produce new outputs. Cached and Removed
-    entries will always use the previous entries and perform no work.
-
-    It is important to track Removed entries while updating the downstream tables, as an upstream 
-    remove can result in multiple downstream entries being removed. However, once all tables are up 
-    to date, the removed entries are no longer needed, and the remaining entries can be considered to
-    be cached. This process is called 'compaction' and results in the actual tables which are stored
-    between runs, as opposed to the 'live' tables that exist during an update.
-
-    Modified entries are similar to added inputs, but with a subtle difference. When an input is Added
-    all outputs are unconditionally added too. However when an input is modified, the outputs may still
-    be the same (for instance something changed elsewhere in a file that had no bearing on the produced
-    output). In this case, the state table checks the results against the previously produced values,
-    and any that are found to be the same instead get a cached state, meaning no new downstream work 
-    will be produced for them. Thus a modified input is the only slot that can have differing output 
-    states.
-    */
+    // A node table is the fundamental structure we use to track changes through the incremental 
+    // generator api. It can be thought of as a series of slots that take their input from an
+    // upstream table and produce 0-or-more outputs. When viewed from a downstream table the outputs
+    // are presented as a single unified list, with each output forming the new input to the downstream
+    // table.
+    // 
+    // Each slot has an associated state which is used to inform the operation that should be performed
+    // to create or update the outputs. States generally flow through from upstream to downstream tables.
+    // For instance an Added state implies that the upstream table produced a value that was not seen 
+    // in the previous iteration, and the table should run whatever transform it tracks on the input 
+    // to produce the outputs. These new outputs will also have a state of Added. A cached input specifies
+    // that the input has not changed, and thus the outputs will be the same as the previous run. Added,
+    // and Modified inputs will always run a transform to produce new outputs. Cached and Removed
+    // entries will always use the previous entries and perform no work.
+    // 
+    // It is important to track Removed entries while updating the downstream tables, as an upstream 
+    // remove can result in multiple downstream entries being removed. However, once all tables are up 
+    // to date, the removed entries are no longer needed, and the remaining entries can be considered to
+    // be cached. This process is called 'compaction' and results in the actual tables which are stored
+    // between runs, as opposed to the 'live' tables that exist during an update.
+    // 
+    // Modified entries are similar to added inputs, but with a subtle difference. When an input is Added
+    // all outputs are unconditionally added too. However when an input is modified, the outputs may still
+    // be the same (for instance something changed elsewhere in a file that had no bearing on the produced
+    // output). In this case, the state table checks the results against the previously produced values,
+    // and any that are found to be the same instead get a cached state, meaning no new downstream work 
+    // will be produced for them. Thus a modified input is the only slot that can have differing output 
+    // states.
 
     internal enum EntryState { Added, Removed, Modified, Cached };
 
@@ -52,7 +50,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// A data structure that tracks the inputs and output of an execution node
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of the items tracked by this table</typeparam>
     internal sealed class NodeStateTable<T> : IStateTable
     {
         internal static NodeStateTable<T> Empty { get; } = new NodeStateTable<T>(ImmutableArray<ImmutableArray<(T, EntryState)>>.Empty, isCompacted: true, exception: null);
@@ -60,11 +58,11 @@ namespace Microsoft.CodeAnalysis
         //PROTOTYPE: there is no need to store the state per item
         //           we can instead store one state per input, with
         //           an optional set for modified states.
-        readonly ImmutableArray<ImmutableArray<(T item, EntryState state)>> _states;
+        private readonly ImmutableArray<ImmutableArray<(T item, EntryState state)>> _states;
 
         private readonly bool _isCompacted;
 
-        readonly Exception? _exception;
+        private readonly Exception? _exception;
 
         private NodeStateTable(ImmutableArray<ImmutableArray<(T, EntryState)>> states, bool isCompacted, Exception? exception)
         {
@@ -98,13 +96,14 @@ namespace Microsoft.CodeAnalysis
             return new NodeStateTable<T>(compacted.ToImmutableAndFree(), isCompacted: true, _exception);
         }
 
+        // PROTOTYPE: this will be called to allow exceptions to flow through the graph
         public static NodeStateTable<T> FromFaultedTable<U>(NodeStateTable<U> table)
         {
             Debug.Assert(table.IsFaulted);
             return new NodeStateTable<T>(Empty._states, isCompacted: true, table._exception);
         }
 
-        public class Builder
+        public sealed class Builder
         {
             private readonly ArrayBuilder<ImmutableArray<(T, EntryState)>> _states = ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance();
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal enum EntryState { Added, Removed, Modified, Cached };
+
+    internal interface IStateTable
+    {
+        IStateTable Compact();
+    }
+
+    /// <summary>
+    /// A data structure that tracks the inputs and output of an execution node
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class NodeStateTable<T> : IStateTable
+    {
+        internal static NodeStateTable<T> Empty { get; } = new NodeStateTable<T>(ImmutableArray<ImmutableArray<(T, EntryState)>>.Empty, 0, exception: null);
+
+        readonly ImmutableArray<ImmutableArray<(T, EntryState)>> _states;
+
+        readonly int _removedCount;
+
+        readonly Exception? _exception;
+
+        private NodeStateTable(ImmutableArray<ImmutableArray<(T, EntryState)>> states, int removedCount, Exception? exception)
+        {
+            _states = states;
+            _removedCount = removedCount;
+            _exception = exception;
+        }
+
+        public bool IsFaulted { get => _exception is not null; }
+
+        //PROTOTYPE: should this just be an indexer?
+        public ImmutableArray<T> GetEntries(int inputIndex)
+        {
+            Debug.Assert(inputIndex < _states.Length);
+            return _states[inputIndex].SelectAsArray(e => e.Item1);
+        }
+
+        public IEnumerator<(int index, T item, EntryState state)> GetEnumerator()
+        {
+            int index = 0;
+            foreach (var entry in _states)
+                foreach (var item in entry)
+                    yield return (index++, item.Item1, item.Item2);
+        }
+
+        public IStateTable Compact()
+        {
+            var compacted = ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance(_states.Length - _removedCount);
+            foreach (var entry in _states)
+            {
+                // we have to keep empty entries
+                // we only remove all entries at once, so only need to check the first item
+                if (entry.Length == 0 || entry[0].Item2 != EntryState.Removed)
+                {
+                    compacted.Add(entry.SelectAsArray(e => (e.Item1, EntryState.Cached)));
+                }
+            }
+            return new NodeStateTable<T>(compacted.ToImmutableAndFree(), 0, _exception);
+        }
+
+        public static NodeStateTable<T> FromFaultedTable<U>(NodeStateTable<U> table)
+        {
+            Debug.Assert(table.IsFaulted);
+            return new NodeStateTable<T>(Empty._states, 0, table._exception);
+        }
+
+        public class Builder
+        {
+            private readonly ArrayBuilder<ImmutableArray<(T, EntryState)>> _states = ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance();
+
+            private int _removedCount = 0;
+
+            private Exception? _exception = null;
+
+            public void AddEntries(ImmutableArray<T> values, EntryState state)
+            {
+                _states.Add(values.Select(v => (v, state)).ToImmutableArray());
+            }
+
+            public void AddEntries(ImmutableArray<(T, EntryState)> values)
+            {
+                _states.Add(values);
+            }
+
+            public void RemoveEntries(int inputIndex)
+            {
+                Debug.Assert(inputIndex < _states.Count);
+                _removedCount++;
+                _states[inputIndex] = _states[inputIndex].Select((t) => (t.Item1, EntryState.Removed)).ToImmutableArray();
+            }
+
+            public void SetEntries(int inputIndex, IEnumerable<(T, EntryState)> values)
+            {
+                Debug.Assert(inputIndex < _states.Count);
+                _states[inputIndex] = values.ToImmutableArray();
+            }
+
+            public void SetFaulted(Exception e)
+            {
+                _exception = e;
+            }
+
+            public NodeStateTable<T> ToImmutableAndFree() => new NodeStateTable<T>(_states.ToImmutableAndFree(), _removedCount, exception: _exception);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -57,6 +57,9 @@ namespace Microsoft.CodeAnalysis
     {
         internal static NodeStateTable<T> Empty { get; } = new NodeStateTable<T>(ImmutableArray<ImmutableArray<(T, EntryState)>>.Empty, exception: null);
 
+        //PROTOTYPE: there is no need to store the state per item
+        //           we can instead store one state per input, with
+        //           an optional set for modified states.
         readonly ImmutableArray<ImmutableArray<(T item, EntryState state)>> _states;
 
         readonly Exception? _exception;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/PipelineStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/PipelineStateTable.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed class PipelineStateTable
+    {
+        // PROTOTYPE(source-generators): should we make a non generic node interface that we can use as the key
+        //                               instead of just object?
+        private readonly ImmutableDictionary<object, IStateTable> _tables;
+
+        internal static PipelineStateTable Empty { get; } = new PipelineStateTable(ImmutableDictionary<object, IStateTable>.Empty);
+
+        private PipelineStateTable(ImmutableDictionary<object, IStateTable> tables)
+        {
+            _tables = tables;
+        }
+
+        public class Builder
+        {
+            private readonly ImmutableDictionary<object, IStateTable>.Builder _tableBuilder = ImmutableDictionary<object, IStateTable>.Empty.ToBuilder();
+
+            private readonly PipelineStateTable _previousTable;
+
+            public Builder(PipelineStateTable previousTable)
+            {
+                _previousTable = previousTable;
+            }
+
+            public NodeStateTable<T> GetLatestStateTableForNode<T>(IIncrementalGeneratorNode<T> source)
+            {
+                // if we've already evaluated node during this build, we can just return the existing result
+                if (_tableBuilder.ContainsKey(source))
+                {
+                    return (NodeStateTable<T>)_tableBuilder[source];
+                }
+
+                // get the previous table, if there was one for this node
+                NodeStateTable<T> previousTable = _previousTable._tables.ContainsKey(source)
+                                                  ? (NodeStateTable<T>)_previousTable._tables[source]
+                                                  : NodeStateTable<T>.Empty;
+
+                // request the node update its state based and store the new result
+                var newTable = source.UpdateStateTable(this, previousTable);
+                _tableBuilder[source] = newTable;
+                return newTable;
+            }
+
+            public PipelineStateTable ToImmutable()
+            {
+                // we can compact the tables at this point, as we'll no longer be using them to determine current state
+                var keys = _tableBuilder.Keys.ToArray();
+                for (int i = 0; i < _tableBuilder.Count; i++)
+                {
+                    _tableBuilder[keys[i]] = _tableBuilder[keys[i]].Compact();
+                }
+
+                return new PipelineStateTable(_tableBuilder.ToImmutable());
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
@@ -6,10 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.CodeAnalysis.SourceGeneration.Nodes
+namespace Microsoft.CodeAnalysis
 {
     // PROTOTYPE(source-generators): these are just internal stubs for now, that let us build the API surface up
-    static class IncrementalValueSourceExtensions
+    internal static class IncrementalValueSourceExtensions
     {
         // 1 => 1 transform 
         internal static IncrementalValueSource<U> Transform<T, U>(this IncrementalValueSource<T> source, Func<T, U> func) => default;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration.Nodes
             return source.TransformMany((item) => (IEnumerable<T>)(filter(item) ? new[] { item } : Array.Empty<T>()));
         }
 
-        // PROTOTYPE: naming. Does GenerateSource make it sound like you can't have multiple IncrementalGeneratorOutputs?
+        // PROTOTYPE(source-generators): naming. Does GenerateSource make it sound like you can't have multiple IncrementalGeneratorOutputs?
 
         // 1 => 1 production
         internal static IncrementalGeneratorOutput GenerateSource<T>(this IncrementalValueSource<T> source, Action<SourceProductionContext, T> action) => default;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ValueSourceExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.SourceGeneration.Nodes
+{
+    // PROTOTYPE(source-generators): these are just internal stubs for now, that let us build the API surface up
+    static class IncrementalValueSourceExtensions
+    {
+        // 1 => 1 transform 
+        internal static IncrementalValueSource<U> Transform<T, U>(this IncrementalValueSource<T> source, Func<T, U> func) => default;
+
+        // 1 => many (or none) transform
+        internal static IncrementalValueSource<U> TransformMany<T, U>(this IncrementalValueSource<T> source, Func<T, IEnumerable<U>> func) => default;
+
+        // collection => collection
+        internal static IncrementalValueSource<U> BatchTransform<T, U>(this IncrementalValueSource<T> source, Func<IEnumerable<T>, U> func) => default;
+
+        // single
+        internal static IncrementalValueSource<U> BatchTransformMany<T, U>(this IncrementalValueSource<T> source, Func<IEnumerable<T>, IEnumerable<U>> func) => default;
+
+        // join many => many ((source1[0], source2), (source1[1], source2) ...)
+        internal static IncrementalValueSource<(T, U)> Join<T, U>(this IncrementalValueSource<T> source1, IncrementalValueSource<U> source2) => default;
+
+        // helper for filtering
+        internal static IncrementalValueSource<T> Filter<T>(this IncrementalValueSource<T> source, Func<T, bool> filter)
+        {
+            return source.TransformMany((item) => (IEnumerable<T>)(filter(item) ? new[] { item } : Array.Empty<T>()));
+        }
+
+        // PROTOTYPE: naming. Does GenerateSource make it sound like you can't have multiple IncrementalGeneratorOutputs?
+
+        // 1 => 1 production
+        internal static IncrementalGeneratorOutput GenerateSource<T>(this IncrementalValueSource<T> source, Action<SourceProductionContext, T> action) => default;
+
+        // single => 1 production
+        internal static IncrementalGeneratorOutput GenerateSourceBatch<T>(this IncrementalValueSource<T> source, Action<SourceProductionContext, IEnumerable<T>> action) => default;
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
@@ -8,17 +8,7 @@ using System.Text;
 
 namespace Microsoft.CodeAnalysis
 {
-    /// <summary>
-    /// A Func based delegate that represents a user provided function
-    /// that has been wrapped to convert exceptions to UserCodeExceptions
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <typeparam name="TResult"></typeparam>
-    /// <param name="arg"></param>
-    /// <returns></returns>
-    internal delegate TResult UserFunc<in T, out TResult>(T arg);
-
-    internal class UserFunctionException : Exception
+    internal sealed class UserFunctionException : Exception
     {
         public UserFunctionException(Exception innerException)
             : base("User provided code threw an exception", innerException)
@@ -28,7 +18,7 @@ namespace Microsoft.CodeAnalysis
 
     internal static class UserFunctionExtensions
     {
-        internal static UserFunc<TInput, TOutput> WrapUserFunction<TInput, TOutput>(this Func<TInput, TOutput> userFunction)
+        internal static Func<TInput, TOutput> WrapUserFunction<TInput, TOutput>(this Func<TInput, TOutput> userFunction)
         {
             return (input) =>
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A Func based delegate that represents a user provided function
+    /// that has been wrapped to convert exceptions to UserCodeExceptions
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="arg"></param>
+    /// <returns></returns>
+    internal delegate TResult UserFunc<in T, out TResult>(T arg);
+
+    internal class UserFunctionException : Exception
+    {
+        public UserFunctionException(Exception innerException)
+            : base("User provided code threw an exception", innerException)
+        {
+        }
+    }
+
+    internal static class UserFunctionExtensions
+    {
+        internal static UserFunc<TInput, TOutput> WrapUserFunction<TInput, TOutput>(this Func<TInput, TOutput> userFunction)
+        {
+            return (input) =>
+            {
+                try
+                {
+                    return userFunction(input);
+                }
+                catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
+                {
+                    throw new UserFunctionException(e);
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
Adds the state table data structures and tests, as well as stubbing out the valuesource[extensions] that will manipulate the tables via nodes.