### PR TITLE
Update publish data for 16.11

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -49,6 +49,7 @@
       "Microsoft.CodeAnalysis.ExternalAccess.IntelliTrace": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.ProjectSystem": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp": "arcade",
+      "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.Razor": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.TypeScript": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.UnitTesting": "vs-impl",
@@ -105,6 +106,7 @@
       "Microsoft.CodeAnalysis.ExternalAccess.IntelliTrace": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.ProjectSystem": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp": "arcade",
+      "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.Razor": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.TypeScript": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.UnitTesting": "arcade",
@@ -171,6 +173,17 @@
       "packageFeeds": "default",
       "channels": [],
       "vsBranch": "rel/d16.10",
+      "vsMajorVersion": 16
+    },
+    "release/dev16.11-vs-deps": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "version": "3.11.*",
+      "packageFeeds": "default",
+      "channels": [],
+      "vsBranch": "rel/d16.11",
       "vsMajorVersion": 16
     },
     "main-vs-deps": {


### PR DESCRIPTION
Noticed the ExternalAccess.OmniSharp.CSharp pacakge was missing from the publish configuration. While updating I saw that we have not added 16.11 config yet.