### PR TITLE
Prepend first statement of using block with a newline, if opening bracket is on same line as using statement

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -125,16 +125,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
                     }
 
                     var openBraceTrailingTrivia = blockSyntax.OpenBraceToken.TrailingTrivia;
-                    var usingHasNotEndOfLineTrivia = usingStatement.CloseParenToken.TrailingTrivia.Count(t => t.IsKind(SyntaxKind.EndOfLineTrivia)) == 0;
+                    var usingHasNotEndOfLineTrivia = usingStatement.CloseParenToken.TrailingTrivia
+                        .Count(t => t.IsKind(SyntaxKind.EndOfLineTrivia)) == 0;
                     if (usingHasNotEndOfLineTrivia)
                     {
-                        var newFirstStatement = statements.First().WithPrependedLeadingTrivia(CSharpSyntaxFacts.Instance.ElasticCarriageReturnLineFeed);
+                        var newFirstStatement = statements.First()
+                            .WithPrependedLeadingTrivia(CSharpSyntaxFacts.Instance.ElasticCarriageReturnLineFeed);
                         statements = statements.Replace(statements.First(), newFirstStatement);
                     }
 
                     if (openBraceTrailingTrivia.Any(t => t.IsSingleOrMultiLineComment()))
                     {
-                        var newFirstStatement = statements.First().WithPrependedLeadingTrivia(openBraceTrailingTrivia);
+                        var newFirstStatement = statements.First()
+                            .WithPrependedLeadingTrivia(openBraceTrailingTrivia);
                         statements = statements.Replace(statements.First(), newFirstStatement);
                     }
 

--- a/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -119,12 +119,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
             {
                 case BlockSyntax blockSyntax:
                     var statements = blockSyntax.Statements;
+                    if (statements.Count() == 0)
+                    {
+                        return blockSyntax.CloseBraceToken.LeadingTrivia;
+                    }
 
                     var openBraceTrailingTrivia = blockSyntax.OpenBraceToken.TrailingTrivia;
+                    var usingHasNotEndOfLineTrivia = usingStatement.CloseParenToken.TrailingTrivia.Count(t => t.IsKind(SyntaxKind.EndOfLineTrivia)) == 0;
+                    if (usingHasNotEndOfLineTrivia)
+                    {
+                        var newFirstStatement = statements.First().WithPrependedLeadingTrivia(CSharpSyntaxFacts.Instance.ElasticCarriageReturnLineFeed);
+                        statements = statements.Replace(statements.First(), newFirstStatement);
+                    }
+
                     if (openBraceTrailingTrivia.Any(t => t.IsSingleOrMultiLineComment()))
                     {
-                        var newFirstStatement = statements.First()
-                            .WithPrependedLeadingTrivia(openBraceTrailingTrivia);
+                        var newFirstStatement = statements.First().WithPrependedLeadingTrivia(openBraceTrailingTrivia);
                         statements = statements.Replace(statements.First(), newFirstStatement);
                     }
 

--- a/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -125,9 +125,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
                     }
 
                     var openBraceTrailingTrivia = blockSyntax.OpenBraceToken.TrailingTrivia;
-                    var usingHasNoEndOfLineTrivia = !usingStatement.CloseParenToken.TrailingTrivia
+                    var usingHasEndOfLineTrivia = usingStatement.CloseParenToken.TrailingTrivia
                         .Any(SyntaxKind.EndOfLineTrivia);
-                    if (usingHasNoEndOfLineTrivia)
+                    if (!usingHasEndOfLineTrivia)
                     {
                         var newFirstStatement = statements.First()
                             .WithPrependedLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);

--- a/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -119,18 +119,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
             {
                 case BlockSyntax blockSyntax:
                     var statements = blockSyntax.Statements;
-                    if (statements.Count() == 0)
+                    if (!statements.Any())
                     {
                         return blockSyntax.CloseBraceToken.LeadingTrivia;
                     }
 
                     var openBraceTrailingTrivia = blockSyntax.OpenBraceToken.TrailingTrivia;
-                    var usingHasNotEndOfLineTrivia = usingStatement.CloseParenToken.TrailingTrivia
-                        .Count(t => t.IsKind(SyntaxKind.EndOfLineTrivia)) == 0;
+                    var usingHasNotEndOfLineTrivia = !usingStatement.CloseParenToken.TrailingTrivia
+                        .Any(SyntaxKind.EndOfLineTrivia); ;
                     if (usingHasNotEndOfLineTrivia)
                     {
                         var newFirstStatement = statements.First()
-                            .WithPrependedLeadingTrivia(CSharpSyntaxFacts.Instance.ElasticCarriageReturnLineFeed);
+                            .WithPrependedLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
                         statements = statements.Replace(statements.First(), newFirstStatement);
                     }
 

--- a/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -125,9 +125,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
                     }
 
                     var openBraceTrailingTrivia = blockSyntax.OpenBraceToken.TrailingTrivia;
-                    var usingHasNotEndOfLineTrivia = !usingStatement.CloseParenToken.TrailingTrivia
-                        .Any(SyntaxKind.EndOfLineTrivia); ;
-                    if (usingHasNotEndOfLineTrivia)
+                    var usingHasNoEndOfLineTrivia = !usingStatement.CloseParenToken.TrailingTrivia
+                        .Any(SyntaxKind.EndOfLineTrivia);
+                    if (usingHasNoEndOfLineTrivia)
                     {
                         var newFirstStatement = statements.First()
                             .WithPrependedLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);

--- a/src/Analyzers/CSharp/Tests/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
@@ -1585,5 +1585,61 @@ class C
 }",
 parseOptions: CSharp8ParseOptions);
         }
+
+        [WorkItem(52970, "https://github.com/dotnet/roslyn/issues/52970")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
+        public async Task TestWithBlockBodyWithOpeningBracketOnSameLineWithNoStatements()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        [||]using (var a = b) {
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        using var a = b;
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
+
+        [WorkItem(52970, "https://github.com/dotnet/roslyn/issues/52970")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
+        public async Task TestWithBlockBodyWithOpeningBracketOnSameLineAndCommentInBlock()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        [||]using (var a = b) {
+            // intentionally empty
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        using var a = b;
+        // intentionally empty
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
@@ -1498,5 +1498,92 @@ class C
 }",
 parseOptions: CSharp8ParseOptions);
         }
+
+        [WorkItem(52970, "https://github.com/dotnet/roslyn/issues/52970")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
+        public async Task TestWithBlockBodyWithOpeningBracketOnSameLine()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        [||]using (var a = b){
+            Console.WriteLine(a);
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        using var a = b;
+        Console.WriteLine(a);
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
+
+        [WorkItem(52970, "https://github.com/dotnet/roslyn/issues/52970")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
+        public async Task TestWithBlockBodyWithOpeningBracketOnSameLine2()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        [||]using (var a = b) {
+            Console.WriteLine(a);
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        using var a = b;
+        Console.WriteLine(a);
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
+
+        [WorkItem(52970, "https://github.com/dotnet/roslyn/issues/52970")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
+        public async Task TestWithBlockBodyWithOpeningBracketAndCommentOnSameLine()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        [||]using (var a = b) { //comment
+            Console.WriteLine(a);
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        using var a = b;  //comment
+        Console.WriteLine(a);
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
     }
 }


### PR DESCRIPTION
Prepend first statement of using block with a newline, if opening bracket is on same line as using statement

Fixes #52970