### PR TITLE
Change functionid value in main as it conflicts with dev17

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -515,6 +515,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         LSP_CompletionListCacheMiss = 486,
 
-        VS_ErrorReportingService_ShowGlobalErrorInfo = 487,
+        VS_ErrorReportingService_ShowGlobalErrorInfo = 489,
     }
 }


### PR DESCRIPTION
VS_ErrorReportingService_ShowGlobalErrorInfo conflicts with ids in https://github.com/dotnet/roslyn/blob/release/dev17.0-vs-deps/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs#L518

So that it's less likely someone uses those ids in main, I've changed the latest main id to be _after_ the ones in dev17.  