### PR TITLE
Run LSP integration on rolling builds only until they're stable

### DIFF
--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -8,14 +8,6 @@ trigger:
 - features/*
 - demos/*
 
-# Branches that trigger builds on PR
-pr:
-- main
-- main-vs-deps
-- release/*
-- features/*
-- demos/*
-
 jobs:
 - job: VS_Integration_LSP
   pool:

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -8,6 +8,8 @@ trigger:
 - features/*
 - demos/*
 
+pr: none
+
 jobs:
 - job: VS_Integration_LSP
   pool:


### PR DESCRIPTION
Since the LSP tests are optional and the github UI is deficient at differentiating optional tests from required, moving these tests to run on rolling builds only until we're ready to make these required.

These can be manually triggered by /azp to run on PRs if needed.

cc @sharwell 