### PR TITLE
Fix syntax code generation to account for kinds specified in parent

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -4376,6 +4376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (keyword.Kind() != SyntaxKind.CaseKeyword) throw new ArgumentException(nameof(keyword));
             if (pattern == null) throw new ArgumentNullException(nameof(pattern));
+            if (colonToken.Kind() != SyntaxKind.ColonToken) throw new ArgumentException(nameof(colonToken));
             return (CasePatternSwitchLabelSyntax)Syntax.InternalSyntax.SyntaxFactory.CasePatternSwitchLabel((Syntax.InternalSyntax.SyntaxToken)keyword.Node!, (Syntax.InternalSyntax.PatternSyntax)pattern.Green, whenClause == null ? null : (Syntax.InternalSyntax.WhenClauseSyntax)whenClause.Green, (Syntax.InternalSyntax.SyntaxToken)colonToken.Node!).CreateRed();
         }
 
@@ -4392,6 +4393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (keyword.Kind() != SyntaxKind.CaseKeyword) throw new ArgumentException(nameof(keyword));
             if (value == null) throw new ArgumentNullException(nameof(value));
+            if (colonToken.Kind() != SyntaxKind.ColonToken) throw new ArgumentException(nameof(colonToken));
             return (CaseSwitchLabelSyntax)Syntax.InternalSyntax.SyntaxFactory.CaseSwitchLabel((Syntax.InternalSyntax.SyntaxToken)keyword.Node!, (Syntax.InternalSyntax.ExpressionSyntax)value.Green, (Syntax.InternalSyntax.SyntaxToken)colonToken.Node!).CreateRed();
         }
 
@@ -4403,6 +4405,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static DefaultSwitchLabelSyntax DefaultSwitchLabel(SyntaxToken keyword, SyntaxToken colonToken)
         {
             if (keyword.Kind() != SyntaxKind.DefaultKeyword) throw new ArgumentException(nameof(keyword));
+            if (colonToken.Kind() != SyntaxKind.ColonToken) throw new ArgumentException(nameof(colonToken));
             return (DefaultSwitchLabelSyntax)Syntax.InternalSyntax.SyntaxFactory.DefaultSwitchLabel((Syntax.InternalSyntax.SyntaxToken)keyword.Node!, (Syntax.InternalSyntax.SyntaxToken)colonToken.Node!).CreateRed();
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -407,13 +407,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.SwitchSection(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.SwitchLabelSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.StatementSyntax>());
 
         private static Syntax.InternalSyntax.CasePatternSwitchLabelSyntax GenerateCasePatternSwitchLabel()
-            => InternalSyntaxFactory.CasePatternSwitchLabel(InternalSyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDiscardPattern(), null, InternalSyntaxFactory.Identifier("ColonToken"));
+            => InternalSyntaxFactory.CasePatternSwitchLabel(InternalSyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDiscardPattern(), null, InternalSyntaxFactory.Token(SyntaxKind.ColonToken));
 
         private static Syntax.InternalSyntax.CaseSwitchLabelSyntax GenerateCaseSwitchLabel()
-            => InternalSyntaxFactory.CaseSwitchLabel(InternalSyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateIdentifierName(), InternalSyntaxFactory.Identifier("ColonToken"));
+            => InternalSyntaxFactory.CaseSwitchLabel(InternalSyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.ColonToken));
 
         private static Syntax.InternalSyntax.DefaultSwitchLabelSyntax GenerateDefaultSwitchLabel()
-            => InternalSyntaxFactory.DefaultSwitchLabel(InternalSyntaxFactory.Token(SyntaxKind.DefaultKeyword), InternalSyntaxFactory.Identifier("ColonToken"));
+            => InternalSyntaxFactory.DefaultSwitchLabel(InternalSyntaxFactory.Token(SyntaxKind.DefaultKeyword), InternalSyntaxFactory.Token(SyntaxKind.ColonToken));
 
         private static Syntax.InternalSyntax.SwitchExpressionSyntax GenerateSwitchExpression()
             => InternalSyntaxFactory.SwitchExpression(GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.SwitchKeyword), InternalSyntaxFactory.Token(SyntaxKind.OpenBraceToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.SwitchExpressionArmSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseBraceToken));
@@ -2334,7 +2334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.CaseKeyword, node.Keyword.Kind);
             Assert.NotNull(node.Pattern);
             Assert.Null(node.WhenClause);
-            Assert.Equal(SyntaxKind.IdentifierToken, node.ColonToken.Kind);
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -2346,7 +2346,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.CaseKeyword, node.Keyword.Kind);
             Assert.NotNull(node.Value);
