### PR TITLE
Cancel all current work with highlight refs when changes come in

### DIFF
--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
         {
         }
 
-        protected override TaggerDelay EventChangeDelay => TaggerDelay.Short;
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.Medium;
 
         protected override ITaggerEventSource CreateEventSource(ITextView textView, ITextBuffer subjectBuffer)
         {

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerConstants.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerConstants.cs
@@ -29,19 +29,12 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         }
 
         internal static TimeSpan ComputeTimeDelay(this TaggerDelay behavior)
-        {
-            switch (behavior)
+            => behavior switch
             {
-                case TaggerDelay.NearImmediate:
-                    return TimeSpan.FromMilliseconds(NearImmediateDelay);
-                case TaggerDelay.Short:
-                    return TimeSpan.FromMilliseconds(ShortDelay);
-                case TaggerDelay.Medium:
-                    return TimeSpan.FromMilliseconds(MediumDelay);
-                case TaggerDelay.OnIdle:
-                default:
-                    return TimeSpan.FromMilliseconds(IdleDelay);
-            }
-        }
+                TaggerDelay.NearImmediate => TimeSpan.FromMilliseconds(NearImmediateDelay),
+                TaggerDelay.Short => TimeSpan.FromMilliseconds(ShortDelay),
+                TaggerDelay.Medium => TimeSpan.FromMilliseconds(MediumDelay),
+                _ => TimeSpan.FromMilliseconds(IdleDelay),
+            };
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// <summary>
             /// Work queue that collects event notifications and kicks off the work to process them.
             /// </summary>
-            private Task _eventWorkQueue;
+            private Task _eventWorkQueue = Task.CompletedTask;
 
             /// <summary>
             /// Series of tokens used to cancel previous outstanding work when new work comes in. Also used as the lock
@@ -153,14 +153,12 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 DebugRecordInitialStackTrace();
 
-                // Start computing the initial set of tags immediately.  We want to get the UI
-                // to a complete state as soon as possible.
-                _eventWorkQueue =
-                    Task.Run(() => ProcessEventsAsync(initialTags: true, _disposalTokenSource.Token), _disposalTokenSource.Token)
-                        .CompletesAsyncOperation(_asyncListener.BeginAsyncOperation(nameof(TagSource)));
-
                 _eventSource = CreateEventSource();
                 Connect();
+
+                // Start computing the initial set of tags immediately.  We want to get the UI
+                // to a complete state as soon as possible.
+                EnqueueWork(initialTags: true);
 
                 return;
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -158,7 +158,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 // Start computing the initial set of tags immediately.  We want to get the UI
                 // to a complete state as soon as possible.
-                _eventWorkQueue = Task.Run(() => ProcessEventsAsync(initialTags: true, _disposalTokenSource.Token), _disposalTokenSource.Token);
+                _eventWorkQueue =
+                    Task.Run(() => ProcessEventsAsync(initialTags: true, _disposalTokenSource.Token), _disposalTokenSource.Token)
+                        .CompletesAsyncOperation(_asyncListener.BeginAsyncOperation(nameof(TagSource)));
 
                 return;
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -199,6 +199,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 // Stop computing any initial tags if we've been asked for them.
                 _disposalTokenSource.Cancel();
+                _cancellationSeries.Dispose();
+
                 _disposed = true;
                 _dataSource.RemoveTagSource(_textViewOpt, _subjectBuffer);
                 GC.SuppressFinalize(this);

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -64,6 +64,10 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// Work queue that collects event notifications and kicks off the work to process them.
             /// </summary>
             private Task _eventWorkQueue;
+
+            /// <summary>
+            /// Series of tokens used to cancel previous outstanding work when new work comes in.
+            /// </summary>
             private readonly CancellationSeries _cancellationSeries;
 
             /// <summary>
@@ -122,12 +126,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _asyncListener = asyncListener;
 
                 _cancellationSeries = new CancellationSeries(_disposalTokenSource.Token);
