### PR TITLE
Remove unexecuted VB assemblies from OptProf test mapping

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -177,10 +177,6 @@
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             },
             {
-              "filename": "/Microsoft.CodeAnalysis.VisualBasic.Features.dll",
-              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
-            },
-            {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.dll",
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             },
@@ -214,10 +210,6 @@
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.Implementation.dll",
-              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
-            },
-            {
-              "filename": "/Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll",
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             },
             {


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1301116

FYI @dibarbet @JoeRobich 