-            Assert.Equal(SyntaxKind.IdentifierToken, node.ColonToken.Kind);
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -2357,7 +2357,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateDefaultSwitchLabel();
 
             Assert.Equal(SyntaxKind.DefaultKeyword, node.Keyword.Kind);
-            Assert.Equal(SyntaxKind.IdentifierToken, node.ColonToken.Kind);
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -10070,13 +10070,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.SwitchSection(new SyntaxList<SwitchLabelSyntax>(), new SyntaxList<StatementSyntax>());
 
         private static CasePatternSwitchLabelSyntax GenerateCasePatternSwitchLabel()
-            => SyntaxFactory.CasePatternSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDiscardPattern(), default(WhenClauseSyntax), SyntaxFactory.Identifier("ColonToken"));
+            => SyntaxFactory.CasePatternSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDiscardPattern(), default(WhenClauseSyntax), SyntaxFactory.Token(SyntaxKind.ColonToken));
 
         private static CaseSwitchLabelSyntax GenerateCaseSwitchLabel()
-            => SyntaxFactory.CaseSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateIdentifierName(), SyntaxFactory.Identifier("ColonToken"));
+            => SyntaxFactory.CaseSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.ColonToken));
 
         private static DefaultSwitchLabelSyntax GenerateDefaultSwitchLabel()
-            => SyntaxFactory.DefaultSwitchLabel(SyntaxFactory.Token(SyntaxKind.DefaultKeyword), SyntaxFactory.Identifier("ColonToken"));
+            => SyntaxFactory.DefaultSwitchLabel(SyntaxFactory.Token(SyntaxKind.DefaultKeyword), SyntaxFactory.Token(SyntaxKind.ColonToken));
 
         private static SwitchExpressionSyntax GenerateSwitchExpression()
             => SyntaxFactory.SwitchExpression(GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.SwitchKeyword), SyntaxFactory.Token(SyntaxKind.OpenBraceToken), new SeparatedSyntaxList<SwitchExpressionArmSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
@@ -11997,7 +11997,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.CaseKeyword, node.Keyword.Kind());
             Assert.NotNull(node.Pattern);
             Assert.Null(node.WhenClause);
-            Assert.Equal(SyntaxKind.IdentifierToken, node.ColonToken.Kind());
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
             var newNode = node.WithKeyword(node.Keyword).WithPattern(node.Pattern).WithWhenClause(node.WhenClause).WithColonToken(node.ColonToken);
             Assert.Equal(node, newNode);
         }
@@ -12009,7 +12009,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.CaseKeyword, node.Keyword.Kind());
             Assert.NotNull(node.Value);
-            Assert.Equal(SyntaxKind.IdentifierToken, node.ColonToken.Kind());
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
             var newNode = node.WithKeyword(node.Keyword).WithValue(node.Value).WithColonToken(node.ColonToken);
             Assert.Equal(node, newNode);
         }
@@ -12020,7 +12020,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateDefaultSwitchLabel();
 
             Assert.Equal(SyntaxKind.DefaultKeyword, node.Keyword.Kind());
-            Assert.Equal(SyntaxKind.IdentifierToken, node.ColonToken.Kind());
+            Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
             var newNode = node.WithKeyword(node.Keyword).WithColonToken(node.ColonToken);
             Assert.Equal(node, newNode);
         }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
@@ -381,7 +381,7 @@ namespace CSharpSyntaxGenerator
 
             while (IsOverride(field))
             {
-                nd = Tree.Types.Single(t => t.Name == nd.Base);
+                nd = GetTreeType(nd.Base);
                 if (nd is Node node)
                 {
                     field = node.Fields.Single(f => f.Name == field.Name);

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
@@ -372,6 +372,38 @@ namespace CSharpSyntaxGenerator
             }
         }
 