-                //_eventWorkQueue = new AsyncBatchingWorkQueue<bool>(
-                //    _dataSource.EventChangeDelay.ComputeTimeDelay(),
-                //    ProcessEventsAsync,
-                //    equalityComparer: null,
-                //    asyncListener,
-                //    _disposalTokenSource.Token);
 
                 _highPriTagsChangedQueue = new AsyncBatchingWorkQueue<NormalizedSnapshotSpanCollection>(
                     TaggerDelay.NearImmediate.ComputeTimeDelay(),

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
     {
         private partial class TagSource
         {
-            private void OnCaretPositionChanged(object sender, CaretPositionChangedEventArgs e)
+            private void OnCaretPositionChanged(object? _, CaretPositionChangedEventArgs e)
             {
                 this.AssertIsForeground();
 
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 RaiseTagsChanged(snapshot.TextBuffer, new DiffResult(added: null, removed: new(oldTagTree.GetSpans(snapshot).Select(s => s.Span))));
             }
 
-            private void OnSubjectBufferChanged(object sender, TextContentChangedEventArgs e)
+            private void OnSubjectBufferChanged(object? _, TextContentChangedEventArgs e)
             {
                 this.AssertIsForeground();
                 UpdateTagsForTextChange(e);
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     : new TagSpanIntervalTree<TTag>(snapshot.TextBuffer, _dataSource.SpanTrackingMode);
             }
 
-            private void OnEventSourceChanged(object sender, TaggerEventArgs _)
+            private void OnEventSourceChanged(object? _1, TaggerEventArgs _2)
             {
                 EnqueueWork(initialTags: false);
             }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -265,6 +265,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                     // Once we assign our state, we're uncancellable.  We must report the changed information
                     // to the editor.  The only case where it's ok not to is if the tagger itself is disposed.
+                    cancellationToken = CancellationToken.None;
+
                     this.CachedTagTrees = newTagTrees;
                     this.State = context.State;
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -177,14 +177,27 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 {
                     // cancel the last piece of computation work and enqueue the next
                     var cancellationToken = initialTags ? _disposalTokenSource.Token : _cancellationSeries.CreateNext();
-                    var nextTask = _eventWorkQueue.ContinueWith(
-                        async _ =>
-                        {
-                            await Task.Delay(_dataSource.EventChangeDelay.ComputeTimeDelay(), cancellationToken).ConfigureAwait(false);
-                            await ProcessEventsAsync(initialTags, cancellationToken).ConfigureAwait(false);
-                        }, cancellationToken, TaskContinuationOptions.LazyCancellation | TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.Default);
-                    _eventWorkQueue = nextTask.Unwrap().CompletesAsyncOperation(_asyncListener.BeginAsyncOperation(nameof(EnqueueWork)));
+                    _eventWorkQueue = EnqueueWorkAsync(_eventWorkQueue, initialTags, cancellationToken);
                 }
+            }
+
+            private async Task EnqueueWorkAsync(Task eventWorkQueue, bool initialTags, CancellationToken cancellationToken)
+            {
+                using var _ = _asyncListener.BeginAsyncOperation(nameof(EnqueueWorkAsync));
+
+                try
+                {
+                    await eventWorkQueue.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex) when (FatalError.ReportAndCatch(ex))
+                {
+                }
+
+                await Task.Delay(_dataSource.EventChangeDelay.ComputeTimeDelay(), cancellationToken).ConfigureAwait(false);
+                await ProcessEventsAsync(initialTags, cancellationToken).ConfigureAwait(false);
             }
 
             private async Task ProcessEventsAsync(bool initialTags, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -167,10 +167,10 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
             private void OnEventSourceChanged(object sender, TaggerEventArgs _)
             {
-                // cancel the last piece of computation work and enqueue the next
-                var cancellationToken = _cancellationSeries.CreateNext();
                 lock (_cancellationSeries)
                 {
+                    // cancel the last piece of computation work and enqueue the next
+                    var cancellationToken = _cancellationSeries.CreateNext();
                     _eventWorkQueue = OnEventSourceChangedAsync(_eventWorkQueue, cancellationToken);
                 }
             }


### PR DESCRIPTION
Highlight refs demonstrates a problem with some of the tagger cleanup that recently went in.  Part of highlight refs is highly synchronous.  Namely that we remove the tags on movement or edits immediately so that we don't show "stale" tags.  This is problematic because the previous pr made it much more efficient to compute tags.  So we could end up with clearing the tags and tehn very efficiently showing them again.

The fix here is in two parts.  The first is that we make the delay for highlight refs closer to the perceived delay that we used to incur in the older less efficient system once we added up all the delays that used to have.

The second is that because we are clearign out the old values, we don't actually want the mode where we take the results we have and introduce them very soon after they're available.  Instead, we explicitly attempt to cancel any computation work and only compute the results against the latest when new events come in.  We initially had a batchign work queue for this.  however, the batch was only ever up to two items (just to say if we were on the initial item on a subsequent item).  because of that, it was just easier to go to simple task queuing to represent this concept of stopping the current set of work and just restarting the new computation

Manual testing in practice indicated that this feels good and non-distracting.  With resutls still coming up in a reasonable amount of time, without it feeling aggressive.