### PR TITLE
Simplify async tagger delays.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/LineSeparators/EditorFormatMapChangedEventSource.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/EditorFormatMapChangedEventSource.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.VisualStudio.Text.Classification;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
@@ -14,11 +11,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
     {
         private readonly IEditorFormatMap _editorFormatMap;
 
-        public EditorFormatMapChangedEventSource(IEditorFormatMap editorFormatMap, TaggerDelay delay)
-            : base(delay)
-        {
-            _editorFormatMap = editorFormatMap;
-        }
+        public EditorFormatMapChangedEventSource(IEditorFormatMap editorFormatMap)
+            => _editorFormatMap = editorFormatMap;
 
         public override void Connect()
             => _editorFormatMap.FormatMappingChanged += OnEditorFormatMapChanged;

--- a/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorTaggerProvider.cs
@@ -59,6 +59,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
             _lineSeparatorTag = new LineSeparatorTag(_editorFormatMap);
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+
         private void OnFormatMappingChanged(object sender, FormatItemsEventArgs e)
         {
             lock (_lineSeperatorTagGate)
@@ -71,8 +73,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
             ITextView textView, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                new EditorFormatMapChangedEventSource(_editorFormatMap, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.NearImmediate));
+                new EditorFormatMapChangedEventSource(_editorFormatMap),
+                TaggerEventSources.OnTextChanged(subjectBuffer));
         }
 
         protected override async Task ProduceTagsAsync(TaggerContext<LineSeparatorTag> context, DocumentSnapshotSpan documentSnapshotSpan, int? caretPosition)

--- a/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightingViewTaggerProvider.cs
@@ -46,12 +46,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
             _braceMatcherService = braceMatcherService;
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnTextChanged(subjectBuffer),
+                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer),
+                TaggerEventSources.OnParseOptionChanged(subjectBuffer));
         }
 
         protected override Task ProduceTagsAsync(TaggerContext<BraceHighlightTag> context, DocumentSnapshotSpan documentSnapshotSpan, int? caretPosition)

--- a/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
     internal class CompilationAvailableTaggerEventSource : ITaggerEventSource
     {
         private readonly ITextBuffer _subjectBuffer;
-        private readonly TaggerDelay _delay;
         private readonly IAsynchronousOperationListener _asyncListener;
 
         /// <summary>
@@ -38,13 +37,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
         public CompilationAvailableTaggerEventSource(
             ITextBuffer subjectBuffer,
-            TaggerDelay delay,
             IThreadingContext threadingContext,
             IAsynchronousOperationListener asyncListener,
             params ITaggerEventSource[] eventSources)
         {
             _subjectBuffer = subjectBuffer;
-            _delay = delay;
             _asyncListener = asyncListener;
             _underlyingSource = TaggerEventSources.Compose(eventSources);
 
@@ -86,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             _workQueue.EnqueueBackgroundTask(async c =>
                 {
                     await document.Project.GetCompilationAsync(c).ConfigureAwait(false);
-                    this.Changed?.Invoke(this, new TaggerEventArgs(_delay));
+                    this.Changed?.Invoke(this, new TaggerEventArgs());
                 },
                 $"{nameof(CompilationAvailableTaggerEventSource)}.{nameof(OnEventSourceChanged)}",
                 500,

--- a/src/EditorFeatures/Core/Implementation/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/CopyPasteAndPrintingClassificationBufferTaggerProvider.Tagger.cs
@@ -45,17 +45,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 _owner = owner;
                 _subjectBuffer = subjectBuffer;
 
-                const TaggerDelay Delay = TaggerDelay.Short;
-
                 // Note: because we use frozen-partial documents for semantic classification, we may end up with incomplete
                 // semantics (esp. during solution load).  Because of this, we also register to hear when the full
                 // compilation is available so that reclassify and bring ourselves up to date.
                 _eventSource = new CompilationAvailableTaggerEventSource(
-                    subjectBuffer, Delay,
+                    subjectBuffer,
                     owner.ThreadingContext,
                     asyncListener,
-                    TaggerEventSources.OnWorkspaceChanged(subjectBuffer, Delay, asyncListener),
-                    TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay));
+                    TaggerEventSources.OnWorkspaceChanged(subjectBuffer, asyncListener),
+                    TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer));
 
                 ConnectToEventSource();
             }
@@ -104,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 }
             }
 
