### PR TITLE
Avoid NullReferenceException in MissingMetadataTypeSymbol if it doesn't have containing module.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Since we do not know what task was being performed, for now we just report a generic
                 // "you must add a reference" error.
 
-                if (containingAssembly.IsMissing)
+                if (containingAssembly?.IsMissing == true)
                 {
                     // error CS0012: The type 'Blah' is defined in an assembly that is not referenced. You must add a reference to assembly 'Goo'.
                     return new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDef, this, containingAssembly.Identity);
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     ModuleSymbol containingModule = this.ContainingModule;
 
-                    if (containingModule.IsMissing)
+                    if (containingModule?.IsMissing == true)
                     {
                         // It looks like required module wasn't added to the compilation.
                         return new CSDiagnosticInfo(ErrorCode.ERR_NoTypeDefFromModule, this, containingModule.Name);
@@ -94,25 +94,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // NOTE: this is another case where we would like to base our decision on which compilation
                     // is the "current" compilation, but we don't want to force consumers of the API to specify.
-                    if (containingAssembly.Dangerous_IsFromSomeCompilation)
+                    if (containingAssembly is object)
                     {
-                        // This scenario is quite tricky and involves a circular reference. Suppose we have
-                        // assembly Alpha that has a type C. Assembly Beta refers to Alpha and uses type C.
-                        // Now we create a new source assembly that replaces Alpha, and refers to Beta.
-                        // The usage of C in Beta will be redirected to refer to the source assembly.
-                        // If C is not in that source assembly then we give the following warning:
+                        if (containingAssembly.Dangerous_IsFromSomeCompilation)
+                        {
+                            // This scenario is quite tricky and involves a circular reference. Suppose we have
+                            // assembly Alpha that has a type C. Assembly Beta refers to Alpha and uses type C.
+                            // Now we create a new source assembly that replaces Alpha, and refers to Beta.
+                            // The usage of C in Beta will be redirected to refer to the source assembly.
+                            // If C is not in that source assembly then we give the following warning:
 
-                        // CS7068: Reference to type 'C' claims it is defined in this assembly, but it is not defined in source or any added modules 
-                        return new CSDiagnosticInfo(ErrorCode.ERR_MissingTypeInSource, this);
+                            // CS7068: Reference to type 'C' claims it is defined in this assembly, but it is not defined in source or any added modules 
+                            return new CSDiagnosticInfo(ErrorCode.ERR_MissingTypeInSource, this);
+                        }
+                        else
+                        {
+                            // The more straightforward scenario is that we compiled Beta against a version of Alpha
+                            // that had C, and then added a reference to a different version of Alpha that
+                            // lacks the type C:
+
+                            // error CS7069: Reference to type 'C' claims it is defined in 'Alpha', but it could not be found
+                            return new CSDiagnosticInfo(ErrorCode.ERR_MissingTypeInAssembly, this, containingAssembly.Name);
+                        }
+                    }
+                    else if (ContainingType is ErrorTypeSymbol { ErrorInfo: { } info})
+                    {
+                        return info;
                     }
                     else
                     {
-                        // The more straightforward scenario is that we compiled Beta against a version of Alpha
-                        // that had C, and then added a reference to a different version of Alpha that
-                        // lacks the type C:
-
-                        // error CS7069: Reference to type 'C' claims it is defined in 'Alpha', but it could not be found
-                        return new CSDiagnosticInfo(ErrorCode.ERR_MissingTypeInAssembly, this, containingAssembly.Name);
+                        // This is the best we can do at this point
+                        return new CSDiagnosticInfo(ErrorCode.ERR_BogusType, string.Empty);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             return new CSDiagnosticInfo(ErrorCode.ERR_MissingTypeInAssembly, this, containingAssembly.Name);
                         }
                     }
-                    else if (ContainingType is ErrorTypeSymbol { ErrorInfo: { } info})
+                    else if (ContainingType is ErrorTypeSymbol { ErrorInfo: { } info })
                     {
                         return info;
                     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ErrorTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ErrorTypeSymbolTests.cs
@@ -108,5 +108,18 @@ class C7 : A<string>.B<object> { }";
                 }
             }
         }
+
+        [WorkItem(52516, "https://github.com/dotnet/roslyn/issues/52516")]
+        [Fact]
+        public void ErrorInfo_01()
+        {
+            var error = new MissingMetadataTypeSymbol.Nested(new UnsupportedMetadataTypeSymbol(), "Test", 0, false);
+            var info = error.ErrorInfo;
+
+            Assert.Equal(ErrorCode.ERR_BogusType, (ErrorCode)info.Code);
+            Assert.Null(error.ContainingModule);
+            Assert.Null(error.ContainingAssembly);
+            Assert.NotNull(error.ContainingSymbol);
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingMetadataTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingMetadataTypeSymbol.vb
@@ -51,17 +51,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 Dim containingAssembly As AssemblySymbol = Me.ContainingAssembly
 
-                If containingAssembly.IsMissing Then
+                If containingAssembly?.IsMissing Then
                     Dim arg = If(Me.SpecialType <> SpecialType.None, DirectCast(CustomSymbolDisplayFormatter.DefaultErrorFormat(Me), Object), Me)
                     Return ErrorFactory.ErrorInfo(ERRID.ERR_UnreferencedAssembly3, containingAssembly.Identity, arg)
                 Else
                     Dim containingModule As ModuleSymbol = Me.ContainingModule
 
-                    If containingModule.IsMissing Then
-                        Return ErrorFactory.ErrorInfo(ERRID.ERR_UnreferencedModule3, containingModule.Name, Me)
+                    If containingModule IsNot Nothing Then
+                        If containingModule.IsMissing Then
+                            Return ErrorFactory.ErrorInfo(ERRID.ERR_UnreferencedModule3, containingModule.Name, Me)
+                        End If
+
+                        Return ErrorFactory.ErrorInfo(ERRID.ERR_TypeRefResolutionError3, Me, containingModule.Name)
                     End If
 
-                    Return ErrorFactory.ErrorInfo(ERRID.ERR_TypeRefResolutionError3, Me, containingModule.Name)
+                    Return If(TryCast(ContainingType, ErrorTypeSymbol)?.ErrorInfo,
+                              ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, String.Empty)) ' This is the best we can do at this point
                 End If
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -24623,5 +24623,17 @@ BC37208: Module 'C.dll' in assembly 'C, Version=0.0.0.0, Culture=neutral, Public
 ]]></errors>)
         End Sub
 
+        <Fact>
+        <WorkItem(52516, "https://github.com/dotnet/roslyn/issues/52516")>
+        Public Sub ErrorInfo_01()
+            Dim [error] = New MissingMetadataTypeSymbol.Nested(New UnsupportedMetadataTypeSymbol(), "Test", 0, False)
+            Dim info = [error].ErrorInfo
+
+            Assert.Equal(ERRID.ERR_UnsupportedType1, CType(info.Code, ERRID))
+            Assert.Null([error].ContainingModule)
+            Assert.Null([error].ContainingAssembly)
+            Assert.NotNull([error].ContainingSymbol)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #52516.