### PR TITLE
Ensure that we register to analyze generated code for MakeFieldReadO…

### DIFF
--- a/src/Analyzers/CSharp/Tests/MakeFieldReadonly/MakeFieldReadonlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeFieldReadonly/MakeFieldReadonlyTests.cs
@@ -1746,5 +1746,38 @@ class Program
     private static object [|t_obj|];
 }");
         }
+
+        [WorkItem(50925, "https://github.com/dotnet/roslyn/issues/50925")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)]
+        public async Task Test_MemberUsedInGeneratedCode()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"<Workspace>
+    <Project Language = ""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath = ""z:\\File1.cs"">
+public sealed partial class Test
+{
+    private int [|_value|];
+
+    public static void M()
+        => _ = new Test { Value = 1 };
+}
+        </Document>
+        <Document FilePath = ""z:\\File2.g.cs"">
+using System.CodeDom.Compiler;
+
+[GeneratedCode(null, null)]
+public sealed partial class Test
+{
+    public int Value
+    {
+        get => _value;
+        set => _value = value;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
     }
 }

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
@@ -65,12 +65,16 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                     customTags: DiagnosticCustomTags.Create(isUnnecessary, isConfigurable, enforceOnBuild));
 #pragma warning restore RS0030 // Do not used banned APIs
 
-        // Code style analyzers should not run on generated code, unless explicitly required by the analyzer.
-        protected virtual GeneratedCodeAnalysisFlags GeneratedCodeAnalysisFlags => GeneratedCodeAnalysisFlags.None;
+        /// <summary>
+        /// Flag indicating whether or not analyzer should receive analysis callbacks for generated code.
+        /// By default, code style analyzers should not run on generated code, so the value is false.
+        /// </summary>
+        protected virtual bool ReceiveAnalysisCallbacksForGeneratedCode => false;
 
         public sealed override void Initialize(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags);
+            var flags = ReceiveAnalysisCallbacksForGeneratedCode ? GeneratedCodeAnalysisFlags.Analyze : GeneratedCodeAnalysisFlags.None;
+            context.ConfigureGeneratedCodeAnalysis(flags);
             context.EnableConcurrentExecution();
 
             InitializeWorker(context);

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
@@ -65,10 +65,12 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                     customTags: DiagnosticCustomTags.Create(isUnnecessary, isConfigurable, enforceOnBuild));
 #pragma warning restore RS0030 // Do not used banned APIs
 
+        // Code style analyzers should not run on generated code, unless explicitly required by the analyzer.
+        protected virtual GeneratedCodeAnalysisFlags GeneratedCodeAnalysisFlags => GeneratedCodeAnalysisFlags.None;
+
         public sealed override void Initialize(AnalysisContext context)
         {
-            // Code style analyzers should not run on generated code.
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags);
             context.EnableConcurrentExecution();
 
             InitializeWorker(context);

--- a/src/Analyzers/Core/Analyzers/MakeFieldReadonly/MakeFieldReadonlyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/MakeFieldReadonly/MakeFieldReadonlyDiagnosticAnalyzer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
 
         // We need to analyze generated code to get callbacks for read/writes to non-generated members in generated code.
-        protected override GeneratedCodeAnalysisFlags GeneratedCodeAnalysisFlags => GeneratedCodeAnalysisFlags.Analyze;
+        protected override bool ReceiveAnalysisCallbacksForGeneratedCode => true;
 
         protected override void InitializeWorker(AnalysisContext context)
         {

--- a/src/Analyzers/Core/Analyzers/MakeFieldReadonly/MakeFieldReadonlyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/MakeFieldReadonly/MakeFieldReadonlyDiagnosticAnalyzer.cs
@@ -31,6 +31,9 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
 
+        // We need to analyze generated code to get callbacks for read/writes to non-generated members in generated code.
+        protected override GeneratedCodeAnalysisFlags GeneratedCodeAnalysisFlags => GeneratedCodeAnalysisFlags.Analyze;
+
         protected override void InitializeWorker(AnalysisContext context)
         {
             context.RegisterCompilationStartAction(compilationStartContext =>


### PR DESCRIPTION
…nly analyzer

Fixes #50925
Note that we only pass in the `Analyze` flag, not the `ReportDiagnostics` flag, so that fields defined in generated code are not flagged.