### PR TITLE
Add test: AddParameters_NoLastWhitespaceTrivia

### DIFF
--- a/src/EditorFeatures/CSharpTest/ChangeSignature/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/AddParameterTests.cs
@@ -1261,5 +1261,47 @@ class C
 }";
             await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task AddParameters_NoLastWhitespaceTrivia()
+        {
+            var markup = @"
+class C
+{
+/// <summary>
+/// </summary>
+/// <param name=""a""></param>
+/// <param name=""b""></param>
+/// <param name=""c""></param>
+public $$C(int a, int b, int c) { }
+
+static C M() => new C(1, 2, 3);
+}
+";
+            var updatedSignature = new AddedParameterOrExistingIndex[]
+            {
+                new(0),
+                new(2),
+                new(1),
+                new(new AddedParameter(null, "int", "d", CallSiteKind.Value, "12345"), "System.Int32")
+            };
+            var updatedCode = @"
+class C
+{
+/// <summary>
+/// </summary>
+/// <param name=""a""></param>
+/// <param name=""c""></param>
+/// <param name=""b""></param>
+/// <param name=""d""></param>
+public C(int a, int c, int b, int d) { }
+
+static C M() => new C(1, 3, 2, 12345);
+}
+";
+
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: updatedCode);
+        }
+
     }
 }


### PR DESCRIPTION
Expecting this test to fail in debug due to an assertion failure deep in the compiler layer. The root cause here is that the given ConstructorDeclarationSyntax doesn't have a whitespace leading trivia. Causing the value of `lastWhiteSpaceTrivia` to remain the `default` literal:

https://github.com/dotnet/roslyn/blob/89d820c823916d4232eeaab027a840d9af28e778/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs#L937

When it's passed to `SyntaxGenerator.DocumentationCommentTrivia`:

https://github.com/dotnet/roslyn/blob/89d820c823916d4232eeaab027a840d9af28e778/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs#L999-L1003

The following assertion fails:

https://github.com/dotnet/roslyn/blob/bc98ed946162622c7564607d276c06928033464e/src/Compilers/Core/Portable/Syntax/SyntaxTrivia.cs#L63

Will see what also happens in Release.