### PR TITLE
When invoking 'generate overrides' respect teh last user action wrt select-all/deselect-all

### DIFF
--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -176,15 +176,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 #pragma warning restore RS0034 // Exported parts should be marked with 'ImportingConstructorAttribute'
 
         public PickMembersResult PickMembers(
-            string title, ImmutableArray<ISymbol> members,
-            ImmutableArray<PickMembersOption> options)
+            string title,
+            ImmutableArray<ISymbol> members,
+            ImmutableArray<PickMembersOption> options,
+            bool selectAll)
         {
             OptionsCallback?.Invoke(options);
             return new PickMembersResult(
                 MemberNames.IsDefault
                     ? members
                     : MemberNames.SelectAsArray(n => members.Single(m => m.Name == n)),
-                options);
+                options,
+                selectAll);
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -118,7 +118,10 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 {
                     // Usually applying this code action pops up a dialog allowing the user to choose which options.
                     // We can't do that here, so instead we just take the defaults until we have more intent data.
-                    var options = new PickMembersResult(dialogAction.ViableMembers, dialogAction.PickMembersOptions);
+                    var options = new PickMembersResult(
+                        dialogAction.ViableMembers,
+                        dialogAction.PickMembersOptions,
+                        selectedAll: true);
                     var operations = await dialogAction.GetOperationsAsync(options: options, cancellationToken).ConfigureAwait(false);
                     return operations == null ? ImmutableArray<CodeActionOperation>.Empty : operations.ToImmutableArray();
                 }

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesOptions.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesOptions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Options.Providers;
+
+namespace Microsoft.CodeAnalysis.GenerateOverrides
+{
+    internal class GenerateOverridesOptions
+    {
+        public static readonly Option2<bool> SelectAll = new(
+            nameof(GenerateOverridesOptions), nameof(SelectAll), defaultValue: true,
+            storageLocations: new RoamingProfileStorageLocation($"TextEditor.Specific.{nameof(GenerateOverridesOptions)}.{nameof(SelectAll)}"));
+
+        [ExportOptionProvider, Shared]
+        internal class GenerateOverridesOptionsProvider : IOptionProvider
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public GenerateOverridesOptionsProvider()
+            {
+            }
+
+            public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
+                GenerateOverridesOptions.SelectAll);
+        }
+    }
+}

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesWithDialogCodeAction.cs
@@ -46,7 +46,8 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
             {
                 var service = _service._pickMembersService_forTestingPurposes ?? _document.Project.Solution.Workspace.Services.GetRequiredService<IPickMembersService>();
                 return service.PickMembers(
-                    FeaturesResources.Pick_members_to_override, _viableMembers,
+                    FeaturesResources.Pick_members_to_override,
+                    _viableMembers,
                     selectAll: _document.Project.Solution.Options.GetOption(GenerateOverridesOptions.SelectAll));
             }
 
@@ -102,9 +103,7 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
                 private readonly bool _selectedAll;
 
                 public ChangeOptionValueOperation(bool selectedAll)
-                {
-                    _selectedAll = selectedAll;
-                }
+                    => _selectedAll = selectedAll;
 
                 public override void Apply(Workspace workspace, CancellationToken cancellationToken)
                 {

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesWithDialogCodeAction.cs
@@ -40,19 +40,21 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
                 _textSpan = textSpan;
             }
 
+            public override string Title => FeaturesResources.Generate_overrides;
+
             public override object GetOptions(CancellationToken cancellationToken)
             {
                 var service = _service._pickMembersService_forTestingPurposes ?? _document.Project.Solution.Workspace.Services.GetRequiredService<IPickMembersService>();
-                return service.PickMembers(FeaturesResources.Pick_members_to_override, _viableMembers);
+                return service.PickMembers(
+                    FeaturesResources.Pick_members_to_override, _viableMembers,
+                    selectAll: _document.Project.Solution.Options.GetOption(GenerateOverridesOptions.SelectAll));
             }
 
             protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(object options, CancellationToken cancellationToken)
             {
                 var result = (PickMembersResult)options;
                 if (result.IsCanceled || result.Members.Length == 0)
-                {
                     return SpecializedCollections.EmptyEnumerable<CodeActionOperation>();
-                }
 
                 var syntaxTree = await _document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 RoslynDebug.AssertNotNull(syntaxTree);
@@ -79,8 +81,11 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
                         options: await _document.GetOptionsAsync(cancellationToken).ConfigureAwait(false)),
                     cancellationToken).ConfigureAwait(false);
 
