### PR TITLE
Update support for finding CodeLens references from source generated files

### DIFF
--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
             Func<CodeLensFindReferencesProgress, Task<T>> onResults, Func<CodeLensFindReferencesProgress, Task<T>> onCapped,
             int searchCap, CancellationToken cancellationToken) where T : struct
         {
-            var document = solution.GetDocument(documentId);
+            var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             if (document == null)
             {
                 return null;

--- a/src/VisualStudio/Core/Def/Implementation/CodeLens/CodeLensCallbackListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeLens/CodeLensCallbackListener.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -21,8 +19,8 @@ using Microsoft.VisualStudio.Language.CodeLens.Remoting;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Settings;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
+using Roslyn.Utilities;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.CodeLens
@@ -82,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         {
             var solution = _workspace.CurrentSolution;
             var (documentId, node) = await GetDocumentIdAndNodeAsync(
-                solution, descriptor, descriptorContext.ApplicableSpan, cancellationToken).ConfigureAwait(false);
+                solution, descriptor, descriptorContext, cancellationToken).ConfigureAwait(false);
             if (documentId == null)
             {
                 return null;
@@ -108,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         {
             var solution = _workspace.CurrentSolution;
             var (documentId, node) = await GetDocumentIdAndNodeAsync(
-                solution, descriptor, descriptorContext.ApplicableSpan, cancellationToken).ConfigureAwait(false);
+                solution, descriptor, descriptorContext, cancellationToken).ConfigureAwait(false);
             if (documentId == null)
             {
                 return null;
@@ -130,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         {
             var solution = _workspace.CurrentSolution;
             var (documentId, node) = await GetDocumentIdAndNodeAsync(
-                solution, descriptor, descriptorContext.ApplicableSpan, cancellationToken).ConfigureAwait(false);
+                solution, descriptor, descriptorContext, cancellationToken).ConfigureAwait(false);
             if (documentId == null)
             {
                 return null;
@@ -141,20 +139,21 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         }
 
         private async Task<(DocumentId?, SyntaxNode?)> GetDocumentIdAndNodeAsync(
-            Solution solution, CodeLensDescriptor descriptor, Span? span, CancellationToken cancellationToken)
+            Solution solution, CodeLensDescriptor descriptor, CodeLensDescriptorContext descriptorContext, CancellationToken cancellationToken)
         {
-            if (span is null)
+            if (descriptorContext.ApplicableSpan is null)
             {
                 return default;
             }
 
-            if (!TryGetDocument(solution, descriptor.ProjectGuid, descriptor.FilePath, out var document))
+            var document = await GetDocumentAsync(solution, descriptor.ProjectGuid, descriptor.FilePath, descriptorContext).ConfigureAwait(false);
+            if (document == null)
             {
                 return default;
             }
 
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var textSpan = span.Value.ToTextSpan();
+            var textSpan = descriptorContext.ApplicableSpan.Value.ToTextSpan();
 
             // TODO: This check avoids ArgumentOutOfRangeException but it's not clear if this is the right solution
             // https://github.com/dotnet/roslyn/issues/44639
@@ -204,13 +203,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
             }
         }
 
-        private bool TryGetDocument(Solution solution, Guid projectGuid, string filePath, [NotNullWhen(true)] out Document? document)
+        private Task<Document?> GetDocumentAsync(Solution solution, Guid projectGuid, string filePath, CodeLensDescriptorContext descriptorContext)
         {
-            document = null;
-
             if (projectGuid == VSConstants.CLSID.MiscellaneousFilesProject_guid)
             {
-                return false;
+                return SpecializedTasks.Default<Document>();
             }
 
             foreach (var candidateId in solution.GetDocumentIdsWithFilePath(filePath))
@@ -218,12 +215,29 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
                 if (_workspace.GetProjectGuid(candidateId.ProjectId) == projectGuid)
                 {
                     var currentContextId = _workspace.GetDocumentIdInCurrentContext(candidateId);
-                    document = solution.GetDocument(currentContextId);
-                    break;
+                    return Task.FromResult(solution.GetDocument(currentContextId));
                 }
             }
 
-            return document != null;
+            // If we couldn't find the document the usual way we did so, then maybe it's source generated; let's try locating it
+            // with the DocumentId we have directly
+            if (TryGetGuid("RoslynDocumentIdGuid", out var documentIdGuid) &&
+                TryGetGuid("RoslynProjectIdGuid", out var projectIdGuid))
+            {
+                var projectId = ProjectId.CreateFromSerialized(projectIdGuid);
+                var documentId = DocumentId.CreateFromSerialized(projectId, documentIdGuid);
+                return _workspace.CurrentSolution.GetDocumentAsync(documentId, includeSourceGenerated: true).AsTask();
+            }
+
+            return SpecializedTasks.Default<Document>();
+
+            bool TryGetGuid(string key, out Guid guid)
+            {
+                guid = Guid.Empty;
+                return descriptorContext.Properties.TryGetValue(key, out var guidStringUntyped) &&
+                    guidStringUntyped is string guidString &&
+                    Guid.TryParse(guidString, out guid);
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeLens/RemoteCodeLensReferencesService.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
                 var referencedDocumentId = DocumentId.CreateFromSerialized(
                     ProjectId.CreateFromSerialized(descriptor.ProjectGuid), descriptor.DocumentGuid);
 
-                var document = solution.GetDocument(referencedDocumentId);
+                var document = await solution.GetDocumentAsync(referencedDocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                 if (document == null)
                 {
                     continue;

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeLensReferences/RemoteCodeLensReferencesService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeLensReferences/RemoteCodeLensReferencesService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private static async ValueTask<SyntaxNode?> TryFindNodeAsync(Solution solution, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocument(documentId);
+            var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             if (document == null)
             {
                 return null;


### PR DESCRIPTION
This allows calls the "references" item to work if the file is a source generated file. This builds off of https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/321244 which fixed up the tagger support for those files.