### PR TITLE
Cleaning up compiler server interface

### DIFF
--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.CodeAnalysis.CommandLine;
 
@@ -29,14 +30,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 
         private static int MainCore(string[] args)
         {
-            var requestId = Guid.NewGuid();
-            using var logger = new CompilerServerLogger($"csc {requestId}");
+            using var logger = new CompilerServerLogger($"csc {Process.GetCurrentProcess().Id}");
 
 #if BOOTSTRAP
             ExitingTraceListener.Install(logger);
 #endif
 
-            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, logger, requestId);
+            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, BuildServerConnection.RunServerCompilationAsync, logger);
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
             ExitingTraceListener.Install(logger);
 #endif
 
-            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, BuildServerConnection.RunServerCompilationAsync, logger);
+            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, BuildClient.GetCompileOnServerFunc(logger));
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
     /// Argument.
     /// 
     /// </summary>
-    internal class BuildRequest
+    internal sealed class BuildRequest
     {
         /// <summary>
         /// The maximum size of a request supported by the compiler server.
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// Strings are encoded via a length prefix as a signed
         /// 32-bit integer, followed by an array of characters.
         /// </summary>
-        public struct Argument
+        public readonly struct Argument
         {
             public readonly ArgumentId ArgumentId;
             public readonly int ArgumentIndex;

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                 var pipeName = !string.IsNullOrEmpty(SharedCompilationId)
                     ? SharedCompilationId
-                    : BuildServerConnection.GetPipeNameForPath(clientDirectory);
+                    : BuildServerConnection.GetPipeName(clientDirectory);
 
                 // Note: using ToolArguments here (the property) since
                 // commandLineCommands (the parameter) may have been mucked with

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -552,7 +552,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     buildRequest,
                     pipeName,
                     clientDirectory,
-                    timeoutOverride: null,
                     logger: logger,
                     cancellationToken: _sharedCompileCts.Token);
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -539,17 +539,23 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     sdkDir: null,
                     tempDir: tempDir);
 
