### PR TITLE
Add AssertOrFailFast

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1478,24 +1478,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (member is NamedTypeSymbol type)
             {
-                Debug.Assert(forDiagnostics);
-                Debug.Assert(Volatile.Read(ref _lazyTypeMembers)?.Values.Any(types => types.Contains(t => t == (object)type)) == true);
+                RoslynDebug.AssertOrFailFast(forDiagnostics);
+                RoslynDebug.AssertOrFailFast(Volatile.Read(ref _lazyTypeMembers)?.Values.Any(types => types.Contains(t => t == (object)type)) == true);
                 return;
             }
             else if (member is TypeParameterSymbol || member is SynthesizedMethodBaseSymbol)
             {
-                Debug.Assert(forDiagnostics);
+                RoslynDebug.AssertOrFailFast(forDiagnostics);
                 return;
             }
             else if (member is FieldSymbol field && field.AssociatedSymbol is EventSymbol e)
             {
-                Debug.Assert(forDiagnostics);
+                RoslynDebug.AssertOrFailFast(forDiagnostics);
                 // Backing fields for field-like events are not added to the members list.
                 member = e;
             }
 
             var declared = Volatile.Read(ref _lazyDeclaredMembersAndInitializers);
-            Debug.Assert(declared != DeclaredMembersAndInitializers.UninitializedSentinel);
+            RoslynDebug.AssertOrFailFast(declared != DeclaredMembersAndInitializers.UninitializedSentinel);
 
             if ((declared is object && (declared.NonTypeMembers.Contains(m => m == (object)member) || declared.RecordPrimaryConstructor == (object)member)) ||
                 Volatile.Read(ref _lazyMembersAndInitializers)?.NonTypeMembers.Contains(m => m == (object)member) == true)
@@ -1503,7 +1503,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            Debug.Assert(false, "Premature symbol exposure.");
+            RoslynDebug.AssertOrFailFast(false, "Premature symbol exposure.");
         }
 
         protected Dictionary<string, ImmutableArray<Symbol>> GetMembersByName()

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -39,7 +39,7 @@ namespace Roslyn.Utilities
         internal static void AssertOrFailFast([DoesNotReturnIf(false)] bool condition, string? message = null)
         {
 #if NET20
-            Debug.Assert(false);
+            Debug.Assert(condition);
 #else
             if (!condition)
             {
@@ -57,7 +57,7 @@ namespace Roslyn.Utilities
                 }
                 else
                 {
-                    Debug.Assert(false);
+                    Debug.Assert(false, message);
                 }
             }
 #endif

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -22,6 +23,40 @@ namespace Roslyn.Utilities
         public static void AssertNotNull<T>([NotNull] T value)
         {
             Assert(value is object, "Unexpected null reference");
+        }
+
+        /// <summary>
+        /// Generally <see cref="Debug.Assert(bool)"/> is a sufficient method for enforcing DEBUG 
+        /// only invariants in our code. When it triggers that providse a nice stack trace for 
+        /// investigation. Generally that is enough.
+        /// 
+        /// There are cases for which a stack is not enough and we need a full heap dump to 
+        /// investigate the failure. This method takes care of that. The behavior is that when running
+        /// in our CI environment if the assert triggers we will rudely crash the process and 
+        /// produce a heap dump for investigation.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal static void AssertOrFailFast(bool condition, string? message = null)
+        {
+            if (!condition)
+            {
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_DUMP_FOLDER")))
+                {
+                    message ??= $"{nameof(AssertOrFailFast)} failed";
+                    var stackTrace = new StackTrace();
+                    Console.WriteLine(message);
+                    Console.WriteLine(stackTrace);
+
+                    // Use FailFast so that the process fails rudely and goes through 
+                    // windows error reporting (on Windows at least). This will allow our 
+                    // Helix environment to capture crash dumps for future investigation
+                    Environment.FailFast(message);
+                }
+                else
+                {
+                    Debug.Assert(false);
+                }
+            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -30,10 +30,10 @@ namespace Roslyn.Utilities
         /// only invariants in our code. When it triggers that providse a nice stack trace for 
         /// investigation. Generally that is enough.
         /// 
-        /// There are cases for which a stack is not enough and we need a full heap dump to 
+        /// <para>There are cases for which a stack is not enough and we need a full heap dump to 
         /// investigate the failure. This method takes care of that. The behavior is that when running
         /// in our CI environment if the assert triggers we will rudely crash the process and 
-        /// produce a heap dump for investigation.
+        /// produce a heap dump for investigation.</para>
         /// </summary>
         [Conditional("DEBUG")]
         internal static void AssertOrFailFast([DoesNotReturnIf(false)] bool condition, string? message = null)

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -38,6 +38,9 @@ namespace Roslyn.Utilities
         [Conditional("DEBUG")]
         internal static void AssertOrFailFast(bool condition, string? message = null)
         {
+#if NET20
+            Debug.Assert(false);
+#else
             if (!condition)
             {
                 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_DUMP_FOLDER")))
@@ -57,6 +60,7 @@ namespace Roslyn.Utilities
                     Debug.Assert(false);
                 }
             }
+#endif
         }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -38,7 +38,7 @@ namespace Roslyn.Utilities
         [Conditional("DEBUG")]
         internal static void AssertOrFailFast([DoesNotReturnIf(false)] bool condition, string? message = null)
         {
-#if NET20
+#if NET20 || NETSTANDARD1_3
             Debug.Assert(condition);
 #else
             if (!condition)

--- a/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Debug.cs
@@ -36,7 +36,7 @@ namespace Roslyn.Utilities
         /// produce a heap dump for investigation.
         /// </summary>
         [Conditional("DEBUG")]
-        internal static void AssertOrFailFast(bool condition, string? message = null)
+        internal static void AssertOrFailFast([DoesNotReturnIf(false)] bool condition, string? message = null)
         {
 #if NET20
             Debug.Assert(false);


### PR DESCRIPTION
This introduces `AssertOrFailFast`. This is like `Debug.Assert` but it
will provide a crash dump when the `Assert` fails in CI runs.