### PR TITLE
Make CodeAction.CustomTags internal

### DIFF
--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <summary>
         /// Gets custom tags for the CodeAction.
         /// </summary>
-        public ImmutableArray<string> CustomTags { get; protected set; } = ImmutableArray<string>.Empty;
+        internal ImmutableArray<string> CustomTags { get; set; } = ImmutableArray<string>.Empty;
 
         /// <summary>
         /// Used by the CodeFixService and CodeRefactoringService to add the Provider Name as a CustomTag.

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -373,13 +373,10 @@ namespace Microsoft.CodeAnalysis.CodeActions
         {
             public SimpleCodeAction(
                 string title,
-                string? equivalenceKey,
-                IEnumerable<string>? customTags = null)
+                string? equivalenceKey)
             {
                 Title = title;
                 EquivalenceKey = equivalenceKey;
-
-                CustomTags = customTags.ToImmutableArrayOrEmpty();
             }
 
             public sealed override string Title { get; }
@@ -392,9 +389,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 string title,
                 ImmutableArray<CodeAction> nestedActions,
                 bool isInlinable,
-                CodeActionPriority priority = CodeActionPriority.Medium,
-                IEnumerable<string>? customTags = null)
-                : base(title, ComputeEquivalenceKey(nestedActions), customTags)
+                CodeActionPriority priority = CodeActionPriority.Medium)
+                : base(title, ComputeEquivalenceKey(nestedActions))
             {
                 Debug.Assert(nestedActions.Length > 0);
                 NestedCodeActions = nestedActions;
@@ -434,9 +430,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
             public DocumentChangeAction(
                 string title,
                 Func<CancellationToken, Task<Document>> createChangedDocument,
-                string? equivalenceKey = null,
-                IEnumerable<string>? customTags = null)
-                : base(title, equivalenceKey, customTags)
+                string? equivalenceKey = null)
+                : base(title, equivalenceKey)
             {
                 _createChangedDocument = createChangedDocument;
             }
@@ -452,9 +447,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
             public SolutionChangeAction(
                 string title,
                 Func<CancellationToken, Task<Solution>> createChangedSolution,
-                string? equivalenceKey = null,
-                IEnumerable<string>? customTags = null)
-                : base(title, equivalenceKey, customTags)
+                string? equivalenceKey = null)
+                : base(title, equivalenceKey)
             {
                 _createChangedSolution = createChangedSolution;
             }
@@ -467,9 +461,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
         {
             public NoChangeAction(
                 string title,
-                string? equivalenceKey = null,
-                IEnumerable<string>? customTags = null)
-                : base(title, equivalenceKey, customTags)
+                string? equivalenceKey = null)
+                : base(title, equivalenceKey)
             {
             }
 

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,7 +1,5 @@
 abstract Microsoft.CodeAnalysis.CodeFixes.DocumentBasedFixAllProvider.FixAllAsync(Microsoft.CodeAnalysis.CodeFixes.FixAllContext fixAllContext, Microsoft.CodeAnalysis.Document document, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>
 const Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.RecordClassName = "record class name" -> string
-Microsoft.CodeAnalysis.CodeActions.CodeAction.CustomTags.get -> System.Collections.Immutable.ImmutableArray<string>
-Microsoft.CodeAnalysis.CodeActions.CodeAction.CustomTags.set -> void
 Microsoft.CodeAnalysis.CodeFixes.DocumentBasedFixAllProvider
 Microsoft.CodeAnalysis.CodeFixes.DocumentBasedFixAllProvider.DocumentBasedFixAllProvider() -> void
 Microsoft.CodeAnalysis.CommandLineProject

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CustomCodeActions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CustomCodeActions.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Utilities;
@@ -17,13 +15,10 @@ namespace Microsoft.CodeAnalysis.CodeActions
         {
             public SimpleCodeAction(
                 string title,
-                string? equivalenceKey = null,
-                IEnumerable<string>? customTags = null)
+                string? equivalenceKey = null)
             {
                 Title = title;
                 EquivalenceKey = equivalenceKey;
-
-                CustomTags = customTags.ToImmutableArrayOrEmpty();
             }
 
             public sealed override string Title { get; }
@@ -37,9 +32,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
             public DocumentChangeAction(
                 string title,
                 Func<CancellationToken, Task<Document>> createChangedDocument,
-                string? equivalenceKey = null,
-                IEnumerable<string>? customTags = null)
-                : base(title, equivalenceKey, customTags)
+                string? equivalenceKey = null)
+                : base(title, equivalenceKey)
             {
                 _createChangedDocument = createChangedDocument;
             }
@@ -55,9 +49,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
             public SolutionChangeAction(
                 string title,
                 Func<CancellationToken, Task<Solution>> createChangedSolution,
-                string? equivalenceKey = null,
-                IEnumerable<string>? customTags = null)
-                : base(title, equivalenceKey, customTags)
+                string? equivalenceKey = null)
+                : base(title, equivalenceKey)
             {
                 _createChangedSolution = createChangedSolution;
             }


### PR DESCRIPTION
To avoid shipping a new public API that we want to remove.