### PR TITLE
Restore APIs used by TypeScript

### DIFF
--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -32,11 +33,19 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public static ITaggerEventSource OnTextChanged(ITextBuffer subjectBuffer)
             => new TextChangedEventSource(subjectBuffer);
 
+        [Obsolete("Legacy api for TypeScript.  Can be removed once they call to the overload without TaggerDelay.")]
+        public static ITaggerEventSource OnTextChanged(ITextBuffer subjectBuffer, TaggerDelay delay)
+            => OnTextChanged(subjectBuffer);
+
         /// <summary>
         /// Reports an event any time the workspace changes.
         /// </summary>
         public static ITaggerEventSource OnWorkspaceChanged(ITextBuffer subjectBuffer, IAsynchronousOperationListener listener)
             => new WorkspaceChangedEventSource(subjectBuffer, listener);
+
+        [Obsolete("Legacy api for TypeScript.  Can be removed once they call to the overload without TaggerDelay.")]
+        public static ITaggerEventSource OnWorkspaceChanged(ITextBuffer subjectBuffer, TaggerDelay delay, IAsynchronousOperationListener listener)
+            => OnWorkspaceChanged(subjectBuffer, listener);
 
         public static ITaggerEventSource OnDocumentActiveContextChanged(ITextBuffer subjectBuffer)
             => new DocumentActiveContextChangedEventSource(subjectBuffer);
@@ -58,6 +67,10 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
         public static ITaggerEventSource OnWorkspaceRegistrationChanged(ITextBuffer subjectBuffer)
             => new WorkspaceRegistrationChangedEventSource(subjectBuffer);
+
+        [Obsolete("Legacy api for TypeScript.  Can be removed once they call to the overload without TaggerDelay.")]
+        public static ITaggerEventSource OnWorkspaceRegistrationChanged(ITextBuffer subjectBuffer, TaggerDelay delay)
+            => OnWorkspaceRegistrationChanged(subjectBuffer);
 
         public static ITaggerEventSource OnViewSpanChanged(IThreadingContext threadingContext, ITextView textView)
             => new ViewSpanChangedEventSource(threadingContext, textView);

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// <summary>
         /// How long the tagger should wait after hearing about an event before recomputing tags.
         /// </summary>
-        protected abstract TaggerDelay EventChangeDelay { get; }
+        protected virtual TaggerDelay EventChangeDelay => TaggerDelay.NearImmediate;
 
         /// <summary>
         /// This controls what delay tagger will use to let editor know about newly inserted tags