-            private void OnEventSourceChanged(object sender, TaggerEventArgs e)
+            private void OnEventSourceChanged(object sender, TaggerEventArgs _)
             {
                 _owner._notificationService.RegisterNotification(
                     OnEventSourceChanged_OnForeground,

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -52,32 +52,32 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             IForegroundNotificationService notificationService,
             ClassificationTypeMap typeMap,
             IAsynchronousOperationListenerProvider listenerProvider)
-            : base(threadingContext, listenerProvider.GetListener(FeatureAttribute.Classification), notificationService)
+            : base(threadingContext,
+                   listenerProvider.GetListener(FeatureAttribute.Classification),
+                   notificationService)
         {
             _typeMap = typeMap;
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {
             this.AssertIsForeground();
-            const TaggerDelay Delay = TaggerDelay.Short;
 
             // Note: we don't listen for OnTextChanged.  They'll get reported by the ViewSpan changing and also the
             // SemanticChange notification. 
             // 
-            // Note: when the user scrolls, we will try to reclassify as soon as possible.  That way we appear
-            // semantically unclassified for a very short amount of time.
-            //
             // Note: because we use frozen-partial documents for semantic classification, we may end up with incomplete
             // semantics (esp. during solution load).  Because of this, we also register to hear when the full
             // compilation is available so that reclassify and bring ourselves up to date.
             return new CompilationAvailableTaggerEventSource(
-                subjectBuffer, Delay,
+                subjectBuffer,
                 ThreadingContext,
                 AsyncListener,
-                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textView, textChangeDelay: Delay, scrollChangeDelay: TaggerDelay.NearImmediate),
-                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, Delay, this.AsyncListener),
-                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, Delay));
+                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textView),
+                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, this.AsyncListener),
+                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer));
         }
 
         protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             _typeMap = typeMap;
         }
 
-        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.Short;
 
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -52,9 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             IForegroundNotificationService notificationService,
             ClassificationTypeMap typeMap,
             IAsynchronousOperationListenerProvider listenerProvider)
-            : base(threadingContext,
-                   listenerProvider.GetListener(FeatureAttribute.Classification),
-                   notificationService)
+            : base(threadingContext, listenerProvider.GetListener(FeatureAttribute.Classification), notificationService)
         {
             _typeMap = typeMap;
         }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -95,14 +95,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             }
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.Short;
         protected override TaggerDelay AddedTagNotificationDelay => TaggerDelay.OnIdle;
 
         protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, TaggerDelay.Medium),
-                TaggerEventSources.OnWorkspaceRegistrationChanged(subjectBuffer, TaggerDelay.Medium),
-                TaggerEventSources.OnDiagnosticsChanged(subjectBuffer, _diagnosticService, TaggerDelay.Short));
+                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer),
+                TaggerEventSources.OnWorkspaceRegistrationChanged(subjectBuffer),
+                TaggerEventSources.OnDiagnosticsChanged(subjectBuffer, _diagnosticService));
         }
 
         protected internal abstract bool IsEnabled { get; }

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTaggerProvider.EventSource.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTaggerProvider.EventSource.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
@@ -12,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
     {
         private sealed class EventSource : AbstractWorkspaceTrackingTaggerEventSource
         {
-            public EventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
-                : base(subjectBuffer, delay)
+            public EventSource(ITextBuffer subjectBuffer)
+                : base(subjectBuffer)
             {
             }
 

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTaggerProvider.cs
@@ -47,14 +47,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
         {
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {
             AssertIsForeground();
 
             return TaggerEventSources.Compose(
-                new EventSource(subjectBuffer, TaggerDelay.Short),
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, TaggerDelay.Short));
+                new EventSource(subjectBuffer),
+                TaggerEventSources.OnTextChanged(subjectBuffer),
+                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer));
         }
 
         protected override async Task ProduceTagsAsync(TaggerContext<ITextMarkerTag> context)

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -53,12 +53,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
             _highlightingService = highlightingService;
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.OnIdle),
-                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnTextChanged(subjectBuffer),
+                TaggerEventSources.OnCaretPositionChanged(textView, subjectBuffer),
+                TaggerEventSources.OnParseOptionChanged(subjectBuffer));
         }
 
         protected override async Task ProduceTagsAsync(TaggerContext<KeywordHighlightTag> context, DocumentSnapshotSpan documentSnapshotSpan, int? caretPosition)

