### PR TITLE
[LSP] Don't generate semantic tokens ResultId unless necessary

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -66,12 +66,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 return new LSP.SemanticTokens { ResultId = newResultId, Data = newSemanticTokensData };
             }
 
+            var resultId = request.PreviousResultId;
             var editArray = ComputeSemanticTokensEdits(oldSemanticTokensData, newSemanticTokensData);
 
             // If we have edits, generate a new ResultId. Otherwise, re-use the previous one.
             if (editArray.Length != 0)
             {
-                var updatedTokens = new LSP.SemanticTokens { ResultId = _tokensCache.GetNextResultId(), Data = newSemanticTokensData };
+                resultId = _tokensCache.GetNextResultId();
+                var updatedTokens = new LSP.SemanticTokens { ResultId = resultId, Data = newSemanticTokensData };
                 await _tokensCache.UpdateCacheAsync(
                     request.TextDocument.Uri, updatedTokens, cancellationToken).ConfigureAwait(false);
             }
@@ -79,7 +81,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             var edits = new SemanticTokensEdits
             {
                 Edits = editArray,
-                ResultId = request.PreviousResultId
+                ResultId = resultId
             };
 
             return edits;

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             var edits = new SemanticTokensEdits
             {
                 Edits = editArray,
-                ResultId = request.PreviousResultId,
+                ResultId = request.PreviousResultId
             };
 
             return edits;

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -66,14 +66,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 return new LSP.SemanticTokens { ResultId = newResultId, Data = newSemanticTokensData };
             }
 
-            var resultId = request.PreviousResultId;
-
             var editArray = ComputeSemanticTokensEdits(oldSemanticTokensData, newSemanticTokensData);
             if (editArray.Length != 0)
             {
                 // If we have edits, generate a new ResultId. Otherwise, re-use the previous one.
-                resultId = _tokensCache.GetNextResultId();
-                var updatedTokens = new LSP.SemanticTokens { ResultId = resultId, Data = newSemanticTokensData };
+                var updatedTokens = new LSP.SemanticTokens { ResultId = _tokensCache.GetNextResultId(), Data = newSemanticTokensData };
                 await _tokensCache.UpdateCacheAsync(
                     request.TextDocument.Uri, updatedTokens, cancellationToken).ConfigureAwait(false);
             }
@@ -81,7 +78,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             var edits = new SemanticTokensEdits
             {
                 Edits = editArray,
-                ResultId = resultId
+                ResultId = request.PreviousResultId,
             };
 
             return edits;

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -71,6 +71,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             var editArray = ComputeSemanticTokensEdits(oldSemanticTokensData, newSemanticTokensData);
             if (editArray.Length != 0)
             {
+                // If we have edits, generate a new ResultId. Otherwise, re-use the previous one.
                 resultId = _tokensCache.GetNextResultId();
                 var updatedTokens = new LSP.SemanticTokens { ResultId = resultId, Data = newSemanticTokensData };
                 await _tokensCache.UpdateCacheAsync(

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -67,9 +67,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             }
 
             var editArray = ComputeSemanticTokensEdits(oldSemanticTokensData, newSemanticTokensData);
+
+            // If we have edits, generate a new ResultId. Otherwise, re-use the previous one.
             if (editArray.Length != 0)
             {
-                // If we have edits, generate a new ResultId. Otherwise, re-use the previous one.
                 var updatedTokens = new LSP.SemanticTokens { ResultId = _tokensCache.GetNextResultId(), Data = newSemanticTokensData };
                 await _tokensCache.UpdateCacheAsync(
                     request.TextDocument.Uri, updatedTokens, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -56,24 +56,30 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             Contract.ThrowIfNull(newSemanticTokensData, "newSemanticTokensData is null.");
 
-            var resultId = _tokensCache.GetNextResultId();
-            var newSemanticTokens = new LSP.SemanticTokens { ResultId = resultId, Data = newSemanticTokensData };
-
-            await _tokensCache.UpdateCacheAsync(
-                request.TextDocument.Uri, newSemanticTokens, cancellationToken).ConfigureAwait(false);
-
             // Getting the cached tokens for the document. If we don't have an applicable cached token set,
             // we can't calculate edits, so we must return all semantic tokens instead.
             var oldSemanticTokensData = await _tokensCache.GetCachedTokensDataAsync(
                 request.TextDocument.Uri, request.PreviousResultId, cancellationToken).ConfigureAwait(false);
             if (oldSemanticTokensData == null)
             {
-                return newSemanticTokens;
+                var newResultId = _tokensCache.GetNextResultId();
+                return new LSP.SemanticTokens { ResultId = newResultId, Data = newSemanticTokensData };
+            }
+
+            var resultId = request.PreviousResultId;
+
+            var editArray = ComputeSemanticTokensEdits(oldSemanticTokensData, newSemanticTokensData);
+            if (editArray.Length != 0)
+            {
+                resultId = _tokensCache.GetNextResultId();
+                var updatedTokens = new LSP.SemanticTokens { ResultId = resultId, Data = newSemanticTokensData };
+                await _tokensCache.UpdateCacheAsync(
+                    request.TextDocument.Uri, updatedTokens, cancellationToken).ConfigureAwait(false);
             }
 
             var edits = new SemanticTokensEdits
             {
-                Edits = ComputeSemanticTokensEdits(oldSemanticTokensData, newSemanticTokensData),
+                Edits = editArray,
                 ResultId = resultId
             };
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensTests.cs
@@ -116,7 +116,11 @@ static class C { }
             Assert.Equal(expectedEdit, ((LSP.SemanticTokensEdits)editResults).Edits.First());
             Assert.Equal("3", ((LSP.SemanticTokensEdits)editResults).ResultId);
 
-            // 4. Re-request whole document handler (may happen if LSP runs into an error)
+            // 4. Edits handler - no changes (ResultId should remain same)
+            var editResultsNoChange = await RunGetSemanticTokensEditsAsync(testLspServer, caretLocation, previousResultId: "3");
+            Assert.Equal("3", ((LSP.SemanticTokensEdits)editResultsNoChange).ResultId);
+
+            // 5. Re-request whole document handler (may happen if LSP runs into an error)
             var wholeDocResults2 = await RunGetSemanticTokensAsync(testLspServer, caretLocation);
             var expectedWholeDocResults2 = new LSP.SemanticTokens
             {


### PR DESCRIPTION
This should result in a small perf improvement. Today, a new ResultId is generated for each semantic tokens edit request (called every ~0.5s) regardless of whether the doc's content has changed. We can switch to re-using the old ResultId instead, which will avoid us inserting into the cache unnecessarily.

cc @ryanbrandenburg 