### PR TITLE
Do not mark our navto pattern match items as having punctuation stripped

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Callback.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Callback.cs
@@ -52,8 +52,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             {
                 var matchedSpans = result.NameMatchSpans.SelectAsArray(t => t.ToSpan());
 
-                var patternMatch = new PatternMatch(GetPatternMatchKind(result.MatchKind),
-                    punctuationStripped: true, result.IsCaseSensitive, matchedSpans);
+                var patternMatch = new PatternMatch(
+                    GetPatternMatchKind(result.MatchKind),
+                    punctuationStripped: false,
+                    result.IsCaseSensitive,
+                    matchedSpans);
 
                 var navigateToItem = new NavigateToItem(
                     result.Name,


### PR DESCRIPTION
Platform woudl like it so that if you search for `Foo` that hte symbol `Foo` has precedent over the file `Foo.cs`.  There are changes they're making on their side, however our unilateral setting of this value ends up causing us to still sort things worse.

Currently there are no cases where roslyn strips punctuation from a search term.  We do support (but not strip) teh form X.Y when searching.  So we can just flip how we set this to help ensure platform can sort these more optimally.