### PR TITLE
Draft: Add test for VB-only option

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic.CodeStyle;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -88,6 +89,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 string.Empty,
                 "[*.cs]\r\ncsharp_style_throw_expression=true:suggestion",
                 (CSharpCodeStyleOptions.PreferThrowExpression, option));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]
+        public async Task TestAddNewBoolVisualBasicCodeStyleOptionWithSeverityAsync()
+        {
+            var option = VisualBasicCodeStyleOptions.PreferSimplifiedObjectCreation.DefaultValue;
+            option.Value = true;
+            option.Notification = CodeStyle.NotificationOption2.Suggestion;
+            await TestAsync(
+                string.Empty,
+                string.Empty,
+                (VisualBasicCodeStyleOptions.PreferSimplifiedObjectCreation, option));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EditorConfigUI)]

--- a/src/Workspaces/VisualBasic/Portable/Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj
+++ b/src/Workspaces/VisualBasic/Portable/Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj
@@ -31,6 +31,7 @@
     <InternalsVisibleTo Include="MonoDevelop.VBNetBinding.Tests" Key="$(MonoDevelopKey)" LoadsWithinVisualStudio="false" />
     <!-- END MONODEVELOP -->
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Test.Utilities2" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures2.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests" />


### PR DESCRIPTION
The following line looks suspicious to me:

https://github.com/dotnet/roslyn/blob/315c2e149ba7889b0937d872274c33fcbfe9af5f/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdateHelper.cs#L89

Will see if the test fails or not.