### PR TITLE
Draft: (No review needed) Test CDATA for metadata-as-source

### DIFF
--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -3113,7 +3113,7 @@ public enum BinaryOperatorKind
     //
     // {FeaturesResources.Summary_colon}
     //     Represents the << operator.
-    LeftShift = 0x8,
+    [|LeftShift|] = 0x8,
 }}";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.CSharp, expectedCS, includeXmlDocComments: true);
         }

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -3106,8 +3106,6 @@ public enum BinaryOperatorKind
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
-using System;
-
 public enum BinaryOperatorKind
 {{
     //

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -3087,5 +3087,35 @@ public class TestType
             var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
             TestContext.VerifyResult(metadataAsSourceFile, expected);
         }
+
+        [WorkItem(22431, "https://github.com/dotnet/roslyn/issues/22431")]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task TestCDATAComment()
+        {
+            var source = @"
+public enum BinaryOperatorKind
+{
+    /// <summary>
+    /// Represents the <![CDATA['<<']]> operator.
+    /// </summary>
+    LeftShift = 0x8,
+}
+";
+            var symbolName = "BinaryOperatorKind.LeftShift";
+            var expectedCS = $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+#endregion
+
+using System;
+
+public enum BinaryOperatorKind
+{{
+    //
+    // {FeaturesResources.Summary_colon}
+    //     Represents the << operator.
+    LeftShift = 0x8,
+}}";
+            await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.CSharp, expectedCS, includeXmlDocComments: true);
+        }
     }
 }


### PR DESCRIPTION
Add test case for #22431

Letting the CI do its work while I'm working locally on another issue that's most likely have the same root cause. Will close and cherry-pick the commit after confirming the test fails in CI and doesn't fail after cherry-picking on top of the fix I have.