### PR TITLE
Introduce local constant results in compiler error when new local name equals identifier name in method block

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -7912,5 +7912,42 @@ class B
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        [WorkItem(52833, "https://github.com/dotnet/roslyn/issues/52833")]
+        public async Task UniqueParameterName()
+        {
+            await TestInRegularAndScriptAsync(@"
+using System.IO;
+
+public class SomeClass
+{
+    public void Foo()
+    {
+        var somePath = Path.Combine(""one"", ""two"");
+        Other([|""someParam""|]);
+    }
+
+    public void Other(string path)
+    {
+    }
+}",
+@"
+using System.IO;
+
+public class SomeClass
+{
+    public void Foo()
+    {
+        var somePath = Path.Combine(""one"", ""two"");
+        const string {|Rename:Path1|} = ""someParam"";
+        Other(Path1);
+    }
+
+    public void Other(string path)
+    {
+    }
+}", 2);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SemanticsFactsService/AbstractSemanticFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SemanticsFactsService/AbstractSemanticFactsService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             s.Kind == SymbolKind.RangeVariable ||
             s.Kind == SymbolKind.Field ||
             s.Kind == SymbolKind.Property ||
-            s.Kind == SymbolKind.NamedType;
+            (s.Kind == SymbolKind.NamedType && s.IsStatic);
 
         public SyntaxToken GenerateUniqueName(
             SemanticModel semanticModel, SyntaxNode location, SyntaxNode containerOpt,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SemanticsFactsService/AbstractSemanticFactsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SemanticsFactsService/AbstractSemanticFactsService.cs
@@ -30,7 +30,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             s.Kind == SymbolKind.Parameter ||
             s.Kind == SymbolKind.RangeVariable ||
             s.Kind == SymbolKind.Field ||
-            s.Kind == SymbolKind.Property;
+            s.Kind == SymbolKind.Property ||
+            s.Kind == SymbolKind.NamedType;
 
         public SyntaxToken GenerateUniqueName(
             SemanticModel semanticModel, SyntaxNode location, SyntaxNode containerOpt,


### PR DESCRIPTION
#52833

Hello!

The issue here was that the name being generated for the highlighted expression matched that of an identifier in the same block. To rectify this, I added NamedType to the list of possible symbol kinds that are relevant as long as the symbol is also static.