### PR TITLE
Fix syntactic range computation.

### DIFF
--- a/src/EditorFeatures/Test2/Classification/SyntacticChangeRangeComputerTests.vb
+++ b/src/EditorFeatures/Test2/Classification/SyntacticChangeRangeComputerTests.vb
@@ -331,5 +331,55 @@ public class C
 ", "
         throw new NotImplementedException();")
         End Function
+
+        <Fact>
+        Public Async Function TestDeleteDuplicateLineBelow() As Task
+            Await TestCSharp(
+"
+using X;
+
+public class C
+{
+    void M1()
+    {
+    }
+
+    void M2()
+    {
+        throw new NotImplementedException();
+{|changed:        [|throw new NotImplementedException();|]
+    }
+|}
+    void M3()
+    {
+    }
+}
+", "")
+        End Function
+
+        <Fact>
+        Public Async Function TestDeleteDuplicateLineAbove() As Task
+            Await TestCSharp(
+"
+using X;
+
+public class C
+{
+    void M1()
+    {
+    }
+
+    void M2()
+    {
+{|changed:        [|throw new NotImplementedException();|]
+        throw |}new NotImplementedException();
+    }
+
+    void M3()
+    {
+    }
+}
+", "")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Classification/SyntacticChangeRangeComputerTests.vb
+++ b/src/EditorFeatures/Test2/Classification/SyntacticChangeRangeComputerTests.vb
@@ -281,5 +281,55 @@ public class C
 }
 ")
         End Function
+
+        <Fact>
+        Public Async Function TestInsertDuplicateLineBelow() As Task
+            Await TestCSharp(
+"
+using X;
+
+public class C
+{
+    void M1()
+    {
+    }
+
+    void M2()
+    {
+        throw new NotImplementedException();[||]
+{|changed:|}    }
+
+    void M3()
+    {
+    }
+}
+", "
+        throw new NotImplementedException();")
+        End Function
+
+        <Fact>
+        Public Async Function TestInsertDuplicateLineAbove() As Task
+            Await TestCSharp(
+"
+using X;
+
+public class C
+{
+    void M1()
+    {
+    }
+
+    void M2()
+    {[||]
+        throw new NotImplementedException();
+{|changed:|}    }
+
+    void M3()
+    {
+    }
+}
+", "
+        throw new NotImplementedException();")
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/SyntacticChangeRangeComputer.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/SyntacticChangeRangeComputer.cs
@@ -125,13 +125,13 @@ namespace Microsoft.CodeAnalysis.Classification
                 return default;
             }
 
-            var oldRootWidth = oldRoot.FullWidth();
-            var newRootWidth = newRoot.FullWidth();
-
             // Only compute the right side if we have time for it.  Otherwise, assume there is nothing in common there.
             var commonRightWidth = 0;
             if (stopwatch.Elapsed < timeout)
                 commonRightWidth = ComputeCommonRightWidth(rightOldStack.Object, rightNewStack.Object);
+
+            var oldRootWidth = oldRoot.FullWidth();
+            var newRootWidth = newRoot.FullWidth();
 
             Contract.ThrowIfTrue(commonLeftWidth > oldRootWidth);
             Contract.ThrowIfTrue(commonLeftWidth > newRootWidth);


### PR DESCRIPTION
Regression introduced with the recent cahnge to report a minimal text change to the editor for classification.  In some cases, teh text change was too minimal, leading to us not classifying.