### PR TITLE
Do not cancel classification change notifications

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -35,12 +35,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         /// </summary>
         internal partial class TagComputer
         {
-            // This is how long we will wait after completing a parse before we tell the editor to
-            // re-classify the file. We do this, since the edit may have non-local changes, or the user
-            // may have made a change that introduced text that we didn't classify because we hadn't
-            // parsed it yet, and we want to get back to a known state.
-            private const int ReportChangeDelayInMilliseconds = TaggerConstants.ShortDelay;
-
             private readonly ITextBuffer _subjectBuffer;
             private readonly WorkspaceRegistration _workspaceRegistration;
             private readonly AsynchronousSerialWorkQueue _workQueue;
@@ -237,8 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                         _workQueue.AssertIsForeground();
                         ReportChangedSpan(changedSpan);
                     },
-                    ReportChangeDelayInMilliseconds,
-                    _listener.BeginAsyncOperation("ReportEntireFileChanged"),
+                    _listener.BeginAsyncOperation("EnqueueProcessSnapshotWorkerAsync.ReportChangedSpan"),
                     _reportChangeCancellationSource.Token);
             }
 

--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             private object _lastProcessedCachedData;
 
             private Workspace _workspace;
-            private CancellationTokenSource _reportChangeCancellationSource;
+            private readonly CancellationTokenSource _reportChangeCancellationSource = new();
 
             private readonly IAsynchronousOperationListener _listener;
             private readonly IForegroundNotificationService _notificationService;
@@ -196,9 +196,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
             private async Task EnqueueProcessSnapshotWorkerAsync(Document currentDocument, CancellationToken cancellationToken)
             {
-                // we will enqueue new one soon, cancel pending refresh right away
-                _reportChangeCancellationSource.Cancel();
-
                 var currentText = await currentDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 var currentSnapshot = currentText.FindCorrespondingEditorTextSnapshot();
                 if (currentSnapshot == null)
@@ -235,7 +232,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                     _lastProcessedCachedData = currentCachedData;
                 }
 
-                _reportChangeCancellationSource = new CancellationTokenSource();
                 _notificationService.RegisterNotification(() =>
                     {
                         _workQueue.AssertIsForeground();

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -156,9 +156,10 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <returns>
         /// The returned syntax tree can be <see langword="null"/> if the <see cref="SupportsSyntaxTree"/> returns <see
-        /// langword="false"/>. This function will return the same value if called multiple times. Specifically, the
-        /// same Task instance will be returned, which will always return the same underlying <see cref="SyntaxTree"/>
-        /// instance.
+        /// langword="false"/>. This function may cause computation to occurr the first time it is called, but will return
+        /// a cached result every subsequent time.  <see cref="SyntaxTree"/>'s can hold onto their roots lazily. So calls 
+        /// to see <see cref="SyntaxTree.GetRoot"/> or <see cref="SyntaxTree.GetRootAsync"/> may end up causing computation
+        /// to occur at that point.
         /// </returns>
         public Task<SyntaxTree?> GetSyntaxTreeAsync(CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Now that we're reporting minimal changes, it's important that all change notifications go through.  So this part of classification is no longer cancellable on normal edits.

@jasonmalinowski  and i also have a plan on how to greatly simplify all this code as we think this is all far too complex for no gain.