### PR TITLE
remarks -> devremarks

### DIFF
--- a/src/Compilers/Core/Portable/DocumentationMode.cs
+++ b/src/Compilers/Core/Portable/DocumentationMode.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Specifies the different documentation comment processing modes.
     /// </summary>
-    /// <remarks>
+    /// <devremarks>
     /// Order matters: least processing to most processing.
-    /// </remarks>
+    /// </devremarks>
     public enum DocumentationMode : byte
     {
         /// <summary>


### PR DESCRIPTION
I don't believe this was intended to be for public documentation. API consumers won't care about this.