### PR TITLE
Catch and report errors in LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor

### DIFF
--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
+using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis.Api;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Suppression;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -18,20 +18,77 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
     internal sealed class LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor
         : ILegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor
     {
+        private readonly VisualStudioWorkspace _workspace;
         private readonly IVisualStudioSuppressionFixService _implementation;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor(IVisualStudioSuppressionFixService implementation)
-            => _implementation = implementation;
+        public LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor(
+            VisualStudioWorkspace workspace,
+            IVisualStudioSuppressionFixService implementation)
+        {
+            _workspace = workspace;
+            _implementation = implementation;
+        }
 
-        public bool AddSuppressions(IVsHierarchy projectHierarchyOpt)
-            => _implementation.AddSuppressions(projectHierarchyOpt);
+        public bool AddSuppressions(IVsHierarchy? projectHierarchy)
+        {
+            var errorReportingService = _workspace.Services.GetRequiredService<IErrorReportingService>();
 
-        public bool AddSuppressions(bool selectedErrorListEntriesOnly, bool suppressInSource, IVsHierarchy projectHierarchyOpt)
-            => _implementation.AddSuppressions(selectedErrorListEntriesOnly, suppressInSource, projectHierarchyOpt);
+            try
+            {
+                return _implementation.AddSuppressions(projectHierarchy);
+            }
+            catch (Exception ex)
+            {
+                errorReportingService.ShowGlobalErrorInfo(
+                    string.Format(ServicesVSResources.Error_updating_suppressions_0, ex.Message),
+                    new InfoBarUI(
+                        WorkspacesResources.Show_Stack_Trace,
+                        InfoBarUI.UIKind.HyperLink,
+                        () => errorReportingService.ShowDetailedErrorInfo(ex), closeAfterAction: true));
+                return false;
+            }
+        }
 
-        public bool RemoveSuppressions(bool selectedErrorListEntriesOnly, IVsHierarchy projectHierarchyOpt)
-            => _implementation.RemoveSuppressions(selectedErrorListEntriesOnly, projectHierarchyOpt);
+        public bool AddSuppressions(bool selectedErrorListEntriesOnly, bool suppressInSource, IVsHierarchy? projectHierarchy)
+        {
+            var errorReportingService = _workspace.Services.GetRequiredService<IErrorReportingService>();
+
+            try
+            {
+                return _implementation.AddSuppressions(selectedErrorListEntriesOnly, suppressInSource, projectHierarchy);
+            }
+            catch (Exception ex)
+            {
+                errorReportingService.ShowGlobalErrorInfo(
+                    string.Format(ServicesVSResources.Error_updating_suppressions_0, ex.Message),
+                    new InfoBarUI(
+                        WorkspacesResources.Show_Stack_Trace,
+                        InfoBarUI.UIKind.HyperLink,
+                        () => errorReportingService.ShowDetailedErrorInfo(ex), closeAfterAction: true));
+                return false;
+            }
+        }
+
+        public bool RemoveSuppressions(bool selectedErrorListEntriesOnly, IVsHierarchy? projectHierarchy)
+        {
+            var errorReportingService = _workspace.Services.GetRequiredService<IErrorReportingService>();
+
+            try
+            {
+                return _implementation.RemoveSuppressions(selectedErrorListEntriesOnly, projectHierarchy);
+            }
+            catch (Exception ex)
+            {
+                errorReportingService.ShowGlobalErrorInfo(
+                    string.Format(ServicesVSResources.Error_updating_suppressions_0, ex.Message),
+                    new InfoBarUI(
+                        WorkspacesResources.Show_Stack_Trace,
+                        InfoBarUI.UIKind.HyperLink,
+                        () => errorReportingService.ShowDetailedErrorInfo(ex), closeAfterAction: true));
+                return false;
+            }
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/IVisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/IVisualStudioSuppressionFixService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
@@ -17,22 +15,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
         /// <summary>
         /// Adds source suppressions for all the diagnostics in the error list, i.e. baseline all active issues.
         /// </summary>
-        /// <param name="projectHierarchyOpt">An optional project hierarchy object in the solution explorer. If non-null, then only the diagnostics from the project will be suppressed.</param>
-        bool AddSuppressions(IVsHierarchy projectHierarchyOpt);
+        /// <param name="projectHierarchy">An optional project hierarchy object in the solution explorer. If non-null, then only the diagnostics from the project will be suppressed.</param>
+        bool AddSuppressions(IVsHierarchy? projectHierarchy);
 
         /// <summary>
         /// Adds source suppressions for diagnostics.
         /// </summary>
         /// <param name="selectedErrorListEntriesOnly">If true, then only the currently selected entries in the error list will be suppressed. Otherwise, all suppressable entries in the error list will be suppressed.</param>
         /// <param name="suppressInSource">If true, then suppressions will be generated inline in the source file. Otherwise, they will be generated in a separate global suppressions file.</param>
-        /// <param name="projectHierarchyOpt">An optional project hierarchy object in the solution explorer. If non-null, then only the diagnostics from the project will be suppressed.</param>
-        bool AddSuppressions(bool selectedErrorListEntriesOnly, bool suppressInSource, IVsHierarchy projectHierarchyOpt);
+        /// <param name="projectHierarchy">An optional project hierarchy object in the solution explorer. If non-null, then only the diagnostics from the project will be suppressed.</param>
+        bool AddSuppressions(bool selectedErrorListEntriesOnly, bool suppressInSource, IVsHierarchy? projectHierarchy);
 
         /// <summary>
         /// Removes source suppressions for suppressed diagnostics.
         /// </summary>
         /// <param name="selectedErrorListEntriesOnly">If true, then only the currently selected entries in the error list will be unsuppressed. Otherwise, all unsuppressable entries in the error list will be unsuppressed.</param>
-        /// <param name="projectHierarchyOpt">An optional project hierarchy object in the solution explorer. If non-null, then only the diagnostics from the project will be unsuppressed.</param>
-        bool RemoveSuppressions(bool selectedErrorListEntriesOnly, IVsHierarchy projectHierarchyOpt);
+        /// <param name="projectHierarchy">An optional project hierarchy object in the solution explorer. If non-null, then only the diagnostics from the project will be unsuppressed.</param>
+        bool RemoveSuppressions(bool selectedErrorListEntriesOnly, IVsHierarchy? projectHierarchy);
     }
 }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1710,4 +1710,7 @@ I agree to all of the foregoing:</value>
   <data name="Search_Settings" xml:space="preserve">
     <value>Search Settings</value>
   </data>
