### PR TITLE
Expand support for context variables

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.cs
@@ -125,6 +125,84 @@ class C
             await VerifyDefaultValueAsync(markup, expectedDefaultValue: null, previousDefaultValue: "prior");
         }
 
+        [Theory]
+        [InlineData("C")]
+        [InlineData("B")]
+        [InlineData("I")]
+        public async Task TestThisInstance(string parameterType)
+        {
+            var markup = $@"
+using System.Collections.Generic;
+interface I {{ }}
+
+class B {{ }}
+
+class C : B, I
+{{
+    void Method()
+    {{
+        this.Target($$);
+    }}
+
+    void Target({parameterType} arg)
+    {{
+    }}
+}}
+";
+
+            await VerifyDefaultValueAsync(markup, "this");
+            await VerifyDefaultValueAsync(markup, expectedDefaultValue: null, previousDefaultValue: "prior");
+        }
+
+        [Theory]
+        [InlineData("object")]
+        [InlineData("string")]
+        public async Task TestThisInstanceNotProvided1(string parameterType)
+        {
+            var markup = $@"
+using System.Collections.Generic;
+interface I {{ }}
+
+class B {{ }}
+
+class C : B, I
+{{
+    void Method()
+    {{
+        this.Target($$);
+    }}
+
+    void Target({parameterType} arg)
+    {{
+    }}
+}}
+";
+
+            await VerifyDefaultValueAsync(markup, null);
+        }
+
+        [Fact]
+        public async Task TestThisInstanceNotProvided2()
+        {
+            var markup = $@"
+using System.Collections.Generic;
+
+class C
+{{
+    static void Method()
+    {{
+        Target($$);
+    }}
+
+    static void Target(C arg)
+    {{
+    }}
+}}
+";
+
+            await VerifyDefaultValueAsync(markup, null);
+        }
+
         // Note: The current implementation checks for exact type match for primitive types. If this changes, some of
         // these tests may need to be updated to account for the new behavior.
         [Theory]

--- a/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.cs
@@ -97,22 +97,25 @@ class C
         }
 
         [Theory]
-        [InlineData("string")]
-        [InlineData("bool")]
-        [InlineData("int?")]
-        public async Task TestInstanceVariable(string type)
+        [InlineData("string", "string")]
+        [InlineData("string", "IEnumerable<char>")]
+        [InlineData("bool", "bool")]
+        [InlineData("int?", "int?")]
+        [InlineData("int", "int?")]
+        public async Task TestInstanceVariable(string fieldType, string parameterType)
         {
             var markup = $@"
+using System.Collections.Generic;
 class C
 {{
-    {type} arg;
+    {fieldType} arg;
 
     void Method()
     {{
         this.Target($$);
     }}
 
-    void Target({type} arg)
+    void Target({parameterType} arg)
     {{
     }}
 }}
@@ -122,8 +125,8 @@ class C
             await VerifyDefaultValueAsync(markup, expectedDefaultValue: null, previousDefaultValue: "prior");
         }
 
-        // Note: The current implementation checks for exact type and name match. If this changes, some of these tests
-        // may need to be updated to account for the new behavior.
+        // Note: The current implementation checks for exact type match for primitive types. If this changes, some of
+        // these tests may need to be updated to account for the new behavior.
         [Theory]
         [InlineData("object", "string")]
         [InlineData("string", "object")]

--- a/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.vb
@@ -80,6 +80,79 @@ End Class
             Await VerifyDefaultValueAsync(markup, expectedDefaultValue:=Nothing, previousDefaultValue:="prior")
         End Function
 
+        <Theory>
+        <InlineData("C")>
+        <InlineData("B")>
+        <InlineData("I")>
+        Public Async Function TestMeInstance(parameterType As String) As Task
+            Dim markup = $"
+Imports System.Collections.Generic
+
+Interface I : End Interface
+Class B : End Class
+
+Class C
+    Inherits B
+    Implements I
+
+    Sub Method()
+        Me.Target($$)
+    End Sub
+
+    Sub Target(arg As {parameterType})
+    End Sub
+End Class
+"
+
+            Await VerifyDefaultValueAsync(markup, "Me")
+            Await VerifyDefaultValueAsync(markup, expectedDefaultValue:=Nothing, previousDefaultValue:="prior")
+        End Function
+
+        <Theory>
+        <InlineData("Object")>
+        <InlineData("String")>
+        Public Async Function TestMeInstanceNotProvided1(parameterType As String) As Task
+            Dim markup = $"
+Imports System.Collections.Generic
+
+Interface I : End Interface
+Class B : End Class
+
+Class C
+    Inherits B
+    Implements I
+
+    Sub Method()
+        Me.Target($$)
+    End Sub
+
+    Sub Target(arg As {parameterType})
+    End Sub
+End Class
+"
+
+            Await VerifyDefaultValueAsync(markup, Nothing)
+        End Function
+
+        <Fact>
+        Public Async Function TestMeInstanceNotProvided2() As Task
+            Dim markup = $"
+Imports System.Collections.Generic
+
+Class C
+
+    Shared Sub Method()
+        Target($$)
+    End Sub
+
+    Shared Sub Target(arg As C)
+    End Sub
+End Class
+"
+
+            Await VerifyDefaultValueAsync(markup, Nothing)
+        End Function
+
         ' Note: The current implementation checks for exact type and name match. If this changes, some of these tests
         ' may need to be updated to account for the new behavior.
         <Theory>

