### PR TITLE
Add support for CompletionList.CommitCharacters in LSP.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -140,6 +140,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return completionListSetting.Data;
         }
 
+        public static bool HasCompletionListCommitCharactersCapability(this ClientCapabilities clientCapabilities)
+        {
+            if (!TryGetVSCompletionListSetting(clientCapabilities, out var completionListSetting))
+            {
+                return false;
+            }
+
+            return completionListSetting.CommitCharacters;
+        }
+
         public static string GetMarkdownLanguageName(this Document document)
         {
             switch (document.Project.Language)

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -371,10 +371,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     commitCharacterReferences[commitCharacters] = existingCount;
                 }
 
-                if (mostUsedCommitCharacters == null)
-                {
-                    return;
-                }
+                Contract.ThrowIfNull(mostUsedCommitCharacters);
 
                 // Promoted the most used commit characters onto the list and then remove these from child items.
                 completionList.CommitCharacters = mostUsedCommitCharacters;
@@ -464,17 +461,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         return false;
                     }
 
-                    var charactersX = x[i].Characters;
-                    var charactersY = y[i].Characters;
-
-                    if (charactersX.Length != charactersY.Length)
+                    var xCharacters = x[i].Characters;
+                    var yCharacters = y[i].Characters;
+                    if (xCharacters.Length != yCharacters.Length)
                     {
                         return false;
                     }
 
