### PR TITLE
Fix spans for cached items at the manager level, not the service level

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -2979,7 +2979,7 @@ public class SomeClass : Base
             var completionList = await GetCompletionListAsync(service, document, testDocument.CursorPosition.Value, CompletionTrigger.Invoke);
             var completionItem = completionList.Items.Where(c => c.DisplayText == "M(in int x)").Single();
 
-            var commit = await service.GetChangeAsync(document, completionItem, completionList.Span, commitKey: null, disallowAddingImports: false, CancellationToken.None);
+            var commit = await service.GetChangeAsync(document, completionItem, completionList.Span, commitKey: null, CancellationToken.None);
 
             var text = await document.GetTextAsync();
             var newText = text.WithChanges(commit.TextChange);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -2979,7 +2979,7 @@ public class SomeClass : Base
             var completionList = await GetCompletionListAsync(service, document, testDocument.CursorPosition.Value, CompletionTrigger.Invoke);
             var completionItem = completionList.Items.Where(c => c.DisplayText == "M(in int x)").Single();
 
-            var commit = await service.GetChangeAsync(document, completionItem, completionList.Span, commitKey: null, CancellationToken.None);
+            var commit = await service.GetChangeAsync(document, completionItem, commitKey: null, CancellationToken.None);
 
             var text = await document.GetTextAsync();
             var newText = text.WithChanges(commit.TextChange);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -29,8 +29,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
         private bool IsExpandedCompletion { get; set; } = true;
 
-        private bool DisallowAddingImports { get; set; }
-
         private bool HideAdvancedMembers { get; set; }
 
         private bool UsePartialSemantic { get; set; } = false;
@@ -40,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             return options
                 .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, ShowImportCompletionItemsOptionValue)
                 .WithChangedOption(CompletionServiceOptions.IsExpandedCompletion, IsExpandedCompletion)
-                .WithChangedOption(CompletionServiceOptions.DisallowAddingImports, DisallowAddingImports)
                 .WithChangedOption(CompletionOptions.HideAdvancedMembers, LanguageNames.CSharp, HideAdvancedMembers)
                 .WithChangedOption(CompletionServiceOptions.UsePartialSemanticForImportCompletion, UsePartialSemantic);
         }
@@ -926,41 +923,6 @@ namespace Baz
     class Bat
     {
         Bar$$
-    }
-}";
-            var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
-            await VerifyCustomCommitProviderAsync(markup, "Bar", expectedCodeAfterCommit, sourceCodeKind: kind);
-        }
-
-        [InlineData(SourceCodeKind.Regular)]
-        [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task Commit_NoImport_InProject_DisallowAddingImports(SourceCodeKind kind)
-        {
-            DisallowAddingImports = true;
-
-            var file1 = $@"
-namespace Foo
-{{
-    public class Bar
-    {{
-    }}
-}}";
-
-            var file2 = @"
-namespace Baz
-{
-    class Bat
-    {
-        $$
-    }
-}";
-            var expectedCodeAfterCommit = @"
-namespace Baz
-{
-    class Bat
-    {
-        Foo.Bar$$
     }
 }";
             var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -195,8 +195,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.None);
             }
 
-            var disallowAddingImports = session.Properties.ContainsProperty(CompletionSource.DisallowAddingImports);
-
             CompletionChange change;
 
             // We met an issue when external code threw an OperationCanceledException and the cancellationToken is not cancelled.
@@ -204,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // See https://github.com/dotnet/roslyn/issues/38455.
             try
             {
-                change = completionService.GetChangeAsync(document, roslynItem, completionListSpan, commitCharacter, disallowAddingImports, cancellationToken).WaitAndGetResult(cancellationToken);
+                change = completionService.GetChangeAsync(document, roslynItem, completionListSpan, commitCharacter, cancellationToken).WaitAndGetResult(cancellationToken);
             }
             catch (OperationCanceledException e) when (e.CancellationToken != cancellationToken && FatalError.ReportAndCatch(e))
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -202,7 +202,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // See https://github.com/dotnet/roslyn/issues/38455.
             try
             {
-                change = completionService.GetChangeAsync(document, roslynItem, completionListSpan, commitCharacter, cancellationToken).WaitAndGetResult(cancellationToken);
+                // Cached items have a span computed at the point they were created.  This span may no 
+                // longer be valid when used again.  In that case, override the span with the latest span
+                // for the completion list itself.
+                if (roslynItem.Flags.IsCached())
+                    roslynItem.Span = completionListSpan;
+
+                change = completionService.GetChangeAsync(document, roslynItem, commitCharacter, cancellationToken).WaitAndGetResult(cancellationToken);
             }
             catch (OperationCanceledException e) when (e.CancellationToken != cancellationToken && FatalError.ReportAndCatch(e))
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         internal const string RoslynItem = nameof(RoslynItem);
         internal const string TriggerLocation = nameof(TriggerLocation);
         internal const string CompletionListSpan = nameof(CompletionListSpan);
