### PR TITLE
Don't suggest to add null checks to nullable reference types

### DIFF
--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -4,16 +4,10 @@
 
 #nullable disable
 
-using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.AddParameter;
-using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.InitializeParameter;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
-using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
 using Roslyn.Test.Utilities;
@@ -161,6 +155,24 @@ using System;
 interface I
 {
     void M([||]string s);
+}";
+
+            await VerifyCS.VerifyRefactoringAsync(code, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestNotOnNullableParameter()
+        {
+            var code = @"
+#nullable enable
+
+using System;
+
+class C
+{
+    void M([||]string? s)
+    {
+    }
 }";
 
             await VerifyCS.VerifyRefactoringAsync(code, code);
@@ -468,6 +480,47 @@ class C
         if (string.IsNullOrEmpty(c))
         {{
             throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(c)}").Replace("\"", "\\\"")}"", nameof(c));
+        }}
+    }}
+}}",
+                CodeActionIndex = 3,
+                CodeActionEquivalenceKey = nameof(FeaturesResources.Add_null_checks_for_all_parameters)
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestMultiNullableParametersSomeNullableReferenceTypes()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+#nullable enable
+
+using System;
+
+class C
+{
+    public C([||]string a, string b, string? c)
+    {
+    }
+}",
+                FixedCode = @$"
+#nullable enable
+
+using System;
+
+class C
+{{
+    public C(string a, string b, string? c)
+    {{
+        if (string.IsNullOrEmpty(a))
+        {{
+            throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(a)}").Replace("\"", "\\\"")}"", nameof(a));
+        }}
+
+        if (string.IsNullOrEmpty(b))
+        {{
+            throw new ArgumentException($""{string.Format(FeaturesResources._0_cannot_be_null_or_empty, "{nameof(b)}").Replace("\"", "\\\"")}"", nameof(b));
         }}
     }}
 }}",

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -237,8 +237,15 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
         protected bool ParameterValidForNullCheck(Document document, IParameterSymbol parameter, SemanticModel semanticModel,
             IBlockOperation blockStatementOpt, CancellationToken cancellationToken)
         {
-            if (!parameter.Type.IsReferenceType &&
-                !parameter.Type.IsNullable())
+            if (parameter.Type.IsReferenceType)
+            {
+                // Don't add null checks to things explicitly declared nullable
+                if (parameter.Type.NullableAnnotation == NullableAnnotation.Annotated)
+                {
+                    return false;
+                }
+            }
+            else if (!parameter.Type.IsNullable())
             {
                 return false;
             }


### PR DESCRIPTION
If a parameter is marked as nullable, then we shouldn't be adding a check for it to be non-null.