### PR TITLE
Porting dev17 related changes from merged interop branch

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,10 +5,10 @@
     Roslyn version
   -->
   <PropertyGroup>
-    <MajorVersion>3</MajorVersion>
-    <MinorVersion>10</MinorVersion>
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>3</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <!--
       By default the assembly version in official builds is "$(MajorVersion).$(MinorVersion).0.0".
@@ -233,7 +233,8 @@
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
-    <MicrosoftVSSDKBuildToolsVersion>16.8.3036</MicrosoftVSSDKBuildToolsVersion>
+    <MicroBuildPluginsSwixBuildVersion>1.1.33</MicroBuildPluginsSwixBuildVersion>
+    <MicrosoftVSSDKBuildToolsVersion>17.0.63-dev17-g3f11f5ab</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftVSSDKVSDConfigToolVersion>16.0.2032702</MicrosoftVSSDKVSDConfigToolVersion>
     <VSLangProjVersion>7.0.3301</VSLangProjVersion>
     <VSLangProj140Version>14.0.25030</VSLangProj140Version>

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -182,6 +182,17 @@
       "vsBranch": "main",
       "vsMajorVersion": 17
     },
+    "release/dev17.0-preview1-nopia-vs-deps": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "version": "4.0.*",
+      "packageFeeds": "default",
+      "channels": [],
+      "vsBranch": "feature/d17initial",
+      "vsMajorVersion": 17
+    },
     "release/dev17.0-preview1-vs-deps": {
       "nugetKind": [
         "Shipping",

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -15,6 +15,7 @@
     <!-- Setting this to the same as CreateVsixContainer ensures that the VS SDK doesn't try to look for a source.extension.vsixmanifest
          when we don't have one. -->
     <CopyVsixManifestToOutput>$(CreateVsixContainer)</CopyVsixManifestToOutput>
+    <SetupProductArch>Neutral</SetupProductArch>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockManagedEditAndContinueDebuggerService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockManagedEditAndContinueDebuggerService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         public Task<ImmutableArray<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
-            => Task.FromResult(ImmutableArray<string>.Empty);
+            => Task.FromResult(ImmutableArray.Create("Baseline", "AddInstanceFieldToExistingType", "AddStaticFieldToExistingType", "AddMethodToExistingType", "NewTypeDefinition"));
 
         public Task PrepareModuleForUpdateAsync(Guid mvid, CancellationToken cancellationToken)
             => Task.CompletedTask;

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
@@ -37,6 +37,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Creating a new type definition.
         /// </summary>
-        NewTypeDefinition = 1 << 2
+        NewTypeDefinition = 1 << 4
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
                 => Task.FromResult(new ManagedEditAndContinueAvailability(ManagedEditAndContinueAvailabilityStatus.Available));
 
             public Task<ImmutableArray<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
-                => Task.FromResult(ImmutableArray<string>.Empty);
+                => Task.FromResult(ImmutableArray.Create("Baseline", "AddInstanceFieldToExistingType", "AddStaticFieldToExistingType", "AddMethodToExistingType", "NewTypeDefinition"));
 
             public Task PrepareModuleForUpdateAsync(Guid module, CancellationToken cancellationToken)
                 => Task.CompletedTask;

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -138,6 +138,7 @@
 
 package name=$(VisualStudioInsertionComponent)
         version=$(VsixVersion)
+        vs.package.productArch=neutral
 
 vs.dependencies
   vs.dependency id=Microsoft.Net.PackageGroup.4.7.2.Redist

--- a/src/Setup/DevDivVsix/ServiceHubConfig/Roslyn.VisualStudio.Setup.ServiceHub.csproj
+++ b/src/Setup/DevDivVsix/ServiceHubConfig/Roslyn.VisualStudio.Setup.ServiceHub.csproj
@@ -38,6 +38,7 @@
 
 package name=$(MSBuildProjectName)
         version=$(VsixVersion)
+        vs.package.productArch=neutral
 
 folder InstallDir:\Common7\ServiceHub\Services\RoslynCodeAnalysisService
   @(_FileEntries, '%0d%0a  ')

--- a/src/Tools/ExternalAccess/DotNetWatch/StubManagedEditAndContinueDebuggerService.cs
+++ b/src/Tools/ExternalAccess/DotNetWatch/StubManagedEditAndContinueDebuggerService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.DotNetWatch
 
         public Task<ImmutableArray<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(ImmutableArray<string>.Empty);
+            return Task.FromResult(ImmutableArray.Create("Baseline", "AddInstanceFieldToExistingType", "AddStaticFieldToExistingType", "AddMethodToExistingType", "NewTypeDefinition"));
         }
 
         public Task PrepareModuleForUpdateAsync(Guid moduleVersionId, CancellationToken cancellationToken)


### PR DESCRIPTION
release/dev17.0-preview1-nopia-vs-deps is created to insert roslyn into d17intial before dev17 interops is merged back, in order to unblock LSP testing with current dev17 builds. This new branch is based on release/dev16.0-vs-deps. With changes in this PR, it should be insert-able to d17intial.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1317002

@dibarbet @JoeRobich @allisonchou 
FYI @NTaylorMullen 