-        internal const string DisallowAddingImports = nameof(DisallowAddingImports);
         internal const string InsertionText = nameof(InsertionText);
         internal const string HasSuggestionItemOptions = nameof(HasSuggestionItemOptions);
         internal const string Description = nameof(Description);
@@ -272,8 +271,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             {
                 options = options
                     .WithChangedOption(CompletionControllerOptions.FilterOutOfScopeLocals, false)
-                    .WithChangedOption(CompletionControllerOptions.ShowXmlDocCommentCompletion, false)
-                    .WithChangedOption(CompletionServiceOptions.DisallowAddingImports, true);
+                    .WithChangedOption(CompletionControllerOptions.ShowXmlDocCommentCompletion, false);
             }
 
             var (completionList, expandItemsAvailable) = await completionService.GetCompletionsInternalAsync(
@@ -317,11 +315,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // to pass this value in when we're committing a completion list item.
                 // It's OK to overwrite this value when expanded items are requested.
                 session.Properties[CompletionListSpan] = completionList.Span;
-
-                if (_isDebuggerTextView)
-                {
-                    session.Properties[DisallowAddingImports] = true;
-                }
 
                 // This is a code supporting original completion scenarios: 
                 // Controller.Session_ComputeModel: if completionList.SuggestionModeItem != null, then suggestionMode = true

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             }
             else
             {
-                await VerifyCustomCommitWorkerAsync(service, document, firstItem, completionList.Span, codeBeforeCommit, expectedCodeAfterCommit, commitChar);
+                await VerifyCustomCommitWorkerAsync(service, document, firstItem, codeBeforeCommit, expectedCodeAfterCommit, commitChar);
             }
         }
 
@@ -527,7 +527,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             CompletionServiceWithProviders service,
             Document document,
             RoslynCompletion.CompletionItem completionItem,
-            TextSpan completionListSpan,
             string codeBeforeCommit,
             string expectedCodeAfterCommit,
             char? commitChar = null)
@@ -549,7 +548,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
             var options = await document.GetOptionsAsync().ConfigureAwait(false);
 
-            var commit = await service.GetChangeAsync(document, completionItem, completionListSpan, commitChar, CancellationToken.None);
+            var commit = await service.GetChangeAsync(document, completionItem, commitChar, CancellationToken.None);
 
             var text = await document.GetTextAsync();
             var newText = text.WithChanges(commit.TextChange);