+        protected List<Kind> GetKindsOfFieldOrNearestParent(TreeType nd, Field field)
+        {
+            if (!IsOverride(field) || field.Kinds.Count > 0)
+            {
+                return field.Kinds;
+            }
+
+            while (IsOverride(field))
+            {
+                nd = Tree.Types.Single(t => t.Name == nd.Base);
+                if (nd is Node node)
+                {
+                    field = node.Fields.Single(f => f.Name == field.Name);
+                }
+                else if (nd is AbstractNode abstractNode)
+                {
+                    field = abstractNode.Fields.Single(f => f.Name == field.Name);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unexpected node type.");
+                }
+
+                if (field.Kinds.Count > 0)
+                {
+                    return field.Kinds;
+                }
+            }
+
+            return null;
+        }
+
         #endregion Node helpers
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
@@ -374,34 +374,18 @@ namespace CSharpSyntaxGenerator
 
         protected List<Kind> GetKindsOfFieldOrNearestParent(TreeType nd, Field field)
         {
-            if (!IsOverride(field) || field.Kinds.Count > 0)
-            {
-                return field.Kinds;
-            }
-
-            while (IsOverride(field))
+            while ((field.Kinds is null || field.Kinds.Count == 0) && IsOverride(field))
             {
                 nd = GetTreeType(nd.Base);
-                if (nd is Node node)
+                field = (nd switch
                 {
-                    field = node.Fields.Single(f => f.Name == field.Name);
-                }
-                else if (nd is AbstractNode abstractNode)
-                {
-                    field = abstractNode.Fields.Single(f => f.Name == field.Name);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Unexpected node type.");
-                }
-
-                if (field.Kinds.Count > 0)
-                {
-                    return field.Kinds;
-                }
+                    Node node => node.Fields,
+                    AbstractNode abstractNode => abstractNode.Fields,
+                    _ => throw new InvalidOperationException("Unexpected node type.")
+                }).Single(f => f.Name == field.Name);
             }
 
-            return null;
+            return field.Kinds;
         }
 
         #endregion Node helpers

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -1620,38 +1620,6 @@ namespace CSharpSyntaxGenerator
             CloseBlock();
         }
 
-        private List<Kind> GetKindsOfFieldOrNearestParent(TreeType nd, Field field)
-        {
-            if (!IsOverride(field) || field.Kinds.Count > 0)
-            {
-                return field.Kinds;
-            }
-
-            while (IsOverride(field))
-            {
-                nd = Tree.Types.Single(t => t.Name == nd.Base);
-                if (nd is Node node)
-                {
-                    field = node.Fields.Single(f => f.Name == field.Name);
-                }
-                else if (nd is AbstractNode abstractNode)
-                {
-                    field = abstractNode.Fields.Single(f => f.Name == field.Name);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Unexpected node type.");
-                }
-
-                if (field.Kinds.Count > 0)
-                {
-                    return field.Kinds;
-                }
-            }
-
-            return null;
-        }
-
         private void WriteRedFactoryParameters(Node nd)
         {
             Write(CommaJoin(

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/TestWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/TestWriter.cs
@@ -150,7 +150,7 @@ namespace CSharpSyntaxGenerator
                 }
                 else if (field.Type == "SyntaxToken")
                 {
-                    var kind = ChooseValidKind(field);
+                    var kind = ChooseValidKind(field, node);
                     var leadingTrivia = isGreen ? "null, " : string.Empty;
                     var trailingTrivia = isGreen ? ", null" : string.Empty;
                     if (kind == "IdentifierToken")
@@ -171,7 +171,7 @@ namespace CSharpSyntaxGenerator
                     }
                     else
                     {
-                        Write($"{syntaxFactory}.Token(SyntaxKind.{ChooseValidKind(field)})");
+                        Write($"{syntaxFactory}.Token(SyntaxKind.{kind})");
                     }
                 }
                 else if (field.Type == "CSharpSyntaxNode")
@@ -257,13 +257,14 @@ namespace CSharpSyntaxGenerator
                     }
                     else if (field.Type == "SyntaxToken")
                     {
+                        var kind = ChooseValidKind(field, node);
                         if (!isGreen)
                         {
-                            WriteLine($"Assert.Equal(SyntaxKind.{ChooseValidKind(field)}, node.{field.Name}.Kind());");
+                            WriteLine($"Assert.Equal(SyntaxKind.{kind}, node.{field.Name}.Kind());");
                         }
                         else
                         {
-                            WriteLine($"Assert.Equal(SyntaxKind.{ChooseValidKind(field)}, node.{field.Name}.Kind);");
+                            WriteLine($"Assert.Equal(SyntaxKind.{kind}, node.{field.Name}.Kind);");
                         }
                     }
                     else
@@ -384,9 +385,10 @@ namespace CSharpSyntaxGenerator
         }
 
         //guess a reasonable kind if there are no constraints
-        private static string ChooseValidKind(Field field)
+        private string ChooseValidKind(Field field, Node nd)
         {
-            return field.Kinds.Any() ? field.Kinds[0].Name : "IdentifierToken";
+            var fieldKinds = GetKindsOfFieldOrNearestParent(nd, field);
+            return fieldKinds?.Any() == true ? fieldKinds[0].Name : "IdentifierToken";
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/52905

Note that some existing overrides in Syntax.xml explicitly re-defines the Kind. So another fix to the linked issue is to not touch the source generator and explicitly specify the Kind.