### PR TITLE
Add support for CompletionList.Data in LSP.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
     <VisualStudioEditorPackagesVersion>16.9.220</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>5.0.0-alpha1.19409.1</ILAsmPackageVersion>
     <ILDAsmPackageVersion>5.0.0-preview.1.20112.8</ILDAsmPackageVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.10.161</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>16.10.1202</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>16.9.30921.310</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftBuildPackagesVersion>16.5.0</MicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,6 +130,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return false;
         }
 
+        public static bool HasCompletionListDataCapability(this ClientCapabilities clientCapabilities)
+        {
+            if (!TryGetVSCompletionListSetting(clientCapabilities, out var completionListSetting))
+            {
+                return false;
+            }
+
+            return completionListSetting.Data;
+        }
+
         public static string GetMarkdownLanguageName(this Document document)
         {
             switch (document.Project.Language)
@@ -155,6 +166,36 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             // belongs to them.
             var spanMapper = document.Services.GetService<ISpanMappingService>();
             return spanMapper != null;
+        }
+
+        private static bool TryGetVSCompletionListSetting(ClientCapabilities clientCapabilities, [NotNullWhen(returnValue: true)] out VSCompletionListSetting? completionListSetting)
+        {
+            if (clientCapabilities is not VSClientCapabilities vsClientCapabilities)
+            {
+                completionListSetting = null;
+                return false;
+            }
+
+            var textDocumentCapability = vsClientCapabilities.TextDocument;
+            if (textDocumentCapability == null)
+            {
+                completionListSetting = null;
+                return false;
+            }
+
+            if (textDocumentCapability.Completion is not VSCompletionSetting vsCompletionSetting)
+            {
+                completionListSetting = null;
+                return false;
+            }
+
+            completionListSetting = vsCompletionSetting.CompletionList;
+            if (completionListSetting == null)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -140,6 +140,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return completionListSetting.Data;
         }
 
+        public static bool HasCompletionListCommitCharactersCapability(this ClientCapabilities clientCapabilities)
+        {
+            if (!TryGetVSCompletionListSetting(clientCapabilities, out var completionListSetting))
+            {
+                return false;
+            }
+
+            return completionListSetting.CommitCharacters;
+        }
+
         public static string GetMarkdownLanguageName(this Document document)
         {
             switch (document.Project.Language)

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -88,7 +89,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var lspVSClientCapability = context.ClientCapabilities.HasVisualStudioLspCapability() == true;
             var snippetsSupported = context.ClientCapabilities.TextDocument?.Completion?.CompletionItem?.SnippetSupport ?? false;
-            var commitCharactersRuleCache = new Dictionary<ImmutableArray<CharacterSetModificationRule>, ImmutableArray<string>>();
+            var commitCharactersRuleCache = new Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]>(CommitCharacterArrayComparer.Instance);
 
             // Cache the completion list so we can avoid recomputation in the resolve handler
             var resultId = _completionListCache.UpdateCache(request.TextDocument, list);
@@ -147,6 +148,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 completionList.Data = completionResolveData;
             }
 
+            if (context.ClientCapabilities.HasCompletionListCommitCharactersCapability())
+            {
+                PromoteCommonCommitCharactersOntoList(completionList);
+            }
+
             var optimizedCompletionList = new LSP.OptimizedVSCompletionList(completionList);
             return optimizedCompletionList;
 
@@ -174,7 +180,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 CompletionResolveData? completionResolveData,
                 bool useVSCompletionItem,
                 CompletionTrigger completionTrigger,
-                Dictionary<ImmutableArray<CharacterSetModificationRule>, ImmutableArray<string>> commitCharacterRulesCache,
+                Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]> commitCharacterRulesCache,
                 CompletionService completionService,
                 string? clientName,
                 bool returnTextEdits,
@@ -210,7 +216,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 CompletionItem item,
                 CompletionResolveData? completionResolveData,
                 CompletionTrigger completionTrigger,
-                Dictionary<ImmutableArray<CharacterSetModificationRule>, ImmutableArray<string>> commitCharacterRulesCache,
+                Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]> commitCharacterRulesCache,
                 CompletionService completionService,
                 string? clientName,
                 bool returnTextEdits,
@@ -299,7 +305,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 }
             }
 