@@ -636,7 +635,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             if (commitChar == '\t' ||
                 CommitManager.IsCommitCharacter(service.GetRules(), firstItem, commitChar))
             {
-                var textChange = (await service.GetChangeAsync(document, firstItem, completionList.Span, commitChar, CancellationToken.None)).TextChange;
+                var textChange = (await service.GetChangeAsync(document, firstItem, commitChar, CancellationToken.None)).TextChange;
 
                 // Adjust TextChange to include commit character, so long as it isn't TAB.
                 if (commitChar != '\t')

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -548,9 +548,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             var textView = workspaceFixture.Target.CurrentDocument.GetTextView();
 
             var options = await document.GetOptionsAsync().ConfigureAwait(false);
-            var disallowAddingImports = options.GetOption(CompletionServiceOptions.DisallowAddingImports);
 
-            var commit = await service.GetChangeAsync(document, completionItem, completionListSpan, commitChar, disallowAddingImports, CancellationToken.None);
+            var commit = await service.GetChangeAsync(document, completionItem, completionListSpan, commitChar, CancellationToken.None);
 
             var text = await document.GetTextAsync();
             var newText = text.WithChanges(commit.TextChange);
@@ -637,7 +636,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             if (commitChar == '\t' ||
                 CommitManager.IsCommitCharacter(service.GetRules(), firstItem, commitChar))
             {
-                var textChange = (await service.GetChangeAsync(document, firstItem, completionList.Span, commitChar, disallowAddingImports: false, CancellationToken.None)).TextChange;
+                var textChange = (await service.GetChangeAsync(document, firstItem, completionList.Span, commitChar, CancellationToken.None)).TextChange;
 
                 // Adjust TextChange to include commit character, so long as it isn't TAB.
                 if (commitChar != '\t')

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -377,8 +377,7 @@ End Class</a>
                 If useDebuggerOptions Then
                     options = options.
                         WithChangedOption(CompletionControllerOptions.FilterOutOfScopeLocals, False).
-                        WithChangedOption(CompletionControllerOptions.ShowXmlDocCommentCompletion, False).
-                        WithChangedOption(CompletionServiceOptions.DisallowAddingImports, True)
+                        WithChangedOption(CompletionControllerOptions.ShowXmlDocCommentCompletion, False)
                 End If
 
                 Dim document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
@@ -152,7 +152,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         internal override Task<CompletionChange> GetChangeAsync(
             Document document,
             CompletionItem item,
-            TextSpan completionListSpan,
             char? commitKey,
             CancellationToken cancellationToken)
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
         }
 
-        internal override Task<CompletionChange> GetChangeAsync(
+        public override Task<CompletionChange> GetChangeAsync(
             Document document,
             CompletionItem item,
             char? commitKey,

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
@@ -154,7 +154,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             CompletionItem item,
             TextSpan completionListSpan,
             char? commitKey,
-            bool disallowAddingImports,
             CancellationToken cancellationToken)
         {
             var kind = item.Properties[KindName];

--- a/src/Features/Core/Portable/Completion/CompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProvider.cs
@@ -75,9 +75,6 @@ namespace Microsoft.CodeAnalysis.Completion
             return Task.FromResult(CompletionChange.Create(new TextChange(item.Span, item.DisplayText)));
         }
 
-        internal virtual Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, TextSpan completionListSpan, char? commitKey, CancellationToken cancellationToken)
-            => GetChangeAsync(document, item, commitKey, cancellationToken);
-
         /// <summary>
         /// True if the provider produces snippet items.
         /// </summary>

--- a/src/Features/Core/Portable/Completion/CompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return Task.FromResult(CompletionChange.Create(new TextChange(item.Span, item.DisplayText)));
         }
 
-        internal virtual Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, TextSpan completionListSpan, char? commitKey, bool disallowAddingImports, CancellationToken cancellationToken)
+        internal virtual Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, TextSpan completionListSpan, char? commitKey, CancellationToken cancellationToken)
             => GetChangeAsync(document, item, commitKey, cancellationToken);
 
         /// <summary>

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -172,24 +172,6 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         /// <summary>
-        /// Preferred overload of <see cref="GetChangeAsync(Document, CompletionItem, char?,
-        /// CancellationToken)"/>.
-        ///
-        /// This overload is passed the value of <see cref="CompletionContext.CompletionListSpan"/>
-        /// which should be used to determine what span should be updated in the original <paramref
-        /// name="document"/> passed in.
-        /// </summary>
-        internal virtual Task<CompletionChange> GetChangeAsync(
-            Document document,
-            CompletionItem item,
-            TextSpan completionListSpan,
-            char? commitCharacter = null,
-            CancellationToken cancellationToken = default)
-        {
-            return GetChangeAsync(document, item, commitCharacter, cancellationToken);
-        }
-
-        /// <summary>
         /// Given a list of completion items that match the current code typed by the user,
         /// returns the item that is considered the best match, and whether or not that
         /// item should be selected or not.

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -184,7 +184,6 @@ namespace Microsoft.CodeAnalysis.Completion
             CompletionItem item,
             TextSpan completionListSpan,
             char? commitCharacter = null,