--- a/src/EditorFeatures/Core/Tagging/AsyncSerialWorkQueue.cs
+++ b/src/EditorFeatures/Core/Tagging/AsyncSerialWorkQueue.cs
@@ -1,0 +1,194 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Shared.Threading
+{
+    // A helper class primarily used for the AsynchronousTagger that can handle the job of
+    // scheduling work to be done on the UI thread and on a background thread.  This class wraps the
+    // TPL and implements things in special ways to provide certain nice bits of functionality.
+    // Specifically: 
+    //
+    // 1) Background actions are run serially.  This allows you to enqueue a whole host of background
+    // work to do, without having to worry about those same background tasks running simultaneously 
+    // and colliding with each other.
+    //
+    // 2) You can start a 'chain' of actions starting with an action that fires after a delay. After
+    // that point you can continue adding actions to that chain.  You can then ask to wait until that
+    // chain of actions completes (very useful for testing purposes). This chain can also be
+    // cancelled very simply.
+    [Obsolete("Legacy API for TypeScript.  Remove once they move to basic Tasks/TPL.")]
+    internal class AsynchronousSerialWorkQueue : ForegroundThreadAffinitizedObject
+    {
+        #region Fields that can be accessed from either thread
+
+        // The task schedulers that we can use to schedule work on the UI thread.
+        private readonly IAsynchronousOperationListener _asyncListener;
+
+        // Lock for serializing access to these objects.
+        private readonly object _gate = new();
+
+        // The current task we are executing on the background.  Kept around so we can serialize
+        // background tasks by continually calling 'SafeContinueWith' on this task.
+        private Task _currentBackgroundTask;
+
+        // The cancellation source for the current chain of work.
+        private CancellationTokenSource _cancellationTokenSource = new();
+
+        #endregion
+
+        public AsynchronousSerialWorkQueue(IThreadingContext threadingContext, IAsynchronousOperationListener asyncListener)
+            : base(threadingContext, assertIsForeground: false)
+        {
+            Contract.ThrowIfNull(asyncListener);
+            _asyncListener = asyncListener;
+
+            // Initialize so we don't have to check for null below. Force the background task to run
+            // on the threadpool. 
+            _currentBackgroundTask = Task.CompletedTask;
+        }
+
+        public CancellationToken CancellationToken => _cancellationTokenSource.Token;
+
+        public void CancelCurrentWork()
+            => CancelCurrentWork(remainCancelled: false);
+
+        public void CancelCurrentWork(bool remainCancelled)
+        {
+            lock (_gate)
+            {
+                remainCancelled |= _cancellationTokenSource.IsCancellationRequested;
+                _cancellationTokenSource.Cancel();
+                if (!remainCancelled)
+                {
+                    _cancellationTokenSource = new CancellationTokenSource();
+                }
+            }
+        }
+
+        public void EnqueueBackgroundWork(Action action, string name, CancellationToken cancellationToken)
+            => EnqueueBackgroundWork(action, name, afterDelay: 0, cancellationToken: cancellationToken);
+
+        public void EnqueueBackgroundWork(Action action, string name, int afterDelay, CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfNull(action);
+
+            var asyncToken = _asyncListener.BeginAsyncOperation(name);
+
+            lock (_gate)
+            {
+                if (afterDelay == 0)
+                {
+                    // Note that we serialized background tasks so that consumers of this type can issue
+                    // multiple background tasks without having to worry about them running
+                    // simultaneously.
+                    _currentBackgroundTask = _currentBackgroundTask.SafeContinueWith(
+                        _ => action(),
+                        cancellationToken,
+                        TaskContinuationOptions.None,
+                        TaskScheduler.Default);
+                }
+                else
+                {
+                    _currentBackgroundTask = _currentBackgroundTask.ContinueWithAfterDelay(
+                        action, cancellationToken, afterDelay, TaskContinuationOptions.None, TaskScheduler.Default);
+                }
+
+                _currentBackgroundTask.CompletesAsyncOperation(asyncToken);
+            }
+        }
+
+        public void EnqueueBackgroundTask(
+            Func<CancellationToken, Task> taskGeneratingFunctionAsync,
+            string name,
+            CancellationToken cancellationToken)
+        {
+            EnqueueBackgroundTask(taskGeneratingFunctionAsync, name, afterDelay: 0, cancellationToken: cancellationToken);
+        }
+
+        public void EnqueueBackgroundTask(
+            Func<CancellationToken, Task> taskGeneratingFunctionAsync,
+            string name, int afterDelay, CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfNull(taskGeneratingFunctionAsync);
+
+            var asyncToken = _asyncListener.BeginAsyncOperation(name);
+
+            lock (_gate)
+            {
+                if (afterDelay == 0)
+                {
+                    // Note that we serialized background tasks so that consumers of this type can issue
+                    // multiple background tasks without having to worry about them running
+                    // simultaneously.
+                    _currentBackgroundTask = _currentBackgroundTask.SafeContinueWithFromAsync(
+                        _ => taskGeneratingFunctionAsync(cancellationToken),
+                        cancellationToken,
+                        TaskContinuationOptions.None,
+                        TaskScheduler.Default);
+                }
+                else
+                {
+                    _currentBackgroundTask = _currentBackgroundTask.ContinueWithAfterDelayFromAsync(
+                        _ => taskGeneratingFunctionAsync(cancellationToken),
+                        cancellationToken,
+                        afterDelay,
+                        TaskContinuationOptions.None,
+                        TaskScheduler.Default);
+                }
+
+                _currentBackgroundTask.CompletesAsyncOperation(asyncToken);
+            }
+        }
+
+        /// <summary>
+        /// Wait until all queued background tasks have been completed.  NOTE: This will NOT pump,
+        /// and it won't wait for any timer foreground tasks to actually enqueue their respective
+        /// background tasks - it just waits for the already enqueued background tasks to finish.
+        /// </summary>
+        public void WaitForPendingBackgroundWork()
+        {
+            AssertIsForeground();
+
+            _currentBackgroundTask.Wait();
+        }
+
+        internal TestAccessor GetTestAccessor()
+        {
+            return new TestAccessor(this);
+        }
+
+        internal readonly struct TestAccessor
+        {
+            private readonly AsynchronousSerialWorkQueue _asynchronousSerialWorkQueue;
+
+            internal TestAccessor(AsynchronousSerialWorkQueue asynchronousSerialWorkQueue)
+            {
+                _asynchronousSerialWorkQueue = asynchronousSerialWorkQueue;
+            }
+
+            /// <summary>
+            /// Wait until all tasks have been completed.  NOTE that this will do a pumping wait if
+            /// called on the UI thread. Also, it isn't guaranteed to be stable in the case of tasks
+            /// enqueuing other tasks in arbitrary orders, though it does support our common pattern of
+            /// "timer task->background task->foreground task with results"
+            /// 
+            /// Use this method very judiciously.  Most of the time, we should be able to just use 
+            /// IAsynchronousOperationListener for tests.
+            /// </summary>
+            public void WaitUntilCompletion()
+            {
+                _asynchronousSerialWorkQueue.AssertIsForeground();
+
+                _asynchronousSerialWorkQueue.WaitForPendingBackgroundWork();
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Editor.Tagging
@@ -15,6 +13,11 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
     internal class TaggerEventArgs : EventArgs
     {
         public TaggerEventArgs()
+        {
+        }
+
+        [Obsolete("Legacy api for TypeScript.  Can be removed once they move to the no-arg constructor.")]
+        public TaggerEventArgs(TaggerDelay delay)
         {
         }
     }


### PR DESCRIPTION
TS currently uses IVT to access this.  We need to restore this to prevent a break until we can get them fully IVT.