### PR TITLE
draft

### DIFF
--- a/src/Features/CSharp/Portable/DocumentationComments/DocumentationCommentSnippetService.cs
+++ b/src/Features/CSharp/Portable/DocumentationComments/DocumentationCommentSnippetService.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp.DocumentationComments
         {
             switch (member.Kind())
             {
-                case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.InterfaceDeclaration:
                 case SyntaxKind.StructDeclaration:
                 case SyntaxKind.DelegateDeclaration:


### PR DESCRIPTION
Records are not supported by this method, however, writing `///` above a record adds the `<summary>` tag as expected. So this method/service looks responsible for something else. Waiting CI to figure that out, then will close the PR and open a new PR to support records if necessary.