### PR TITLE
Remove labeling based on issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/analyzer-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/analyzer-suggestion.md
@@ -1,7 +1,6 @@
 ---
 name: Analyzer suggestion
 about: Suggest a Roslyn analyzer related to code style. Semantic/code quality analyzers are developed in roslyn-analyzers repository.
-labels: [Area-IDE, Feature Request]
 ---
 
 **Brief description:**


### PR DESCRIPTION
I believe some issues were opened with this template that got automatically labeled with "Feature Request", but they are not analyzer suggestions. Not even feature requests. Some were bugs for example.