### PR TITLE
Workaround bug in LSP client in 16.10p2 in integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Roslyn.Test.Utilities;
@@ -59,6 +60,11 @@ namespace Roslyn.VisualStudio.IntegrationTests
                     VisualStudio.Editor.SetUseSuggestionMode(false);
                     ClearEditor();
                 }
+
+                // Work around potential hangs in 16.10p2 caused by the roslyn LSP server not completing initialization before solution closed.
+                // By waiting for the async operation tracking roslyn LSP server activation to complete we should never
+                // encounter the scenario where the solution closes while activation is incomplete.
+                VisualStudio.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.LanguageServer);
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -332,6 +332,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 // Disable roaming settings to avoid interference from the online user profile
                 Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"ApplicationPrivateSettings\\Microsoft\\VisualStudio\" RoamingEnabled string \"1*System.Boolean*False\"")).WaitForExit();
 
+                // HACK: 16.10P2 contains an LSP client bug where on solution closed, server activation tasks that are not already completed / cancelled
+                // do not properly get cancelled.  When a new solution is opened these incomplete server ativation tasks are not cleared.
+                // Any feature that waits for LSP server activations to complete will hang on the old incomplete server activation tasks.
+                //
+                // The roslyn C# always active server and intellicode's refactorings LSP server are the only LSP servers active on C# files in 16.10p2.
+                // To work around potential hangs where the intellicode server activation does not complete before solution close, we disable their LSP server entirely.
+                // To work around potential hangs in the roslyn C# server, we wait for the async listener around the LSP server activation to complete before proceeding.
+                // Editor tracking bug (to be fixed in 16.10P3) - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1322125
+                Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"ApplicationPrivateSettings\\Microsoft\\VisualStudio\\IntelliCode\" Refactorings string \"0*System.Int32*2\"")).WaitForExit();
+
                 // Disable background download UI to avoid toasts
                 Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"FeatureFlags\\Setup\\BackgroundDownload\" Value dword 0")).WaitForExit();
 


### PR DESCRIPTION
The LSP client has a bug in 16.10p2 where server activation tasks that are not completed will never get completed if the solution is closed.  Then when a solution is re-opened, these activation tasks are not cleared, so features that wait for LSP to initialize just hang on these never completing tasks.

The fix comes in two parts:
1.  Disable intellicode's LSP server.  We don't control this one, so we just disable it to prevent it from creating one of these never completing tasks.
2.  For our roslyn C# server (for cntrl+Q), we now wait for it to completely initialize before we proceed with the test.  Therefore we can never close the solution while initialization is in progress.

This is fixed on the LSP client side in 16.10p3, but this should prevent us from breaking when the queue switches over to 16.10p2
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1322125

TODO: 
✅~~Target 16.10~~
✅~~Make sure tests pass on 16.10p2 queue (a few times)~~
1.  https://dev.azure.com/dnceng/public/_build/results?buildId=1119847&view=results
2.  https://dev.azure.com/dnceng/public/_build/results?buildId=1119945&view=results
3.  https://dev.azure.com/dnceng/public/_build/results?buildId=1120134&view=results