### PR TITLE
Correctly handle unification use site diagnostics in substituted named type symbols

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -159,6 +159,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
+        internal override bool GetUnificationUseSiteDiagnosticRecursive(ref DiagnosticInfo result, Symbol owner, ref HashSet<TypeSymbol> checkedTypes)
+            => OriginalDefinition.GetUnificationUseSiteDiagnosticRecursive(ref result, owner, ref checkedTypes)
+               || ContainingType.GetUnificationUseSiteDiagnosticRecursive(ref result, owner, ref checkedTypes);
+
         public sealed override IEnumerable<string> MemberNames
         {
             get


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1279758/. @AlekseyTs @dotnet/roslyn-compiler for review.