### PR TITLE
Operators declared in an interface must be implicitly public.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedConversionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedConversionSymbol.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 containingType,
                 location,
                 syntax,
-                MakeDeclarationModifiers(syntax, location, diagnostics),
+                MakeDeclarationModifiers(containingType.IsInterface, syntax, location, diagnostics),
                 hasBody: syntax.HasAnyBody(),
                 isExpressionBodied: syntax.Body == null && syntax.ExpressionBody != null,
                 isIterator: SyntaxFacts.HasYieldOperations(syntax.Body),

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 containingType,
                 location,
                 syntax,
-                MakeDeclarationModifiers(syntax, location, diagnostics),
+                MakeDeclarationModifiers(containingType.IsInterface, syntax, location, diagnostics),
                 hasBody: syntax.HasAnyBody(),
                 isExpressionBodied: syntax.Body == null && syntax.ExpressionBody != null,
                 isIterator: SyntaxFacts.HasYieldOperations(syntax.Body),

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -94,9 +94,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected static DeclarationModifiers MakeDeclarationModifiers(BaseMethodDeclarationSyntax syntax, Location location, BindingDiagnosticBag diagnostics)
+        protected static DeclarationModifiers MakeDeclarationModifiers(bool inInterface, BaseMethodDeclarationSyntax syntax, Location location, BindingDiagnosticBag diagnostics)
         {
-            var defaultAccess = DeclarationModifiers.Private;
+            var defaultAccess = inInterface ? DeclarationModifiers.Public : DeclarationModifiers.Private;
             var allowedModifiers =
                 DeclarationModifiers.AccessibilityMask |
                 DeclarationModifiers.Static |

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -43457,6 +43457,236 @@ I2.-
         }
 
         [Fact]
+        [WorkItem(52202, "https://github.com/dotnet/roslyn/issues/52202")]
+        public void Operators_32()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    static I1 operator +(I1 x)
+    {
+        System.Console.WriteLine(""+"");
+        return x;
+    }
+
+    static I1 operator -(I1 x)
+    {
+        System.Console.WriteLine(""-"");
+        return x;
+    }
+
+    static I1 operator !(I1 x)
+    {
+        System.Console.WriteLine(""!"");
+        return x;
+    }
+
+    static I1 operator ~(I1 x)
+    {
+        System.Console.WriteLine(""~"");
+        return x;
+    }
+
+    static I1 operator ++(I1 x)
+    {
+        System.Console.WriteLine(""++"");
+        return x;
+    }
+
+    static I1 operator --(I1 x)
+    {
+        System.Console.WriteLine(""--"");
+        return x;
+    }
+
+    static bool operator true(I1 x)
+    {
+        System.Console.WriteLine(""true"");
+        return true;
+    }
+
+    static bool operator false(I1 x)
+    {
+        System.Console.WriteLine(""false"");
+        return false;
+    }
+
+    static I1 operator +(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""+2"");
+        return x;
+    }
+
+    static I1 operator -(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""-2"");
+        return x;
+    }
+
+    static I1 operator *(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""*"");
+        return x;
+    }
+
+    static I1 operator /(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""/"");
+        return x;
+    }
+
+    static I1 operator %(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""%"");
+        return x;
+    }
+
+    static I1 operator &(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""&"");
+        return x;
+    }
+
+    static I1 operator |(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""|"");
+        return x;
+    }
+
+    static I1 operator ^(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""^"");
+        return x;
+    }
+
+    static I1 operator <<(I1 x, int y)
+    {
+        System.Console.WriteLine(""<<"");
+        return x;
+    }
+
+    static I1 operator >>(I1 x, int y)
+    {
+        System.Console.WriteLine("">>"");
+        return x;
+    }
+
+    static I1 operator >(I1 x, I1 y)
+    {
+        System.Console.WriteLine("">"");
+        return x;
+    }
+
+    static I1 operator <(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""<"");
+        return x;
+    }
+
+    static I1 operator >=(I1 x, I1 y)
+    {
+        System.Console.WriteLine("">="");
+        return x;
+    }
+
+    static I1 operator <=(I1 x, I1 y)
+    {
+        System.Console.WriteLine(""<="");
+        return x;
+    }
+}
+";
+
+            var source2 =
+@"
+class Test2 : I1
+{
+    static void Main()
+    {
+        I1 x = new Test2();
+        I1 y = new Test2();
+
+        x = +x;
+        x = -x;
+        x = !x;
+        x = ~x;
+        x = ++x;
+        x = x--;
+
+        x = x + y;
+        x = x - y;
+        x = x * y;
+        x = x / y;
+        x = x % y;
+        if (x && y) { }
+        x = x | y;
+        x = x ^ y;
+        x = x << 1;
+        x = x >> 2;
+        x = x > y;
+        x = x < y;
+        x = x >= y;
+        x = x <= y;
+    }
+}
+";
+
+            var expectedOutput =
+@"
++
+-
+!
+~
+++
+--
++2
+-2
+*
+/
+%
+false
+&
+true
+|
+^
+<<
+>>
+>
+<
+>=
+<=
+";
+
+            var compilation1 = CreateCompilation(source1 + source2, options: TestOptions.DebugExe,
+                                                 targetFramework: TargetFramework.NetCoreApp,
+                                                 parseOptions: TestOptions.Regular);
+
+            var i1 = compilation1.GlobalNamespace.GetTypeMember("I1");
+
+            foreach (var member in i1.GetMembers())
+            {
+                Assert.Equal(Accessibility.Public, member.DeclaredAccessibility);
+            }
+
+            CompileAndVerify(compilation1, expectedOutput: !ExecutionConditionUtil.IsMonoOrCoreClr ? null : expectedOutput, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics(); ;
+
+            CompilationReference compilationReference = compilation1.ToMetadataReference();
+            MetadataReference metadataReference = compilation1.EmitToImageReference();
+
+            var compilation2 = CreateCompilation(source2, new[] { compilationReference }, options: TestOptions.DebugExe,
+                                                 targetFramework: TargetFramework.NetCoreApp,
+                                                 parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation2, expectedOutput: !ExecutionConditionUtil.IsMonoOrCoreClr ? null : expectedOutput, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics(); ;
+
+            var compilation3 = CreateCompilation(source2, new[] { metadataReference }, options: TestOptions.DebugExe,
+                                                 parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation3, expectedOutput: !ExecutionConditionUtil.IsMonoOrCoreClr ? null : expectedOutput, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics(); ;
+        }
+
+        [Fact]
         public void RuntimeFeature_01()
         {
             var compilation1 = CreateCompilation("", options: TestOptions.DebugDll,


### PR DESCRIPTION
Fixes #52202.