--- a/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/ArgumentProviders/ContextVariableArgumentProviderTests.vb
@@ -55,19 +55,23 @@ End Class
         End Function
 
         <Theory>
-        <InlineData("String")>
-        <InlineData("Boolean")>
-        <InlineData("Integer?")>
-        Public Async Function TestInstanceVariable(type As String) As Task
+        <InlineData("String", "String")>
+        <InlineData("String", "IEnumerable(Of Char)")>
+        <InlineData("Boolean", "Boolean")>
+        <InlineData("Integer?", "Integer?")>
+        <InlineData("Integer", "Integer?")>
+        Public Async Function TestInstanceVariable(fieldType As String, parameterType As String) As Task
             Dim markup = $"
+Imports System.Collections.Generic
+
 Class C
-    Dim arg As {type}
+    Dim arg As {fieldType}
 
     Sub Method()
         Me.Target($$)
     End Sub
 
-    Sub Target(arg As {type})
+    Sub Target(arg As {parameterType})
     End Sub
 End Class
 "

--- a/src/Features/CSharp/Portable/Completion/Providers/ContextVariableArgumentProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/Providers/ContextVariableArgumentProvider.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
@@ -20,6 +22,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         public ContextVariableArgumentProvider()
         {
         }
+
+        protected override string ThisOrMeKeyword => SyntaxFacts.GetText(SyntaxKind.ThisKeyword);
+
+        protected override bool IsInstanceContext(SyntaxTree syntaxTree, SyntaxToken targetToken, SemanticModel semanticModel, CancellationToken cancellationToken)
+            => syntaxTree.IsInstanceContext(targetToken, semanticModel, cancellationToken);
 
         public override async Task ProvideArgumentAsync(ArgumentContext context)
         {

--- a/src/Features/VisualBasic/Portable/Completion/Providers/ContextVariableArgumentProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/Providers/ContextVariableArgumentProvider.vb
@@ -3,8 +3,10 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Composition
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     <ExportArgumentProvider(NameOf(ContextVariableArgumentProvider), LanguageNames.VisualBasic)>
@@ -17,5 +19,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
         End Sub
+
+        Protected Overrides ReadOnly Property ThisOrMeKeyword As String
+            Get
+                Return SyntaxFacts.GetText(SyntaxKind.MeKeyword)
+            End Get
+        End Property
+
+        Protected Overrides Function IsInstanceContext(syntaxTree As SyntaxTree, targetToken As SyntaxToken, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Boolean
+            ' Uses logic from MeKeywordRecommender, restricted by knowledge that this is an invocation within an
+            ' expression
+            If targetToken.GetInnermostDeclarationContext().IsKind(SyntaxKind.ClassBlock, SyntaxKind.StructureBlock) Then
+                If targetToken.GetContainingMemberBlockBegin().TypeSwitch(
+                    Function(methodBase As MethodBaseSyntax) Not methodBase.Modifiers.Any(SyntaxKind.SharedKeyword),
+                    Function(propertyStatement As PropertyStatementSyntax) Not propertyStatement.Modifiers.Any(SyntaxKind.SharedKeyword),
+                    Function(eventStatement As EventStatementSyntax) Not eventStatement.Modifiers.Any(SyntaxKind.SharedKeyword)) Then
+
+                    Return True
+                End If
+
+                Dim containingMember = targetToken.GetContainingMember()
+                If TypeOf containingMember Is FieldDeclarationSyntax Then
+                    Dim fieldDecl = DirectCast(containingMember, FieldDeclarationSyntax)
+                    If Not fieldDecl.Modifiers.Any(SyntaxKind.SharedKeyword) Then
+                        Return True
+                    End If
+                End If
+            End If
+
+            Return False
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
* Relax cases where names must match to [special types](https://github.com/dotnet/roslyn/blob/315c2e149ba7889b0937d872274c33fcbfe9af5f/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs#L377-L406) which are not local variables. In other cases, type checks are preferred.
* Allow implicit type conversions provided the source is not a special type.
* Allow `this` and `Me` as context variables