### PR TITLE
Fix out of bounds exception when mapping between spans in classification

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
@@ -14,6 +14,9 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -78,6 +81,69 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
             await checkpoint.Task;
             Assert.Equal(1, actualVersionNumber);
             Assert.Equal(37, actualLength);
+            Assert.Equal(2, callstacks.Count);
+        }
+
+        [WorkItem(1032665, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1032665")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestTagsChangedAfterDelete()
+        {
+            var code =
+@"class Goo";
+            using var workspace = TestWorkspace.CreateCSharp(code);
+            var document = workspace.Documents.First();
+            var subjectBuffer = document.GetTextBuffer();
+
+            var checkpoint = new Checkpoint();
+
+            var typeMap = workspace.ExportProvider.GetExportedValue<ClassificationTypeMap>();
+
+            var tagComputer = new SyntacticClassificationTaggerProvider.TagComputer(
+                new SyntacticClassificationTaggerProvider(
+                    workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
+                    typeMap,
+                    AsynchronousOperationListenerProvider.NullProvider),
+                subjectBuffer,
+                AsynchronousOperationListenerProvider.NullListener,
+                typeMap,
+                diffTimeout: TimeSpan.MaxValue);
+
+            // Capture the expected value before the await, in case it changes.
+            var expectedLength = subjectBuffer.CurrentSnapshot.Length;
+            int? actualVersionNumber = null;
+            int? actualLength = null;
+            var callstacks = new List<string>();
+            tagComputer.TagsChanged += (s, e) =>
+            {
+                actualVersionNumber = e.Span.Snapshot.Version.VersionNumber;
+                actualLength = e.Span.Length;
+                callstacks.Add(new StackTrace().ToString());
+                checkpoint.Release();
+            };
+
+            await checkpoint.Task;
+            Assert.Equal(0, actualVersionNumber);
+            Assert.Equal(expectedLength, actualLength);
+            Assert.Equal(1, callstacks.Count);
+
+            checkpoint = new Checkpoint();
+
+            // Now delete the last character.
+            var snapshot = subjectBuffer.Delete(new Span(subjectBuffer.CurrentSnapshot.Length - 1, 1));
+
+            // Try to get the tags prior to TagsChanged firing.  This will force us to use the previous 
+            // data we've cached to produce the new results.
+            tagComputer.GetTags(new NormalizedSnapshotSpanCollection(subjectBuffer.CurrentSnapshot.GetFullSpan()));
+
+            expectedLength = snapshot.Length;
+
+            // NOTE: TagsChanged is raised on the UI thread, so there is no race between
+            // assigning expected here and verifying in the event handler, because the
+            // event handler can't run until we await.
+            await checkpoint.Task;
+
+            Assert.Equal(1, actualVersionNumber);
+            Assert.Equal(2, actualLength);
             Assert.Equal(2, callstacks.Count);
         }
     }

--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 else
                 {
                     using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var tempList);
-                    AddSyntacticClassificationsForDocument(classificationService, span, lastProcessedDocument, lastProcessedRoot, tempList);
+                    AddSyntacticClassificationsForDocument(classificationService, translatedSpan, lastProcessedDocument, lastProcessedRoot, tempList);
 
                     var currentSnapshot = span.Snapshot;
                     var currentText = currentSnapshot.AsText();


### PR DESCRIPTION
This was an incorrect mapping done when i did the recent refactoring.  You can see in the origina code taht we should be using the translated span: https://github.com/dotnet/roslyn/commit/012a1fb7840f17d909c94345b64c34d3cc0decc0?branch=012a1fb7840f17d909c94345b64c34d3cc0decc0&diff=split#diff-7a46c1cd528894bf67c0ad8cc4a7758ad9764a9bf240492a7c36157f3b710b81L435