-                    for (var j = 0; j < charactersX.Length; j++)
+                    for (var j = 0; j < xCharacters.Length; j++)
                     {
-                        if (charactersX[j] != charactersY[j])
+                        if (xCharacters[j] != yCharacters[j])
                         {
                             return false;
                         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -266,7 +266,6 @@ class B : A
             var completionList = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
                 completionParams, clientCapabilities, null, CancellationToken.None);
 
-
             // Emulate client behavior of promoting "Data" completion list properties onto completion items.
             if (clientCapabilities.HasCompletionListDataCapability() &&
                 completionList is VSCompletionList vsCompletionList &&

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
     {
 
         [Fact]
-        public async Task TestGetCompletionsAsync_PromotesComitCharctersToListAsync()
+        public async Task TestGetCompletionsAsync_PromotesCommitCharactersToListAsync()
         {
             var clientCapabilities = new LSP.VSClientCapabilities
             {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -19,6 +19,54 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
 {
     public class CompletionTests : AbstractLanguageServerProtocolTests
     {
+
+        [Fact]
+        public async Task TestGetCompletionsAsync_PromotesComitCharctersToListAsync()
+        {
+            var clientCapabilities = new LSP.VSClientCapabilities
+            {
+                SupportsVisualStudioExtensions = true,
+                TextDocument = new LSP.TextDocumentClientCapabilities()
+                {
+                    Completion = new LSP.VSCompletionSetting()
+                    {
+                        CompletionList = new LSP.VSCompletionListSetting()
+                        {
+                            CommitCharacters = true,
+                        }
+                    }
+                }
+            };
+            var markup =
+@"class A
+{
+    void M()
+    {
+        {|caret:|}
+    }
+}";
+            using var testLspServer = CreateTestLspServer(markup, out var locations);
+            var completionParams = CreateCompletionParams(
+                locations["caret"].Single(),
+                invokeKind: LSP.VSCompletionInvokeKind.Explicit,
+                triggerCharacter: "\0",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+
+            var expected = await CreateCompletionItemAsync(label: "A", kind: LSP.CompletionItemKind.Class, tags: new string[] { "Class", "Internal" },
+                request: completionParams, document: document, commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
+            var expectedCommitCharacters = expected.CommitCharacters;
+
+            // Null out the commit characters since we're expecting the commit characters will be lifted onto the completion list.
+            expected.CommitCharacters = null;
+
+            var results = await RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities).ConfigureAwait(false);
+            AssertJsonEquals(expected, results.Items.First());
+            var vsCompletionList = Assert.IsAssignableFrom<LSP.VSCompletionList>(results);
+            Assert.Equal(expectedCommitCharacters, vsCompletionList.CommitCharacters.Value.First);
+        }
+
         [Fact]
         public async Task TestGetCompletionsAsync()
         {
@@ -442,9 +490,18 @@ partial class C
             Assert.Null(results.Items.First().InsertText);
         }
 
-        private static async Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
+
+        private static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
         {
             var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
+            return RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities);
+        }
+
+        private static async Task<LSP.CompletionList> RunGetCompletionsAsync(
+            TestLspServer testLspServer,
+            LSP.CompletionParams completionParams,
+            LSP.VSClientCapabilities clientCapabilities)
+        {
             return await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
                 completionParams, clientCapabilities, null, CancellationToken.None);
         }


### PR DESCRIPTION
- Ultimately this is a performance optimization where instead of re-specifying commit characters on every completion item the platform now can specify if it supports specifying resolve data at the completion list level. We of course only lift common commit characters onto the completion list and if other commit character arrays are provided they overwrite what the completion list specifies.
 - Throughout this I found a few quirks of the pre-existing LSP completion system. It'd cache commit character arrays but it'd then re-allocate them when building out commit character arrays because ImmutableArray's are a struct and then passing them into a class would then box them. To combat this I changed the commit character rule cache to cache the actual LSP completion lists (`string[]`).
- Also had to update how the commit character rule cache had its keys looked up because there looked to be two separate instances of the commit character rules which were equivalent but not reference equivalent. To do this I added a comparer that did a better job at comparing modification rules.
- Added new completion test to validate that commit characters get lifted onto the completion list.

**Before:**
|                                                    Method | Optimized |      Mean |     Error |    StdDev |    Median |   Op/s |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|---------------------------------------------------------- |---------- |----------:|----------:|----------:|----------:|-------:|----------:|---------:|---------:|----------:|
| 'Completion List Roundtrip Serialization/Deserialization' |     False | 20.741 ms | 0.3760 ms | 0.3333 ms | 20.705 ms |  48.21 | 1218.7500 | 406.2500 | 125.0000 |   7.71 MB |
|                           'Completion List Serialization' |     False |  8.404 ms | 0.1669 ms | 0.1394 ms |  8.403 ms | 118.99 |  406.2500 | 171.8750 | 109.3750 |    2.7 MB |
|                         'Completion List Deserialization' |     False | 11.080 ms | 0.1913 ms | 0.1696 ms | 11.056 ms |  90.25 |  734.3750 | 250.0000 |        - |   4.42 MB |
| 'Completion List Roundtrip Serialization/Deserialization' |      True | 13.464 ms | 0.2680 ms | 0.3485 ms | 13.339 ms |  74.27 |  906.2500 | 265.6250 | 125.0000 |   5.82 MB |
|                           'Completion List Serialization' |      True |  2.198 ms | 0.0433 ms | 0.0735 ms |  2.173 ms | 455.01 |  246.0938 | 121.0938 | 121.0938 |    1.4 MB |
|                         'Completion List Deserialization' |      True | 11.282 ms | 0.2177 ms | 0.4914 ms | 11.021 ms |  88.64 |  734.3750 | 250.0000 |        - |   4.42 MB |

**After:**
|                                                    Method | Optimized |        Mean |     Error |    StdDev |     Op/s |    Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|---------------------------------------------------------- |---------- |------------:|----------:|----------:|---------:|---------:|---------:|--------:|-----------:|
| 'Completion List Roundtrip Serialization/Deserialization' |     False | 10,464.5 us |  49.75 us |  38.84 us |    95.56 | 921.8750 | 234.3750 | 31.2500 | 5869.54 KB |
|                           'Completion List Serialization' |     False |  3,730.7 us |  12.03 us |  10.66 us |   268.05 | 394.5313 |  82.0313 | 39.0625 | 2478.64 KB |
|                         'Completion List Deserialization' |     False |  5,623.2 us | 103.71 us | 141.95 us |   177.83 | 453.1250 | 132.8125 |       - | 2792.52 KB |
| 'Completion List Roundtrip Serialization/Deserialization' |      True |  5,764.7 us |  27.03 us |  22.57 us |   173.47 | 492.1875 | 156.2500 | 39.0625 | 3082.98 KB |
|                           'Completion List Serialization' |      True |    362.8 us |   7.09 us |   9.47 us | 2,756.68 |  41.5039 |  41.5039 | 41.5039 |  290.46 KB |
|                         'Completion List Deserialization' |      True |  5,599.2 us |  77.27 us |  64.53 us |   178.60 | 453.1250 | 132.8125 |       - | 2792.52 KB |

**Results (Optimized):**
Roundtrip: 2.3x faster
Serialization: 6.1x faster
Deserialization: 2x faster

Fixes dotnet/aspnetcore#31886