-            bool disallowAddingImports = false,
             CancellationToken cancellationToken = default)
         {
             return GetChangeAsync(document, item, commitCharacter, cancellationToken);

--- a/src/Features/Core/Portable/Completion/CompletionServiceOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceOptions.cs
@@ -21,12 +21,6 @@ namespace Microsoft.CodeAnalysis.Completion
             = new(nameof(CompletionServiceOptions), nameof(UsePartialSemanticForImportCompletion), defaultValue: true);
 
         /// <summary>
-        /// Indicates if the completion should be disallowed to add imports.
-        /// </summary>
-        public static readonly Option2<bool> DisallowAddingImports
-            = new(nameof(CompletionServiceOptions), nameof(DisallowAddingImports), defaultValue: false);
-
-        /// <summary>
         /// Timeout value used for time-boxing completion of unimported extension methods.
         /// Value less than 0 means no timebox; value == 0 means immediate timeout (for testing purpose)
         /// </summary>

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -576,19 +576,6 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
-        internal override async Task<CompletionChange> GetChangeAsync(
-            Document document,
-            CompletionItem item,
-            TextSpan completionListSpan,
-            char? commitKey,
-            CancellationToken cancellationToken)
-        {
-            var provider = GetProvider(item);
-            return provider != null
-                ? await provider.GetChangeAsync(document, item, completionListSpan, commitKey, cancellationToken).ConfigureAwait(false)
-                : CompletionChange.Create(new TextChange(completionListSpan, item.DisplayText));
-        }
-
         bool IEqualityComparer<ImmutableHashSet<string>>.Equals(ImmutableHashSet<string> x, ImmutableHashSet<string> y)
         {
             if (x == y)

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -581,12 +581,11 @@ namespace Microsoft.CodeAnalysis.Completion
             CompletionItem item,
             TextSpan completionListSpan,
             char? commitKey,
-            bool disallowAddingImports,
             CancellationToken cancellationToken)
         {
             var provider = GetProvider(item);
             return provider != null
-                ? await provider.GetChangeAsync(document, item, completionListSpan, commitKey, disallowAddingImports, cancellationToken).ConfigureAwait(false)
+                ? await provider.GetChangeAsync(document, item, completionListSpan, commitKey, cancellationToken).ConfigureAwait(false)
                 : CompletionChange.Create(new TextChange(completionListSpan, item.DisplayText));
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected abstract string GenericSuffix { get; }
 
         protected override bool ShouldProvideCompletion(CompletionContext completionContext, SyntaxContext syntaxContext)
-            => syntaxContext.IsRightOfNameSeparator && IsAddingImportsSupported(completionContext.Document, completionContext.Options.GetOption(CompletionServiceOptions.DisallowAddingImports));
+            => syntaxContext.IsRightOfNameSeparator && IsAddingImportsSupported(completionContext.Document);
 
         protected override void LogCommit()
             => CompletionProvidersLogger.LogCommitOfExtensionMethodImportCompletionItem();

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return namespacesInScope;
         }
 
-        internal override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem completionItem, TextSpan completionListSpan, char? commitKey, bool disallowAddingImports, CancellationToken cancellationToken)
+        internal override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem completionItem, TextSpan completionListSpan, char? commitKey, CancellationToken cancellationToken)
         {
             LogCommit();
             var containingNamespace = ImportCompletionItem.GetContainingNamespace(completionItem);
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             async Task<bool> ShouldCompleteWithFullyQualifyTypeName()
             {
-                if (!IsAddingImportsSupported(document, disallowAddingImports))
+                if (!IsAddingImportsSupported(document))
                 {
                     return true;
                 }
@@ -218,13 +218,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 && !IsFinalSemicolonOfUsingOrExtern(node, leftToken);
         }
 
-        protected static bool IsAddingImportsSupported(Document document, bool disallowAddingImports)
+        protected static bool IsAddingImportsSupported(Document document)
         {
-            if (disallowAddingImports)
-            {
-                return false;
-            }
-
             var workspace = document.Project.Solution.Workspace;
 
             // Certain types of workspace don't support document change, e.g. DebuggerIntelliSenseWorkspace

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -107,7 +107,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return namespacesInScope;
         }
 
-        internal override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem completionItem, TextSpan completionListSpan, char? commitKey, CancellationToken cancellationToken)
+        public override async Task<CompletionChange> GetChangeAsync(
+            Document document, CompletionItem completionItem, char? commitKey, CancellationToken cancellationToken)
         {
             LogCommit();
             var containingNamespace = ImportCompletionItem.GetContainingNamespace(completionItem);
@@ -127,13 +128,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             if (await ShouldCompleteWithFullyQualifyTypeName().ConfigureAwait(false))
             {
                 var completionText = $"{containingNamespace}.{insertText}";
-                return CompletionChange.Create(new TextChange(completionListSpan, completionText));
+                return CompletionChange.Create(new TextChange(completionItem.Span, completionText));
             }
 
             // Find context node so we can use it to decide where to insert using/imports.
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-            var addImportContextNode = root.FindToken(completionListSpan.Start, findInsideTrivia: true).Parent;
+            var addImportContextNode = root.FindToken(completionItem.Span.Start, findInsideTrivia: true).Parent;
 
             // Add required using/imports directive.
             var addImportService = document.GetRequiredLanguageService<IAddImportsService>();
@@ -167,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             //       above, we will get a TextChange of "AsnEncodedDat" with 0 length span, instead of a change of 
             //       the full display text with a span of length 1. This will later mess up span-tracking and end up 
             //       with "AsnEncodedDatasd" in the code.
-            builder.Add(new TextChange(completionListSpan, insertText));
+            builder.Add(new TextChange(completionItem.Span, insertText));
 
             // Then get the combined change
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -205,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 //      }
                 //
                 // Here we will always choose to qualify the unimported type, just to be consistent and keeps things simple.
-                return await IsInImportsDirectiveAsync(document, completionListSpan.Start, cancellationToken).ConfigureAwait(false);
+                return await IsInImportsDirectiveAsync(document, completionItem.Span.Start, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
         private static async Task<string> GetInsertionTextAsync(Document document, CompletionItem item, TextSpan completionListSpan, CancellationToken cancellationToken)
         {
             var service = CompletionService.GetService(document);
-            var change = await service.GetChangeAsync(document, item, completionListSpan, commitCharacter: null, cancellationToken).ConfigureAwait(false);
+            var change = await service.GetChangeAsync(document, item, commitCharacter: null, cancellationToken).ConfigureAwait(false);
             var text = change.TextChange.NewText;
             var nonCharIndex = text.IndexOfAny(s_punctuation);
             return nonCharIndex > 0

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
         private static async Task<string> GetInsertionTextAsync(Document document, CompletionItem item, TextSpan completionListSpan, CancellationToken cancellationToken)
         {
             var service = CompletionService.GetService(document);
-            var change = await service.GetChangeAsync(document, item, completionListSpan, commitCharacter: null, disallowAddingImports: false, cancellationToken).ConfigureAwait(false);
+            var change = await service.GetChangeAsync(document, item, completionListSpan, commitCharacter: null, cancellationToken).ConfigureAwait(false);
             var text = change.TextChange.NewText;
             var nonCharIndex = text.IndexOfAny(s_punctuation);
             return nonCharIndex > 0

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -410,8 +410,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var completionOptions = documentOptions
                 .WithChangedOption(CompletionOptions.SnippetsBehavior, SnippetsRule.NeverInclude)
                 .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, false)
-                .WithChangedOption(CompletionServiceOptions.IsExpandedCompletion, false)
-                .WithChangedOption(CompletionServiceOptions.DisallowAddingImports, true);
+                .WithChangedOption(CompletionServiceOptions.IsExpandedCompletion, false);
             return completionOptions;
         }
 

--- a/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
@@ -23,16 +23,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion
             CancellationToken cancellationToken = default)
             => completionService.GetCompletionsInternalAsync(document, caretPosition, trigger, roles, options, cancellationToken);
 
-        public static Task<CompletionChange> GetChangeAsync(
-            this CompletionService completionService,
-            Document document,
-            CompletionItem item,
-            TextSpan completionListSpan,
-            char? commitCharacter = null,
-            bool disallowAddingImports = false,
-            CancellationToken cancellationToken = default)
-            => completionService.GetChangeAsync(document, item, commitCharacter, cancellationToken);
-
         public static string GetProviderName(this CompletionItem completionItem) => completionItem.ProviderName;
 
         public static PerLanguageOption<bool?> ShowItemsFromUnimportedNamespaces = (PerLanguageOption<bool?>)CompletionOptions.ShowItemsFromUnimportedNamespaces;

--- a/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion
             char? commitCharacter = null,
             bool disallowAddingImports = false,
             CancellationToken cancellationToken = default)
-            => completionService.GetChangeAsync(document, item, completionListSpan, commitCharacter, disallowAddingImports, cancellationToken);
+            => completionService.GetChangeAsync(document, item, commitCharacter, cancellationToken);
 
         public static string GetProviderName(this CompletionItem completionItem) => completionItem.ProviderName;
 


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/53259