### PR TITLE
Revert "[main] Update dependencies from dotnet/arcade"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,17 +3,17 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21216.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21167.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>53fe29e220fc0db05eafd5c6bc6c8fb9ee7cec7c</Sha>
+      <Sha>0ca849f0b71866b007fedaaa938cee63f8d056a6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.10.0-3.21216.10">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>9bfe989ad46e3f457d33ed800c3be012cec5afc6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21216.2">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21167.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>53fe29e220fc0db05eafd5c6bc6c8fb9ee7cec7c</Sha>
+      <Sha>0ca849f0b71866b007fedaaa938cee63f8d056a6</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/common/cross/arm64/tizen-fetch.sh
+++ b/eng/common/cross/arm64/tizen-fetch.sh
@@ -157,7 +157,7 @@ fetch_tizen_pkgs()
 Inform "Initialize arm base"
 fetch_tizen_pkgs_init standard base
 Inform "fetch common packages"
-fetch_tizen_pkgs aarch64 gcc glibc glibc-devel libicu libicu-devel libatomic linux-glibc-devel keyutils keyutils-devel libkeyutils
+fetch_tizen_pkgs aarch64 gcc glibc glibc-devel libicu libicu-devel libatomic linux-glibc-devel
 Inform "fetch coreclr packages"
 fetch_tizen_pkgs aarch64 lldb lldb-devel libgcc libstdc++ libstdc++-devel libunwind libunwind-devel lttng-ust-devel lttng-ust userspace-rcu-devel userspace-rcu
 Inform "fetch corefx packages"

--- a/eng/common/cross/build-android-rootfs.sh
+++ b/eng/common/cross/build-android-rootfs.sh
@@ -106,7 +106,6 @@ __AndroidPackages+=" libandroid-glob"
 __AndroidPackages+=" liblzma"
 __AndroidPackages+=" krb5"
 __AndroidPackages+=" openssl"
-__AndroidPackages+=" openldap"
 
 for path in $(wget -qO- http://termux.net/dists/stable/main/binary-$__AndroidArch/Packages |\
     grep -A15 "Package: \(${__AndroidPackages// /\\|}\)" | grep -v "static\|tool" | grep Filename); do

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -55,13 +55,11 @@ __UbuntuPackages+=" libcurl4-openssl-dev"
 __UbuntuPackages+=" libkrb5-dev"
 __UbuntuPackages+=" libssl-dev"
 __UbuntuPackages+=" zlib1g-dev"
-__UbuntuPackages+=" libldap2-dev"
 
 __AlpinePackages+=" curl-dev"
 __AlpinePackages+=" krb5-dev"
 __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
-__AlpinePackages+=" openldap-dev"
 
 __FreeBSDBase="12.1-RELEASE"
 __FreeBSDPkg="1.12.0"
@@ -70,13 +68,11 @@ __FreeBSDPackages+=" icu"
 __FreeBSDPackages+=" libinotify"
 __FreeBSDPackages+=" lttng-ust"
 __FreeBSDPackages+=" krb5"
-__FreeBSDPackages+=" libslapi-2.4"
 
 __IllumosPackages="icu-64.2nb2"
 __IllumosPackages+=" mit-krb5-1.16.2nb4"
 __IllumosPackages+=" openssl-1.1.1e"
 __IllumosPackages+=" zlib-1.2.11"
-__IllumosPackages+=" openldap-client-2.4.49"
 
 __UseMirror=0
 