+                var pipeName = !string.IsNullOrEmpty(SharedCompilationId)
+                    ? SharedCompilationId
+                    : BuildServerConnection.GetPipeNameForPath(buildPaths.ClientDirectory);
+
                 // Note: using ToolArguments here (the property) since
                 // commandLineCommands (the parameter) may have been mucked with
                 // (to support using the dotnet cli)
                 var responseTask = BuildServerConnection.RunServerCompilationAsync(
                     requestId,
                     Language,
-                    RoslynString.IsNullOrEmpty(SharedCompilationId) ? null : SharedCompilationId,
                     GetArguments(ToolArguments, responseFileCommands).ToList(),
                     buildPaths,
+                    pipeName: pipeName,
                     keepAlive: null,
-                    libEnvVariable: LibDirectoryToUse(),
+                    libDirectory: LibDirectoryToUse(),
+                    timeoutOverride: null,
+                    createServerFunc: BuildServerConnection.TryCreateServer,
                     logger: logger,
                     cancellationToken: _sharedCompileCts.Token);
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -532,6 +532,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 
+                // Note: using ToolArguments here (the property) since
+                // commandLineCommands (the parameter) may have been mucked with
+                // (to support using the dotnet cli)
                 var buildRequest = BuildServerConnection.CreateBuildRequest(
                     requestId,
                     Language,
@@ -545,9 +548,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     ? SharedCompilationId
                     : BuildServerConnection.GetPipeName(clientDirectory);
 
-                // Note: using ToolArguments here (the property) since
-                // commandLineCommands (the parameter) may have been mucked with
-                // (to support using the dotnet cli)
                 var responseTask = BuildServerConnection.RunServerBuildRequestAsync(
                     buildRequest,
                     pipeName,

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 var clientDirectory = Path.GetDirectoryName(PathToManagedTool);
                 if (clientDirectory is null || tempDirectory is null)
                 {
-                    LogCompilationMessage(logger, requestId, CompilationKind.Tool, $"using command line tool because we could not find client directory '{PathToManagedTool}'");
+                    LogCompilationMessage(logger, requestId, CompilationKind.Tool, $"using command line tool because we could not find client or temp directory '{PathToManagedTool}'");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
 

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -11,6 +11,7 @@ using Moq;
 using System.IO;
 using Roslyn.Test.Utilities;
 using Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -11,7 +11,6 @@ using Moq;
 using System.IO;
 using Roslyn.Test.Utilities;
 using Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
-using Microsoft.Build.Utilities;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -85,15 +85,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
         }
 
-        /// <summary>
-        /// Was a server running with the specified session key during the execution of this call?
-        /// </summary>
-        private static bool? WasServerRunning(string pipeName)
-        {
-            string mutexName = BuildServerConnection.GetServerMutexName(pipeName);
-            return BuildServerConnection.WasServerMutexOpen(mutexName);
-        }
-
         internal static IClientConnectionHost CreateClientConnectionHost(string pipeName, ICompilerServerLogger logger) => new NamedPipeClientConnectionHost(pipeName, logger);
 
         internal static ICompilerServerHost CreateCompilerServerHost(ICompilerServerLogger logger)
@@ -159,71 +150,18 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             return controller.RunServer(pipeName, compilerServerHost, clientConnectionHost, listener, keepAlive, cancellationToken);
         }
 
-        internal int RunShutdown(string pipeName, bool waitForProcess = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        internal int RunShutdown(string pipeName, CancellationToken cancellationToken = default) =>
+            RunShutdownAsync(pipeName, waitForProcess: true, cancellationToken).GetAwaiter().GetResult();
+
+        internal async Task<int> RunShutdownAsync(string pipeName, bool waitForProcess, CancellationToken cancellationToken = default)
         {
-            return RunShutdownAsync(pipeName, waitForProcess, timeout, cancellationToken).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Shutting down the server is an inherently racy operation.  The server can be started or stopped by
-        /// external parties at any time.
-        /// 
-        /// This function will return success if at any time in the function the server is determined to no longer
-        /// be running.
-        /// </summary>
-        internal async Task<int> RunShutdownAsync(string pipeName, bool waitForProcess = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
-        {
-            if (WasServerRunning(pipeName) == false)
-            {
-                // The server holds the mutex whenever it is running, if it's not open then the 
-                // server simply isn't running.
-                return CommonCompiler.Succeeded;
-            }
-
-            try
-            {
-                var realTimeout = timeout != null
-                    ? (int)timeout.Value.TotalMilliseconds
-                    : Timeout.Infinite;
-                var response = await BuildServerConnection.RunServerShutdownRequestAsync(
-                    pipeName,
-                    timeoutOverride: realTimeout,
-                    _logger,
-                    cancellationToken).ConfigureAwait(false);
-
-                if (response is ShutdownBuildResponse shutdownBuildResponse)
-                {
-                    if (waitForProcess)
-                    {
-                        try
-                        {
-                            var process = Process.GetProcessById(shutdownBuildResponse.ServerProcessId);
-                            process.WaitForExit();
-                        }
-                        catch (Exception)
-                        {
-                            // There is an inherent race here with the server process.  If it has already shutdown
-                            // by the time we try to access it then the operation has succeed.
-                        }
-                    }
-
-                    return CommonCompiler.Succeeded;
-                }
-
-                return CommonCompiler.Failed;
-            }
-            catch (Exception)
-            {
-                if (WasServerRunning(pipeName) == false)
-                {
-                    // If the server was in the process of shutting down when we connected then it's reasonable
-                    // for an exception to happen.  If the mutex has shutdown at this point then the server 
-                    // is shut down.
-                    return CommonCompiler.Succeeded;
-                }
-
-                return CommonCompiler.Failed;
-            }
+            var success = await BuildServerConnection.RunServerShutdownRequestAsync(
+                pipeName,
+                timeoutOverride: null,
+                waitForProcess: waitForProcess,
+                _logger,
+                cancellationToken).ConfigureAwait(false);
+            return success ? CommonCompiler.Succeeded : CommonCompiler.Failed;
         }
 
         internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown)

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         private static string? GetDefaultPipeName()
         {
-            return BuildServerConnection.GetPipeNameForPath(BuildClient.GetClientDirectory());
+            return BuildServerConnection.GetPipeName(BuildClient.GetClientDirectory());
         }
 
         internal int RunServer(

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -185,14 +185,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 var realTimeout = timeout != null
                     ? (int)timeout.Value.TotalMilliseconds
                     : Timeout.Infinite;
-                var request = BuildRequest.CreateShutdown();
-                var response = await BuildServerConnection.RunServerBuildRequestAsync(
-                    BuildRequest.CreateShutdown(),
+                var response = await BuildServerConnection.RunServerShutdownRequestAsync(
                     pipeName,
-                    clientDirectory: AppDomain.CurrentDomain.BaseDirectory!,
-                    _logger,
                     timeoutOverride: realTimeout,
-                    createServerIfNotRunning: false,
+                    _logger,
                     cancellationToken).ConfigureAwait(false);
 
                 if (response is ShutdownBuildResponse shutdownBuildResponse && waitForProcess)

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -98,23 +98,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         internal static ICompilerServerHost CreateCompilerServerHost(ICompilerServerLogger logger)
         {
-            // VBCSCompiler is installed in the same directory as csc.exe and vbc.exe which is also the 
-            // location of the response files.
-            //
-            // BaseDirectory was mistakenly marked as potentially null in 3.1
-            // https://github.com/dotnet/runtime/pull/32486
-            var clientDirectory = AppDomain.CurrentDomain.BaseDirectory!;
+            var clientDirectory = BuildClient.GetClientDirectory();
             var sdkDirectory = BuildClient.GetSystemSdkDirectory();
-
             return new CompilerServerHost(clientDirectory, sdkDirectory, logger);
         }
 
         private static string? GetDefaultPipeName()
         {
-            // BaseDirectory was mistakenly marked as nullable in 3.1
-            // https://github.com/dotnet/runtime/pull/32486
-            var clientDirectory = AppDomain.CurrentDomain.BaseDirectory!;
-            return BuildServerConnection.GetPipeNameForPath(clientDirectory);
+            return BuildServerConnection.GetPipeNameForPath(BuildClient.GetClientDirectory());
         }
 
         internal int RunServer(

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -33,8 +33,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             private readonly BuildPaths _buildPaths;
             private readonly List<ServerData> _serverDataList = new List<ServerData>();
             private readonly XunitCompilerServerLogger _logger;
-            private bool _allowServer = true;
-            private int _failedCreatedServerCount = 0;
 
             public ServerTests(ITestOutputHelper testOutputHelper)
             {
@@ -71,18 +69,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 var serverData = ServerUtil.CreateServer(_logger, pipeName).GetAwaiter().GetResult();
                 _serverDataList.Add(serverData);
                 return serverData;
-            }
-
-            private bool TryCreateServer(string pipeName)
-            {
-                if (!_allowServer)
-                {
-                    _failedCreatedServerCount++;
-                    return false;
-                }
-
-                CreateServer(pipeName);
-                return true;
             }
 
             [Fact]
@@ -155,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     async () => await connection);
 
                 // Create server and try again
-                Assert.True(TryCreateServer(pipeName));
+                using var serverData = CreateServer(pipeName);
                 Assert.True(await tryConnectToNamedPipe(Timeout.Infinite, cancellationToken: default));
 
                 async Task<bool> tryConnectToNamedPipe(int timeoutMs, CancellationToken cancellationToken)
@@ -165,41 +151,27 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 }
             }
 
-            [ConditionalFact(typeof(DesktopOnly))]
-            public void OnlyStartsOneServer()
-            {
-                var ranLocal = false;
-                var client = CreateClient(
-                    compileFunc: delegate
-                    {
-                        ranLocal = true;
-                        throw new Exception();
-                    });
-
-                for (var i = 0; i < 5; i++)
-                {
-                    client.RunCompilation(new[] { "/shared" }, _buildPaths, new StringWriter(), pipeName: _pipeName);
-                }
-
-                Assert.Equal(1, _serverDataList.Count);
-                Assert.False(ranLocal);
-            }
-
             [Fact]
             public void FallbackToCsc()
             {
-                _allowServer = false;
                 var ranLocal = false;
-                var client = CreateClient(compileFunc: delegate
-                {
-                    ranLocal = true;
-                    return 0;
-                });
+                var ranServer = false;
+                var client = CreateClient(
+                    compileFunc: (_, _, _, _) =>
+                    {
+                        ranLocal = true;
+                        return 0;
+                    },
+                    compileOnServerFunc: (_, _, _) =>
+                    {
+                        ranServer = true;
+                        return Task.FromResult<BuildResponse>(new RejectedBuildResponse(""));
+                    });
 
                 var exitCode = client.RunCompilation(new[] { "/shared" }, _buildPaths, pipeName: _pipeName).ExitCode;
                 Assert.Equal(0, exitCode);
                 Assert.True(ranLocal);
-                Assert.Equal(1, _failedCreatedServerCount);
+                Assert.True(ranServer);
                 Assert.Equal(0, _serverDataList.Count);
             }
         }

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 language ??= RequestLanguage.CSharpCompile;
                 compileFunc ??= delegate { return 0; };
                 compileOnServerFunc ??= delegate { throw new InvalidOperationException(); };
-                return new BuildClient(language.Value, compileFunc, compileOnServerFunc, _logger);
+                return new BuildClient(language.Value, compileFunc, compileOnServerFunc);
             }
 
             private ServerData CreateServer(string pipeName)

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -58,12 +58,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             private BuildClient CreateClient(
                 RequestLanguage? language = null,
                 CompileFunc compileFunc = null,
-                CreateServerFunc createServerFunc = null)
+                CompileOnServerFunc compileOnServerFunc = null)
             {
                 language ??= RequestLanguage.CSharpCompile;
                 compileFunc ??= delegate { return 0; };
-                createServerFunc ??= ((_, pipeName, _) => TryCreateServer(pipeName));
-                return new BuildClient(language.Value, compileFunc, _logger, createServerFunc);
+                compileOnServerFunc ??= delegate { throw new InvalidOperationException(); };
+                return new BuildClient(language.Value, compileFunc, compileOnServerFunc, _logger);
             }
 
             private ServerData CreateServer(string pipeName)

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -317,17 +317,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void GetPipeNameForPathOptSlashes()
             {
                 var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
-                var name = BuildServerConnection.GetPipeNameForPath(path);
-                Assert.Equal(name, BuildServerConnection.GetPipeNameForPath(path));
-                Assert.Equal(name, BuildServerConnection.GetPipeNameForPath(path + Path.DirectorySeparatorChar));
-                Assert.Equal(name, BuildServerConnection.GetPipeNameForPath(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
+                var name = BuildServerConnection.GetPipeName(path);
+                Assert.Equal(name, BuildServerConnection.GetPipeName(path));
+                Assert.Equal(name, BuildServerConnection.GetPipeName(path + Path.DirectorySeparatorChar));
+                Assert.Equal(name, BuildServerConnection.GetPipeName(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
             }
 
             [Fact]
             public void GetPipeNameForPathOptLength()
             {
                 var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
-                var name = BuildServerConnection.GetPipeNameForPath(path);
+                var name = BuildServerConnection.GetPipeName(path);
                 // We only have ~50 total bytes to work with on mac, so the base path must be small
                 Assert.Equal(43, name.Length);
             }

--- a/src/Compilers/Server/VBCSCompilerTests/BuildServerConnectionTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildServerConnectionTests.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CommandLine;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
+{
+    public sealed class BuildServerConnectionTests : IDisposable
+    {
+        internal TempRoot TempRoot { get; } = new TempRoot();
+        internal XunitCompilerServerLogger Logger { get; }
+
+        public BuildServerConnectionTests(ITestOutputHelper testOutputHelper)
+        {
+            Logger = new XunitCompilerServerLogger(testOutputHelper);
+        }
+
+        public void Dispose()
+        {
+            TempRoot.Dispose();
+        }
+
+        [Fact]
+        public async Task OnlyStartOneServer()
+        {
+            ServerData? serverData = null;
+            try
+            {
+                var pipeName = ServerUtil.GetPipeName();
+                var workingDirectory = TempRoot.CreateDirectory().Path;
+                for (var i = 0; i < 5; i++)
+                {
+                    var response = await BuildServerConnection.RunServerBuildRequestAsync(
+                        ProtocolUtil.CreateEmptyCSharp(workingDirectory),
+                        pipeName,
+                        timeoutOverride: Timeout.Infinite,
+                        tryCreateServerFunc: (pipeName, logger) =>
+                        {
+                            Assert.Null(serverData);
+                            serverData = ServerData.Create(logger, pipeName);
+                            return true;
+                        },
+                        Logger,
+                        cancellationToken: default);
+                    Assert.True(response is CompletedBuildResponse);
+                }
+            }
+            finally
+            {
+                serverData?.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task UseExistingServer()
+        {
+            using var serverData = await ServerUtil.CreateServer(Logger);
+            var ran = false;
+            var workingDirectory = TempRoot.CreateDirectory().Path;
+            for (var i = 0; i < 5; i++)
+            {
+                var response = await BuildServerConnection.RunServerBuildRequestAsync(
+                    ProtocolUtil.CreateEmptyCSharp(workingDirectory),
+                    serverData.PipeName,
+                    timeoutOverride: Timeout.Infinite,
+                    tryCreateServerFunc: (_, _) =>
+                    {
+                        ran = true;
+                        return false;
+                    },
+                    Logger,
+                    cancellationToken: default);
+                Assert.True(response is CompletedBuildResponse);
+            }
+
+            Assert.False(ran);
+        }
+
+        /// <summary>
+        /// Simulate the case where the server process crashes or hangs on startup 
+        /// and make sure the client properly fails
+        /// </summary>
+        [Fact]
+        public async Task SimulateServerCrashingOnStartup()
+        {
+            var pipeName = ServerUtil.GetPipeName();
+            var ran = false;
+            var response = await BuildServerConnection.RunServerBuildRequestAsync(
+                ProtocolUtil.CreateEmptyCSharp(TempRoot.CreateDirectory().Path),
+                pipeName,
+                timeoutOverride: (int)TimeSpan.FromSeconds(2).TotalMilliseconds,
+                tryCreateServerFunc: (_, _) =>
+                {
+                    ran = true;
+
+                    // Correct this is a lie. The server did not start. But it also does a nice
+                    // job of simulating a hung or crashed server.
+                    return true;
+                },
+                Logger,
+                cancellationToken: default);
+            Assert.True(response is RejectedBuildResponse);
+            Assert.True(ran);
+        }
+
+        [Fact]
+        public async Task FailedServer()
+        {
+            var pipeName = ServerUtil.GetPipeName();
+            var workingDirectory = TempRoot.CreateDirectory().Path;
+            var count = 0;
+            for (var i = 0; i < 5; i++)
+            {
+                var response = await BuildServerConnection.RunServerBuildRequestAsync(
+                    ProtocolUtil.CreateEmptyCSharp(workingDirectory),
+                    pipeName,
+                    timeoutOverride: Timeout.Infinite,
+                    tryCreateServerFunc: (_, _) =>
+                    {
+                        count++;
+                        return false;
+                    },
+                    Logger,
+                    cancellationToken: default);
+                Assert.True(response is RejectedBuildResponse);
+            }
+
+            Assert.Equal(5, count);
+        }
+    }
+}

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -205,11 +205,7 @@ End Module")
             CheckForBadShared(arguments);
             CreateFiles(currentDirectory, filesInDirectory);
 
-            // Create a client to run the build.  Infinite timeout is used to account for the
-            // case where these tests are run under extreme load.  In high load scenarios the
-            // client will correctly drop down to a local compilation if the server doesn't respond
-            // fast enough.
-            var client = ServerUtil.CreateBuildClient(language, _logger, timeoutOverride: Timeout.Infinite);
+            var client = ServerUtil.CreateBuildClient(language, _logger);
 
             var sdkDir = ServerUtil.DefaultSdkDirectory;
 

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -160,18 +160,18 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             // case where these tests are run under extreme load.  In high load scenarios the
             // client will correctly drop down to a local compilation if the server doesn't respond
             // fast enough.
-            CompileOnServerFunc compileOnServerFunc = (request, pipeName, clientDirectory, logger, cancellationToken) =>
+            CompileOnServerFunc compileOnServerFunc = (request, pipeName, cancellationToken) =>
                 BuildServerConnection.RunServerBuildRequestAsync(
                     request,
                     pipeName,
-                    clientDirectory,
+                    clientDirectory: null,
                     logger,
                     timeoutOverride: Timeout.Infinite,
-                    createServerIfNotRunning: true,
+                    createServerIfNotRunning: false,
                     cancellationToken);
 
             var compileFunc = GetCompileFunc(language);
-            return new BuildClient(language, compileFunc, compileOnServerFunc, logger);
+            return new BuildClient(language, compileFunc, compileOnServerFunc);
         }
 
         internal static CompileFunc GetCompileFunc(RequestLanguage language)

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -54,10 +54,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Logger = new XunitCompilerServerLogger(testOutputHelper);
             }
 
-            private Task<int> RunShutdownAsync(string pipeName, bool waitForProcess = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default(CancellationToken))
+            private Task<int> RunShutdownAsync(string pipeName, bool waitForProcess = true, CancellationToken cancellationToken = default(CancellationToken))
             {
                 var appSettings = new NameValueCollection();
-                return new BuildServerController(appSettings, Logger).RunShutdownAsync(pipeName, waitForProcess, timeout, cancellationToken);
+                return new BuildServerController(appSettings, Logger).RunShutdownAsync(pipeName, waitForProcess, cancellationToken);
             }
 
             [Fact]

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
             if (hasShared)
             {
-                pipeName = pipeName ?? GetPipeName(buildPaths);
+                pipeName = pipeName ?? BuildServerConnection.GetPipeName(buildPaths.ClientDirectory);
                 var libDirectory = Environment.GetEnvironmentVariable("LIB");
                 var serverResult = RunServerCompilation(textWriter, parsedArgs, buildPaths, libDirectory, pipeName, keepAliveOpt);
                 if (serverResult.HasValue)
@@ -295,16 +295,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     Debug.Assert(false);
                     return null;
             }
-        }
-
-        /// <summary>
-        /// Given the full path to the directory containing the compiler exes,
-        /// retrieves the name of the pipe for client/server communication on
-        /// that instance of the compiler.
-        /// </summary>
-        private static string GetPipeName(BuildPaths buildPaths)
-        {
-            return BuildServerConnection.GetPipeNameForPath(buildPaths.ClientDirectory);
         }
 
         private static IEnumerable<string> GetCommandLineArgs(IEnumerable<string> args)

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         }
 
         public static CompileOnServerFunc GetCompileOnServerFunc(ICompilerServerLogger logger) => (buildRequest, pipeName, cancellationToken) =>
-            BuildServerConnection.RunServerCompilationAsync(
+            BuildServerConnection.RunServerBuildRequestAsync(
                 buildRequest,
                 pipeName,
                 GetClientDirectory(),

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             _language = language;
             _compileFunc = compileFunc;
             _logger = logger;
-            _createServerFunc = createServerFunc ?? BuildServerConnection.TryCreateServerCore;
+            _createServerFunc = createServerFunc ?? BuildServerConnection.TryCreateServer;
             _timeoutOverride = timeoutOverride;
         }
 
@@ -95,7 +95,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var originalArguments = GetCommandLineArgs(arguments);
             return client.RunCompilation(originalArguments, buildPaths, requestId: requestId).ExitCode;
         }
-
 
         /// <summary>
         /// Run a compilation through the compiler server and print the output
@@ -226,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     buildPaths.SdkDirectory,
                     buildPaths.TempDirectory);
 
-                var buildResponseTask = BuildServerConnection.RunServerCompilationCoreAsync(
+                var buildResponseTask = BuildServerConnection.RunServerCompilationAsync(
                     requestId ?? Guid.NewGuid(),
                     _language,
                     arguments,

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -23,45 +23,6 @@ using static Microsoft.CodeAnalysis.CommandLine.NativeMethods;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
-    /// <summary>
-    /// This type is functionally identical to BuildPaths. Unfortunately BuildPaths cannot be used in our MSBuild 
-    /// layer as it's defined in Microsoft.CodeAnalysis. Yet we need the same functionality in our build server 
-    /// communication layer which is shared between MSBuild and non-MSBuild components. This is the problem that 
-    /// BuildPathsAlt fixes as the type lives with the build server communication code.
-    /// </summary>
-    internal sealed class BuildPathsAlt
-    {
-        /// <summary>
-        /// The path which contains the compiler binaries and response files.
-        /// </summary>
-        internal string ClientDirectory { get; }
-
-        /// <summary>
-        /// The path in which the compilation takes place.
-        /// </summary>
-        internal string WorkingDirectory { get; }
-
-        /// <summary>
-        /// The path which contains mscorlib.  This can be null when specified by the user or running in a 
-        /// CoreClr environment.
-        /// </summary>
-        internal string? SdkDirectory { get; }
-
-        /// <summary>
-        /// The temporary directory a compilation should use instead of <see cref="Path.GetTempPath"/>.  The latter
-        /// relies on global state individual compilations should ignore.
-        /// </summary>
-        internal string? TempDirectory { get; }
-
-        internal BuildPathsAlt(string clientDir, string workingDir, string? sdkDir, string? tempDir)
-        {
-            ClientDirectory = clientDir;
-            WorkingDirectory = workingDir;
-            SdkDirectory = sdkDir;
-            TempDirectory = tempDir;
-        }
-    }
-
     internal sealed class BuildServerConnection
     {
         // Spend up to 1s connecting to existing process (existing processes should be always responsive).

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -131,14 +131,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
             string pipeName,
             string clientDirectory,
             ICompilerServerLogger logger,
-            CancellationToken cancellationToken) =>
-            RunServerBuildRequestAsync(
-                buildRequest,
-                pipeName,
-                timeoutOverride: null,
-                tryCreateServerFunc: (pipeName, logger) => TryCreateServer(clientDirectory, pipeName, logger),
-                logger,
-                cancellationToken);
+            CancellationToken cancellationToken)
+                => RunServerBuildRequestAsync(
+                    buildRequest,
+                    pipeName,
+                    timeoutOverride: null,
+                    tryCreateServerFunc: (pipeName, logger) => TryCreateServer(clientDirectory, pipeName, logger),
+                    logger,
+                    cancellationToken);
 
         internal static async Task<BuildResponse> RunServerBuildRequestAsync(
             BuildRequest buildRequest,

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -77,34 +77,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// </summary>
         internal static bool IsCompilerServerSupported => GetPipeNameForPath("") is object;
 
-        public static Task<BuildResponse> RunServerCompilationAsync(
-            Guid requestId,
-            RequestLanguage language,
-            string? sharedCompilationId,
-            List<string> arguments,
-            BuildPathsAlt buildPaths,
-            string? keepAlive,
-            string? libEnvVariable,
-            ICompilerServerLogger logger,
-            CancellationToken cancellationToken)
-        {
-            var pipeNameOpt = sharedCompilationId ?? GetPipeNameForPath(buildPaths.ClientDirectory);
-
-            return RunServerCompilationCoreAsync(
-                requestId,
-                language,
-                arguments,
-                buildPaths,
-                pipeNameOpt,
-                keepAlive,
-                libEnvVariable,
-                timeoutOverride: null,
-                createServerFunc: TryCreateServerCore,
-                logger: logger,
-                cancellationToken: cancellationToken);
-        }
-
-        internal static async Task<BuildResponse> RunServerCompilationCoreAsync(
+        internal static async Task<BuildResponse> RunServerCompilationAsync(
             Guid requestId,
             RequestLanguage language,
             List<string> arguments,
@@ -423,7 +396,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             return RuntimeHostInfo.GetProcessInfo(serverPathWithoutExtension, commandLineArgs);
         }
 
-        internal static bool TryCreateServerCore(string clientDir, string pipeName, ICompilerServerLogger logger)
+        internal static bool TryCreateServer(string clientDir, string pipeName, ICompilerServerLogger logger)
         {
             var serverInfo = GetServerProcessInfo(clientDir, pipeName);
 

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -96,7 +96,11 @@ namespace Microsoft.CodeAnalysis.CommandLine
                         try
                         {
                             var process = Process.GetProcessById(shutdownBuildResponse.ServerProcessId);
+#if NET50_OR_GREATER
+                            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+#else
                             process.WaitForExit();
+#endif
                         }
                         catch (Exception)
                         {
@@ -337,14 +341,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
         }
 
         /// <summary>
-        /// Attempt to connect to the server and return a null task if connection failed. This
-        /// method will throw on cancellation
+        /// Attempt to connect to the server and return a null <see cref="NamedPipeClientStream"/> if connection 
+        /// failed. This method will throw on cancellation.
         /// </summary>
-        /// <param name="pipeName"></param>
-        /// <param name="timeoutMs"></param>
-        /// <param name="logger"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
         internal static async Task<NamedPipeClientStream?> TryConnectToServerAsync(
             string pipeName,
             int timeoutMs,

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -30,7 +30,6 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 
         private static int MainCore(string[] args)
         {
-            var requestId = Guid.NewGuid();
             using var logger = new CompilerServerLogger($"vbc {Process.GetCurrentProcess().Id}");
 
 #if BOOTSTRAP

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
             ExitingTraceListener.Install(logger);
 #endif
 
-            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, BuildServerConnection.RunServerCompilationAsync, logger);
+            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, BuildClient.GetCompileOnServerFunc(logger));
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.CodeAnalysis.CommandLine;
 
@@ -30,13 +31,13 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
         private static int MainCore(string[] args)
         {
             var requestId = Guid.NewGuid();
-            using var logger = new CompilerServerLogger($"vbc {requestId}");
+            using var logger = new CompilerServerLogger($"vbc {Process.GetCurrentProcess().Id}");
 
 #if BOOTSTRAP
             ExitingTraceListener.Install(logger);
 #endif
 
-            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, logger, requestId);
+            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, BuildServerConnection.RunServerCompilationAsync, logger);
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)


### PR DESCRIPTION
The logic for how to communicate with the compiler server was spread out amongst a number of types in the code and it was causing a few problems: 

1. Made the server protocol hard to understand because you had to dig through 3-4 different types to understand the interactions.
2. Made testing real scenarios difficult because the logic was in the wrong places (why should the csc.exe know anything about how connections are managed?) 
3. Lead to too many knobs being put into the APIs that created scenarios that needed to be tested that never actually occurred in production code. 

This change was mostly spurred by (2) above. In a recent bug fix I ended up spending far too much time trying to write a very simple test. It motivated me to finally fix this up.

The bulk of the change is in `BuildServerConnection.cs`. That is now the central point for all logic around how the server is started, build requests are processed and how the server is shut down. All logic for that set of interaction should now be centralized here. 