-            static string[]? GetCommitCharacters(CompletionItem item, Dictionary<ImmutableArray<CharacterSetModificationRule>, ImmutableArray<string>> currentRuleCache)
+            static string[]? GetCommitCharacters(CompletionItem item, Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]> currentRuleCache)
             {
                 var commitCharacterRules = item.Rules.CommitCharacterRules;
 
@@ -309,9 +315,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     return null;
                 }
 
-                if (currentRuleCache.TryGetValue(commitCharacterRules, out var currentRules))
+                if (currentRuleCache.TryGetValue(commitCharacterRules, out var cachedCommitCharacters))
                 {
-                    return currentRules.ToArray();
+                    return cachedCommitCharacters;
                 }
 
                 using var _ = PooledHashSet<char>.GetInstance(out var commitCharacters);
@@ -333,9 +339,50 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     }
                 }
 
-                var commitCharacterSet = commitCharacters.Select(c => c.ToString()).ToImmutableArray();
-                currentRuleCache.Add(item.Rules.CommitCharacterRules, commitCharacterSet);
-                return commitCharacterSet.ToArray();
+                var lspCommitCharacters = commitCharacters.Select(c => c.ToString()).ToArray();
+                currentRuleCache.Add(item.Rules.CommitCharacterRules, lspCommitCharacters);
+                return lspCommitCharacters;
+            }
+
+            static void PromoteCommonCommitCharactersOntoList(LSP.VSCompletionList completionList)
+            {
+                var commitCharacterReferences = new Dictionary<object, int>();
+                var mostUsedCount = 0;
+                string[]? mostUsedCommitCharacters = null;
+                for (var i = 0; i < completionList.Items.Length; i++)
+                {
+                    var completionItem = completionList.Items[i];
+                    var commitCharacters = completionItem.CommitCharacters;
+                    if (commitCharacters == null)
+                    {
+                        continue;
+                    }
+
+                    commitCharacterReferences.TryGetValue(commitCharacters, out var existingCount);
+                    existingCount++;
+
+                    if (existingCount > mostUsedCount)
+                    {
+                        // Capture the most used commit character counts so we don't need to re-iterate the array later
+                        mostUsedCommitCharacters = commitCharacters;
+                        mostUsedCount = existingCount;
+                    }
+
+                    commitCharacterReferences[commitCharacters] = existingCount;
+                }
+
+                Contract.ThrowIfNull(mostUsedCommitCharacters);
+
+                // Promoted the most used commit characters onto the list and then remove these from child items.
+                completionList.CommitCharacters = mostUsedCommitCharacters;
+                for (var i = 0; i < completionList.Items.Length; i++)
+                {
+                    var completionItem = completionList.Items[i];
+                    if (completionItem.CommitCharacters == mostUsedCommitCharacters)
+                    {
+                        completionItem.CommitCharacters = null;
+                    }
+                }
             }
         }
 
@@ -393,6 +440,51 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             public CompletionListCache GetCache()
                 => _completionHandler._completionListCache;