--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -38,7 +38,7 @@ if ($allXlfFiles) {
     $langXlfFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory\*\*.$firstLangCode.xlf"
 }
 $langXlfFiles | ForEach-Object {
-    $null = $_.Name -Match "(.+)\.[\w-]+\.xlf" # matches '[filename].[langcode].xlf
+    $null = $_.Name -Match "([^.]+)\.[\w-]+\.xlf" # matches '[filename].[langcode].xlf'
     
     $destinationFile = "$($_.Directory.FullName)\$($Matches.1).xlf"
     $xlfFiles += Copy-Item "$($_.FullName)" -Destination $destinationFile -PassThru
@@ -52,7 +52,7 @@ $locJson = @{
             LanguageSet = $LanguageSet
             LocItems = @(
                 $locFiles | ForEach-Object {
-                    $outputPath = "$(($_.DirectoryName | Resolve-Path -Relative) + "\")" 
+                    $outputPath = "Localize\$(($_.DirectoryName | Resolve-Path -Relative) + "\")" 
                     $continue = $true
                     foreach ($exclusion in $exclusions.Exclusions) {
                         if ($outputPath.Contains($exclusion))
@@ -79,7 +79,7 @@ $locJson = @{
 }
 
 $json = ConvertTo-Json $locJson -Depth 5
-Write-Host "LocProject.json generated:`n`n$json`n`n"
+Write-Host "(NETCORE_ENGINEERING_TELEMETRY=Build) LocProject.json generated:`n`n$json`n`n"
 Pop-Location
 
 if (!$UseCheckedInLocProjectJson) {
@@ -91,7 +91,7 @@ else {
     Set-Content "$SourcesDirectory\Localize\LocProject-generated.json" $json
 
     if ((Get-FileHash "$SourcesDirectory\Localize\LocProject-generated.json").Hash -ne (Get-FileHash "$SourcesDirectory\Localize\LocProject.json").Hash) {
-        Write-PipelineTelemetryError -Category "OneLocBuild" -Message "Existing LocProject.json differs from generated LocProject.json. Download LocProject-generated.json and compare them."
+        Write-PipelineTaskError -Type "warning" -Message "Existing LocProject.json differs from generated LocProject.json. Download LocProject-generated.json and compare them."
         
         exit 1
     }

--- a/eng/common/performance/blazor_perf.proj
+++ b/eng/common/performance/blazor_perf.proj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
+    <Python>python3</Python>
+    <HelixPreCommands>$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
+      <PayloadDirectory>%(Identity)</PayloadDirectory>
+    </HelixCorrelationPayload>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
+    <ScenarioDirectory>%HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\</ScenarioDirectory>
+    <BlazorDirectory>$(ScenarioDirectory)blazor\</BlazorDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
+    <ScenarioDirectory>$HELIX_CORRELATION_PAYLOAD/performance/src/scenarios/</ScenarioDirectory>
+    <BlazorDirectory>$(ScenarioDirectory)blazor/</BlazorDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <HelixWorkItem Include="SOD - New Blazor Template - Publish">
+        <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+        <PreCommands>cd $(BlazorDirectory);$(Python) pre.py publish --msbuild %27/p:_TrimmerDumpDependencies=true%27 --msbuild-static AdditionalMonoLinkerOptions=%27&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;%27 --binlog %27./traces/blazor_publish.binlog%27</PreCommands>
+        <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+        <PostCommands>$(Python) post.py</PostCommands>
+    </HelixWorkItem>
+  </ItemGroup>
+</Project>

--- a/eng/common/performance/crossgen_perf.proj
+++ b/eng/common/performance/crossgen_perf.proj
@@ -1,0 +1,110 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
+      <PayloadDirectory>%(Identity)</PayloadDirectory>
+    </HelixCorrelationPayload>
+  </ItemGroup>
+
+  <!-- 
+    Crossgen and Crossgen2 Scenario WorkItems 
+  -->
+  <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
+    <Python>py -3</Python>
+    <HelixPreCommands>$(HelixPreCommands)</HelixPreCommands>
+    <CoreRoot>%HELIX_CORRELATION_PAYLOAD%\Core_Root</CoreRoot>
+    <ScenarioDirectory>%HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\</ScenarioDirectory>
+    <CrossgenDirectory>$(ScenarioDirectory)crossgen\</CrossgenDirectory>
+    <Crossgen2Directory>$(ScenarioDirectory)crossgen2\</Crossgen2Directory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
+    <Python>python3</Python>
+    <HelixPreCommands>$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/startup/Startup;chmod +x $HELIX_WORKITEM_PAYLOAD/startup/perfcollect;sudo apt update;chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
+    <CoreRoot>$HELIX_CORRELATION_PAYLOAD/Core_Root</CoreRoot>
+    <ScenarioDirectory>$HELIX_CORRELATION_PAYLOAD/performance/src/scenarios/</ScenarioDirectory>
+    <CrossgenDirectory>$(ScenarioDirectory)crossgen/</CrossgenDirectory>
+    <Crossgen2Directory>$(ScenarioDirectory)crossgen2/</Crossgen2Directory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SingleAssembly Include="System.Net.WebProxy.dll"/>                 <!-- Approx. 10 KB as of 2020/10 -->
+    <SingleAssembly Include="System.Net.Http.Json.dll"/>                <!-- Approx. 20 KB as of 2020/10 -->
+    <SingleAssembly Include="System.Drawing.Primitives.dll"/>           <!-- Approx. 50 KB as of 2020/10 -->
+    <SingleAssembly Include="System.ServiceModel.Syndication.dll"/>     <!-- Approx. 100 KB as of 2020/10 -->
+    <SingleAssembly Include="System.Net.Sockets.dll"/>                  <!-- Approx. 200 KB as of 2020/10 -->
+    <SingleAssembly Include="System.Linq.Expressions.dll"/>             <!-- Approx. 500 KB as of 2020/10 -->
+    <SingleAssembly Include="System.Data.Common.dll"/>                  <!-- Approx. 1 MB as of 2020/10 -->
+    <SingleAssembly Include="Microsoft.CodeAnalysis.dll"/>              <!-- Approx. 2 MB as of 2020/10 -->
+    <SingleAssembly Include="System.Private.Xml.dll"/>                  <!-- Approx. 3 MB as of 2020/10 -->
+    <SingleAssembly Include="Microsoft.CodeAnalysis.VisualBasic.dll"/>  <!-- Approx. 4 MB as of 2020/10 -->
+    <SingleAssembly Include="Microsoft.CodeAnalysis.CSharp.dll"/>       <!-- Approx. 4 MB as of 2020/10 -->
+    <SingleAssembly Include="System.Private.CoreLib.dll"/>              <!-- Approx. 10 MB as of 2020/10 -->
+  </ItemGroup>
+  <ItemGroup>
+    <Composite Include="framework-r2r.dll.rsp"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <CrossgenWorkItem Include="@(SingleAssembly)">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <Command>$(Python) $(CrossgenDirectory)test.py crossgen --core-root $(CoreRoot) --test-name %(Identity)</Command>
+    </CrossgenWorkItem>
+  </ItemGroup>
+
+  <ItemGroup> 
+    <Crossgen2WorkItem Include="@(SingleAssembly)">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <Command>$(Python) $(Crossgen2Directory)test.py crossgen2 --core-root $(CoreRoot) --single %(Identity)</Command>
+    </Crossgen2WorkItem>
+  </ItemGroup>
+
+  <ItemGroup> 
+    <Crossgen2SingleThreadedWorkItem Include="@(SingleAssembly)">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <Command>$(Python) $(Crossgen2Directory)test.py crossgen2 --core-root $(CoreRoot) --single %(Identity) --singlethreaded True</Command>
+    </Crossgen2SingleThreadedWorkItem>
+  </ItemGroup>
+
+  <ItemGroup>
+    <CrossgenSizeOnDiskWorkItem Include="@(SingleAssembly)" Condition="'$(Architecture)' == 'x64'">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands>$(Python) $(CrossgenDirectory)pre.py crossgen --core-root $(CoreRoot) --single %(Identity) </PreCommands>
+      <Command>$(Python) $(CrossgenDirectory)test.py sod --scenario-name &quot;Crossgen %(Identity) Size&quot; --dirs ./crossgen.out/</Command>
+      <PostCommands>$(Python) $(CrossgenDirectory)post.py</PostCommands>
+    </CrossgenSizeOnDiskWorkItem>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Crossgen2SizeOnDiskWorkItem Include="@(SingleAssembly)" Condition="'$(Architecture)' == 'x64'">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands>$(Python) $(Crossgen2Directory)pre.py crossgen2 --core-root $(CoreRoot) --single %(Identity) </PreCommands>
+      <Command>$(Python) $(Crossgen2Directory)test.py sod --scenario-name &quot;Crossgen2 %(Identity) Size&quot; --dirs ./crossgen.out/</Command>
+      <PostCommands>$(Python) $(Crossgen2Directory)post.py</PostCommands>
+    </Crossgen2SizeOnDiskWorkItem>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Enable crossgen tests on Windows x64 and Windows x86 -->
+    <HelixWorkItem Include="@(CrossgenWorkItem -> 'Crossgen %(Identity)')" Condition="'$(AGENT_OS)' == 'Windows_NT'">
+      <Timeout>4:00</Timeout>
+    </HelixWorkItem>
+    <!-- Enable crossgen2 tests on Windows x64 and Linux x64 -->
+    <HelixWorkItem Include="@(Crossgen2WorkItem -> 'Crossgen2 %(Identity)')" Condition="'$(Architecture)' == 'x64'">
+      <Timeout>4:00</Timeout>
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(Crossgen2SingleThreadedWorkItem -> 'Crossgen2 single-threaded %(Identity)')" Condition="'$(Architecture)' == 'x64'">
+      <Timeout>4:00</Timeout>
+    </HelixWorkItem>
+    <HelixWorkItem Include="Crossgen2 Composite Framework R2R" Condition="'$(Architecture)' == 'x64'">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>	
+      <Command>$(Python) $(Crossgen2Directory)test.py crossgen2 --core-root $(CoreRoot) --composite $(Crossgen2Directory)framework-r2r.dll.rsp</Command>
+      <Timeout>1:00</Timeout>  
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(CrossgenSizeOnDiskWorkItem -> 'Crossgen Size on Disk %(Identity)')" Condition="'$(Architecture)' == 'x64'">
+      <Timeout>4:00</Timeout>  
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(Crossgen2SizeOnDiskWorkItem -> 'Crossgen2 Size on Disk %(Identity)')" Condition="'$(Architecture)' == 'x64'">
+      <Timeout>4:00</Timeout>  
+    </HelixWorkItem>
+  </ItemGroup>
+</Project>

--- a/eng/common/performance/microbenchmarks.proj
+++ b/eng/common/performance/microbenchmarks.proj
@@ -1,0 +1,144 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+
+  <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
+    <WorkItemCommand>%HELIX_CORRELATION_PAYLOAD%\performance\scripts\benchmarks_ci.py --csproj %HELIX_CORRELATION_PAYLOAD%\performance\$(TargetCsproj)</WorkItemCommand>
+    <CliArguments>--dotnet-versions %DOTNET_VERSION% --cli-source-info args --cli-branch %PERFLAB_BRANCH% --cli-commit-sha %PERFLAB_HASH% --cli-repository https://github.com/%PERFLAB_REPO% --cli-source-timestamp %PERFLAB_BUILDTIMESTAMP%</CliArguments>
+    <Python>py -3</Python>
+    <CoreRun>%HELIX_CORRELATION_PAYLOAD%\Core_Root\CoreRun.exe</CoreRun>
+    <BaselineCoreRun>%HELIX_CORRELATION_PAYLOAD%\Baseline_Core_Root\CoreRun.exe</BaselineCoreRun>
+    
+    <HelixPreCommands>$(HelixPreCommands);call %HELIX_CORRELATION_PAYLOAD%\performance\tools\machine-setup.cmd;set PYTHONPATH=%HELIX_WORKITEM_PAYLOAD%\scripts%3B%HELIX_WORKITEM_PAYLOAD%</HelixPreCommands>
+    <ArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts</ArtifactsDirectory>
+    <BaselineArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
+    <ResultsComparer>%HELIX_CORRELATION_PAYLOAD%\performance\src\tools\ResultsComparer\ResultsComparer.csproj</ResultsComparer>
+    <DotnetExe>%HELIX_CORRELATION_PAYLOAD%\performance\tools\dotnet\$(Architecture)\dotnet.exe</DotnetExe>
+    <Percent>%25%25</Percent>
+    <XMLResults>%HELIX_WORKITEM_ROOT%\testResults.xml</XMLResults>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT' and '$(RunFromPerfRepo)' == 'false'">
+    <BaseDirectory>$HELIX_CORRELATION_PAYLOAD</BaseDirectory>
+    <PerformanceDirectory>$(BaseDirectory)/performance</PerformanceDirectory>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT' and '$(RunFromPerfRepo)' == 'true'">
+    <BaseDirectory>$HELIX_WORKITEM_PAYLOAD</BaseDirectory>
+    <PerformanceDirectory>$(BaseDirectory)</PerformanceDirectory>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
+    <WorkItemCommand>$(PerformanceDirectory)/scripts/benchmarks_ci.py --csproj $(PerformanceDirectory)/$(TargetCsproj)</WorkItemCommand>
+    <CliArguments>--dotnet-versions $DOTNET_VERSION --cli-source-info args --cli-branch $PERFLAB_BRANCH --cli-commit-sha $PERFLAB_HASH --cli-repository https://github.com/$PERFLAB_REPO --cli-source-timestamp $PERFLAB_BUILDTIMESTAMP</CliArguments>
+    <Python>python3</Python>
+    <CoreRun>$(BaseDirectory)/Core_Root/corerun</CoreRun>
+    <BaselineCoreRun>$(BaseDirectory)/Baseline_Core_Root/corerun</BaselineCoreRun>
+    <HelixPreCommands>$(HelixPreCommands);chmod +x $(PerformanceDirectory)/tools/machine-setup.sh;. $(PerformanceDirectory)/tools/machine-setup.sh</HelixPreCommands>
+    <ArtifactsDirectory>$(BaseDirectory)/artifacts/BenchmarkDotNet.Artifacts</ArtifactsDirectory>
+    <BaselineArtifactsDirectory>$(BaseDirectory)/artifacts/BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
+    <ResultsComparer>$(PerformanceDirectory)/src/tools/ResultsComparer/ResultsComparer.csproj</ResultsComparer>
+    <DotnetExe>$(PerformanceDirectory)/tools/dotnet/$(Architecture)/dotnet</DotnetExe>
+    <Percent>%25</Percent>
+    <XMLResults>$HELIX_WORKITEM_ROOT/testResults.xml</XMLResults>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WasmDotnet)' == 'true'">
+    <CliArguments>$(CliArguments) --wasm</CliArguments>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' == 'Windows_NT'">
+    <CoreRunArgument>--corerun %HELIX_CORRELATION_PAYLOAD%\dotnet-mono\shared\Microsoft.NETCore.App\6.0.0\corerun.exe</CoreRunArgument>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' != 'Windows_NT'">
+    <CoreRunArgument>--corerun $(BaseDirectory)/dotnet-mono/shared/Microsoft.NETCore.App/6.0.0/corerun</CoreRunArgument>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseCoreRun)' == 'true'">
+    <CoreRunArgument>--corerun $(CoreRun)</CoreRunArgument>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseBaselineCoreRun)' == 'true'">
+    <BaselineCoreRunArgument>--corerun $(BaselineCoreRun)</BaselineCoreRunArgument>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(WorkItemCommand)' != ''">
+    <WorkItemCommand>$(Python) $(WorkItemCommand) --incremental no --architecture $(Architecture) -f $(_Framework) $(PerfLabArguments)</WorkItemCommand>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_Framework)' != 'net461'">
+    <WorkItemCommand>$(WorkItemCommand) $(CliArguments)</WorkItemCommand>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <WorkItemTimeout>2:30</WorkItemTimeout>
+    <WorkItemTimeout Condition="'$(HelixSourcePrefix)' != 'official'">0:15</WorkItemTimeout>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
+      <PayloadDirectory>%(Identity)</PayloadDirectory>
+    </HelixCorrelationPayload>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <PartitionCount>30</PartitionCount>
+  </PropertyGroup>
+  <ItemGroup>
+    <Partition Include="$(BuildConfig).Partition0" Index="0" />
+    <Partition Include="$(BuildConfig).Partition1" Index="1" />
+    <Partition Include="$(BuildConfig).Partition2" Index="2" />
+    <Partition Include="$(BuildConfig).Partition3" Index="3" />
+    <Partition Include="$(BuildConfig).Partition4" Index="4" />
+    <Partition Include="$(BuildConfig).Partition5" Index="5" />
+    <Partition Include="$(BuildConfig).Partition6" Index="6" />
+    <Partition Include="$(BuildConfig).Partition7" Index="7" />
+    <Partition Include="$(BuildConfig).Partition8" Index="8" />
+    <Partition Include="$(BuildConfig).Partition9" Index="9" />
+    <Partition Include="$(BuildConfig).Partition10" Index="10" />
+    <Partition Include="$(BuildConfig).Partition11" Index="11" />
+    <Partition Include="$(BuildConfig).Partition12" Index="12" />
+    <Partition Include="$(BuildConfig).Partition13" Index="13" />
+    <Partition Include="$(BuildConfig).Partition14" Index="14" />
+    <Partition Include="$(BuildConfig).Partition15" Index="15" />
+    <Partition Include="$(BuildConfig).Partition16" Index="16" />
+    <Partition Include="$(BuildConfig).Partition17" Index="17" />
+    <Partition Include="$(BuildConfig).Partition18" Index="18" />
+    <Partition Include="$(BuildConfig).Partition19" Index="19" />
+    <Partition Include="$(BuildConfig).Partition20" Index="20" />
+    <Partition Include="$(BuildConfig).Partition21" Index="21" />
+    <Partition Include="$(BuildConfig).Partition22" Index="22" />
+    <Partition Include="$(BuildConfig).Partition23" Index="23" />
+    <Partition Include="$(BuildConfig).Partition24" Index="24" />
+    <Partition Include="$(BuildConfig).Partition25" Index="25" />
+    <Partition Include="$(BuildConfig).Partition26" Index="26" />
+    <Partition Include="$(BuildConfig).Partition27" Index="27" />
+    <Partition Include="$(BuildConfig).Partition28" Index="28" />
+    <Partition Include="$(BuildConfig).Partition29" Index="29" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Compare)' == 'true'">
+    <FailOnTestFailure>false</FailOnTestFailure>
+  </PropertyGroup>
+
+  <!-- 
+    Partition the Microbenchmarks project, but nothing else
+  -->
+  <ItemGroup Condition="$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
+    <HelixWorkItem Include="@(Partition)">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-artifacts $(BaselineArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</PreCommands>
+      <Command>$(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(DotnetExe) run -f $(_Framework) -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults);$(FinalCommand)</PostCommands>
+      <Timeout>$(WorkItemTimeout)</Timeout>
+    </HelixWorkItem>
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
+    <HelixWorkItem Include="$(BuildConfig).WorkItem">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-artifacts $(BaselineArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument)"</PreCommands>
+      <Command>$(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument)"</Command>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(DotnetExe) run -f $(_Framework) -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults)</PostCommands>
+      <Timeout>4:00</Timeout>
+    </HelixWorkItem>
+  </ItemGroup>
+</Project>

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -1,0 +1,139 @@
+Param(
+    [string] $SourceDirectory=$env:BUILD_SOURCESDIRECTORY,
+    [string] $CoreRootDirectory,
+    [string] $BaselineCoreRootDirectory,
+    [string] $Architecture="x64",
+    [string] $Framework="net5.0",
+    [string] $CompilationMode="Tiered",
+    [string] $Repository=$env:BUILD_REPOSITORY_NAME,
+    [string] $Branch=$env:BUILD_SOURCEBRANCH,
+    [string] $CommitSha=$env:BUILD_SOURCEVERSION,
+    [string] $BuildNumber=$env:BUILD_BUILDNUMBER,
+    [string] $RunCategories="Libraries Runtime",
+    [string] $Csproj="src\benchmarks\micro\MicroBenchmarks.csproj",
+    [string] $Kind="micro",
+    [switch] $LLVM,
+    [switch] $MonoInterpreter,
+    [switch] $MonoAOT, 
+    [switch] $Internal,
+    [switch] $Compare,
+    [string] $MonoDotnet="",
+    [string] $Configurations="CompilationMode=$CompilationMode RunKind=$Kind",
+    [string] $LogicalMachine=""
+)
+
+$RunFromPerformanceRepo = ($Repository -eq "dotnet/performance") -or ($Repository -eq "dotnet-performance")
+$UseCoreRun = ($CoreRootDirectory -ne [string]::Empty)
+$UseBaselineCoreRun = ($BaselineCoreRootDirectory -ne [string]::Empty)
+
+$PayloadDirectory = (Join-Path $SourceDirectory "Payload")
+$PerformanceDirectory = (Join-Path $PayloadDirectory "performance")
+$WorkItemDirectory = (Join-Path $SourceDirectory "workitem")
+$ExtraBenchmarkDotNetArguments = "--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true"
+$Creator = $env:BUILD_DEFINITIONNAME
+$PerfLabArguments = ""
+$HelixSourcePrefix = "pr"
+
+$Queue = ""
+
+if ($Internal) {
+    switch ($LogicalMachine) {
+        "perftiger" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf"  }
+        "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf"  }
+        "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf"  }
+        Default { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
+    }
+    $PerfLabArguments = "--upload-to-perflab-container"
+    $ExtraBenchmarkDotNetArguments = ""
+    $Creator = ""
+    $HelixSourcePrefix = "official"
+}
+else {
+    $Queue = "Windows.10.Amd64.ClientRS4.DevEx.15.8.Open"
+}
+
+if($MonoInterpreter)
+{
+    $ExtraBenchmarkDotNetArguments = "--category-exclusion-filter NoInterpreter"
+}
+
+if($MonoDotnet -ne "")
+{
+    $Configurations += " LLVM=$LLVM MonoInterpreter=$MonoInterpreter MonoAOT=$MonoAOT"
+    if($ExtraBenchmarkDotNetArguments -eq "")
+    {
+        #FIX ME: We need to block these tests as they don't run on mono for now
+        $ExtraBenchmarkDotNetArguments = "--exclusion-filter *Perf_Image* *Perf_NamedPipeStream*"
+    }
+    else
+    {
+        #FIX ME: We need to block these tests as they don't run on mono for now
+        $ExtraBenchmarkDotNetArguments += " --exclusion-filter *Perf_Image* *Perf_NamedPipeStream*"
+    }
+}
+
+# FIX ME: This is a workaround until we get this from the actual pipeline
+$CommonSetupArguments="--channel master --queue $Queue --build-number $BuildNumber --build-configs $Configurations --architecture $Architecture"
+$SetupArguments = "--repository https://github.com/$Repository --branch $Branch --get-perf-hash --commit-sha $CommitSha $CommonSetupArguments"
+
+
+if ($RunFromPerformanceRepo) {
+    $SetupArguments = "--perf-hash $CommitSha $CommonSetupArguments"
+    
+    robocopy $SourceDirectory $PerformanceDirectory /E /XD $PayloadDirectory $SourceDirectory\artifacts $SourceDirectory\.git
+}
+else {
+    git clone --branch master --depth 1 --quiet https://github.com/dotnet/performance $PerformanceDirectory
+}
+
+if($MonoDotnet -ne "")
+{
+    $UsingMono = "true"
+    $MonoDotnetPath = (Join-Path $PayloadDirectory "dotnet-mono")
+    Move-Item -Path $MonoDotnet -Destination $MonoDotnetPath
+}
+
+if ($UseCoreRun) {
+    $NewCoreRoot = (Join-Path $PayloadDirectory "Core_Root")
+    Move-Item -Path $CoreRootDirectory -Destination $NewCoreRoot
+}
+if ($UseBaselineCoreRun) {
+    $NewBaselineCoreRoot = (Join-Path $PayloadDirectory "Baseline_Core_Root")
+    Move-Item -Path $BaselineCoreRootDirectory -Destination $NewBaselineCoreRoot
+}
+
+$DocsDir = (Join-Path $PerformanceDirectory "docs")
+robocopy $DocsDir $WorkItemDirectory
+
+# Set variables that we will need to have in future steps
+$ci = $true
+
+. "$PSScriptRoot\..\pipeline-logging-functions.ps1"
+
+# Directories
+Write-PipelineSetVariable -Name 'PayloadDirectory' -Value "$PayloadDirectory" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'PerformanceDirectory' -Value "$PerformanceDirectory" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'WorkItemDirectory' -Value "$WorkItemDirectory" -IsMultiJobVariable $false
+
+# Script Arguments
+Write-PipelineSetVariable -Name 'Python' -Value "py -3" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'ExtraBenchmarkDotNetArguments' -Value "$ExtraBenchmarkDotNetArguments" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'SetupArguments' -Value "$SetupArguments" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'PerfLabArguments' -Value "$PerfLabArguments" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'BDNCategories' -Value "$RunCategories" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'TargetCsproj' -Value "$Csproj" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'Kind' -Value "$Kind" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'Architecture' -Value "$Architecture" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'UseCoreRun' -Value "$UseCoreRun" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'UseBaselineCoreRun' -Value "$UseBaselineCoreRun" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'RunFromPerfRepo' -Value "$RunFromPerformanceRepo" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'Compare' -Value "$Compare" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'MonoDotnet' -Value "$UsingMono" -IsMultiJobVariable $false
+
+# Helix Arguments
+Write-PipelineSetVariable -Name 'Creator' -Value "$Creator" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'Queue' -Value "$Queue" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'HelixSourcePrefix' -Value "$HelixSourcePrefix" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name '_BuildConfig' -Value "$Architecture.$Kind.$Framework" -IsMultiJobVariable $false
+
+exit 0

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+
+source_directory=$BUILD_SOURCESDIRECTORY
+core_root_directory=
+baseline_core_root_directory=
+architecture=x64
+framework=net5.0
+compilation_mode=tiered
+repository=$BUILD_REPOSITORY_NAME
+branch=$BUILD_SOURCEBRANCH
+commit_sha=$BUILD_SOURCEVERSION
+build_number=$BUILD_BUILDNUMBER
+internal=false
+compare=false
+mono_dotnet=
+kind="micro"
+llvm=false
+monointerpreter=false
+monoaot=false
+run_categories="Libraries Runtime"
+csproj="src\benchmarks\micro\MicroBenchmarks.csproj"
+configurations="CompliationMode=$compilation_mode RunKind=$kind"
+run_from_perf_repo=false
+use_core_run=true
+use_baseline_core_run=true
+using_mono=false
+wasm_runtime_loc=
+using_wasm=false
+use_latest_dotnet=false
+logical_machine=
+
+while (($# > 0)); do
+  lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
+  case $lowerI in
+    --sourcedirectory)
+      source_directory=$2
+      shift 2
+      ;;
+    --corerootdirectory)
+      core_root_directory=$2
+      shift 2
+      ;;
+    --baselinecorerootdirectory)
+      baseline_core_root_directory=$2
+      shift 2
+      ;;
+    --architecture)
+      architecture=$2
+      shift 2
+      ;;
+    --framework)
+      framework=$2
+      shift 2
+      ;;
+    --compilationmode)
+      compilation_mode=$2
+      shift 2
+      ;;
+    --logicalmachine)
+      logical_machine=$2
+      shift 2
+      ;;
+    --repository)
+      repository=$2
+      shift 2
+      ;;
+    --branch)
+      branch=$2
+      shift 2
+      ;;
+    --commitsha)
+      commit_sha=$2
+      shift 2
+      ;;
+    --buildnumber)
+      build_number=$2
+      shift 2
+      ;;
+    --kind)
+      kind=$2
+      configurations="CompilationMode=$compilation_mode RunKind=$kind"
+      shift 2
+      ;;
+    --runcategories)
+      run_categories=$2
+      shift 2
+      ;;
+    --csproj)
+      csproj=$2
+      shift 2
+      ;;
+    --internal)
+      internal=true
+      shift 1
+      ;;
+    --alpine)
+      alpine=true
+      shift 1
+      ;;
+    --llvm)
+      llvm=true
+      shift 1
+      ;;
+    --monointerpreter)
+      monointerpreter=true
+      shift 1
+      ;;
+    --monoaot)
+      monoaot=true
+      shift 1
+      ;;
+    --monodotnet)
+      mono_dotnet=$2
+      shift 2
+      ;;
+    --wasm)
+      wasm_runtime_loc=$2
+      shift 2
+      ;;
+    --compare)
+      compare=true
+      shift 1
+      ;;
+    --configurations)
+      configurations=$2
+      shift 2
+      ;;
+    --latestdotnet)
+      use_latest_dotnet=true
+      shift 1
+      ;;
+    *)
+      echo "Common settings:"
+      echo "  --corerootdirectory <value>    Directory where Core_Root exists, if running perf testing with --corerun"
+      echo "  --architecture <value>         Architecture of the testing being run"
+      echo "  --configurations <value>       List of key=value pairs that will be passed to perf testing infrastructure."
+      echo "                                 ex: --configurations \"CompilationMode=Tiered OptimzationLevel=PGO\""
+      echo "  --help                         Print help and exit"
+      echo ""
+      echo "Advanced settings:"
+      echo "  --framework <value>            The framework to run, if not running in master"
+      echo "  --compliationmode <value>      The compilation mode if not passing --configurations"
+      echo "  --sourcedirectory <value>      The directory of the sources. Defaults to env:BUILD_SOURCESDIRECTORY"
+      echo "  --repository <value>           The name of the repository in the <owner>/<repository name> format. Defaults to env:BUILD_REPOSITORY_NAME"
+      echo "  --branch <value>               The name of the branch. Defaults to env:BUILD_SOURCEBRANCH"
+      echo "  --commitsha <value>            The commit sha1 to run against. Defaults to env:BUILD_SOURCEVERSION"
+      echo "  --buildnumber <value>          The build number currently running. Defaults to env:BUILD_BUILDNUMBER"
+      echo "  --csproj                       The relative path to the benchmark csproj whose tests should be run. Defaults to src\benchmarks\micro\MicroBenchmarks.csproj"
+      echo "  --kind <value>                 Related to csproj. The kind of benchmarks that should be run. Defaults to micro"
+      echo "  --runcategories <value>        Related to csproj. Categories of benchmarks to run. Defaults to \"coreclr corefx\""
+      echo "  --internal                     If the benchmarks are running as an official job."
+      echo "  --monodotnet                   Pass the path to the mono dotnet for mono performance testing."
+      echo "  --wasm                         Path to the unpacked wasm runtime pack."
+      echo "  --latestdotnet                 --dotnet-versions will not be specified. --dotnet-versions defaults to LKG version in global.json "
+      echo "  --alpine                       Set for runs on Alpine"
+      echo ""
+      exit 0
+      ;;
+  esac
+done
+
+if [ "$repository" == "dotnet/performance" ] || [ "$repository" == "dotnet-performance" ]; then
+    run_from_perf_repo=true
+fi
+
+if [ -z "$configurations" ]; then
+    configurations="CompilationMode=$compilation_mode"
+fi
+
+if [ -z "$core_root_directory" ]; then
+    use_core_run=false
+fi
+
+if [ -z "$baseline_core_root_directory" ]; then
+    use_baseline_core_run=false
+fi
+
+payload_directory=$source_directory/Payload
+performance_directory=$payload_directory/performance
+workitem_directory=$source_directory/workitem
+extra_benchmark_dotnet_arguments="--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true"
+perflab_arguments=
+queue=Ubuntu.1804.Amd64.Open
+creator=$BUILD_DEFINITIONNAME
+helix_source_prefix="pr"
+
+if [[ "$internal" == true ]]; then
+    perflab_arguments="--upload-to-perflab-container"
+    helix_source_prefix="official"
+    creator=
+    extra_benchmark_dotnet_arguments=
+    
+    if [[ "$architecture" = "arm64" ]]; then
+        queue=Ubuntu.1804.Arm64.Perf
+    else
+        if [[ "$logical_machine" = "perfowl" ]]; then
+            queue=Ubuntu.1804.Amd64.Owl.Perf
+        else
+            queue=Ubuntu.1804.Amd64.Tiger.Perf
+        fi
+    fi
+
+    if [[ "$alpine" = "true" ]]; then
+        queue=alpine.amd64.tiger.perf
+    fi
+else
+    if [[ "$architecture" = "arm64" ]]; then
+        queue=ubuntu.1804.armarch.open
+    else
+        queue=Ubuntu.1804.Amd64.Open
+    fi
+
+    if [[ "$alpine" = "true" ]]; then
+        queue=alpine.amd64.tiger.perf
+    fi
+fi
+
+if [[ "$mono_dotnet" != "" ]] && [[ "$monointerpreter" == "false" ]]; then
+    configurations="$configurations LLVM=$llvm MonoInterpreter=$monointerpreter MonoAOT=$monoaot"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --category-exclusion-filter NoMono"
+fi
+
+if [[ "$wasm_runtime_loc" != "" ]]; then
+    configurations="CompilationMode=wasm RunKind=$kind"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --category-exclusion-filter NoInterpreter NoWASM NoMono"
+fi
+
+if [[ "$mono_dotnet" != "" ]] && [[ "$monointerpreter" == "true" ]]; then
+    configurations="$configurations LLVM=$llvm MonoInterpreter=$monointerpreter MonoAOT=$monoaot"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --category-exclusion-filter NoInterpreter NoMono"
+fi
+
+common_setup_arguments="--channel master --queue $queue --build-number $build_number --build-configs $configurations --architecture $architecture"
+setup_arguments="--repository https://github.com/$repository --branch $branch --get-perf-hash --commit-sha $commit_sha $common_setup_arguments"
+
+if [[ "$run_from_perf_repo" = true ]]; then
+    payload_directory=
+    workitem_directory=$source_directory
+    performance_directory=$workitem_directory
+    setup_arguments="--perf-hash $commit_sha $common_setup_arguments"
+else
+    git clone --branch master --depth 1 --quiet https://github.com/dotnet/performance $performance_directory
+    
+    docs_directory=$performance_directory/docs
+    mv $docs_directory $workitem_directory
+fi
+
+if [[ "$wasm_runtime_loc" != "" ]]; then
+    using_wasm=true
+    wasm_dotnet_path=$payload_directory/dotnet-wasm
+    mv $wasm_runtime_loc $wasm_dotnet_path
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmMainJS \$HELIX_CORRELATION_PAYLOAD/dotnet-wasm/runtime-test.js --wasmEngine /home/helixbot/.jsvu/v8 --customRuntimePack \$HELIX_CORRELATION_PAYLOAD/dotnet-wasm"
+fi
+
+if [[ "$mono_dotnet" != "" ]]; then
+    using_mono=true
+    mono_dotnet_path=$payload_directory/dotnet-mono
+    mv $mono_dotnet $mono_dotnet_path
+fi
+
+if [[ "$use_core_run" = true ]]; then
+    new_core_root=$payload_directory/Core_Root
+    mv $core_root_directory $new_core_root
+fi
+
+if [[ "$use_baseline_core_run" = true ]]; then
+  new_baseline_core_root=$payload_directory/Baseline_Core_Root
+  mv $baseline_core_root_directory $new_baseline_core_root
+fi
+
+ci=true
+
+_script_dir=$(pwd)/eng/common
+. "$_script_dir/pipeline-logging-functions.sh"
+
+# Make sure all of our variables are available for future steps
+Write-PipelineSetVariable -name "UseCoreRun" -value "$use_core_run" -is_multi_job_variable false
+Write-PipelineSetVariable -name "UseBaselineCoreRun" -value "$use_baseline_core_run" -is_multi_job_variable false
+Write-PipelineSetVariable -name "Architecture" -value "$architecture" -is_multi_job_variable false
+Write-PipelineSetVariable -name "PayloadDirectory" -value "$payload_directory" -is_multi_job_variable false
+Write-PipelineSetVariable -name "PerformanceDirectory" -value "$performance_directory" -is_multi_job_variable false
+Write-PipelineSetVariable -name "WorkItemDirectory" -value "$workitem_directory" -is_multi_job_variable false
+Write-PipelineSetVariable -name "Queue" -value "$queue" -is_multi_job_variable false
+Write-PipelineSetVariable -name "SetupArguments" -value "$setup_arguments" -is_multi_job_variable false
+Write-PipelineSetVariable -name "Python" -value "python3" -is_multi_job_variable false
+Write-PipelineSetVariable -name "PerfLabArguments" -value "$perflab_arguments" -is_multi_job_variable false
+Write-PipelineSetVariable -name "ExtraBenchmarkDotNetArguments" -value "$extra_benchmark_dotnet_arguments" -is_multi_job_variable false
+Write-PipelineSetVariable -name "BDNCategories" -value "$run_categories" -is_multi_job_variable false
+Write-PipelineSetVariable -name "TargetCsproj" -value "$csproj" -is_multi_job_variable false
+Write-PipelineSetVariable -name "RunFromPerfRepo" -value "$run_from_perf_repo" -is_multi_job_variable false
+Write-PipelineSetVariable -name "Creator" -value "$creator" -is_multi_job_variable false
+Write-PipelineSetVariable -name "HelixSourcePrefix" -value "$helix_source_prefix" -is_multi_job_variable false
+Write-PipelineSetVariable -name "Kind" -value "$kind" -is_multi_job_variable false
+Write-PipelineSetVariable -name "_BuildConfig" -value "$architecture.$kind.$framework" -is_multi_job_variable false
+Write-PipelineSetVariable -name "Compare" -value "$compare" -is_multi_job_variable false
+Write-PipelineSetVariable -name "MonoDotnet" -value "$using_mono" -is_multi_job_variable false
+Write-PipelineSetVariable -name "WasmDotnet" -value "$using_wasm" -is_multi_job_variable false

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -11,7 +11,6 @@ parameters:
 
   SourcesDirectory: $(Build.SourcesDirectory)
   CreatePr: true
