### PR TITLE
Rename Basic to Visual Basic in Visual Studio options page

### DIFF
--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     ' The option page configuration is duplicated in PackageRegistration.pkgdef.
     '
     ' VB option pages tree
-    '   Basic
+    '   Visual Basic
     '     General (from editor)
     '     Scroll Bars (from editor)
     '     Tabs (from editor)

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -30,6 +30,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     '     Advanced
     '     Code Style (category)
     '       General
+    '       Naming
+    '     IntelliSense
     <ProvideLanguageEditorOptionPage(GetType(AdvancedOptionPage), "Basic", Nothing, "Advanced", "#102", 10160)>
     <ProvideLanguageEditorToolsOptionCategory("Basic", "Code Style", "#109")>
     <ProvideLanguageEditorOptionPage(GetType(CodeStylePage), "Basic", "Code Style", "General", "#111", 10161)>

--- a/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
@@ -57,7 +57,7 @@
 // The option page configuration is duplicated on VisualBasicPackage type definition.
 //
 // VB option pages tree
-//   Basic
+//   Visual Basic
 //     General (from editor)
 //     Scroll Bars (from editor)
 //     Tabs (from editor)

--- a/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/PackageRegistration.pkgdef
@@ -65,6 +65,8 @@
 //     Code Style (category)
 //       General
 //       Naming
+//     IntelliSense
+
 
 [$RootKey$\Languages\Language Services\Basic\EditorToolsOptions\IntelliSense]
 @="#112"
@@ -167,7 +169,7 @@
 [$RootKey$\Languages\Language Services\Basic]
 @="{e34acdc0-baae-11d0-88bf-00a0c9110049}"
 "Package"="{574fc912-f74f-4b4e-92c3-f695c208a2bb}"
-"LangResID"=dword:00000000
+"LangResID"=dword:00000065
 
 "DefaultToInsertSpaces"=dword:00000001
 "EnableAdvancedMembersOption"=dword:00000001


### PR DESCRIPTION
This does the first point of the design meeting notes in https://github.com/dotnet/roslyn/issues/34990#issuecomment-507082470.