-                return SpecializedCollections.SingletonEnumerable(
-                    new ApplyChangesOperation(newDocument.Project.Solution));
+                return new CodeActionOperation[]
+                    {
+                        new ApplyChangesOperation(newDocument.Project.Solution),
+                        new ChangeOptionValueOperation(result.SelectedAll),
+                    };
             }
 
             private Task<ISymbol> GenerateOverrideAsync(
@@ -92,7 +97,25 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
                     cancellationToken: cancellationToken);
             }
 
-            public override string Title => FeaturesResources.Generate_overrides;
+            private class ChangeOptionValueOperation : CodeActionOperation
+            {
+                private readonly bool _selectedAll;
+
+                public ChangeOptionValueOperation(bool selectedAll)
+                {
+                    _selectedAll = selectedAll;
+                }
+
+                public override void Apply(Workspace workspace, CancellationToken cancellationToken)
+                {
+                    if (workspace.Options.GetOption(GenerateOverridesOptions.SelectAll) == _selectedAll)
+                        return;
+
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(
+                        workspace.CurrentSolution.Options.WithChangedOption(
+                            GenerateOverridesOptions.SelectAll, _selectedAll)));
+                }
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/PickMembers/IPickMembersService.cs
+++ b/src/Features/Core/Portable/PickMembers/IPickMembersService.cs
@@ -13,7 +13,8 @@ namespace Microsoft.CodeAnalysis.PickMembers
     {
         PickMembersResult PickMembers(
             string title, ImmutableArray<ISymbol> members,
-            ImmutableArray<PickMembersOption> options = default);
+            ImmutableArray<PickMembersOption> options = default,
+            bool selectAll = true);
     }
 
     internal class PickMembersOption

--- a/src/Features/Core/Portable/PickMembers/PickMembersResult.cs
+++ b/src/Features/Core/Portable/PickMembers/PickMembersResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.PickMembers
@@ -16,15 +14,22 @@ namespace Microsoft.CodeAnalysis.PickMembers
         public readonly ImmutableArray<ISymbol> Members;
         public readonly ImmutableArray<PickMembersOption> Options;
 
+        /// <summary>
+        /// <see langword="true"/> if 'Select All' was chosen.  <see langword="false"/> if 'Deselect All' was chosen.
+        /// </summary>
+        public readonly bool SelectedAll;
+
         private PickMembersResult(bool isCanceled)
             => IsCanceled = isCanceled;
 
         public PickMembersResult(
             ImmutableArray<ISymbol> members,
-            ImmutableArray<PickMembersOption> options)
+            ImmutableArray<PickMembersOption> options,
+            bool selectedAll)
         {
             Members = members;
             Options = options;
+            SelectedAll = selectedAll;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/VisualStudioPickMembersService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/VisualStudioPickMembersService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Composition;
@@ -26,21 +24,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PickMembers
             => _glyphService = glyphService;
 
         public PickMembersResult PickMembers(
-            string title, ImmutableArray<ISymbol> members, ImmutableArray<PickMembersOption> options)
+            string title,
+            ImmutableArray<ISymbol> members,
+            ImmutableArray<PickMembersOption> options,
+            bool selectAll)
         {
             options = options.NullToEmpty();
 
-            var viewModel = new PickMembersDialogViewModel(_glyphService, members, options);
+            var viewModel = new PickMembersDialogViewModel(_glyphService, members, options, selectAll);
             var dialog = new PickMembersDialog(viewModel, title);
             var result = dialog.ShowModal();
 
-            if (result.HasValue && result.Value)
+            if (result == true)
             {
                 return new PickMembersResult(
                     viewModel.MemberContainers.Where(c => c.IsChecked)
                                               .Select(c => c.Symbol)
                                               .ToImmutableArray(),
-                    options);
+                    options,
+                    viewModel.SelectedAll);
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47806

The general idea is this: eery time the user chooses 'select all' or 'deselect all' in the dialog, we use that as hint to the next opening of hte dialog to decide if we should start with all items selected or deselected.

This means that if someone is in a mode where they're overrriding all/most of hte members (for example, when creating types that suclass Object and override Equals/GetHashCode/ToString) that they continue selecting all members.  However, if they're in a mode where they're overriding a small set of items (for example, object hierarchies with tons of virtual members) they can choose to 'deselect all' and then in the future only have to select the items they care about, isntead of deselecting the items they don't care about.

This is a partial mitigation for https://github.com/dotnet/roslyn/issues/47806.  Other things we'd likely want to do are allow for a filter-box to filter down to a smaller set of symbols by name that hte user cares about, as well as allowing symbols to be grouped by their containing type to make browsing easier.