### PR TITLE
Enable on-demand file logging for diagnostics

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -45,6 +45,9 @@
 
                     <CheckBox x:Name="Show_Remove_Unused_References_command_in_Solution_Explorer_experimental"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_Remove_Unused_References_command_in_Solution_Explorer_experimental}" />
+
+                    <CheckBox x:Name="Enable_file_logging_for_diagnostics"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_file_logging_for_diagnostics}" />
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="UsingDirectivesGroupBox"

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.CSharp);
             BindToOption(Enable_navigation_to_decompiled_sources, FeatureOnOffOptions.NavigateToDecompiledSources);
             BindToOption(Use_64bit_analysis_process, RemoteHostOptions.OOP64Bit);
+            BindToOption(Enable_file_logging_for_diagnostics, InternalDiagnosticsOptions.EnableFileLoggingForDiagnostics);
             BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer_experimental, FeatureOnOffOptions.OfferRemoveUnusedReferences, () =>
             {
                 // If the option has not been set by the user, check if the option to remove unused references

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -270,5 +270,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public static string Enable_all_features_in_opened_files_from_source_generators_experimental
             => ServicesVSResources.Enable_all_features_in_opened_files_from_source_generators_experimental;
+
+        public static string Option_Enable_file_logging_for_diagnostics
+            => ServicesVSResources.Enable_file_logging_for_diagnostics;
     }
 }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1653,6 +1653,9 @@ I agree to all of the foregoing:</value>
   <data name="Show_Remove_Unused_References_command_in_Solution_Explorer_experimental" xml:space="preserve">
     <value>Show "Remove Unused References" command in Solution Explorer (experimental)</value>
   </data>
+  <data name="Enable_file_logging_for_diagnostics" xml:space="preserve">
+    <value>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</value>
+  </data>
   <data name="This_action_cannot_be_undone_Do_you_wish_to_continue" xml:space="preserve">
     <value>This action cannot be undone. Do you wish to continue?</value>
   </data>

--- a/src/VisualStudio/Core/Def/Telemetry/VisualStudioWorkspaceTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VisualStudioWorkspaceTelemetryService.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                 CodeMarkerLogger.Instance,
                 new EtwLogger(_optionsService),
                 new VSTelemetryLogger(telemetrySession),
+                new FileLogger(_optionsService),
                 Logger.GetLogger());
 
         protected override void TelemetrySessionInitialized()

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Povolit diagnostiku pull (experimentální, vyžaduje restart)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Pull-Diagnose aktivieren (experimentell, Neustart erforderlich)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Habilitar diagnósticos "pull" (experimental, requiere reiniciar)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Activer les diagnostics de 'tirage (pull)' (expérimental, nécessite un redémarrage)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Abilita diagnostica 'pull' (sperimentale, richiede il riavvio)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">'pull' 診断を有効にする (試験段階、再起動が必要)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">'풀' 진단 사용(실험적, 다시 시작 필요)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Włącz diagnostykę operacji „pull” (eksperymentalne, wymaga ponownego uruchomienia)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Habilitar o diagnóstico de 'pull' (experimental, exige uma reinicialização)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">Включить диагностику "pull" (экспериментальная функция, требуется перезапуск)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">'Pull' tanılamasını etkinleştir (deneysel, yeniden başlatma gerekir)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">启用“拉取”诊断(实验性，需要重启)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -297,6 +297,11 @@
         <target state="new">Enable all features in opened files from source generators (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_file_logging_for_diagnostics">
+        <source>Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</source>
+        <target state="new">Enable file logging for diagnostics (logged in '%Temp%\Roslyn' folder)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Enable_pull_diagnostics_experimental_requires_restart">
         <source>Enable 'pull' diagnostics (experimental, requires restart)</source>
         <target state="translated">啟用 'pull' 診斷 (實驗性，需要重新啟動)</target>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -32,6 +32,8 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_use_64bit_analysis_process}" />
                     <CheckBox x:Name="Show_Remove_Unused_References_command_in_Solution_Explorer_experimental"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_Remove_Unused_References_command_in_Solution_Explorer_experimental}" />
+                    <CheckBox x:Name="Enable_file_logging_for_diagnostics"
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_file_logging_for_diagnostics}" />
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="ImportDirectivesGroupBox"

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -4,6 +4,7 @@
 
 Imports System.Windows
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Editor.Implementation.SplitComment
@@ -41,6 +42,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.VisualBasic)
             BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.VisualBasic)
             BindToOption(Use_64bit_analysis_process, RemoteHostOptions.OOP64Bit)
+            BindToOption(Enable_file_logging_for_diagnostics, InternalDiagnosticsOptions.EnableFileLoggingForDiagnostics)
             BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer_experimental, FeatureOnOffOptions.OfferRemoveUnusedReferences,
                          Function()
                              ' If the option has Not been set by the user, check if the option to remove unused references

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -286,5 +286,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Public ReadOnly Property Enable_all_features_in_opened_files_from_source_generators_experimental As String =
              ServicesVSResources.Enable_all_features_in_opened_files_from_source_generators_experimental
