### PR TITLE
IDE 008 When there are optional parameters inside incomplete lambda

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -2796,6 +2796,53 @@ class C
     }
 }");
             }
+
+            [WorkItem(38822, @"https://github.com/dotnet/roslyn/issues/38822")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+            public async Task TestOptionalParameterConstructorInIncompleteLambda()
+            {
+                await TestMissingInRegularAndScriptAsync(@"
+using System;
+
+namespace Test
+{
+    public class InstanceType
+    {
+        public InstanceType(object a = null) { }
+    }
+
+    public static class Example
+    {
+        public static void Test()
+        {
+            Action lambda = () =>
+            {
+                var _ = new [|InstanceType|]();  // IDE1008: 'InstanceType' does not contain a constructor that takes that many arguments
+                var _ = 0  // CS1002: ; expected
+            };
+        }
+    }
+}");
+            }
+
+            [WorkItem(38822, @"https://github.com/dotnet/roslyn/issues/38822")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+            public async Task TestOptionalParameterConstructorInIncompleteLambdaWithWarning()
+            {
+                await TestMissingInRegularAndScriptAsync(@"
+using System;
+
+public class C
+{
+    public static Action Test() => () =>
+    {
+        new [|C|](); // error IDE1008: 'C' does not contain a constructor that takes that many arguments.
+#warning warn
+    };
+
+    C(int i=0) { }
+}");
+            }
         }
 
         [WorkItem(5274, "https://github.com/dotnet/roslyn/issues/5274")]

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -65,15 +65,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
                 var argToParameterDictionary = ArgumentToParameterMapping(args, constructor.Parameters, model);
                 return GetCountOfOptionalParameters(constructor) + argToParameterDictionary.Count == constructor.Parameters.Length;
 
-                /*for (var i = 0; i < args.Count; i++)
-                {
-                    var typeInfo = model.GetTypeInfo(args[i].Expression);
-                    if (!constructor.Parameters[i].Type.Equals(typeInfo.ConvertedType))
-                    {
-                        return false;
-                    }
-                }*/
-
             }).Length;
 
             if (count == 0)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -46,10 +46,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
             }
 
             var count = constructors.Value
-            .WhereAsArray(constructor => constructor.Parameters.Length == args.Count)
             .WhereAsArray(constructor =>
             {
-                for (var i = 0; i < constructor.Parameters.Length; i++)
+                if (constructor.Parameters.Length == args.Count)
+                {
+                    return true;
+                }
+                else
+                {
+                    var optionalCount = 0;
+                    foreach (var parameter in constructor.Parameters)
+                    {
+                        if (parameter.IsOptional)
+                        {
+                            optionalCount++;
+                        }
+                    }
+
+                    return optionalCount + args.Count == constructor.Parameters.Length;
+                }
+            })
+            .WhereAsArray(constructor =>
+            {
+                for (var i = 0; i < args.Count; i++)
                 {
                     var typeInfo = model.GetTypeInfo(args[i].Expression);
                     if (!constructor.Parameters[i].Type.Equals(typeInfo.ConvertedType))
@@ -60,6 +79,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
 
                 return true;
             }).Length;
+            /*var count = 0;
+            foreach (var constructor in constructors)
+            {
+                var optionalCount = 0;
+                foreach (var parameter in constructor.Parameters)
+                {
+                    if (parameter.IsOptional)
+                    {
+                        optionalCount++;
+                    }
+                }
+
+
+                if (constructor.Parameters.Length == args.Count || optionalCount + args.Count == constructor.Parameters.Length)
+                {
+                    for (var i = 0; i < args.Count; i++)
+                    {
+                        var typeInfo = model.GetTypeInfo(args[i].Expression);
+                        if (!constructor.Parameters[i].Type.Equals(typeInfo.ConvertedType))
+                        {
+                            count--;
+                            break;
+                        }
+                    }
+                }
+
+                count++;
+            }*/
 
             if (count == 0)
             {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -79,34 +79,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
 
                 return true;
             }).Length;
-            /*var count = 0;
-            foreach (var constructor in constructors)
-            {
-                var optionalCount = 0;
-                foreach (var parameter in constructor.Parameters)
-                {
-                    if (parameter.IsOptional)
-                    {
-                        optionalCount++;
-                    }
-                }
-
-
-                if (constructor.Parameters.Length == args.Count || optionalCount + args.Count == constructor.Parameters.Length)
-                {
-                    for (var i = 0; i < args.Count; i++)
-                    {
-                        var typeInfo = model.GetTypeInfo(args[i].Expression);
-                        if (!constructor.Parameters[i].Type.Equals(typeInfo.ConvertedType))
-                        {
-                            count--;
-                            break;
-                        }
-                    }
-                }
-
-                count++;
-            }*/
 
             if (count == 0)
             {


### PR DESCRIPTION
#38822 
Hola!

This analyzer option appears when you are instantiating a constructor that has optional parameters in an incomplete lambda. I added checks to see if any of the parameters are optional and adding those to the arguments before returning false. 
I also create a mapping of argument to parameter and determine if that value plus the the optional parameters matches the constructors parameter list length.