### PR TITLE
Hold onto the TextBufferContainer for a ITextBuffer weakly

### DIFF
--- a/src/EditorFeatures/Test/TextEditor/TextBufferContainerTests.cs
+++ b/src/EditorFeatures/Test/TextEditor/TextBufferContainerTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.TextEditor
+{
+    [UseExportProvider]
+    public class TextBufferContainerTests
+    {
+        [Fact]
+        public void TextBufferContainersHeldWeakly()
+        {
+            var exportProvider = EditorTestCompositions.Editor.ExportProviderFactory.CreateExportProvider();
+            var bufferFactory = exportProvider.GetExportedValue<ITextBufferFactoryService>();
+
+            var buffer = bufferFactory.CreateTextBuffer();
+            var textContainer = ObjectReference.CreateFromFactory(() => buffer.AsTextContainer());
+
+            // As long as the buffer is alive and CurrentSnapshot hasn't changed, we'll still have the container alive through the path that
+            // a ITextSnapshot holds the SourceText, and the SourceText holds the TextContainer. That's not really a big deal
+            // since we're not holding onto any snapshots we weren't before. So move the text buffer snapshot forward to something else
+            // which means our old container should now be collectable, since the old SourceText is also collectable.
+            buffer.Insert(0, "Hello, World!");
+
+            textContainer.AssertReleased();
+
+            GC.KeepAlive(buffer);
+        }
+    }
+}


### PR DESCRIPTION
We have a ConditionalWeakTable that ensures that we don't create more than one TextBufferContainer for the same SourceTextContainer. However, if .AsTextContainer() is called on a ITextBuffer, that meant that the container would live around as long as the buffer lived around. This is problematic but it's pretty subtle why.

The SourceText that we create that wraps an ITextImage holds onto it's container strongly, but the container holds onto original buffer weakly; the intent here is if a file is closed, the buffer can be GCed even if there's still underlying Solution snapshots still using that text, which might exist some time after. The implementation of SourceTextContainer.CurrentText works by going to the text buffer's current snapshot and getting the text, but if the text buffer has been GCed, it tries to return a "_currentText" which represents the last text that was handed out. That _currentText is held strongly, and when we create a SourceTextContainer is created for the original contents of the buffer.

If somebody subscribes to text changes for a SourceTextContainer, any time a change happens we update _currentText. However, if somebody were to create a SourceTextContainer, and never observe the text, nor subscribe to any events, the SourceTextContainer will never update _currentText, so it's rooting an older version of the text from when it was first created. And since we keep the SourceTextContainer alive as long as the buffer is alive, this means an errant call to create a SourceTextContainer for a random buffer will root the original editor snapshot, as well as the entire change history for that buffer.

It turns out we have exactly such a call here:

https://github.com/dotnet/roslyn/blob/b0d6af5faf9933db4de0608ec5f41c5a1dc309ab/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioActiveDocumentTracker.cs#L245-L246

That runs any time a new text buffer gets activated. If that's not a Roslyn file (say it's just a random .txt file), then we'll end up creating a SourceTextContainer that will now root the original snapshot, but won't do antyhing to update _currentText. Thus, as long as that file is open, we will leak all intermediate versions.

The fix taken here is to weakly hold the created TextBufferContainer; that way a call like in VisualStudioActiveDocumentTracker.cs won't root anything if it isn't actually used. There is still a potential second bug where if the container is held around but never subscribed to text changes, it still won't update _currentText which is still not ideal, but can be fixed in a separate commit.