### PR TITLE
Remove tagger functionality related to pausing/resumign tagging.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs
@@ -67,18 +67,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             _workQueue.CancelCurrentWork();
         }
 
-        public event EventHandler UIUpdatesPaused
-        {
-            add { _underlyingSource.UIUpdatesPaused += value; }
-            remove { _underlyingSource.UIUpdatesPaused -= value; }
-        }
-
-        public event EventHandler UIUpdatesResumed
-        {
-            add { _underlyingSource.UIUpdatesResumed += value; }
-            remove { _underlyingSource.UIUpdatesResumed -= value; }
-        }
-
         private void OnEventSourceChanged(object? sender, TaggerEventArgs args)
         {
             // First, notify anyone listening to us that something definitely changed.

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs
@@ -18,16 +18,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public abstract void Disconnect();
 
         public event EventHandler<TaggerEventArgs>? Changed;
-        public event EventHandler? UIUpdatesPaused;
-        public event EventHandler? UIUpdatesResumed;
 
         protected virtual void RaiseChanged()
             => this.Changed?.Invoke(this, new TaggerEventArgs(_delay));
-
-        protected virtual void RaiseUIUpdatesPaused()
-            => this.UIUpdatesPaused?.Invoke(this, EventArgs.Empty);
-
-        protected virtual void RaiseUIUpdatesResumed()
-            => this.UIUpdatesResumed?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.CompositionEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.CompositionEventSource.cs
@@ -29,41 +29,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
             public event EventHandler<TaggerEventArgs> Changed
             {
-                add
-                {
-                    _providers.Do(p => p.Changed += value);
-                }
-
-                remove
-                {
-                    _providers.Do(p => p.Changed -= value);
-                }
-            }
-
-            public event EventHandler UIUpdatesPaused
-            {
-                add
-                {
-                    _providers.Do(p => p.UIUpdatesPaused += value);
-                }
-
-                remove
-                {
-                    _providers.Do(p => p.UIUpdatesPaused -= value);
-                }
-            }
-
-            public event EventHandler UIUpdatesResumed
-            {
-                add
-                {
-                    _providers.Do(p => p.UIUpdatesResumed += value);
-                }
-
-                remove
-                {
-                    _providers.Do(p => p.UIUpdatesResumed -= value);
-                }
+                add => _providers.Do(p => p.Changed += value);
+                remove => _providers.Do(p => p.Changed -= value);
             }
         }
     }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ViewSpanChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ViewSpanChangedEventSource.cs
@@ -26,8 +26,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             private ITextSnapshot? _viewVisualSnapshot;
 
             public event EventHandler<TaggerEventArgs>? Changed;
-            public event EventHandler UIUpdatesPaused { add { } remove { } }
-            public event EventHandler UIUpdatesResumed { add { } remove { } }
 
             public ViewSpanChangedEventSource(IThreadingContext threadingContext, ITextView textView, TaggerDelay textChangeDelay, TaggerDelay scrollChangeDelay)
             {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -65,11 +65,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             private readonly ITaggerEventSource _eventSource;
 
             /// <summary>
-            /// During the time that we are paused from updating the UI, we will use these tags instead.
-            /// </summary>
-            private ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> _previousCachedTagTrees;
-
-            /// <summary>
             /// accumulated text changes since last tag calculation
             /// </summary>
             private TextChangeRange? _accumulatedTextChanges_doNotAccessDirectly;
@@ -80,9 +75,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             #endregion
 
             public event Action<ICollection<KeyValuePair<ITextBuffer, DiffResult>>, bool> TagsChangedForBuffer;
-
-            public event EventHandler Paused;
-            public event EventHandler Resumed;
 
             /// <summary>
             /// A cancellation source we use for the initial tagging computation.  We only cancel
@@ -228,8 +220,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _workQueue.AssertIsForeground();
 
                 _eventSource.Changed += OnEventSourceChanged;
-                _eventSource.UIUpdatesResumed += OnUIUpdatesResumed;
-                _eventSource.UIUpdatesPaused += OnUIUpdatesPaused;
 
                 if (_dataSource.TextChangeBehavior.HasFlag(TaggerTextChangeBehavior.TrackTextChanges))
                 {
@@ -269,8 +259,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     _subjectBuffer.Changed -= OnSubjectBufferChanged;
                 }
 
-                _eventSource.UIUpdatesPaused -= OnUIUpdatesPaused;
-                _eventSource.UIUpdatesResumed -= OnUIUpdatesResumed;
                 _eventSource.Changed -= OnEventSourceChanged;
             }
 
@@ -293,12 +281,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             {
                 TagsChangedForBuffer?.Invoke(collection, initialTags);
             }
