### PR TITLE
Introduce Parameter - filter out instance references for invocation refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceParameter/IntroduceParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceParameter/IntroduceParameterTests.cs
@@ -1582,6 +1582,129 @@ class TestClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceParameter)]
+        public async Task TestThisImplicitInExpression()
+        {
+            var code =
+@"using System;
+class TestClass
+{
+    public int M1()
+    {
+        return 5;
+    }
+
+    public int M(int x, int y)
+    {
+        int m = [|x * M1();|]
+        return m;
+    }
+}";
+
+            var expected =
+@"using System;
+class TestClass
+{
+    public int M1()
+    {
+        return 5;
+    }
+
+    public int GetM(int x)
+    {
+        return x * M1();
+    }
+
+    public int M(int x, int y, int m)
+    {
+        return m;
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, index: 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceParameter)]
+        public async Task TestStaticMethodCallInExpression()
+        {
+            var code =
+@"using System;
+class TestClass
+{
+    public static int M1()
+    {
+        return 5;
+    }
+
+    public int M(int x, int y)
+    {
+        int m = [|x * M1();|]
+        return m;
+    }
+}";
+
+            var expected =
+@"using System;
+class TestClass
+{
+    public static int M1()
+    {
+        return 5;
+    }
+
+    public int M(int x, int y, int m)
+    {
+        return m;
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, index: 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceParameter)]
+        public async Task TestBaseKeywordInExpression()
+        {
+            var code =
+@"using System;
+class Net
+{
+    public int _value = 6;
+}
+
+class Perl : Net
+{
+    public new int _value = 7;
+
+    public void Write()
+    {
+        int x = [|base._value + 1;|]
+    }
+}";
+
+            var expected =
+@"using System;
+class Net
+{
+    public int _value = 6;
+}
+
+class Perl : Net
+{
+    public new int _value = 7;
+
+    public int GetX()
+    {
+        return base._value + 1;
+    }
+
+    public void Write(int x)
+    {
+    }
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, index: 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceParameter)]
         public async Task TestFieldReferenceInOptionalParameter()
         {
             var code =

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceParameterService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceParameterService.cs
@@ -167,11 +167,11 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             }
             else
             {
-                if (children is not null)
+                foreach (var child in children)
                 {
-                    foreach (var child in children)
+                    if (OperationOrChildIsInstanceReference(child, child.Children))
                     {
-                        return OperationOrChildIsInstanceReference(child, child.Children);
+                        return true;
                     }
                 }
             }

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceParameterService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceParameterService.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -112,74 +113,6 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
         }
 
         /// <summary>
-        /// Determines if the expression is something that should have code actions displayed for it.
-        /// Depends upon the identifiers in the expression mapping back to parameters.
-        /// Does not handle params parameters.
-        /// </summary>
-        private static async Task<(bool shouldDisplay, bool containsClassExpression)> ShouldExpressionDisplayCodeActionAsync(
-            Document document, TExpressionSyntax expression, CancellationToken cancellationToken)
-        {
-            var variablesInExpression = expression.DescendantNodes();
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var containsClassSpecificStatement = false;
-            foreach (var variable in variablesInExpression)
-            {
-                var symbol = semanticModel.GetSymbolInfo(variable, cancellationToken).Symbol;
-
-                // If the expression contains locals or range variables then we do not want to offer
-                // code actions since there will be errors at call sites.
-                if (symbol is IRangeVariableSymbol or ILocalSymbol)
-                {
-                    return (false, false);
-                }
-
-                if (symbol is IParameterSymbol parameter)
-                {
-                    // We do not want to offer code actions if the expressions contains references
-                    // to params parameters because it is difficult to know what is being referenced
-                    // at the callsites.
-                    if (parameter.IsParams)
-                    {
-                        return (false, false);
-                    }
-                }
-
-                var operation = semanticModel.GetOperation(variable, cancellationToken);
-                if (operation is null || containsClassSpecificStatement)
-                {
-                    continue;
-                }
-
-                // If expression contains this or base keywords, implicitly or explicitly,
-                // then we do not want to refactor call sites that are not overloads/trampolines
-                // because we do not know if the class specific information is available in other documents.
-                containsClassSpecificStatement = OperationOrChildIsInstanceReference(operation, operation.Children);
-            }
-
-            return (true, containsClassSpecificStatement);
-        }
-
-        private static bool OperationOrChildIsInstanceReference(IOperation operation, IEnumerable<IOperation> children)
-        {
-            if (operation.Kind is OperationKind.InstanceReference)
-            {
-                return true;
-            }
-            else
-            {
-                foreach (var child in children)
-                {
-                    if (OperationOrChildIsInstanceReference(child, child.Children))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Creates new code actions for each introduce parameter possibility.
         /// Does not create actions for overloads/trampoline if there are optional parameters or if the methodSymbol
         /// is a constructor.
@@ -229,6 +162,47 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 return new MyCodeAction(actionName, c => IntroduceParameterAsync(
                     document, expression, methodSymbol, containingMethod, allOccurrences, selectedCodeAction, c));
             }
+        }
+
+        /// <summary>
+        /// Determines if the expression is something that should have code actions displayed for it.
+        /// Depends upon the identifiers in the expression mapping back to parameters.
+        /// Does not handle params parameters.
+        /// </summary>
+        private static async Task<(bool shouldDisplay, bool containsClassExpression)> ShouldExpressionDisplayCodeActionAsync(
+            Document document, TExpressionSyntax expression, CancellationToken cancellationToken)
+        {
+            var variablesInExpression = expression.DescendantNodes();
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var variable in variablesInExpression)
+            {
+                var symbol = semanticModel.GetSymbolInfo(variable, cancellationToken).Symbol;
+
+                // If the expression contains locals or range variables then we do not want to offer
+                // code actions since there will be errors at call sites.
+                if (symbol is IRangeVariableSymbol or ILocalSymbol)
+                {
+                    return (false, false);
+                }
+
+                if (symbol is IParameterSymbol parameter)
+                {
+                    // We do not want to offer code actions if the expressions contains references
+                    // to params parameters because it is difficult to know what is being referenced
+                    // at the callsites.
+                    if (parameter.IsParams)
+                    {
+                        return (false, false);
+                    }
+                }
+            }
+
+            // If expression contains this or base keywords, implicitly or explicitly,
+            // then we do not want to refactor call sites that are not overloads/trampolines
+            // because we do not know if the class specific information is available in other documents.
+            var containsClassSpecificStatement = ExpressionVisitor.CheckIfInstanceReference(semanticModel, expression, cancellationToken);
+
+            return (true, containsClassSpecificStatement);
         }
 
         /// <summary>
@@ -309,6 +283,36 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             }
 
             return methodCallSites;
+        }
+
+        private class ExpressionVisitor : OperationWalker
+        {
+            private bool _containsInstanceReference;
+
+            public static bool CheckIfInstanceReference(SemanticModel semanticModel,
+                TExpressionSyntax expression, CancellationToken cancellationToken)
+            {
+                var visitor = new ExpressionVisitor();
+                var operation = semanticModel.GetOperation(expression, cancellationToken);
+                visitor.Visit(operation);
+                return visitor._containsInstanceReference;
+            }
+
+            public override void Visit(IOperation? operation)
+            {
+                if (operation == null)
+                {
+                    return;
+                }
+
+                if (operation.Kind == OperationKind.InstanceReference)
+                {
+                    _containsInstanceReference = true;
+                    return;
+                }
+
+                base.Visit(operation);
+            }
         }
 
         private class MyCodeAction : SolutionChangeAction


### PR DESCRIPTION
#52748

Hello! :) 

I am putting in a fix to handle instance references that are explicit or implicit. It now creates an IOperation from each ISymbol and recurses through their children to see if any of them are OperationKind.InstanceReference.