### PR TITLE
Only show an OOP error message once per feature area per session

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         /// show the same message again, block that from happening so we don't spam the user with
         /// the same message.  When the info bar item is dismissed though, we then may show the
         /// same message in the future.  This is important for user clarity as it's possible for 
-        /// a feature to fail for some reason, then work fine for a while, then fail again.  We
+        /// a feature to fail for some reason, then work fine for a while, then fail again.  We want
         /// the second failure message to be reported to ensure the user is not confused.
         /// </summary>
         private readonly HashSet<string> _currentlyShowingMessages = new();

--- a/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InfoBar/VisualStudioInfoBarService.cs
@@ -26,6 +26,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private readonly SVsServiceProvider _serviceProvider;
         private readonly IAsynchronousOperationListener _listener;
 
+        /// <summary>
+        /// Keep track of the messages that are currently being shown to the user.  If we would 
+        /// show the same message again, block that from happening so we don't spam the user with
+        /// the same message.  When the info bar item is dismissed though, we then may show the
+        /// same message in the future.  This is important for user clarity as it's possible for 
+        /// a feature to fail for some reason, then work fine for a while, then fail again.  We
+        /// the second failure message to be reported to ensure the user is not confused.
+        /// </summary>
+        private readonly HashSet<string> _currentlyShowingMessages = new();
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioInfoBarService(
@@ -71,11 +81,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         private void CreateInfoBar(IVsInfoBarHost infoBarHost, string message, InfoBarUI[] items)
         {
+            this.AssertIsForeground();
+
             if (!(_serviceProvider.GetService(typeof(SVsInfoBarUIFactory)) is IVsInfoBarUIFactory factory))
             {
                 // no info bar factory, don't do anything
                 return;
             }
+
+            // If we're already shown this same message to the user, then do not bother showing it
+            // to them again.  It will just be noisy.
+            if (_currentlyShowingMessages.Contains(message))
+                return;
 
             var textSpans = new List<IVsInfoBarTextSpan>()
             {
@@ -104,19 +121,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             var infoBarModel = new InfoBarModel(
                 textSpans,
-                actionItems.ToArray(),
+                actionItems,
                 KnownMonikers.StatusInformation,
                 isCloseButtonVisible: true);
 
-            if (!TryCreateInfoBarUI(factory, infoBarModel, out var infoBarUI))
-            {
+            var infoBarUI = factory.CreateInfoBar(infoBarModel);
+            if (infoBarUI == null)
                 return;
-            }
 
             uint? infoBarCookie = null;
-            var eventSink = new InfoBarEvents(items, () =>
+            var eventSink = new InfoBarEvents(items, onClose: () =>
             {
-                // run given onClose action if there is one.
+                // Remove the message from the list that we're keeping track of.  Future identical
+                // messages can now be shown.
+                _currentlyShowingMessages.Remove(message);
+
+                // Run given onClose action if there is one.
                 items.FirstOrDefault(i => i.Kind == InfoBarUI.UIKind.Close).Action?.Invoke();
 
                 if (infoBarCookie.HasValue)
@@ -129,6 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             infoBarCookie = cookie;
 
             infoBarHost.AddInfoBar(infoBarUI);
+            _currentlyShowingMessages.Add(message);
         }
 
         private class InfoBarEvents : IVsInfoBarUIEvents
@@ -164,12 +185,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             public void OnClosed(IVsInfoBarUIElement infoBarUIElement)
                 => _onClose();
-        }
-
-        private static bool TryCreateInfoBarUI(IVsInfoBarUIFactory infoBarUIFactory, IVsInfoBar infoBar, out IVsInfoBarUIElement uiElement)
-        {
-            uiElement = infoBarUIFactory.CreateInfoBar(infoBar);
-            return uiElement != null;
         }
     }
 }

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO.Pipelines;
@@ -40,12 +39,6 @@ namespace Microsoft.CodeAnalysis.Remote
             public void Dispose()
                 => _proxyRental.Dispose();
         }
-
-        /// <summary>
-        /// Set features that we've already shown an error message for.  This preventsspamming the UI with many 
-        /// messages about the issue which can be highly annoying.
-        /// </summary>
-        private static readonly HashSet<string> s_featuresWithShownErrorMessages = new();
 
         private readonly IErrorReportingService? _errorReportingService;
         private readonly IRemoteHostClientShutdownCancellationService? _shutdownCancellationService;
@@ -412,19 +405,10 @@ namespace Microsoft.CodeAnalysis.Remote
             // Currently, ConnectionLostException is also throw when the result of the RPC method fails to serialize 
             // (see https://github.com/microsoft/vs-streamjsonrpc/issues/549)
 
-            var featureName = _serviceDescriptor.GetFeatureDisplayName();
-
-            // Only pass through the first error we encounter per feature.  Note that all errors will
-            // have already been reported to us an NFW, so we'll still get any data we need, even if 
-            // we're not showing subsequent errors about that feature to the user.
-            lock (s_featuresWithShownErrorMessages)
-            {
-                if (!s_featuresWithShownErrorMessages.Add(featureName))
-                    return;
-            }
-
             string message;
             Exception? internalException = null;
+            var featureName = _serviceDescriptor.GetFeatureDisplayName();
+
             if (IsRemoteIOException(exception))
             {
                 message = string.Format(RemoteWorkspacesResources.Feature_0_is_currently_unavailable_due_to_an_intermittent_error, featureName, exception.Message);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51076