-  AutoCompletePr: false
   UseCheckedInLocProjectJson: false
   LanguageSet: VS_Main_Languages
   LclSource: lclFilesInRepo
@@ -47,21 +46,16 @@ jobs:
 
     - task: OneLocBuild@2
       displayName: OneLocBuild
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         locProj: Localize/LocProject.json
         outDir: $(Build.ArtifactStagingDirectory)
         lclSource: ${{ parameters.LclSource }}
         lclPackageId: ${{ parameters.LclPackageId }}
         isCreatePrSelected: ${{ parameters.CreatePr }}
-        ${{ if eq(parameters.CreatePr, true) }}:
-          isAutoCompletePrSelected: ${{ parameters.AutoCompletePr }}
+        repoType: ${{ parameters.RepoType }}
+        gitHubPatVariable: "${{ parameters.GithubPat }}"
         packageSourceAuth: patAuth
         patVariable: ${{ parameters.CeapexPat }}
-        ${{ if eq(parameters.RepoType, 'gitHub') }}:
-          repoType: ${{ parameters.RepoType }}
-          gitHubPatVariable: "${{ parameters.GithubPat }}"
       condition: always()
 
     - task: PublishBuildArtifacts@1

--- a/eng/common/templates/job/performance.yml
+++ b/eng/common/templates/job/performance.yml
@@ -1,0 +1,95 @@
+parameters:
+  steps: []                       # optional -- any additional steps that need to happen before pulling down the performance repo and sending the performance benchmarks to helix (ie building your repo)
+  variables: []                   # optional -- list of additional variables to send to the template
+  jobName: ''                     # required -- job name
+  displayName: ''                 # optional -- display name for the job. Will use jobName if not passed
+  pool: ''                        # required -- name of the Build pool
+  container: ''                   # required -- name of the container
+  osGroup: ''                     # required -- operating system for the job
+  extraSetupParameters: ''        # optional -- extra arguments to pass to the setup script
+  frameworks: ['netcoreapp3.0']   # optional -- list of frameworks to run against
+  continueOnError: 'false'        # optional -- determines whether to continue the build if the step errors
+  dependsOn: ''                   # optional -- dependencies of the job
+  timeoutInMinutes: 320           # optional -- timeout for the job
+  enableTelemetry: false          # optional -- enable for telemetry
+
+jobs:
+- template: ../jobs/jobs.yml
+  parameters:
+    dependsOn: ${{ parameters.dependsOn }}
+    enableTelemetry: ${{ parameters.enableTelemetry }}
+    enablePublishBuildArtifacts: true
+    continueOnError: ${{ parameters.continueOnError }}
+    
+    jobs:
+      - job: '${{ parameters.jobName }}'
+
+        ${{ if ne(parameters.displayName, '') }}:
+          displayName: '${{ parameters.displayName }}'
+        ${{ if eq(parameters.displayName, '') }}:
+          displayName: '${{ parameters.jobName }}'
+
+        timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
+        variables:
+
+        - ${{ each variable in parameters.variables }}:
+          - ${{ if ne(variable.name, '') }}:
+            - name: ${{ variable.name }}
+              value: ${{ variable.value }}
+          - ${{ if ne(variable.group, '') }}:
+            - group: ${{ variable.group }}
+
+        - IsInternal: ''
+        - HelixApiAccessToken: ''
+        - HelixPreCommand: ''
+
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - ${{ if eq( parameters.osGroup, 'Windows_NT') }}:
+            - HelixPreCommand: 'set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)"'
+            - IsInternal: -Internal
+          - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+            - HelixPreCommand: 'export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)"'
+            - IsInternal: --internal
+            
+          - group: DotNet-HelixApi-Access
+          - group: dotnet-benchview
+
+        workspace:
+          clean: all
+        pool:
+          ${{ parameters.pool }}
+        container: ${{ parameters.container }}
+        strategy:
+          matrix:
+            ${{ each framework in parameters.frameworks }}:
+              ${{ framework }}:
+                _Framework: ${{ framework }}
+        steps:
+        - checkout: self
+          clean: true
+        # Run all of the steps to setup repo
+        - ${{ each step in parameters.steps }}:
+          - ${{ step }}
+        - powershell: $(Build.SourcesDirectory)\eng\common\performance\performance-setup.ps1 $(IsInternal) -Framework $(_Framework) ${{ parameters.extraSetupParameters }}
+          displayName: Performance Setup (Windows)
+          condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
+          continueOnError: ${{ parameters.continueOnError }}
+        - script: $(Build.SourcesDirectory)/eng/common/performance/performance-setup.sh $(IsInternal) --framework $(_Framework) ${{ parameters.extraSetupParameters }}
+          displayName: Performance Setup (Unix)
+          condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
+          continueOnError: ${{ parameters.continueOnError }}
+        - script: $(Python) $(PerformanceDirectory)/scripts/ci_setup.py $(SetupArguments)
+          displayName: Run ci setup script
+        # Run perf testing in helix
+        - template: /eng/common/templates/steps/perf-send-to-helix.yml
+          parameters:
+            HelixSource: '$(HelixSourcePrefix)/$(Build.Repository.Name)/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
+            HelixType: 'test/performance/$(Kind)/$(_Framework)/$(Architecture)'
+            HelixAccessToken: $(HelixApiAccessToken)
+            HelixTargetQueues: $(Queue)
+            HelixPreCommands: $(HelixPreCommand)
+            Creator: $(Creator)
+            WorkItemTimeout: 4:00 # 4 hours
+            WorkItemDirectory: '$(WorkItemDirectory)' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
+            CorrelationPayloadDirectory: '$(PayloadDirectory)' # it gets checked out to a folder with shorter path than WorkItemDirectory so we can avoid file name too long exceptions

