### PR TITLE
Relax an assert to avoid a false failure in case of a race.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/ConstantFieldsInProgress.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ConstantFieldsInProgress.vb
@@ -29,6 +29,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Public Function AnyDependencies() As Boolean
+            Return _dependencies.Any()
+        End Function
+
         Friend Sub AddDependency(field As SourceFieldSymbol)
             _dependencies.Add(field)
         End Sub
@@ -52,6 +56,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 #End If
                 _builder.Add(field)
             End Sub
+
+            Friend Function Any() As Boolean
+                Return _builder.Count <> 0
+            End Function
 
             <Conditional("DEBUG")>
             Friend Sub Freeze()

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundFieldAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundFieldAccess.vb
@@ -51,7 +51,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
 #If DEBUG Then
-                ValidateConstantValue(Me.Type, result)
+                If constantsInProgress Is Nothing OrElse
+                   constantsInProgress.IsEmpty OrElse
+                   Not constantsInProgress.AnyDependencies() Then
+                    ValidateConstantValue(Me.Type, result)
+                End If
 #End If
                 Return result
             End Get


### PR DESCRIPTION
Fixes #52624.