### PR TITLE
Produce heap dumps on bootstrap failure

### DIFF
--- a/src/Compilers/Shared/ExitingTraceListener.cs
+++ b/src/Compilers/Shared/ExitingTraceListener.cs
@@ -52,7 +52,10 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var message = builder.ToString();
             Logger.Log(message);
 
-            Environment.Exit(1);
+            // Use FailFast so that the process fails rudely and goes through 
+            // windows error reporting (on Windows at least). This will allow our 
+            // CI environment to capture crash dumps for future investigation
+            Environment.FailFast(message);
         }
     }
 }


### PR DESCRIPTION
Use `Environment.FailFast` so we trigger a crash when an assertion fails
in the bootstrap phase. The rest of our setup for the build correctness
legs should ensure this results in a captured heap dump