+        }
+
+        private class CommitCharacterArrayComparer : IEqualityComparer<ImmutableArray<CharacterSetModificationRule>>
+        {
+            public static readonly CommitCharacterArrayComparer Instance = new();
+
+            private CommitCharacterArrayComparer()
+            {
+            }
+
+            public bool Equals([AllowNull] ImmutableArray<CharacterSetModificationRule> x, [AllowNull] ImmutableArray<CharacterSetModificationRule> y)
+            {
+                for (var i = 0; i < x.Length; i++)
+                {
+                    var xKind = x[i].Kind;
+                    var yKind = y[i].Kind;
+                    if (xKind != yKind)
+                    {
+                        return false;
+                    }
+
+                    var xCharacters = x[i].Characters;
+                    var yCharacters = y[i].Characters;
+                    if (xCharacters.Length != yCharacters.Length)
+                    {
+                        return false;
+                    }
+
+                    for (var j = 0; j < xCharacters.Length; j++)
+                    {
+                        if (xCharacters[j] != yCharacters[j])
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            public int GetHashCode([DisallowNull] ImmutableArray<CharacterSetModificationRule> obj)
+            {
+                var combinedHash = Hash.CombineValues(obj);
+                return combinedHash;
+            }
         }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -266,7 +266,6 @@ class B : A
             var completionList = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
                 completionParams, clientCapabilities, null, CancellationToken.None);
 
-
             // Emulate client behavior of promoting "Data" completion list properties onto completion items.
             if (clientCapabilities.HasCompletionListDataCapability() &&
                 completionList is VSCompletionList vsCompletionList &&

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -273,7 +273,8 @@ class B : A
             {
                 foreach (var completionItem in completionList.Items)
                 {
-                    completionItem.Data ??= vsCompletionList.Data;
+                    Assert.Null(completionItem.Data);
+                    completionItem.Data = vsCompletionList.Data;
                 }
             }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -24,6 +24,53 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
     public class CompletionResolveTests : AbstractLanguageServerProtocolTests
     {
         [Fact]
+        public async Task TestResolveCompletionItemFromListAsync()
+        {
+            var markup =
+@"class A
+{
+    void M()
+    {
+        {|caret:|}
+    }
+}";
+            using var testLspServer = CreateTestLspServer(markup, out var locations);
+            var tags = new string[] { "Class", "Internal" };
+            var completionParams = CreateCompletionParams(
+                locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
+
+            var clientCapabilities = new LSP.VSClientCapabilities
+            {
+                SupportsVisualStudioExtensions = true,
+                TextDocument = new TextDocumentClientCapabilities()
+                {
+                    Completion = new VSCompletionSetting()
+                    {
+                        CompletionList = new VSCompletionListSetting()
+                        {
+                            Data = true,
+                        }
+                    }
+                }
+            };
+            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities);
+            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "A");
+            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
+            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+            var clientCompletionItem = ConvertToClientCompletionItem(serverCompletionItem);
+
+            var description = new ClassifiedTextElement(CreateClassifiedTextRunForClass("A"));
+
+            var expected = CreateResolvedCompletionItem(clientCompletionItem, description, "class A", null);
+
+            var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
+                testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
+            AssertJsonEquals(expected, results);
+            var vsCompletionList = Assert.IsAssignableFrom<VSCompletionList>(completionList);
+            Assert.NotNull(vsCompletionList.Data);
+        }
+
+        [Fact]
         public async Task TestResolveCompletionItemAsync()
         {
             var markup =
@@ -205,11 +252,33 @@ class B : A
                 new ClassifiedTextRun("class name", className)
             };
 
-        private static async Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
+        private static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
         {
             var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
-            return await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
+            return RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities);
+        }
+
+        private static async Task<LSP.CompletionList> RunGetCompletionsAsync(
+            TestLspServer testLspServer,
+            LSP.CompletionParams completionParams,
+            LSP.VSClientCapabilities clientCapabilities)
+        {
+            var completionList = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
                 completionParams, clientCapabilities, null, CancellationToken.None);
+
+
+            // Emulate client behavior of promoting "Data" completion list properties onto completion items.
+            if (clientCapabilities.HasCompletionListDataCapability() &&
+                completionList is VSCompletionList vsCompletionList &&
+                vsCompletionList.Data != null)
+            {
+                foreach (var completionItem in completionList.Items)
+                {
+                    completionItem.Data ??= vsCompletionList.Data;
+                }
+            }
+
+            return completionList;
         }
 
         private static LSP.VSCompletionItem ConvertToClientCompletionItem(LSP.CompletionItem serverCompletionItem)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -19,6 +19,54 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
 {
     public class CompletionTests : AbstractLanguageServerProtocolTests
     {
+
+        [Fact]
+        public async Task TestGetCompletionsAsync_PromotesCommitCharactersToListAsync()
+        {
+            var clientCapabilities = new LSP.VSClientCapabilities
+            {
+                SupportsVisualStudioExtensions = true,
+                TextDocument = new LSP.TextDocumentClientCapabilities()
+                {
+                    Completion = new LSP.VSCompletionSetting()
+                    {
+                        CompletionList = new LSP.VSCompletionListSetting()
+                        {
+                            CommitCharacters = true,
+                        }
+                    }
+                }
+            };
+            var markup =
+@"class A
+{
+    void M()
+    {
+        {|caret:|}
+    }
+}";
+            using var testLspServer = CreateTestLspServer(markup, out var locations);
+            var completionParams = CreateCompletionParams(
+                locations["caret"].Single(),
+                invokeKind: LSP.VSCompletionInvokeKind.Explicit,
+                triggerCharacter: "\0",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+
+            var expected = await CreateCompletionItemAsync(label: "A", kind: LSP.CompletionItemKind.Class, tags: new string[] { "Class", "Internal" },
+                request: completionParams, document: document, commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
+            var expectedCommitCharacters = expected.CommitCharacters;
+
+            // Null out the commit characters since we're expecting the commit characters will be lifted onto the completion list.
+            expected.CommitCharacters = null;
+
+            var results = await RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities).ConfigureAwait(false);
+            AssertJsonEquals(expected, results.Items.First());
+            var vsCompletionList = Assert.IsAssignableFrom<LSP.VSCompletionList>(results);
+            Assert.Equal(expectedCommitCharacters, vsCompletionList.CommitCharacters.Value.First);
+        }
+
         [Fact]
         public async Task TestGetCompletionsAsync()
         {
@@ -442,9 +490,18 @@ partial class C
             Assert.Null(results.Items.First().InsertText);
         }
 
-        private static async Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
+
+        private static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
         {
             var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
+            return RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities);
+        }
+
+        private static async Task<LSP.CompletionList> RunGetCompletionsAsync(
+            TestLspServer testLspServer,
+            LSP.CompletionParams completionParams,
+            LSP.VSClientCapabilities clientCapabilities)
+        {
             return await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
                 completionParams, clientCapabilities, null, CancellationToken.None);
         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -490,7 +490,6 @@ partial class C
             Assert.Null(results.Items.First().InsertText);
         }
 
-
         private static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
         {
             var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };


### PR DESCRIPTION
- Ultimately this is a performance optimization where instead of re-specifying resolve data on every completion item the platform now can specify if it supports specifying resolve data at the completion list level.
- Added new completion resolve test and updated testing infrastructure to lift resolve data from completion list.

**Before:**
|                                                    Method | Optimized |      Mean |     Error |    StdDev |   Op/s |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|---------------------------------------------------------- |---------- |----------:|----------:|----------:|-------:|----------:|---------:|---------:|----------:|
| 'Completion List Roundtrip Serialization/Deserialization' |     False | 29.379 ms | 0.5844 ms | 1.0976 ms |  34.04 | 1562.5000 | 593.7500 | 250.0000 |   9.48 MB |
|                           'Completion List Serialization' |     False | 11.038 ms | 0.2194 ms | 0.2155 ms |  90.60 |  562.5000 | 281.2500 | 281.2500 |   3.33 MB |
|                         'Completion List Deserialization' |     False | 15.353 ms | 0.2995 ms | 0.2941 ms |  65.13 |  921.8750 | 375.0000 |        - |   5.57 MB |
| 'Completion List Roundtrip Serialization/Deserialization' |      True | 18.469 ms | 0.1742 ms | 0.1455 ms |  54.15 | 1093.7500 | 500.0000 | 125.0000 |   7.09 MB |
|                           'Completion List Serialization' |      True |  4.574 ms | 0.0823 ms | 0.1207 ms | 218.64 |  242.1875 | 117.1875 | 117.1875 |   1.53 MB |
|                         'Completion List Deserialization' |      True | 15.000 ms | 0.0846 ms | 0.0707 ms |  66.67 |  921.8750 | 375.0000 |        - |   5.57 MB |

**After:**
|                                                    Method | Optimized |      Mean |     Error |    StdDev |   Op/s |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|---------------------------------------------------------- |---------- |----------:|----------:|----------:|-------:|----------:|---------:|---------:|----------:|
| 'Completion List Roundtrip Serialization/Deserialization' |     False | 19.500 ms | 0.2663 ms | 0.2224 ms |  51.28 | 1218.7500 | 406.2500 | 125.0000 |   7.71 MB |
|                           'Completion List Serialization' |     False |  8.026 ms | 0.1524 ms | 0.1351 ms | 124.60 |  406.2500 | 171.8750 | 109.3750 |    2.7 MB |
|                         'Completion List Deserialization' |     False | 10.513 ms | 0.2078 ms | 0.2845 ms |  95.12 |  734.3750 | 250.0000 |        - |   4.42 MB |
| 'Completion List Roundtrip Serialization/Deserialization' |      True | 12.622 ms | 0.2425 ms | 0.3153 ms |  79.22 |  906.2500 | 265.6250 | 125.0000 |   5.82 MB |
|                           'Completion List Serialization' |      True |  2.043 ms | 0.0089 ms | 0.0079 ms | 489.44 |  246.0938 | 121.0938 | 121.0938 |    1.4 MB |
|                         'Completion List Deserialization' |      True | 10.563 ms | 0.2048 ms | 0.2734 ms |  94.67 |  734.3750 | 250.0000 |        - |   4.42 MB |

**Results (Optimized):**
Roundtrip: 1.5x faster
Serialization: 2.2x faster
Deserialization: 1.4x faster

Fixes dotnet/aspnetcore#31883