### PR TITLE
Fix quick info LSP tests to wait for the quick info session

### DIFF
--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -8,7 +8,15 @@ trigger:
 - features/*
 - demos/*
 
-pr: none
+# Branches that are allowed to trigger a build via /azp run.
+# Automatic building of all PRs is disabled in the pipelines trigger page as described in
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers
+pr:
+- main
+- main-vs-deps
+- release/*
+- features/*
+- demos/*
 
 jobs:
 - job: VS_Integration_LSP

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -9,8 +9,8 @@ trigger:
 - demos/*
 
 # Branches that are allowed to trigger a build via /azp run.
-# Automatic building of all PRs is disabled in the pipelines trigger page as described in
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers
+# Automatic building of all PRs is disabled in the pipeline's trigger page.
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers
 pr:
 - main
 - main-vs-deps

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 var view = GetActiveTextView();
                 var broker = GetComponentModelService<IAsyncQuickInfoBroker>();
 
-                var session = broker.GetSession(view);
+                var session = Helper.Retry(() => broker.GetSession(view), Helper.HangMitigatingTimeout);
 
                 using var cts = new CancellationTokenSource(Helper.HangMitigatingTimeout);
                 while (session.State != QuickInfoSessionState.Visible)


### PR DESCRIPTION
Also fixed the triggers on the lsp pipeline to allow for /azp run (without automatically showing up on PRs)