+
+        Public ReadOnly Property Option_Enable_file_logging_for_diagnostics As String =
+            ServicesVSResources.Enable_file_logging_for_diagnostics
     End Module
 End Namespace

--- a/src/Workspaces/Core/Portable/Diagnostics/InternalDiagnosticsOptions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/InternalDiagnosticsOptions.cs
@@ -30,5 +30,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public static readonly Option2<DiagnosticMode> RazorDiagnosticMode = new(nameof(InternalDiagnosticsOptions), nameof(RazorDiagnosticMode), defaultValue: DiagnosticMode.Pull,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "RazorDiagnosticMode"));
+
+        public static readonly Option2<bool> EnableFileLoggingForDiagnostics = new(nameof(InternalDiagnosticsOptions), nameof(EnableFileLoggingForDiagnostics), defaultValue: false,
+            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "EnableFileLoggingForDiagnostics"));
     }
 }

--- a/src/Workspaces/Core/Portable/Log/FileLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/FileLogger.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Internal.Log
+{
+    /// <summary>
+    /// A logger that publishes events to a log file.
+    /// </summary>
+    internal sealed class FileLogger : ILogger
+    {
+        private readonly object _gate;
+        private readonly string _logFilePath;
+        private readonly StringBuilder _buffer;
+        private bool _enabled;
+
+        public FileLogger(IGlobalOptionService optionService, string logFilePath)
+        {
+            _logFilePath = logFilePath;
+            _gate = new();
+            _buffer = new();
+            _enabled = optionService.GetOption(InternalDiagnosticsOptions.EnableFileLoggingForDiagnostics);
+            optionService.OptionChanged += OptionService_OptionChanged;
+        }
+
+        public FileLogger(IGlobalOptionService optionService)
+            : this(optionService, Path.Combine(Path.GetTempPath(), "Roslyn", "Telemetry", GetLogFileName()))
+        {
+        }
+
+        private static string GetLogFileName()
+            => DateTime.Now.ToString().Replace(' ', '_').Replace('/', '_').Replace(':', '_') + ".log";
+
+        private void OptionService_OptionChanged(object? sender, OptionChangedEventArgs e)
+        {
+            if (e.Option == InternalDiagnosticsOptions.EnableFileLoggingForDiagnostics)
+            {
+                Contract.ThrowIfNull(e.Value);
+
+                _enabled = (bool)e.Value;
+            }
+        }
+
+        public bool IsEnabled(FunctionId functionId)
+        {
+            if (!_enabled)
+            {
+                return false;
+            }
+
+            // Limit logged function IDs to keep a reasonable log file size.
+            var str = functionId.ToString();
+            return str.StartsWith("Diagnostic") ||
+                str.StartsWith("CodeAnalysisService") ||
+                str.StartsWith("Workspace") ||
+                str.StartsWith("WorkCoordinator") ||
+                str.StartsWith("IncrementalAnalyzerProcessor") ||
+                str.StartsWith("ExternalErrorDiagnosticUpdateSource");
+        }
+
+        private void Log(FunctionId functionId, string message)
+        {
+            lock (_gate)
+            {
+                _buffer.AppendLine($"{DateTime.Now} ({functionId}) : {message}");
+
+                try
+                {
+                    if (!File.Exists(_logFilePath))
+                    {
+                        Directory.CreateDirectory(PathUtilities.GetDirectoryName(_logFilePath));
+                        File.Create(_logFilePath);
+                    }
+
+                    File.AppendAllText(_logFilePath, _buffer.ToString());
+                    _buffer.Clear();
+                }
+                catch (IOException)
+                {
+                    // Ignore IOException, we will log the buffer contents in next Log call.
+                }
+            }
+        }
+
+        public void Log(FunctionId functionId, LogMessage logMessage)
+            => Log(functionId, logMessage.GetMessage());
+
+        public void LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
+            => LogBlockEvent(functionId, logMessage, uniquePairId, "BlockStart");
+
+        public void LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
+            => LogBlockEvent(functionId, logMessage, uniquePairId, cancellationToken.IsCancellationRequested ? "BlockCancelled" : "BlockEnd");
+
+        private void LogBlockEvent(FunctionId functionId, LogMessage logMessage, int uniquePairId, string blockEvent)
+            => Log(functionId, $"[{blockEvent} - {uniquePairId}] {logMessage.GetMessage()}");
+    }
+}


### PR DESCRIPTION
Fixes #51521
Adds a new option to enable logging diagnostics information to a log file inside the temp folder, which the user can submit for any intellisense diagnostics/error list related issues. We are not investing in a full-fledged system here as we anticipate many architectural changes in the diagnostics system in Dev17. The support added here is a short term solution to enable getting additional logs.