### PR TITLE
Multi-target Microsoft.CodeAnalysis.Workspaces.Desktop

### DIFF
--- a/src/Workspaces/Core/Desktop/Microsoft.CodeAnalysis.Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Microsoft.CodeAnalysis.Workspaces.Desktop.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis</RootNamespace>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.ComponentModel.Composition" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />


### PR DESCRIPTION
Workspaces.Desktop is an increasingly-misnamed part of Roslyn; it's where we put types that we wanted to ship as a public API or public implementation that didn't run on the original "portable" forms of .NET. Since the introduction of netstandard most of that code ended up moving back to the main Workspaces binary, leaving only a few types that use the original form of MEF, and one that depended on the desktop reading of app.config. At this point, that code can now also run on netcoreapp3.1 too, so let's support that.

This unblocks some folks who need to create a MEF composition on .NET Core using VS MEF but don't otherwise have an implementation of IMefHostExportProvider that is usable for them.