+  <data name="Error_updating_suppressions_0" xml:space="preserve">
+    <value>Error updating suppressions: {0}</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Vyhodnocování (počet úloh ve frontě: {0})</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Auswertung ({0} Tasks in der Warteschlange)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Evaluando ({0} tareas en cola)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Évaluation ({0} tâches en file d'attente)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">In fase di valutazione ({0} attività in coda)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">評価中 ({0} 個のタスクがキューにあります)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">평가 중(큐의 {0}개 작업)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Szacowanie (zadania w kolejce: {0})</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Avaliando ({0} tarefas na fila)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Оценка (задач в очереди: {0})</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">Değerlendiriliyor (kuyrukta {0} görev var)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">正在评估(队列中有 {0} 个任务)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -332,6 +332,11 @@
         <target state="new">Error</target>
         <note />
       </trans-unit>
+      <trans-unit id="Error_updating_suppressions_0">
+        <source>Error updating suppressions: {0}</source>
+        <target state="new">Error updating suppressions: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Evaluating_0_tasks_in_queue">
         <source>Evaluating ({0} tasks in queue)</source>
         <target state="translated">正在評估 (佇列中的 {0} 工作)</target>


### PR DESCRIPTION
These operations are invoked directly by menu commands, so exceptions thrown by the methods will crash the application. Update each command handler to catch the exception and report a gold bar plus telemetry rather than crash.

Fixes #53160