--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -1,0 +1,50 @@
+# Please remember to update the documentation if you make changes to these parameters!
+parameters:
+  ProjectFile: ''                        # required -- project file that specifies the helix workitems
+  HelixSource: 'pr/default'              # required -- sources must start with pr/, official/, prodcon/, or agent/
+  HelixType: 'tests/default/'            # required -- Helix telemetry which identifies what type of data this is; should include "test" for clarity and must end in '/'
+  HelixBuild: $(Build.BuildNumber)       # required -- the build number Helix will use to identify this -- automatically set to the AzDO build number
+  HelixTargetQueues: ''                  # required -- semicolon delimited list of Helix queues to test on; see https://helix.dot.net/ for a list of queues
+  HelixAccessToken: ''                   # required -- access token to make Helix API requests; should be provided by the appropriate variable group
+  HelixPreCommands: ''                   # optional -- commands to run before Helix work item execution
+  HelixPostCommands: ''                  # optional -- commands to run after Helix work item execution
+  WorkItemDirectory: ''                  # optional -- a payload directory to zip up and send to Helix; requires WorkItemCommand; incompatible with XUnitProjects
+  CorrelationPayloadDirectory: ''        # optional -- a directory to zip up and send to Helix as a correlation payload
+  IncludeDotNetCli: false                # optional -- true will download a version of the .NET CLI onto the Helix machine as a correlation payload; requires DotNetCliPackageType and DotNetCliVersion
+  DotNetCliPackageType: ''               # optional -- either 'sdk', 'runtime' or 'aspnetcore-runtime'; determines whether the sdk or runtime will be sent to Helix; see https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+  DotNetCliVersion: ''                   # optional -- version of the CLI to send to Helix; based on this: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+  EnableXUnitReporter: false             # optional -- true enables XUnit result reporting to Mission Control
+  WaitForWorkItemCompletion: true        # optional -- true will make the task wait until work items have been completed and fail the build if work items fail. False is "fire and forget."
+  Creator: ''                            # optional -- if the build is external, use this to specify who is sending the job
+  DisplayNamePrefix: 'Send job to Helix' # optional -- rename the beginning of the displayName of the steps in AzDO 
+  condition: succeeded()                 # optional -- condition for step to execute; defaults to succeeded()
+  continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
+  osGroup: ''                            # required -- operating system for the job
+            
+
+steps:
+- template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+  parameters:
+    osGroup: ${{ parameters.osGroup }}
+    sendParams: $(Build.SourcesDirectory)/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
+    displayName: ${{ parameters.DisplayNamePrefix }}
+    condition: ${{ parameters.condition }}
+    shouldContinueOnError: ${{ parameters.continueOnError }}
+    environment:
+      BuildConfig: $(_BuildConfig)
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+      Creator: ${{ parameters.Creator }}
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -36,7 +36,7 @@ steps:
 
     ${{ coalesce(parameters.platform.buildScript, './build.sh') }} --ci \
       --configuration $buildConfig \
-      --restore --build --pack --publish -bl \
+      --restore --build --pack --publish \
       $officialBuildArgs \
       $targetRidArgs \
       /p:SourceBuildNonPortable=${{ parameters.platform.nonPortable }} \

--- a/global.json
+++ b/global.json
@@ -12,7 +12,7 @@
     "xcopy-msbuild": "16.8.0-preview2.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21216.2",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21216.2"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21167.3",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21167.3"
   }
 }


### PR DESCRIPTION
Reverts dotnet/roslyn#52683

Publishing is currently failing on all signed builds.  It started with this commit.  Testing a revert.

Passing build - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4676216&view=logs&s=43bc2acf-84b9-56c3-9391-690a0fcfcd12
