### PR TITLE
Add code-remote-base to c# and vb content type definitions

### DIFF
--- a/src/EditorFeatures/CSharp/ContentType/ContentTypeDefinitions.cs
+++ b/src/EditorFeatures/CSharp/ContentType/ContentTypeDefinitions.cs
@@ -17,6 +17,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.ContentType
         [Export]
         [Name(ContentTypeNames.CSharpContentType)]
         [BaseDefinition(ContentTypeNames.RoslynContentType)]
+        // Adds the LSP base content type to ensure the LSP client activates on C# files.
+        // From Microsoft.VisualStudio.LanguageServer.Client.CodeRemoteContentDefinition.CodeRemoteBaseTypeName
+        // We cannot directly reference the LSP client package in EditorFeatures as it is a VS dependency.
+        [BaseDefinition("code-languageserver-base")]
         public static readonly ContentTypeDefinition CSharpContentTypeDefinition;
 
         [Export]

--- a/src/EditorFeatures/VisualBasic/ContentType/ContentTypeDefinitions.vb
+++ b/src/EditorFeatures/VisualBasic/ContentType/ContentTypeDefinitions.vb
@@ -11,10 +11,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ContentType
 
         ''' <summary>
         ''' Definition of the primary VB content type.
+        ''' Also adds the LSP base content type To ensure the LSP client activates On C# files.
+        ''' From Microsoft.VisualStudio.LanguageServer.Client.CodeRemoteContentDefinition.CodeRemoteBaseTypeName
+        ''' We cannot directly reference the LSP client package in EditorFeatures as it Is a VS dependency.
         ''' </summary>
         <Export()>
         <Name(ContentTypeNames.VisualBasicContentType)>
         <BaseDefinition(ContentTypeNames.RoslynContentType)>
+        <BaseDefinition("code-languageserver-base")>
         Public ReadOnly VisualBasicContentTypeDefinition As ContentTypeDefinition
 
         <Export()>

--- a/src/EditorFeatures/VisualBasic/ContentType/ContentTypeDefinitions.vb
+++ b/src/EditorFeatures/VisualBasic/ContentType/ContentTypeDefinitions.vb
@@ -11,9 +11,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ContentType
 
         ''' <summary>
         ''' Definition of the primary VB content type.
-        ''' Also adds the LSP base content type To ensure the LSP client activates On C# files.
+        ''' Also adds the LSP base content type to ensure the LSP client activates On VB files.
         ''' From Microsoft.VisualStudio.LanguageServer.Client.CodeRemoteContentDefinition.CodeRemoteBaseTypeName
-        ''' We cannot directly reference the LSP client package in EditorFeatures as it Is a VS dependency.
+        ''' We cannot directly reference the LSP client package in EditorFeatures as it is a VS dependency.
         ''' </summary>
         <Export()>
         <Name(ContentTypeNames.VisualBasicContentType)>


### PR DESCRIPTION
This tells the LSP client that it should activate on these content types.  How did this work before?
1.  Intellicode adds this base content type to the C# content type - https://devdiv.visualstudio.com/DevDiv/_git/IntelliCode-VS?path=%2Fsrc%2FVSIX%2FIntelliCode.VSIX%2FRefactorings%2FContentTypeDefinitions.cs&_a=contents&version=GBmain
2. On workspace load, we load our server ourselves.  This allows cntrl+Q to see the roslyn LSP server in C#/VB projects.
3. Any other local LSP feature that works off of the buffer in VB did not work.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1302281/
