### PR TITLE
Remove unnecessary initial notification code in the tagger

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -72,38 +72,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 _tagSource.OnTaggerAdded(this);
                 _tagSource.TagsChangedForBuffer += OnTagsChangedForBuffer;
-
-                // There is a many-to-one relationship between Taggers and TagSources.  i.e. one
-                // tag-source can be used by many Taggers.  As such, we may be a tagger that is 
-                // wrapping a tag-source that has already produced tags and had sent out the 
-                // notifications about those tags.
-                //
-                // However, we still want to notify the code consuming us that we have tags to
-                // display.  That way, tags can display as soon as possible when someone creates
-                // a new tagger for a view/buffer.
-                //
-                // Note: we have to do this in the future instead of right now because we haven't
-                // even been returned to the caller for them to hook up to change notifications
-                // from us.
-                notificationService.RegisterNotification(
-                    () =>
-                    {
-                        if (this.TagsChanged == null)
-                        {
-                            // don't bother reporting tags if no one is listening.
-                            return;
-                        }
-
-                        var tags = _tagSource.TryGetTagIntervalTreeForBuffer(_subjectBuffer);
-                        if (tags != null)
-                        {
-                            var collection = new NormalizedSnapshotSpanCollection(
-                                tags.GetSpans(_subjectBuffer.CurrentSnapshot).Select(ts => ts.Span));
-                            this.NotifyEditorNow(collection);
-                        }
-                    },
-                    listener.BeginAsyncOperation(GetType().FullName + ".ctor-ReportInitialTags"),
-                    _cancellationTokenSource.Token);
             }
 
             public void Dispose()


### PR DESCRIPTION
Because we can create taggers on demand that we pass out that are all backed by a single entity that actually computes and caches tags, we had a system whereby if you requested another tagger we would create it and then re-issue a TagsChanged call for any tags previously computed.

I have validated with platform/editor that this pattern is not necessary.  Tag consumers know they may get existing taggers, and that they are responsible for an initial query of hte tagger to get all tags, withotu waiting for an intiial TagsChanged.  TagsChanged it defined to let someone know that whatever they queried before is no longer necessary valid, not that tagger transitioned from nothing to the initial set of tags.