### PR TITLE
Add telemetry for when the infobar is shown

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Extensions;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
@@ -22,7 +23,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         public string HostDisplayName => "Visual Studio";
 
         public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
-            => _infoBarService.ShowInfoBar(message, items);
+        {
+            _infoBarService.ShowInfoBar(message, items);
+
+            // Have to use KeyValueLogMessage so it gets reported in telemetry
+            Logger.Log(FunctionId.VS_ErrorReportingService_ShowGlobalErrorInfo, KeyValueLogMessage.Create(m =>
+            {
+                m["errorMessage"] = message;
+            }));
+        }
 
         public void ShowDetailedErrorInfo(Exception exception)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -514,5 +514,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Intellicode_UnknownIntent = 485,
 
         LSP_CompletionListCacheMiss = 486,
+
+        VS_ErrorReportingService_ShowGlobalErrorInfo = 487,
     }
 }


### PR DESCRIPTION
Add telemetry for when the infobar is shown from using IErrorReportingService in VS

Fixes #52500 