--- a/src/EditorFeatures/Core/Implementation/Structure/AbstractStructureTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Structure/AbstractStructureTaggerProvider.cs
@@ -50,6 +50,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
             ProjectionBufferFactoryService = projectionBufferFactoryService;
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.OnIdle;
+
         protected sealed override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {
             // We listen to the following events:
@@ -64,16 +66,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
             //    the file will not have outline spans.  When the workspace is created, we want to
             //    then produce the right outlining spans.
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.OnIdle),
-                TaggerEventSources.OnParseOptionChanged(subjectBuffer, TaggerDelay.OnIdle),
-                TaggerEventSources.OnWorkspaceRegistrationChanged(subjectBuffer, TaggerDelay.OnIdle),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCodeLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForDeclarationLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCommentsAndPreprocessorRegions, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCodeLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForDeclarationLevelConstructs, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCommentsAndPreprocessorRegions, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnTextChanged(subjectBuffer),
+                TaggerEventSources.OnParseOptionChanged(subjectBuffer),
+                TaggerEventSources.OnWorkspaceRegistrationChanged(subjectBuffer),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCodeLevelConstructs),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForDeclarationLevelConstructs),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowBlockStructureGuidesForCommentsAndPreprocessorRegions),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCodeLevelConstructs),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForDeclarationLevelConstructs),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.ShowOutliningForCommentsAndPreprocessorRegions),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions));
         }
 
         /// <summary>

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
@@ -56,22 +56,24 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             _listener = listenerProvider.GetListener(FeatureAttribute.InlineParameterNameHints);
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+
         protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textViewOpt, textChangeDelay: TaggerDelay.Short, scrollChangeDelay: TaggerDelay.NearImmediate),
-                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.NearImmediate, _listener),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.DisplayAllOverride, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLiteralParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForObjectCreationParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForOtherParameters, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatMatchMethodIntent, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatDifferOnlyBySuffix, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForTypes, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForImplicitVariableTypes, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLambdaParameterTypes, TaggerDelay.NearImmediate),
-                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForImplicitObjectCreation, TaggerDelay.NearImmediate));
+                TaggerEventSources.OnViewSpanChanged(ThreadingContext, textViewOpt),
+                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, _listener),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.DisplayAllOverride),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForParameters),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLiteralParameters),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForObjectCreationParameters),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForOtherParameters),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatMatchMethodIntent),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.SuppressForParametersThatDifferOnlyBySuffix),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.EnabledForTypes),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForImplicitVariableTypes),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForLambdaParameterTypes),
+                TaggerEventSources.OnOptionChanged(subjectBuffer, InlineHintsOptions.ForImplicitObjectCreation));
         }
 
         protected override IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsDataTaggerProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             _listener = listenerProvider.GetListener(FeatureAttribute.InlineParameterNameHints);
         }
 
