### PR TITLE
Override the public GetChangeAsync in UnnamedSymbolCompletionProvider

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
@@ -149,12 +149,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
         }
 
-        internal override Task<CompletionChange> GetChangeAsync(
+        public override Task<CompletionChange> GetChangeAsync(
             Document document,
             CompletionItem item,
-            TextSpan completionListSpan,
             char? commitKey,
-            bool disallowAddingImports,
             CancellationToken cancellationToken)
         {
             var kind = item.Properties[KindName];


### PR DESCRIPTION
Currently, we are overriding the _internal_ overload here, which causes any public users to get incorrect text edits (just the DisplayText inserted in the current location). We aren't actually using any of the internal parameters, and the default internal implementation just delegates to the public version.