### PR TITLE
Adhere to new lines for braces formatting option in property pattern clauses

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -9929,39 +9929,25 @@ class A
 }", changedOptionSet: changingOptions);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(52413, "https://github.com/dotnet/roslyn/issues/52413")]
-        public async Task NewLinesForBraces_PropertyPatternClauses_SingleLine()
+        public async Task NewLinesForBraces_PropertyPatternClauses_SingleLine(bool option)
         {
             var changingOptions = new OptionsCollection(LanguageNames.CSharp)
             {
-                { NewLinesForBracesInObjectCollectionArrayInitializers, false },
+                { NewLinesForBracesInObjectCollectionArrayInitializers, option },
             };
-            await AssertFormatAsync(
-                @"
+            var code = @"
 class A
 {
     public string Name { get; }
 
     public bool IsFoo(A a)
     {
-        return a is {
-            Name: ""foo"",
-        };
+        return a is { Name: ""foo"" };
     }
-}",
-                @"
-class A
-{
-    public string Name { get; }
-
-    public bool IsFoo(A a)
-    {
-        return a is {
-            Name: ""foo"",
-        };
-    }
-}", changedOptionSet: changingOptions);
+}";
+            await AssertFormatAsync(code, code, changedOptionSet: changingOptions);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -9930,6 +9930,41 @@ class A
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(52413, "https://github.com/dotnet/roslyn/issues/52413")]
+        public async Task NewLinesForBraces_PropertyPatternClauses_SingleLine()
+        {
+            var changingOptions = new OptionsCollection(LanguageNames.CSharp)
+            {
+                { NewLinesForBracesInObjectCollectionArrayInitializers, false },
+            };
+            await AssertFormatAsync(
+                @"
+class A
+{
+    public string Name { get; }
+
+    public bool IsFoo(A a)
+    {
+        return a is {
+            Name: ""foo"",
+        };
+    }
+}",
+                @"
+class A
+{
+    public string Name { get; }
+
+    public bool IsFoo(A a)
+    {
+        return a is {
+            Name: ""foo"",
+        };
+    }
+}", changedOptionSet: changingOptions);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task RecordClass()
         {
             await AssertFormatAsync(

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -9862,6 +9862,74 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(52413, "https://github.com/dotnet/roslyn/issues/52413")]
+        public async Task NewLinesForBraces_PropertyPatternClauses_Default()
+        {
+            await AssertFormatAsync(
+                @"
+class A
+{
+    public string Name { get; }
+
+    public bool IsFoo(A a)
+    {
+        return a is
+        {
+            Name: ""foo"",
+        };
+    }
+}",
+                @"
+class A
+{
+    public string Name { get; }
+
+    public bool IsFoo(A a)
+    {
+        return a is {
+            Name: ""foo"",
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(52413, "https://github.com/dotnet/roslyn/issues/52413")]
+        public async Task NewLinesForBraces_PropertyPatternClauses_NonDefault()
+        {
+            var changingOptions = new OptionsCollection(LanguageNames.CSharp)
+            {
+                { NewLinesForBracesInObjectCollectionArrayInitializers, false },
+            };
+            await AssertFormatAsync(
+                @"
+class A
+{
+    public string Name { get; }
+
+    public bool IsFoo(A a)
+    {
+        return a is {
+            Name: ""foo"",
+        };
+    }
+}",
+                @"
+class A
+{
+    public string Name { get; }
+
+    public bool IsFoo(A a)
+    {
+        return a is
+        {
+            Name: ""foo"",
+        };
+    }
+}", changedOptionSet: changingOptions);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task RecordClass()
         {
             await AssertFormatAsync(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -126,9 +126,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            // new { - Object Initialization, or with { - Record with initializer
+            // new { - Object Initialization, or with { - Record with initializer, or is { - property pattern clauses
             if (currentToken.IsKind(SyntaxKind.OpenBraceToken) &&
-                (currentToken.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) || currentToken.Parent.IsKind(SyntaxKind.WithInitializerExpression)))
+                (currentToken.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) ||
+                currentToken.Parent.IsKind(SyntaxKind.WithInitializerExpression) ||
+                currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause)))
             {
                 if (!_options.NewLinesForBracesInObjectCollectionArrayInitializers)
                 {
@@ -154,15 +156,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent != null && currentTokenParentParent is AccessorDeclarationSyntax)
             {
                 if (!_options.NewLinesForBracesInAccessors)
-                {
-                    operation = CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
-                }
-            }
-
-            // * { - in property pattern clauses in pattern matching context
-            if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause))
-            {
-                if (!_options.NewLinesForBracesInObjectCollectionArrayInitializers)
                 {
                     operation = CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
                 }
@@ -322,10 +315,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // new MyObject { - Object Initialization
             // new List<int> { - Collection Initialization
             // with { - Record with initializer
-            if (currentToken.Kind() == SyntaxKind.OpenBraceToken &&
-                (currentToken.Parent.Kind() == SyntaxKind.ObjectInitializerExpression ||
-                currentToken.Parent.Kind() == SyntaxKind.CollectionInitializerExpression ||
-                currentToken.Parent.Kind() == SyntaxKind.WithInitializerExpression))
+            // is { - property pattern clauses
+            if (currentToken.IsKind(SyntaxKind.OpenBraceToken) &&
+                (currentToken.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) ||
+                currentToken.Parent.IsKind(SyntaxKind.CollectionInitializerExpression) ||
+                currentToken.Parent.IsKind(SyntaxKind.WithInitializerExpression) ||
+                currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause)))
             {
                 if (_options.NewLinesForBracesInObjectCollectionArrayInitializers)
                 {
@@ -371,19 +366,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentToken.Kind() == SyntaxKind.OpenBraceToken && currentTokenParentParent != null && currentTokenParentParent is AccessorDeclarationSyntax)
             {
                 if (_options.NewLinesForBracesInAccessors)
-                {
-                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
-                }
-                else
-                {
-                    return null;
-                }
-            }
-
-            // * { - in property pattern clauses in pattern matching context
-            if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause))
-            {
-                if (_options.NewLinesForBracesInObjectCollectionArrayInitializers)
                 {
                     return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -159,6 +159,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
+            // * { - in property pattern clauses in pattern matching context
+            if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause))
+            {
+                if (!_options.NewLinesForBracesInObjectCollectionArrayInitializers)
+                {
+                    operation = CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
+                }
+            }
+
             // * { - in the anonymous Method context
             if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent != null && currentTokenParentParent.IsKind(SyntaxKind.AnonymousMethodExpression))
             {
@@ -371,6 +380,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
+            // * { - in property pattern clauses in pattern matching context
+            if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause))
+            {
+                if (_options.NewLinesForBracesInObjectCollectionArrayInitializers)
+                {
+                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
             // * { - in the anonymous Method context
             if (currentToken.Kind() == SyntaxKind.OpenBraceToken && currentTokenParentParent != null && currentTokenParentParent.Kind() == SyntaxKind.AnonymousMethodExpression)
             {
@@ -437,7 +459,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            // Wrapping - Leave statements on same line (false): 
+            // Wrapping - Leave statements on same line (false):
             // Insert a newline between the previous statement and this one.
             // ; *
             if (previousToken.Kind() == SyntaxKind.SemicolonToken


### PR DESCRIPTION
Example:

```editorconfig
[*.cs]
csharp_new_line_before_open_brace = none
```

```cs
public class TestInner {
    public string Name { get; }
}

public class Test {
    public string Name { get; }
    public TestInner Inner { get; }
}

public class Program {
    public bool IsAbc(Test test) {
        return test is { // Here
            Name: "foo",
            Inner: { // Here
                Name: "bar"
            }
        };
    }
}
```

Before this change, the lines noted above would report IDE0055 and the suggested code fix converts to using a new line (violating our config). After this change, the formatting rule is now respected in `is` pattern matching clauses, just like in all other places.

Closes #52413