-        protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.Short;
 
         protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -18,7 +18,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -55,14 +54,16 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
         {
         }
 
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.Short;
+
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {
             // Note: we don't listen for OnTextChanged.  Text changes to this buffer will get
             // reported by OnSemanticChanged.
             return TaggerEventSources.Compose(
-                TaggerEventSources.OnCaretPositionChanged(textView, textView.TextBuffer, TaggerDelay.Short),
-                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, TaggerDelay.OnIdle, AsyncListener),
-                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer, TaggerDelay.Short));
+                TaggerEventSources.OnCaretPositionChanged(textView, textView.TextBuffer),
+                TaggerEventSources.OnWorkspaceChanged(subjectBuffer, AsyncListener),
+                TaggerEventSources.OnDocumentActiveContextChanged(subjectBuffer));
         }
 
         protected override SnapshotPoint? GetCaretPoint(ITextView textViewOpt, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs
@@ -9,10 +9,9 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 {
     internal abstract class AbstractTaggerEventSource : ITaggerEventSource
     {
-        private readonly TaggerDelay _delay;
-
-        protected AbstractTaggerEventSource(TaggerDelay delay)
-            => _delay = delay;
+        protected AbstractTaggerEventSource()
+        {
+        }
 
         public abstract void Connect();
         public abstract void Disconnect();
@@ -20,6 +19,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public event EventHandler<TaggerEventArgs>? Changed;
 
         protected virtual void RaiseChanged()
-            => this.Changed?.Invoke(this, new TaggerEventArgs(_delay));
+            => this.Changed?.Invoke(this, new TaggerEventArgs());
     }
 }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractWorkspaceTrackingTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractWorkspaceTrackingTaggerEventSource.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
@@ -20,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         protected ITextBuffer SubjectBuffer { get; }
         protected Workspace? CurrentWorkspace { get; private set; }
 
-        protected AbstractWorkspaceTrackingTaggerEventSource(ITextBuffer subjectBuffer, TaggerDelay delay) : base(delay)
+        protected AbstractWorkspaceTrackingTaggerEventSource(ITextBuffer subjectBuffer)
         {
             this.SubjectBuffer = subjectBuffer;
             _workspaceRegistration = Workspace.GetWorkspaceRegistration(subjectBuffer.AsTextContainer());

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.CaretPositionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.CaretPositionChangedEventSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
@@ -15,8 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             private readonly ITextView _textView;
 
-            public CaretPositionChangedEventSource(ITextView textView, ITextBuffer subjectBuffer, TaggerDelay delay)
-                : base(delay)
+            public CaretPositionChangedEventSource(ITextView textView, ITextBuffer subjectBuffer)
             {
                 Contract.ThrowIfNull(textView);
                 Contract.ThrowIfNull(subjectBuffer);

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DiagnosticsChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DiagnosticsChangedEventSource.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             private readonly ITextBuffer _subjectBuffer;
             private readonly IDiagnosticService _service;
 
-            public DiagnosticsChangedEventSource(ITextBuffer subjectBuffer, IDiagnosticService service, TaggerDelay delay)
-                : base(delay)
+            public DiagnosticsChangedEventSource(ITextBuffer subjectBuffer, IDiagnosticService service)
             {
                 _subjectBuffer = subjectBuffer;
                 _service = service;

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DocumentActiveContextChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DocumentActiveContextChangedEventSource.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
     {
         private class DocumentActiveContextChangedEventSource : AbstractWorkspaceTrackingTaggerEventSource
         {
-            public DocumentActiveContextChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
-                : base(subjectBuffer, delay)
+            public DocumentActiveContextChangedEventSource(ITextBuffer subjectBuffer)
+                : base(subjectBuffer)
             {
             }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.OptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.OptionChangedEventSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Text;
 
@@ -15,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             private readonly IOption _option;
             private IOptionService? _optionService;
 
-            public OptionChangedEventSource(ITextBuffer subjectBuffer, IOption option, TaggerDelay delay) : base(subjectBuffer, delay)
+            public OptionChangedEventSource(ITextBuffer subjectBuffer, IOption option) : base(subjectBuffer)
                 => _option = option;
 
             protected override void ConnectToWorkspace(Workspace workspace)

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
     {
         private class ParseOptionChangedEventSource : AbstractWorkspaceTrackingTaggerEventSource
         {
-            public ParseOptionChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
-                : base(subjectBuffer, delay)
+            public ParseOptionChangedEventSource(ITextBuffer subjectBuffer)
+                : base(subjectBuffer)
             {
             }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ReadOnlyRegionsChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ReadOnlyRegionsChangedEventSource.cs
@@ -14,11 +14,9 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             private readonly ITextBuffer _subjectBuffer;
 
-            public ReadOnlyRegionsChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
-                : base(delay)
+            public ReadOnlyRegionsChangedEventSource(ITextBuffer subjectBuffer)
             {
                 Contract.ThrowIfNull(subjectBuffer);
-
                 _subjectBuffer = subjectBuffer;
             }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SelectionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SelectionChangedEventSource.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
@@ -14,11 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             private readonly ITextView _textView;
 
-            public SelectionChangedEventSource(ITextView textView, TaggerDelay delay)
-                : base(delay)
-            {
-                _textView = textView;
-            }
+            public SelectionChangedEventSource(ITextView textView)
+                => _textView = textView;
 
             public override void Connect()
                 => _textView.Selection.SelectionChanged += OnSelectionChanged;

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.TextChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.TextChangedEventSource.cs
@@ -14,11 +14,9 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             private readonly ITextBuffer _subjectBuffer;
 
-            public TextChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
-                : base(delay)
+            public TextChangedEventSource(ITextBuffer subjectBuffer)
             {
                 Contract.ThrowIfNull(subjectBuffer);
-
                 _subjectBuffer = subjectBuffer;
             }
 
@@ -31,9 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             private void OnTextBufferChanged(object? sender, TextContentChangedEventArgs e)
             {
                 if (e.Changes.Count == 0)
-                {
                     return;
-                }
 
                 this.RaiseChanged();
             }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceChangedEventSource.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -20,9 +19,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
             public WorkspaceChangedEventSource(
                 ITextBuffer subjectBuffer,
-                TaggerDelay delay,
                 IAsynchronousOperationListener asyncListener)
-                : base(subjectBuffer, delay)
+                : base(subjectBuffer)
             {
                 // That will ensure that even if we get a flurry of workspace events that we
                 // only process a tag change once.

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceRegistrationChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceRegistrationChangedEventSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
@@ -11,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
     {
         private class WorkspaceRegistrationChangedEventSource : AbstractWorkspaceTrackingTaggerEventSource
         {
-            public WorkspaceRegistrationChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
-                : base(subjectBuffer, delay)
+            public WorkspaceRegistrationChangedEventSource(ITextBuffer subjectBuffer)
+                : base(subjectBuffer)
             {
             }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.cs
@@ -7,12 +7,9 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
-using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
 
@@ -29,69 +26,40 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public static ITaggerEventSource Compose(IEnumerable<ITaggerEventSource> eventSources)
             => new CompositionEventSource(eventSources.ToArray());
 
-        public static ITaggerEventSource OnCaretPositionChanged(ITextView textView, ITextBuffer subjectBuffer, TaggerDelay delay)
-            => new CaretPositionChangedEventSource(textView, subjectBuffer, delay);
+        public static ITaggerEventSource OnCaretPositionChanged(ITextView textView, ITextBuffer subjectBuffer)
+            => new CaretPositionChangedEventSource(textView, subjectBuffer);
 
-        public static ITaggerEventSource OnTextChanged(ITextBuffer subjectBuffer, TaggerDelay delay)
-        {
-            Contract.ThrowIfNull(subjectBuffer);
-
-            return new TextChangedEventSource(subjectBuffer, delay);
-        }
+        public static ITaggerEventSource OnTextChanged(ITextBuffer subjectBuffer)
+            => new TextChangedEventSource(subjectBuffer);
 
         /// <summary>
         /// Reports an event any time the workspace changes.
         /// </summary>
-        public static ITaggerEventSource OnWorkspaceChanged(
-            ITextBuffer subjectBuffer, TaggerDelay delay, IAsynchronousOperationListener listener)
-        {
-            return new WorkspaceChangedEventSource(subjectBuffer, delay, listener);
-        }
+        public static ITaggerEventSource OnWorkspaceChanged(ITextBuffer subjectBuffer, IAsynchronousOperationListener listener)
+            => new WorkspaceChangedEventSource(subjectBuffer, listener);
 
-        public static ITaggerEventSource OnDocumentActiveContextChanged(ITextBuffer subjectBuffer, TaggerDelay delay)
-            => new DocumentActiveContextChangedEventSource(subjectBuffer, delay);
+        public static ITaggerEventSource OnDocumentActiveContextChanged(ITextBuffer subjectBuffer)
+            => new DocumentActiveContextChangedEventSource(subjectBuffer);
 
-        public static ITaggerEventSource OnSelectionChanged(
-            ITextView textView,
-            TaggerDelay delay)
-        {
-            return new SelectionChangedEventSource(textView, delay);
-        }
+        public static ITaggerEventSource OnSelectionChanged(ITextView textView)
+            => new SelectionChangedEventSource(textView);
 
-        public static ITaggerEventSource OnReadOnlyRegionsChanged(ITextBuffer subjectBuffer, TaggerDelay delay)
-        {
-            Contract.ThrowIfNull(subjectBuffer);
+        public static ITaggerEventSource OnReadOnlyRegionsChanged(ITextBuffer subjectBuffer)
+            => new ReadOnlyRegionsChangedEventSource(subjectBuffer);
 
-            return new ReadOnlyRegionsChangedEventSource(subjectBuffer, delay);
-        }
+        public static ITaggerEventSource OnOptionChanged(ITextBuffer subjectBuffer, IOption option)
+            => new OptionChangedEventSource(subjectBuffer, option);
 
-        public static ITaggerEventSource OnOptionChanged(
-            ITextBuffer subjectBuffer,
-            IOption option,
-            TaggerDelay delay)
-        {
-            return new OptionChangedEventSource(subjectBuffer, option, delay);
-        }
+        public static ITaggerEventSource OnDiagnosticsChanged(ITextBuffer subjectBuffer, IDiagnosticService service)
+            => new DiagnosticsChangedEventSource(subjectBuffer, service);
 
-        public static ITaggerEventSource OnDiagnosticsChanged(
-            ITextBuffer subjectBuffer,
-            IDiagnosticService service,
-            TaggerDelay delay)
-        {
-            return new DiagnosticsChangedEventSource(subjectBuffer, service, delay);
-        }
+        public static ITaggerEventSource OnParseOptionChanged(ITextBuffer subjectBuffer)
+            => new ParseOptionChangedEventSource(subjectBuffer);
 
-        public static ITaggerEventSource OnParseOptionChanged(
-            ITextBuffer subjectBuffer,
-            TaggerDelay delay)
-        {
-            return new ParseOptionChangedEventSource(subjectBuffer, delay);
-        }
+        public static ITaggerEventSource OnWorkspaceRegistrationChanged(ITextBuffer subjectBuffer)
+            => new WorkspaceRegistrationChangedEventSource(subjectBuffer);
 
-        public static ITaggerEventSource OnWorkspaceRegistrationChanged(ITextBuffer subjectBuffer, TaggerDelay delay)
-            => new WorkspaceRegistrationChangedEventSource(subjectBuffer, delay);
-
-        public static ITaggerEventSource OnViewSpanChanged(IThreadingContext threadingContext, ITextView textView, TaggerDelay textChangeDelay, TaggerDelay scrollChangeDelay)
-            => new ViewSpanChangedEventSource(threadingContext, textView, textChangeDelay, scrollChangeDelay);
+        public static ITaggerEventSource OnViewSpanChanged(IThreadingContext threadingContext, ITextView textView)
+            => new ViewSpanChangedEventSource(threadingContext, textView);
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 // notifications for when those options change.
                 var optionChangedEventSources =
                     _dataSource.Options.Concat<IOption>(_dataSource.PerLanguageOptions)
-                        .Select(o => TaggerEventSources.OnOptionChanged(_subjectBuffer, o, TaggerDelay.NearImmediate)).ToList();
+                        .Select(o => TaggerEventSources.OnOptionChanged(_subjectBuffer, o)).ToList();
 
                 if (optionChangedEventSources.Count == 0)
                 {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _workQueue.CancelCurrentWork();
                 RegisterNotification(
                     () => RecomputeTagsForeground(initialTags: false),
-                    (int)e.Delay.ComputeTimeDelay().TotalMilliseconds,
+                    (int)_dataSource.EventChangeDelay.ComputeTimeDelay().TotalMilliseconds,
                     GetCancellationToken(initialTags: false));
             }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -88,6 +88,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 #endif
         }
 
+        /// <summary>
+        /// How long the tagger should wait after hearing about an event before recomputing tags.
+        /// </summary>
         protected abstract TaggerDelay EventChangeDelay { get; }
 
         internal IAccurateTagger<T>? CreateTaggerWorker<T>(ITextView textViewOpt, ITextBuffer subjectBuffer) where T : ITag

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -88,6 +88,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 #endif
         }
 
+        protected abstract TaggerDelay EventChangeDelay { get; }
+
         internal IAccurateTagger<T>? CreateTaggerWorker<T>(ITextView textViewOpt, ITextBuffer subjectBuffer) where T : ITag
         {
             if (!subjectBuffer.GetFeatureOnOffOption(EditorComponentOnOffOptions.Tagger))

--- a/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
@@ -14,16 +14,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
     /// </summary>
     internal class TaggerEventArgs : EventArgs
     {
-        /// <summary>
-        /// They amount of time to wait before the <see cref="AbstractAsynchronousTaggerProvider{TTag}"/>
-        /// checks for new tags and updates the user interface.
-        /// </summary>
-        public TaggerDelay Delay { get; }
-
-        /// <summary>
-        /// Creates a new <see cref="TaggerEventArgs"/>
-        /// </summary>
-        public TaggerEventArgs(TaggerDelay delay)
-            => this.Delay = delay;
+        public TaggerEventArgs()
+        {
+        }
     }
 }

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -140,6 +140,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
                 _eventSource = eventSource;
             }
 
+            protected override TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
+
             protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
                 => _eventSource;
 
@@ -161,7 +163,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
         private sealed class TestTaggerEventSource : AbstractTaggerEventSource
         {
             public TestTaggerEventSource()
-                : base(delay: TaggerDelay.NearImmediate)
             {
             }
 


### PR DESCRIPTION
The previous model allowed fine-grained tagging delays based on events.  However, in practice that doesn't lead to any substantive improvements.  The high priority items still run as soon as posisble (normally 'near immediate') and the less important items happen so rarely that having more complex logic to deal with them isn't helpful.  For example, when switching from debug/release, we might be on a longer delay.  However, that sort of switching happens orders of magnitude less often than typing, so specializing that scenario to have us just wait a second longer (or less) doesn't really buy the experience anything, at the cost of lots more complexity.