### PR TITLE
Policheck fix

### DIFF
--- a/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
         class CSharpClass
         {
-            VBCl$$ass vb
+            VB$$Class vb
         }
         </Document>
     </Project>

--- a/src/EditorFeatures/Test2/GoToDefinition/VisualBasicGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/VisualBasicGoToDefinitionTests.vb
@@ -694,7 +694,7 @@ class C
         <Document>
             Class SomeClass
             End Class
-            Cl$$ass OtherClass
+            C$$lass OtherClass
                 Dim obj As SomeClass
             End Class
         </Document>


### PR DESCRIPTION
Our placeholder cursor split the word 'class' and makes some bad words, and it is catched by policheck.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1320142
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1320141
