### PR TITLE
Make ExitingTraceListener log visible

### DIFF
--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -29,12 +29,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 
         private static int MainCore(string[] args)
         {
-#if BOOTSTRAP
-            ExitingTraceListener.Install();
-#endif
-
             var requestId = Guid.NewGuid();
             using var logger = new CompilerServerLogger($"csc {requestId}");
+
+#if BOOTSTRAP
+            ExitingTraceListener.Install(logger);
+#endif
+
             return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, logger, requestId);
         }
 

--- a/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
+++ b/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
@@ -112,7 +112,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
         public CompilerServerLogger(string identifier)
         {
             _identifier = identifier;
-            var processId = Process.GetCurrentProcess().Id;
 
             try
             {
@@ -124,6 +123,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     // Otherwise, assume that the environment variable specifies the name of the log file.
                     if (Directory.Exists(loggingFileName))
                     {
+                        var processId = Process.GetCurrentProcess().Id;
                         loggingFileName = Path.Combine(loggingFileName, $"server.{processId}.log");
                     }
 

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             try
             {
 #if BOOTSTRAP
-                ExitingTraceListener.Install();
+                ExitingTraceListener.Install(logger);
 #endif
 
 #if NET472

--- a/src/Compilers/Shared/ExitingTraceListener.cs
+++ b/src/Compilers/Shared/ExitingTraceListener.cs
@@ -18,6 +18,13 @@ namespace Microsoft.CodeAnalysis.CommandLine
     /// </summary>
     internal sealed class ExitingTraceListener : TraceListener
     {
+        internal ICompilerServerLogger Logger { get; } 
+
+        internal ExitingTraceListener(ICompilerServerLogger logger)
+        {
+            Logger = logger;
+        }
+
         public override void Write(string message)
         {
             Exit(message);
@@ -28,13 +35,13 @@ namespace Microsoft.CodeAnalysis.CommandLine
             Exit(message);
         }
 
-        internal static void Install()
+        internal static void Install(ICompilerServerLogger logger)
         {
             Trace.Listeners.Clear();
-            Trace.Listeners.Add(new ExitingTraceListener());
+            Trace.Listeners.Add(new ExitingTraceListener(logger));
         }
 
-        private static void Exit(string originalMessage)
+        private void Exit(string originalMessage)
         {
             var builder = new StringBuilder();
             builder.AppendLine($"Debug.Assert failed with message: {originalMessage}");
@@ -43,21 +50,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
             builder.AppendLine(stackTrace.ToString());
 
             var message = builder.ToString();
-            var logFullName = GetLogFileFullName();
-            File.WriteAllText(logFullName, message);
-
-            Console.WriteLine(message);
-            Console.WriteLine($"Log at: {logFullName}");
+            Logger.Log(message);
 
             Environment.Exit(1);
-        }
-
-        private static string GetLogFileFullName()
-        {
-            var assembly = typeof(ExitingTraceListener).Assembly;
-            var name = $"{Path.GetFileName(assembly.Location)}.tracelog";
-            var path = Path.GetDirectoryName(assembly.Location);
-            return Path.Combine(path, name);
         }
     }
 }

--- a/src/Compilers/Shared/ExitingTraceListener.cs
+++ b/src/Compilers/Shared/ExitingTraceListener.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
     /// </summary>
     internal sealed class ExitingTraceListener : TraceListener
     {
-        internal ICompilerServerLogger Logger { get; } 
+        internal ICompilerServerLogger Logger { get; }
 
         internal ExitingTraceListener(ICompilerServerLogger logger)
         {

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -29,12 +29,13 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 
         private static int MainCore(string[] args)
         {
-#if BOOTSTRAP
-            ExitingTraceListener.Install();
-#endif
-
             var requestId = Guid.NewGuid();
             using var logger = new CompilerServerLogger($"vbc {requestId}");
+
+#if BOOTSTRAP
+            ExitingTraceListener.Install(logger);
+#endif
+
             return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, logger, requestId);
         }
 


### PR DESCRIPTION
The `ExitingTraceListener` is installed in `BOOTSTRAP` runs as the only
`TraceListener`. This means if a `Debug.Assert` call fails instead of
popping up a dialog and hanging the build job the process will exit with
a failure code.

The intent of the type was to also write out the full stack trace and
log to disk. That way we could discover exactly what was going wrong in
the run after the fact. Unfortunately it was writing it out to disk at a
location that wasn't uploaded in the build artifacts log.

This change has the listener write its messages via
`ICompilerServerLogger`. That is already where we collect all of our
compilation diagnostics hence it's putting the information in a place we
are already looking and is designed to be persisted on failed builds.