### PR TITLE
Remove NotImplementedExvception from being thrown.

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/Preview/PreviewPaneService.cs
+++ b/src/EditorFeatures/Core.Cocoa/Preview/PreviewPaneService.cs
@@ -97,12 +97,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
             var helpLinkUri = BrowserHelper.GetHelpLink(data);
             var helpLinkToolTip = BrowserHelper.GetHelpLinkToolTip(data.Id, helpLinkUri);
 
-            Guid optionPageGuid = default;
-            if (data.Properties.TryGetValue("OptionName", out _))
-            {
-                data.Properties.TryGetValue("OptionLanguage", out _);
-            }
-
             return new PreviewPane(
                 severityIcon: null,//TODO: Mac GetSeverityIconForDiagnostic(diagnostic),
                 id: data.Id, title: title,

--- a/src/EditorFeatures/Core.Cocoa/Preview/PreviewPaneService.cs
+++ b/src/EditorFeatures/Core.Cocoa/Preview/PreviewPaneService.cs
@@ -101,7 +101,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
             if (data.Properties.TryGetValue("OptionName", out _))
             {
                 data.Properties.TryGetValue("OptionLanguage", out _);
-                throw new NotImplementedException();
             }
 
             return new PreviewPane(

--- a/src/EditorFeatures/Core.Cocoa/Preview/PreviewPaneService.cs
+++ b/src/EditorFeatures/Core.Cocoa/Preview/PreviewPaneService.cs
@@ -104,8 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 helpLink: helpLinkUri,
                 helpLinkToolTipText: helpLinkToolTip,
                 previewContent: previewContent,
-                logIdVerbatimInTelemetry: data.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry),
-                optionPageGuid: optionPageGuid);
+                logIdVerbatimInTelemetry: data.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry));
         }
     }
 }


### PR DESCRIPTION
What are the general guidelines for logging events in this case?

It feels wrong to throw an exception because options are not implemented (especially with 0 context about which options are problematic).

cc @jasonmalinowski @KirillOsenkov