### PR TITLE
Catch exceptions within LazyToolTip

### DIFF
--- a/src/EditorFeatures/Core.Wpf/QuickInfo/LazyToolTip.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/LazyToolTip.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.Editor.QuickInfo
 {
@@ -50,26 +51,40 @@ namespace Microsoft.CodeAnalysis.Editor.QuickInfo
 
             private void OnToolTipOpening(object sender, ToolTipEventArgs e)
             {
-                AssertIsForeground();
+                try
+                {
+                    AssertIsForeground();
 
-                Debug.Assert(_element.ToolTip == this);
-                Debug.Assert(_disposableToolTip == null);
+                    Debug.Assert(_element.ToolTip == this);
+                    Debug.Assert(_disposableToolTip == null);
 
-                _disposableToolTip = _createToolTip();
-                _element.ToolTip = _disposableToolTip.ToolTip;
+                    _disposableToolTip = _createToolTip();
+                    _element.ToolTip = _disposableToolTip.ToolTip;
+                }
+                catch (Exception ex) when (FatalError.ReportAndCatch(ex))
+                {
+                    // Do nothing, since this is a WPF event handler and propagating the exception would cause a crash
+                }
             }
 
             private void OnToolTipClosing(object sender, ToolTipEventArgs e)
             {
-                AssertIsForeground();
+                try
+                {
+                    AssertIsForeground();
 
-                Debug.Assert(_disposableToolTip != null);
-                Debug.Assert(_element.ToolTip == _disposableToolTip.ToolTip);
+                    Debug.Assert(_disposableToolTip != null);
+                    Debug.Assert(_element.ToolTip == _disposableToolTip.ToolTip);
 
-                _element.ToolTip = this;
+                    _element.ToolTip = this;
 
-                _disposableToolTip.Dispose();
-                _disposableToolTip = null;
+                    _disposableToolTip.Dispose();
+                    _disposableToolTip = null;
+                }
+                catch (Exception ex) when (FatalError.ReportAndCatch(ex))
+                {
+                    // Do nothing, since this is a WPF event handler and propagating the exception would cause a crash
+                }
             }
         }
     }


### PR DESCRIPTION
This change converts a case involving a rare application crash to use our standard error handling/reporting strategy without crashing.

Fixes [AB#621364](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/621364)