-
-            private void RaisePaused()
-                => this.Paused?.Invoke(this, EventArgs.Empty);
-
-            private void RaiseResumed()
-                => this.Resumed?.Invoke(this, EventArgs.Empty);
 
             private static T NextOrDefault<T>(IEnumerator<T> enumerator)
                 => enumerator.MoveNext() ? enumerator.Current : default;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -44,22 +44,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// </summary>
         private partial class TagSource
         {
-            private void OnUIUpdatesPaused(object sender, EventArgs e)
-            {
-                _workQueue.AssertIsForeground();
-                _previousCachedTagTrees = CachedTagTrees;
-
-                RaisePaused();
-            }
-
-            private void OnUIUpdatesResumed(object sender, EventArgs e)
-            {
-                _workQueue.AssertIsForeground();
-                _previousCachedTagTrees = null;
-
-                RaiseResumed();
-            }
-
             private void OnEventSourceChanged(object sender, TaggerEventArgs e)
             {
                 // First, cancel any previous requests (either still queued, or started).  We no longer
@@ -634,12 +618,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             {
                 _workQueue.AssertIsForeground();
 
-                // If we're currently pausing updates to the UI, then just use the tags we had before we
-                // were paused so that nothing changes.  
-                //
                 // We're on the UI thread, so it's safe to access these variables.
-                var map = _previousCachedTagTrees ?? this.CachedTagTrees;
-                map.TryGetValue(buffer, out var tags);
+                this.CachedTagTrees.TryGetValue(buffer, out var tags);
                 return tags;
             }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -72,8 +72,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 _tagSource.OnTaggerAdded(this);
                 _tagSource.TagsChangedForBuffer += OnTagsChangedForBuffer;
-                _tagSource.Paused += OnPaused;
-                _tagSource.Resumed += OnResumed;
 
                 // There is a many-to-one relationship between Taggers and TagSources.  i.e. one
                 // tag-source can be used by many Taggers.  As such, we may be a tagger that is 
@@ -113,17 +111,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _cancellationTokenSource.Cancel();
                 _cancellationTokenSource.Dispose();
 
-                _tagSource.Resumed -= OnResumed;
-                _tagSource.Paused -= OnPaused;
                 _tagSource.TagsChangedForBuffer -= OnTagsChangedForBuffer;
                 _tagSource.OnTaggerDisposed(this);
             }
-
-            private void OnPaused(object sender, EventArgs e)
-                => _batchChangeNotifier.Pause();
-
-            private void OnResumed(object sender, EventArgs e)
-                => _batchChangeNotifier.Resume();
 
             private void OnTagsChangedForBuffer(
                 ICollection<KeyValuePair<ITextBuffer, DiffResult>> changes, bool initialTags)

--- a/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Tagging/ITaggerEventSource.cs
@@ -34,15 +34,5 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// recompute tags.
         /// </summary>
         event EventHandler<TaggerEventArgs> Changed;
-
-        /// <summary>
-        /// The tagger should stop updating the UI with the tags it's produced.
-        /// </summary>
-        event EventHandler UIUpdatesPaused;
-
-        /// <summary>
-        /// The tagger can start notifying the UI about its tags again.
-        /// </summary>
-        event EventHandler UIUpdatesResumed;
     }
 }


### PR DESCRIPTION
So, fun fact: The tagging infrastructure has a way for external event sources to say: hey, please don't update tags now, as it might be distracting for the user.  

Specifically, this was originally written so that when completion was popped up we could disable error squiggles, as there was a concern that those would be distracting while completion was up.

It turns out that behavior regressed when we added async completion.  We simply forgot to hook this up back then:

![image](https://user-images.githubusercontent.com/4564579/115129634-87621a00-9f9c-11eb-8430-541208a9ae76.png)

However, this was *two years* ago, and not a single person has noticed.  No one on the roslyn team noticed, nor did anyone external.  The reason for this is likely twofold:

1. we still are waiting 1.5 seconds to display teh squiggle.  So during normal typing, it rarely appears.  This is in contrast to one of our concers early on which was that suiggles might be more aggressive and could show up very soon when typing.  Once we moved to the model of always waiting until a 1.5 second 'rest', the propensity for squiggles to just come/go very quickly while typing went away
2. the presence of the squiggle itself is not so bad.  We used to have many more cases where we might end up squiggling a huge swath of code (esp. in lambdas).  We did a lot of work to avoid that, and to make the squiggle regions narrower and more precise.  This took us from potentially having many lines of sguiggles appearing behind completion lists, to generally only a little bit of surrounding text being suiggled.

Given that no one noticed, and that our experience seems fine and has had teh major experience problems already addressed, i'm removing all the complexity in the tagger architecture related to this.