### PR TITLE
Bail-out early to avoid creating a new immutable array with same elements

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1074,12 +1074,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Compilation compilation,
             SuppressMessageAttributeState suppressMessageState)
         {
-            if (diagnostics.IsEmpty)
+            if (diagnostics.IsEmpty || compilation.Options.ReportSuppressedDiagnostics)
             {
                 return diagnostics;
             }
 
-            var reportSuppressedDiagnostics = compilation.Options.ReportSuppressedDiagnostics;
             var builder = ImmutableArray.CreateBuilder<Diagnostic>();
             for (var i = 0; i < diagnostics.Length; i++)
             {
@@ -1089,7 +1088,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 #endif
 
                 var diagnostic = suppressMessageState.ApplySourceSuppressions(diagnostics[i]);
-                if (!reportSuppressedDiagnostics && diagnostic.IsSuppressed)
+                if (diagnostic.IsSuppressed)
                 {
                     // Diagnostic suppressed in source.
                     continue;


### PR DESCRIPTION
If `ReportSuppressedDiagnostics` is true, we'll end up executing the following:


```csharp
            var builder = ImmutableArray.CreateBuilder<Diagnostic>();
            for (var i = 0; i < diagnostics.Length; i++)
            {
#if DEBUG
                // We should have ignored diagnostics with invalid locations and reported analyzer exception diagnostic for the same.
                DiagnosticAnalysisContextHelpers.VerifyDiagnosticLocationsInCompilation(diagnostics[i], compilation);
#endif

                var diagnostic = suppressMessageState.ApplySourceSuppressions(diagnostics[i]);
                builder.Add(diagnostic);
            }

            return builder.ToImmutable();
```

This is unnecessary and work, instead, return the diagnostics array as-is.

@mavasani for review.