### PR TITLE
Use segmented dictionaries in SyntaxNodeExtensions.CurrentNodes

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -191,13 +192,13 @@ namespace Microsoft.CodeAnalysis
 
         private class CurrentNodes
         {
-            private readonly Dictionary<SyntaxAnnotation, IReadOnlyList<SyntaxNode>> _idToNodeMap;
+            private readonly ImmutableSegmentedDictionary<SyntaxAnnotation, IReadOnlyList<SyntaxNode>> _idToNodeMap;
 
             public CurrentNodes(SyntaxNode root)
             {
                 // there could be multiple nodes with same annotation if a tree is rewritten with
                 // same node injected multiple times.
-                var map = new Dictionary<SyntaxAnnotation, List<SyntaxNode>>();
+                var map = new SegmentedDictionary<SyntaxAnnotation, List<SyntaxNode>>();
 
                 foreach (var node in root.GetAnnotatedNodesAndTokens(IdAnnotationKind).Select(n => n.AsNode()!))
                 {
@@ -215,7 +216,7 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                _idToNodeMap = map.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<SyntaxNode>)ImmutableArray.CreateRange(kv.Value));
+                _idToNodeMap = map.ToImmutableSegmentedDictionary(kv => kv.Key, kv => (IReadOnlyList<SyntaxNode>)ImmutableArray.CreateRange(kv.Value));
             }
 
             public IReadOnlyList<SyntaxNode> GetNodes(SyntaxAnnotation id)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs
@@ -192,6 +192,7 @@ namespace Microsoft.CodeAnalysis
 
         private class CurrentNodes
         {
+            [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1320760", Constraint = "Avoid large object heap allocations")]
             private readonly ImmutableSegmentedDictionary<SyntaxAnnotation, IReadOnlyList<SyntaxNode>> _idToNodeMap;
 
             public CurrentNodes(SyntaxNode root)


### PR DESCRIPTION
Prior to this change, 28% of the total allocations observed in [AB#1320760](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1320760) occurred in the Large Object Heap. After this change, only 1% of the total allocations are in the Large Object Heap.