### PR TITLE
Fix exception logic in MSBuild

### DIFF
--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         internal readonly PropertyDictionary _store = new PropertyDictionary();
 
         public InteractiveCompiler()
+            : base(ErrorString.ResourceManager)
         {
-            TaskResources = ErrorString.ResourceManager;
         }
 
         #region Properties - Please keep these alphabetized.

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -56,9 +56,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         internal abstract RequestLanguage Language { get; }
 
         public ManagedCompiler()
+            : base(ErrorString.ResourceManager)
         {
-            TaskResources = ErrorString.ResourceManager;
-
             // If there is a crash, the runtime error is output to stderr and
             // we want MSBuild to print it out regardless of verbosity.
             LogStandardErrorAsError = true;
@@ -489,6 +488,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
+            using var logger = new CompilerServerLogger($"MSBuild {Process.GetCurrentProcess().Id}");
+            return ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+        }
+
+        internal int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands, ICompilerServerLogger logger)
+        {
             if (ProvideCommandLineArgs)
             {
                 CommandLineArgs = GetArguments(commandLineCommands, responseFileCommands)
@@ -502,10 +507,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             try
             {
-                using var logger = new CompilerServerLogger($"MSBuild {Process.GetCurrentProcess().Id}");
+                var requestId = Guid.NewGuid();
+                logger.Log($"Compilation request {requestId}, PathToTool={pathToTool}");
+
                 string workingDir = CurrentDirectoryToUse();
                 string? tempDir = BuildServerConnection.GetTempPath(workingDir);
-                var requestId = Guid.NewGuid();
 
                 if (!UseSharedCompilation ||
                     HasToolBeenOverridden ||
@@ -557,9 +563,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
             catch (Exception e)
             {
-                var util = new TaskLoggingHelper(this);
-                util.LogErrorWithCodeFromResources("Compiler_UnexpectedException");
-                util.LogErrorFromException(e, showStackTrace: true, showDetail: true, file: null);
+                Log.LogErrorWithCodeFromResources("Compiler_UnexpectedException");
+                Log.LogErrorFromException(e);
                 ExitCode = -1;
             }
             finally

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Resources;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.CodeAnalysis.BuildTasks
@@ -34,6 +35,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// "Native" in this context means "native invocation", and running the executable directly.
         /// </summary>
         protected abstract string PathToNativeTool { get; }
+
+        protected ManagedToolTask(ResourceManager resourceManager)
+            : base(resourceManager)
+        {
+        }
 
         /// <summary>
         /// GenerateCommandLineCommands generates the actual OS-level arguments:

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 using Moq;
 using System.IO;
 using Roslyn.Test.Utilities;
+using Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {
@@ -497,6 +498,23 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
             Assert.Equal("/out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        [WorkItem(52467, "https://github.com/dotnet/roslyn/issues/52467")]
+        public void UnexpectedExceptionLogsMessage()
+        {
+            var engine = new MockEngine();
+            var csc = new Csc()
+            {
+                BuildEngine = engine,
+            };
+
+            csc.ExecuteTool(@"q:\path\csc.exe", "", "", new TestableCompilerServerLogger()
+            {
+                LogFunc = delegate { throw new Exception(""); }
+            });
+            Assert.False(string.IsNullOrEmpty(engine.Log));
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TestableCompilerServerLogger.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TestableCompilerServerLogger.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CommandLine;
+
+namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities
+{
+    internal sealed class TestableCompilerServerLogger : ICompilerServerLogger
+    {
+        public bool IsLogging { get; set; }
+        public Action<string> LogFunc { get; set; } = delegate { throw new InvalidOperationException(); };
+
+        public void Log(string message) => LogFunc(message);
+    }
+}

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using Microsoft.CodeAnalysis.BuildTasks;
+using Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -461,6 +462,23 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             vbc = new Vbc();
             vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
             Assert.Equal("/optionstrict:custom /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        [WorkItem(52467, "https://github.com/dotnet/roslyn/issues/52467")]
+        public void UnexpectedExceptionLogsMessage()
+        {
+            var engine = new MockEngine();
+            var vbc = new Vbc()
+            {
+                BuildEngine = engine,
+            };
+
+            vbc.ExecuteTool(@"q:\path\vbc.exe", "", "", new TestableCompilerServerLogger()
+            {
+                LogFunc = delegate { throw new Exception(""); }
+            });
+            Assert.False(string.IsNullOrEmpty(engine.Log));
         }
     }
 }


### PR DESCRIPTION
The unexpected exception logic uses resources to add localized messages
to the MSBuild log. Turns out our tasks were not properly hooking up
resources into the log. That means when unexpected exceptions happen the
information for them was completely lost because logging through an
`InvalidOperationException` which wasn't handled.

Fix the resources to be properly initialized and added a few tests to
enforce it.

closes #52467
