### PR TITLE
Fix code cleanup registration for VB

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixerProvider.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixerProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeCleanup
 {
     [Export(typeof(ICodeCleanUpFixerProvider))]
-    [AppliesToProject(ContentTypeNames.CSharpContentType)]
+    [AppliesToProject("CSharp")]
     [ContentType(ContentTypeNames.CSharpContentType)]
     internal class CSharpCodeCleanUpFixerProvider : AbstractCodeCleanUpFixerProvider
     {

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodeCleanupFixerProvider.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodeCleanupFixerProvider.vb
@@ -11,7 +11,7 @@ Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeCleanup
     <Export(GetType(ICodeCleanUpFixerProvider))>
-    <AppliesToProject(ContentTypeNames.VisualBasicContentType)>
+    <AppliesToProject("VB")>
     <ContentType(ContentTypeNames.VisualBasicContentType)>
     Friend Class VisualBasicCodeCleanUpFixerProvider
         Inherits AbstractCodeCleanUpFixerProvider


### PR DESCRIPTION
This tried to use the VB content type name for what should have been the VB project capability. To avoid confusion, the C# one is also updated -- the C# content type and capability happen to be the same string value, but avoiding use of ContentTypeNames makes it clear AppliesToProject is not taking a content type, conceptually.

This adds this:

![image](https://user-images.githubusercontent.com/201340/116149103-96c91d80-a696-11eb-99f9-56f963755e3f.png)
