### PR TITLE
  Move from calling Create to calling a specific constructor

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2695,7 +2695,7 @@ moreArguments:
 
                 case BoundKind.ImplicitReceiver:
                 case BoundKind.ObjectOrCollectionValuePlaceholder:
-                case BoundKind.InterpolatedStringBuilderPlaceholder: // PROTOTYPE(interp-string): we likely need to update this when custom builder types are supported
+                case BoundKind.InterpolatedStringHandlerPlaceholder: // PROTOTYPE(interp-string): we likely need to update this when custom builder types are supported
                     // binder uses this as a placeholder when binding members inside an object initializer
                     // just say it does not escape anywhere, so that we do not get false errors.
                     return scopeOfTheContainingExpression;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -167,13 +167,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Generates a new <see cref="BoundBadExpression"/> with no known type, given lookupResultKind and given symbols for GetSemanticInfo API,
         /// and the given bound children.
         /// </summary>
-        private BoundBadExpression BadExpression(SyntaxNode syntax, LookupResultKind resultKind, ImmutableArray<Symbol> symbols, ImmutableArray<BoundExpression> childNodes)
+        private BoundBadExpression BadExpression(SyntaxNode syntax, LookupResultKind resultKind, ImmutableArray<Symbol> symbols, ImmutableArray<BoundExpression> childNodes, bool wasCompilerGenerated = false)
         {
             return new BoundBadExpression(syntax,
                 resultKind,
                 symbols,
                 childNodes.SelectAsArray((e, self) => self.BindToTypeForErrorRecovery(e), this),
-                CreateErrorType());
+                CreateErrorType())
+            { WasCompilerGenerated = wasCompilerGenerated };
         }
 
         /// <summary>
@@ -4401,6 +4402,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+#nullable enable
+        /// <summary>
+        /// Helper method to create a synthesized constructor invocation.
+        /// </summary>
+        private BoundExpression MakeClassCreationExpression(
+            NamedTypeSymbol type,
+            ImmutableArray<BoundExpression> arguments,
+            SyntaxNode node,
+            BindingDiagnosticBag diagnostics)
+        {
+            Debug.Assert(type.TypeKind is TypeKind.Class or TypeKind.Struct);
+            var analyzedArguments = AnalyzedArguments.GetInstance();
+
+            try
+            {
+                analyzedArguments.Arguments.AddRange(arguments);
+
+                if (type.IsStatic)
+                {
+                    diagnostics.Add(ErrorCode.ERR_InstantiatingStaticClass, node.Location, type);
+                    return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, initializerOpt: null, typeSyntax: null, diagnostics, wasCompilerGenerated: true);
+                }
+
+                var creation = BindClassCreationExpression(node, type.Name, node, type, analyzedArguments, diagnostics);
+                creation.WasCompilerGenerated = true;
+                return creation;
+            }
+            finally
+            {
+                analyzedArguments.Free();
+            }
+        }
+
         internal BoundExpression BindObjectCreationForErrorRecovery(BoundUnconvertedObjectCreationExpression node, BindingDiagnosticBag diagnostics)
         {
             var arguments = AnalyzedArguments.GetInstance(node.Arguments, node.ArgumentRefKindsOpt, node.ArgumentNamesOpt);
@@ -4409,17 +4443,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private BoundExpression MakeBadExpressionForObjectCreation(ObjectCreationExpressionSyntax node, TypeSymbol type, AnalyzedArguments analyzedArguments, BindingDiagnosticBag diagnostics)
+        private BoundExpression MakeBadExpressionForObjectCreation(ObjectCreationExpressionSyntax node, TypeSymbol type, AnalyzedArguments analyzedArguments, BindingDiagnosticBag diagnostics, bool wasCompilerGenerated = false)
         {
-            return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, node.Initializer, node.Type, diagnostics);
+            return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, node.Initializer, node.Type, diagnostics, wasCompilerGenerated);
         }
 
-        private BoundExpression MakeBadExpressionForObjectCreation(SyntaxNode node, TypeSymbol type, AnalyzedArguments analyzedArguments, InitializerExpressionSyntax initializerOpt, SyntaxNode typeSyntax, BindingDiagnosticBag diagnostics)
+        /// <param name="typeSyntax">If <paramref name="initializerOpt"/> is not null, this should not be null.</param>
+        private BoundExpression MakeBadExpressionForObjectCreation(SyntaxNode node, TypeSymbol type, AnalyzedArguments analyzedArguments, InitializerExpressionSyntax? initializerOpt, SyntaxNode? typeSyntax, BindingDiagnosticBag diagnostics, bool wasCompilerGenerated = false)
         {
             var children = ArrayBuilder<BoundExpression>.GetInstance();
             children.AddRange(BuildArgumentsForErrorRecovery(analyzedArguments));
             if (initializerOpt != null)
             {
+                Debug.Assert(typeSyntax is not null);
                 var boundInitializer = BindInitializerExpression(syntax: initializerOpt,
                                                                  type: type,
                                                                  typeSyntax: typeSyntax,
@@ -4428,8 +4464,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 children.Add(boundInitializer);
             }
 
-            return new BoundBadExpression(node, LookupResultKind.NotCreatable, ImmutableArray.Create<Symbol>(type), children.ToImmutableAndFree(), type);
+            return new BoundBadExpression(node, LookupResultKind.NotCreatable, ImmutableArray.Create<Symbol?>(type), children.ToImmutableAndFree(), type) { WasCompilerGenerated = wasCompilerGenerated };
         }
+#nullable disable
 
         private BoundObjectInitializerExpressionBase BindInitializerExpression(
             InitializerExpressionSyntax syntax,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     format = new BoundLiteral(interpolation.FormatClause, ConstantValue.Create(text), stringType, hasErrors);
                                 }
 
-                                builder.Add(new BoundStringInsert(interpolation, value, alignment, format, isInterpolatedStringBuilderAppendCall: false));
+                                builder.Add(new BoundStringInsert(interpolation, value, alignment, format, isInterpolatedStringHandlerAppendCall: false));
                                 if (!isResultConstant ||
                                     value.ConstantValue == null ||
                                     !(interpolation is { FormatClause: null, AlignmentClause: null }) ||
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // We have 4 possible lowering strategies, dependent on the contents of the string, in this order:
             //  1. The string is a constant value. We can just use the final value.
-            //  2. The WellKnownType InterpolatedStringBuilder is available, and none of the interpolation holes contain an await expression.
+            //  2. The WellKnownType DefaultInterpolatedStringHandler is available, and none of the interpolation holes contain an await expression.
             //     The builder is a ref struct, and we can guarantee the lifetime won't outlive the stack if the string doesn't contain any
             //     awaits, but if it does we cannot use it. This builder is the only way that ref structs can be directly used as interpolation
             //     hole components, which means that ref structs components and await expressions cannot be combined. It is already illegal for
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //  3. The string is composed entirely of components that are strings themselves. We can turn this into a single call to string.Concat.
             //     We prefer the builder over this because the builder can use pooling to avoid new allocations, while this call will potentially
             //     need to allocate a param array.
-            //  4. The string has heterogeneous data and either InterpolatedStringBuilder is unavailable, or one of the holes contains an await
+            //  4. The string has heterogeneous data and either InterpolatedStringHandler is unavailable, or one of the holes contains an await
             //     expression. This is turned into a call to string.Format.
             //
             // We need to do the determination of 1, 2, or 3/4 up front, rather than in lowering, as it affects diagnostics (ref structs not being
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // object.
             return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
 
-            BoundInterpolatedString constructWithData(ImmutableArray<BoundExpression> parts, InterpolatedStringBuilderData? data)
+            BoundInterpolatedString constructWithData(ImmutableArray<BoundExpression> parts, InterpolatedStringHandlerData? data)
                 => new BoundInterpolatedString(
                     unconvertedInterpolatedString.Syntax,
                     data,
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                var interpolatedStringBuilderType = Compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder);
+                var interpolatedStringBuilderType = Compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler);
                 if (interpolatedStringBuilderType is MissingMetadataTypeSymbol)
                 {
                     return false;
@@ -261,12 +261,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(baseStringLength), intType) { WasCompilerGenerated = true },
                     new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(numFormatHoles), intType) { WasCompilerGenerated = true });
 
-            // PROTOTYPE(interp-string): Support optional out param for whether the builder was created successfully and passing in other required args
+                // PROTOTYPE(interp-string): Support optional out param for whether the builder was created successfully and passing in other required args
                 BoundExpression? createExpression = MakeClassCreationExpression(interpolatedStringBuilderType, arguments, unconvertedInterpolatedString.Syntax, diagnostics);
 
                 result = constructWithData(
                     appendCalls,
-                    new InterpolatedStringBuilderData(
+                    new InterpolatedStringHandlerData(
                         interpolatedStringBuilderType,
                         createExpression,
                         usesBoolReturn,
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             partsBuilder.AddRange(unconvertedInterpolatedString.Parts, i);
                         }
 
-                        partsBuilder.Add(insert.Update(newValue, insert.Alignment, insert.Format, isInterpolatedStringBuilderAppendCall: false));
+                        partsBuilder.Add(insert.Update(newValue, insert.Alignment, insert.Format, isInterpolatedStringHandlerAppendCall: false));
                     }
                     else
                     {
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private (ImmutableArray<BoundExpression> AppendFormatCalls, bool UsesBoolReturn) BindInterpolatedStringAppendCalls(BoundUnconvertedInterpolatedString source, TypeSymbol builderType, BindingDiagnosticBag diagnostics)
         {
-            // PROTOTYPE(interp-string): Update the spec with the rules around InterpolatedStringBuilderAttribute. For now, we assume that any
+            // PROTOTYPE(interp-string): Update the spec with the rules around InterpolatedStringHandlerAttribute. For now, we assume that any
             // type that makes it to this method is actually an interpolated string builder type, and we should fully report any binding errors
             // we encounter while doing this work.
 
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (ImmutableArray<BoundExpression>.Empty, false);
             }
 
-            var implicitBuilderReceiver = new BoundInterpolatedStringBuilderPlaceholder(source.Syntax, builderType) { WasCompilerGenerated = true };
+            var implicitBuilderReceiver = new BoundInterpolatedStringHandlerPlaceholder(source.Syntax, builderType) { WasCompilerGenerated = true };
             bool? builderPatternExpectsBool = null;
             var builderAppendCalls = ArrayBuilder<BoundExpression>.GetInstance(source.Parts.Length);
             var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(3);
@@ -389,8 +389,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     bool methodReturnsBool = returnType.SpecialType == SpecialType.System_Boolean;
                     if (!methodReturnsBool && returnType.SpecialType != SpecialType.System_Void)
                     {
-                        // Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.
-                        diagnostics.Add(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnMalformed, part.Syntax.Location, method);
+                        // Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.
+                        diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnMalformed, part.Syntax.Location, method);
                     }
                     else if (builderPatternExpectsBool == null)
                     {
@@ -398,9 +398,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else if (builderPatternExpectsBool != methodReturnsBool)
                     {
-                        // Interpolated string builder method '{0}' has inconsistent return types. Expected to return '{1}'.
+                        // Interpolated string handler method '{0}' has inconsistent return types. Expected to return '{1}'.
                         var expected = builderPatternExpectsBool == true ? Compilation.GetSpecialType(SpecialType.System_Boolean) : Compilation.GetSpecialType(SpecialType.System_Void);
-                        diagnostics.Add(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnInconsistent, part.Syntax.Location, method, expected);
+                        diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnInconsistent, part.Syntax.Location, method, expected);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     msgId.Localize(),
                     MessageID.IDS_SK_METHOD.Localize());
 
-                return BadExpression(node, LookupResultKind.Empty, ImmutableArray.Create(symbol), args.Add(receiver));
+                return BadExpression(node, LookupResultKind.Empty, ImmutableArray.Create(symbol), args.Add(receiver), wasCompilerGenerated: true);
             }
 
             boundExpression = CheckValue(boundExpression, BindValueKind.RValueOrMethodGroup, diagnostics);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -34,7 +34,7 @@
   <ValueType Name="NullableAnnotation"/>
   <ValueType Name="ErrorCode"/>
   <ValueType Name="ImmutableBindingDiagnostic"/>
-  <ValueType Name="InterpolatedStringBuilderData"/>
+  <ValueType Name="InterpolatedStringHandlerData"/>
 
   <AbstractNode Name="BoundInitializer" Base="BoundNode"/>
 
@@ -2015,17 +2015,17 @@
   </Node>
 
   <Node Name="BoundInterpolatedString" Base="BoundInterpolatedStringBase">
-    <Field Name="InterpolationData" Type="InterpolatedStringBuilderData?"/>
+    <Field Name="InterpolationData" Type="InterpolatedStringHandlerData?"/>
   </Node>
 
-  <Node Name="BoundInterpolatedStringBuilderPlaceholder" Base="BoundValuePlaceholderBase"/>
+  <Node Name="BoundInterpolatedStringHandlerPlaceholder" Base="BoundValuePlaceholderBase"/>
 
   <Node Name="BoundStringInsert" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol?" Override="true" Null="always"/>
     <Field Name="Value" Type="BoundExpression" Null="disallow"/>
     <Field Name="Alignment" Type="BoundExpression?"/>
     <Field Name="Format" Type="BoundLiteral?"/>
-    <Field Name="IsInterpolatedStringBuilderAppendCall" Type="bool"/>
+    <Field Name="IsInterpolatedStringHandlerAppendCall" Type="bool"/>
   </Node>
   
     <!-- An 'is pattern'. The fields DecisionDag, WhenTrueLabel, and WhenFalseLabel represent the inner pattern

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringBuilderData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringBuilderData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -9,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal readonly struct InterpolatedStringBuilderData
     {
         public readonly TypeSymbol BuilderType;
-        public readonly BoundCall? Construction;
+        public readonly BoundExpression? Construction;
         public readonly bool UsesBoolReturns;
         /// <summary>
         /// The scope of the expression that contained the interpolated string during initial binding. This is used to determine the SafeToEscape rules
@@ -17,8 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public readonly uint ScopeOfContainingExpression;
 
-        public InterpolatedStringBuilderData(TypeSymbol builderType, BoundCall? construction, bool usesBoolReturns, uint scopeOfContainingExpression)
+        public InterpolatedStringBuilderData(TypeSymbol builderType, BoundExpression? construction, bool usesBoolReturns, uint scopeOfContainingExpression)
         {
+            Debug.Assert(construction is BoundObjectCreationExpression or BoundDynamicObjectCreationExpression or BoundBadExpression);
             BuilderType = builderType;
             Construction = construction;
             UsesBoolReturns = usesBoolReturns;

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal readonly struct InterpolatedStringBuilderData
+    internal readonly struct InterpolatedStringHandlerData
     {
         public readonly TypeSymbol BuilderType;
         public readonly BoundExpression? Construction;
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public readonly uint ScopeOfContainingExpression;
 
-        public InterpolatedStringBuilderData(TypeSymbol builderType, BoundExpression? construction, bool usesBoolReturns, uint scopeOfContainingExpression)
+        public InterpolatedStringHandlerData(TypeSymbol builderType, BoundExpression? construction, bool usesBoolReturns, uint scopeOfContainingExpression)
         {
             Debug.Assert(construction is BoundObjectCreationExpression or BoundDynamicObjectCreationExpression or BoundBadExpression);
             BuilderType = builderType;

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6610,16 +6610,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The positional member '{0}' found corresponding to this parameter is hidden.</value>
   </data>
   <data name="IDS_FeatureImprovedInterpolatedStrings" xml:space="preserve">
-    <value>interpolated string builders</value>
+    <value>interpolated string handlers</value>
   </data>
-  <data name="ERR_InterpolatedStringBuilderMethodReturnMalformed" xml:space="preserve">
-    <value>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</value>
+  <data name="ERR_InterpolatedStringHandlerMethodReturnMalformed" xml:space="preserve">
+    <value>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</value>
     <comment>void and bool are keywords</comment>
   </data>
-  <data name="ERR_InterpolatedStringBuilderMethodReturnInconsistent" xml:space="preserve">
-    <value>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</value>
+  <data name="ERR_InterpolatedStringHandlerMethodReturnInconsistent" xml:space="preserve">
+    <value>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</value>
   </data>
-  <data name="ERR_InterpolatedStringBuilderInvalidCreateMethod" xml:space="preserve">
-    <value>Interpolated string builder type '{0}' does not have a valid 'Create' method.</value>
+  <data name="ERR_InterpolatedStringHandlerInvalidCreateMethod" xml:space="preserve">
+    <value>Interpolated string handler type '{0}' does not have a valid 'Create' method.</value>
   </data> 
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1937,9 +1937,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InheritingFromRecordWithSealedToString = 8912,
         ERR_HiddenPositionalMember = 8913,
 
-        ERR_InterpolatedStringBuilderMethodReturnMalformed = 9001,
-        ERR_InterpolatedStringBuilderMethodReturnInconsistent = 9002,
-        ERR_InterpolatedStringBuilderInvalidCreateMethod = 9003,
+        ERR_InterpolatedStringHandlerMethodReturnMalformed = 9001,
+        ERR_InterpolatedStringHandlerMethodReturnInconsistent = 9002,
+        ERR_InterpolatedStringHandlerInvalidCreateMethod = 9003,
 
         #endregion diagnostics introduced for C# 10.0
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node)
+        public override BoundNode VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node)
         {
             // PROTOTYPE(interp-string): handle if necessary
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9517,7 +9517,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        public override BoundNode? VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node)
+        public override BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node)
         {
             // PROTOTYPE(interp-string): handle if necessary
             SetNotNullResult(node);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         NameOfOperator,
         UnconvertedInterpolatedString,
         InterpolatedString,
-        InterpolatedStringBuilderPlaceholder,
+        InterpolatedStringHandlerPlaceholder,
         StringInsert,
         IsPatternExpression,
         ConstantPattern,
@@ -7211,7 +7211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundInterpolatedString : BoundInterpolatedStringBase
     {
-        public BoundInterpolatedString(SyntaxNode syntax, InterpolatedStringBuilderData? interpolationData, ImmutableArray<BoundExpression> parts, ConstantValue? constantValueOpt, TypeSymbol? type, bool hasErrors = false)
+        public BoundInterpolatedString(SyntaxNode syntax, InterpolatedStringHandlerData? interpolationData, ImmutableArray<BoundExpression> parts, ConstantValue? constantValueOpt, TypeSymbol? type, bool hasErrors = false)
             : base(BoundKind.InterpolatedString, syntax, parts, constantValueOpt, type, hasErrors || parts.HasErrors())
         {
 
@@ -7221,11 +7221,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 
-        public InterpolatedStringBuilderData? InterpolationData { get; }
+        public InterpolatedStringHandlerData? InterpolationData { get; }
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitInterpolatedString(this);
 
-        public BoundInterpolatedString Update(InterpolatedStringBuilderData? interpolationData, ImmutableArray<BoundExpression> parts, ConstantValue? constantValueOpt, TypeSymbol? type)
+        public BoundInterpolatedString Update(InterpolatedStringHandlerData? interpolationData, ImmutableArray<BoundExpression> parts, ConstantValue? constantValueOpt, TypeSymbol? type)
         {
             if (interpolationData.Equals(this.InterpolationData) || parts != this.Parts || constantValueOpt != this.ConstantValueOpt || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
@@ -7237,26 +7237,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundInterpolatedStringBuilderPlaceholder : BoundValuePlaceholderBase
+    internal sealed partial class BoundInterpolatedStringHandlerPlaceholder : BoundValuePlaceholderBase
     {
-        public BoundInterpolatedStringBuilderPlaceholder(SyntaxNode syntax, TypeSymbol? type, bool hasErrors)
-            : base(BoundKind.InterpolatedStringBuilderPlaceholder, syntax, type, hasErrors)
+        public BoundInterpolatedStringHandlerPlaceholder(SyntaxNode syntax, TypeSymbol? type, bool hasErrors)
+            : base(BoundKind.InterpolatedStringHandlerPlaceholder, syntax, type, hasErrors)
         {
         }
 
-        public BoundInterpolatedStringBuilderPlaceholder(SyntaxNode syntax, TypeSymbol? type)
-            : base(BoundKind.InterpolatedStringBuilderPlaceholder, syntax, type)
+        public BoundInterpolatedStringHandlerPlaceholder(SyntaxNode syntax, TypeSymbol? type)
+            : base(BoundKind.InterpolatedStringHandlerPlaceholder, syntax, type)
         {
         }
 
         [DebuggerStepThrough]
-        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitInterpolatedStringBuilderPlaceholder(this);
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitInterpolatedStringHandlerPlaceholder(this);
 
-        public BoundInterpolatedStringBuilderPlaceholder Update(TypeSymbol? type)
+        public BoundInterpolatedStringHandlerPlaceholder Update(TypeSymbol? type)
         {
             if (!TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundInterpolatedStringBuilderPlaceholder(this.Syntax, type, this.HasErrors);
+                var result = new BoundInterpolatedStringHandlerPlaceholder(this.Syntax, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -7266,7 +7266,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundStringInsert : BoundExpression
     {
-        public BoundStringInsert(SyntaxNode syntax, BoundExpression value, BoundExpression? alignment, BoundLiteral? format, bool isInterpolatedStringBuilderAppendCall, bool hasErrors = false)
+        public BoundStringInsert(SyntaxNode syntax, BoundExpression value, BoundExpression? alignment, BoundLiteral? format, bool isInterpolatedStringHandlerAppendCall, bool hasErrors = false)
             : base(BoundKind.StringInsert, syntax, null, hasErrors || value.HasErrors() || alignment.HasErrors() || format.HasErrors())
         {
 
@@ -7275,7 +7275,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Value = value;
             this.Alignment = alignment;
             this.Format = format;
-            this.IsInterpolatedStringBuilderAppendCall = isInterpolatedStringBuilderAppendCall;
+            this.IsInterpolatedStringHandlerAppendCall = isInterpolatedStringHandlerAppendCall;
         }
 
 
@@ -7287,15 +7287,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundLiteral? Format { get; }
 
-        public bool IsInterpolatedStringBuilderAppendCall { get; }
+        public bool IsInterpolatedStringHandlerAppendCall { get; }
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitStringInsert(this);
 
-        public BoundStringInsert Update(BoundExpression value, BoundExpression? alignment, BoundLiteral? format, bool isInterpolatedStringBuilderAppendCall)
+        public BoundStringInsert Update(BoundExpression value, BoundExpression? alignment, BoundLiteral? format, bool isInterpolatedStringHandlerAppendCall)
         {
-            if (value != this.Value || alignment != this.Alignment || format != this.Format || isInterpolatedStringBuilderAppendCall != this.IsInterpolatedStringBuilderAppendCall)
+            if (value != this.Value || alignment != this.Alignment || format != this.Format || isInterpolatedStringHandlerAppendCall != this.IsInterpolatedStringHandlerAppendCall)
             {
-                var result = new BoundStringInsert(this.Syntax, value, alignment, format, isInterpolatedStringBuilderAppendCall, this.HasErrors);
+                var result = new BoundStringInsert(this.Syntax, value, alignment, format, isInterpolatedStringHandlerAppendCall, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -8400,8 +8400,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitUnconvertedInterpolatedString((BoundUnconvertedInterpolatedString)node, arg);
                 case BoundKind.InterpolatedString:
                     return VisitInterpolatedString((BoundInterpolatedString)node, arg);
-                case BoundKind.InterpolatedStringBuilderPlaceholder:
-                    return VisitInterpolatedStringBuilderPlaceholder((BoundInterpolatedStringBuilderPlaceholder)node, arg);
+                case BoundKind.InterpolatedStringHandlerPlaceholder:
+                    return VisitInterpolatedStringHandlerPlaceholder((BoundInterpolatedStringHandlerPlaceholder)node, arg);
                 case BoundKind.StringInsert:
                     return VisitStringInsert((BoundStringInsert)node, arg);
                 case BoundKind.IsPatternExpression:
@@ -8633,7 +8633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitNameOfOperator(BoundNameOfOperator node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitUnconvertedInterpolatedString(BoundUnconvertedInterpolatedString node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitInterpolatedString(BoundInterpolatedString node, A arg) => this.DefaultVisit(node, arg);
-        public virtual R VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitStringInsert(BoundStringInsert node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitIsPatternExpression(BoundIsPatternExpression node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitConstantPattern(BoundConstantPattern node, A arg) => this.DefaultVisit(node, arg);
@@ -8840,7 +8840,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitNameOfOperator(BoundNameOfOperator node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitUnconvertedInterpolatedString(BoundUnconvertedInterpolatedString node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitInterpolatedString(BoundInterpolatedString node) => this.DefaultVisit(node);
-        public virtual BoundNode? VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitStringInsert(BoundStringInsert node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitIsPatternExpression(BoundIsPatternExpression node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitConstantPattern(BoundConstantPattern node) => this.DefaultVisit(node);
@@ -9680,7 +9680,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.VisitList(node.Parts);
             return null;
         }
-        public override BoundNode? VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node) => null;
+        public override BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node) => null;
         public override BoundNode? VisitStringInsert(BoundStringInsert node)
         {
             this.Visit(node.Value);
@@ -10845,7 +10845,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(node.InterpolationData, parts, node.ConstantValueOpt, type);
         }
-        public override BoundNode? VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node)
+        public override BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(type);
@@ -10856,7 +10856,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? alignment = (BoundExpression?)this.Visit(node.Alignment);
             BoundLiteral? format = (BoundLiteral?)this.Visit(node.Format);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(value, alignment, format, node.IsInterpolatedStringBuilderAppendCall);
+            return node.Update(value, alignment, format, node.IsInterpolatedStringHandlerAppendCall);
         }
         public override BoundNode? VisitIsPatternExpression(BoundIsPatternExpression node)
         {
@@ -13129,14 +13129,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return updatedNode;
         }
 
-        public override BoundNode? VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node)
+        public override BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node)
         {
             if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
                 return node;
             }
 
-            BoundInterpolatedStringBuilderPlaceholder updatedNode = node.Update(infoAndType.Type);
+            BoundInterpolatedStringHandlerPlaceholder updatedNode = node.Update(infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -13150,12 +13150,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(value, alignment, format, node.IsInterpolatedStringBuilderAppendCall);
+                updatedNode = node.Update(value, alignment, format, node.IsInterpolatedStringHandlerAppendCall);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(value, alignment, format, node.IsInterpolatedStringBuilderAppendCall);
+                updatedNode = node.Update(value, alignment, format, node.IsInterpolatedStringHandlerAppendCall);
             }
             return updatedNode;
         }
@@ -15060,7 +15060,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
-        public override TreeDumperNode VisitInterpolatedStringBuilderPlaceholder(BoundInterpolatedStringBuilderPlaceholder node, object? arg) => new TreeDumperNode("interpolatedStringBuilderPlaceholder", null, new TreeDumperNode[]
+        public override TreeDumperNode VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node, object? arg) => new TreeDumperNode("interpolatedStringHandlerPlaceholder", null, new TreeDumperNode[]
         {
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
@@ -15072,7 +15072,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("value", null, new TreeDumperNode[] { Visit(node.Value, null) }),
             new TreeDumperNode("alignment", null, new TreeDumperNode[] { Visit(node.Alignment, null) }),
             new TreeDumperNode("format", null, new TreeDumperNode[] { Visit(node.Format, null) }),
-            new TreeDumperNode("isInterpolatedStringBuilderAppendCall", node.IsInterpolatedStringBuilderAppendCall, null),
+            new TreeDumperNode("isInterpolatedStringHandlerAppendCall", node.IsInterpolatedStringHandlerAppendCall, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -42,12 +42,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// local temp.
         /// </summary>
         /// <remarks>Caller is responsible for freeing the ArrayBuilder</remarks>
-        private (ArrayBuilder<BoundExpression> BuilderPatternExpressions, BoundLocal Result) RewriteToInterpolatedStringBuilderPattern(BoundInterpolatedString node)
+        private (ArrayBuilder<BoundExpression> BuilderPatternExpressions, BoundLocal Result) RewriteToInterpolatedStringHandlerPattern(BoundInterpolatedString node)
         {
             Debug.Assert(node.InterpolationData is { Construction: not null });
             Debug.Assert(node.Parts.All(static p => p is BoundCall or BoundStringInsert { Value: BoundCall }));
             var data = node.InterpolationData.Value;
-            var builderTempSymbol = _factory.InterpolatedStringBuilderLocal(data.BuilderType, data.ScopeOfContainingExpression, node.Syntax);
+            var builderTempSymbol = _factory.InterpolatedStringHandlerLocal(data.BuilderType, data.ScopeOfContainingExpression, node.Syntax);
             var builderTemp = _factory.Local(builderTempSymbol);
 
             // PROTOTYPE(interp-string): Support dynamic creation
@@ -177,10 +177,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.InterpolationData is not null)
             {
                 // If we can lower to the builder pattern, do so.
-                (ArrayBuilder<BoundExpression> builderPatternExpressions, BoundLocal builderTemp) = RewriteToInterpolatedStringBuilderPattern(node);
+                (ArrayBuilder<BoundExpression> builderPatternExpressions, BoundLocal builderTemp) = RewriteToInterpolatedStringHandlerPattern(node);
 
                 // resultTemp = builderTemp.ToStringAndClear();
-                var toStringAndClear = (MethodSymbol)Binder.GetWellKnownTypeMember(_compilation, WellKnownMember.System_Runtime_CompilerServices_InterpolatedStringBuilder__ToStringAndClear, _diagnostics, syntax: node.Syntax);
+                var toStringAndClear = (MethodSymbol)Binder.GetWellKnownTypeMember(_compilation, WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear, _diagnostics, syntax: node.Syntax);
                 BoundExpression toStringAndClearCall = toStringAndClear is not null
                     ? BoundCall.Synthesized(node.Syntax, builderTemp, toStringAndClear)
                     : new BoundBadExpression(node.Syntax, LookupResultKind.Empty, symbols: ImmutableArray<Symbol?>.Empty, childBoundNodes: ImmutableArray<BoundExpression>.Empty, node.Type);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -50,9 +50,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             var builderTempSymbol = _factory.InterpolatedStringBuilderLocal(data.BuilderType, data.ScopeOfContainingExpression, node.Syntax);
             var builderTemp = _factory.Local(builderTempSymbol);
 
-            // PROTOTYPE(interp-string): Support optional out param for whether the builder was created successfully and passing in other required args
-            // var builder = Construction(baseStringLength, numFormatHoles);
-            var builderConstruction = _factory.AssignmentExpression(builderTemp, (BoundExpression)VisitCall(data.Construction));
+            // PROTOTYPE(interp-string): Support dynamic creation
+            // var builder = new BuilderType(baseStringLength, numFormatHoles);
+            Debug.Assert(data.Construction is BoundObjectCreationExpression);
+            var builderConstruction = _factory.AssignmentExpression(builderTemp, (BoundExpression)VisitObjectCreationExpression((BoundObjectCreationExpression)data.Construction));
 
             var usesBoolReturn = data.UsesBoolReturns;
             var builderPatternExpressions = ArrayBuilder<BoundExpression>.GetInstance(usesBoolReturn ? 2 : node.Parts.Length);

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 );
         }
 
-        public LocalSymbol InterpolatedStringBuilderLocal(
+        public LocalSymbol InterpolatedStringHandlerLocal(
             TypeSymbol type,
             uint valEscapeScope,
             SyntaxNode syntax
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new SynthesizedLocalWithValEscape(
                 CurrentFunction,
                 TypeWithAnnotations.Create(type),
-                SynthesizedLocalKind.InterpolatedStringBuilder,
+                SynthesizedLocalKind.InterpolatedStringHandler,
                 valEscapeScope,
                 syntax
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Vnitřní chyba v kompilátoru jazyka C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Interner Fehler im C#-Compiler.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Error interno en el compilador de C#.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Erreur interne dans le compilateur C#.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Si è verificato un errore interno nel compilatore C#.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -512,19 +512,19 @@
         <target state="translated">C# コンパイラで内部エラーが発生しました。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -512,19 +512,19 @@
         <target state="translated">C# 컴파일러의 내부 오류입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Błąd wewnętrzny w kompilatorze języka C#.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Erro interno no compilador C#.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -512,19 +512,19 @@
         <target state="translated">Внутренняя ошибка в компиляторе C#.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -512,19 +512,19 @@
         <target state="translated">C# derleyicisinde iç hata oluştu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -512,19 +512,19 @@
         <target state="translated">C# 编译器中出现内部错误。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -512,19 +512,19 @@
         <target state="translated">C# 編譯器中的內部錯誤。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderInvalidCreateMethod">
-        <source>Interpolated string builder type '{0}' does not have a valid 'Create' method.</source>
-        <target state="new">Interpolated string builder type '{0}' does not have a valid 'Create' method.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerInvalidCreateMethod">
+        <source>Interpolated string handler type '{0}' does not have a valid 'Create' method.</source>
+        <target state="new">Interpolated string handler type '{0}' does not have a valid 'Create' method.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnInconsistent">
-        <source>Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
-        <target state="new">Interpolated string builder method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnInconsistent">
+        <source>Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</source>
+        <target state="new">Interpolated string handler method '{0}' has inconsistent return type. Expected to return '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringBuilderMethodReturnMalformed">
-        <source>Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
-        <target state="new">Interpolated string builder method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
+      <trans-unit id="ERR_InterpolatedStringHandlerMethodReturnMalformed">
+        <source>Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</source>
+        <target state="new">Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
@@ -998,8 +998,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureImprovedInterpolatedStrings">
-        <source>interpolated string builders</source>
-        <target state="new">interpolated string builders</target>
+        <source>interpolated string handlers</source>
+        <target state="new">interpolated string handlers</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureSealedToStringInRecord">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -1199,7 +1199,7 @@ static class C
         }
 
         // PROTOTYPE(interp-string): Define how these are represented in IOperation
-        private string GetInterpolatedStringBuilderDefinition(bool includeSpanOverloads, bool useDefaultParameters, bool useBoolReturns, string returnExpression = null)
+        private string GetInterpolatedStringHandlerDefinition(bool includeSpanOverloads, bool useDefaultParameters, bool useBoolReturns, string returnExpression = null)
         {
             Debug.Assert(returnExpression == null || useBoolReturns);
 
@@ -1208,10 +1208,10 @@ static class C
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength, int formattedCount)
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -1318,13 +1318,13 @@ namespace System.Runtime.CompilerServices
 
         [ConditionalTheory(typeof(NoIOperationValidation))]
         [CombinatorialData]
-        public void InterpolatedStringBuilder_OverloadsAndBoolReturns(bool useDefaultParameters, bool useBoolReturns)
+        public void InterpolatedStringHandler_OverloadsAndBoolReturns(bool useDefaultParameters, bool useBoolReturns)
         {
             var source =
 @"int a = 1;
 System.Console.WriteLine($""base{a}{a,1}{a:X}{a,2:Y}"");";
 
-            string interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters, useBoolReturns);
+            string interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters, useBoolReturns);
 
             string expectedOutput = useDefaultParameters ?
 @"base
@@ -1359,34 +1359,34 @@ value:1,alignment:2:format:Y";
   // Code size       80 (0x50)
   .maxstack  4
   .locals init (int V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  ldc.i4.4
   IL_0005:  ldc.i4.4
-  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldstr      ""base""
-  IL_0012:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0012:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0017:  ldloca.s   V_1
   IL_0019:  ldloc.0
-  IL_001a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+  IL_001a:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
   IL_001f:  ldloca.s   V_1
   IL_0021:  ldloc.0
   IL_0022:  ldc.i4.1
-  IL_0023:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int)""
+  IL_0023:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int)""
   IL_0028:  ldloca.s   V_1
   IL_002a:  ldloc.0
   IL_002b:  ldstr      ""X""
-  IL_0030:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, string)""
+  IL_0030:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, string)""
   IL_0035:  ldloca.s   V_1
   IL_0037:  ldloc.0
   IL_0038:  ldc.i4.2
   IL_0039:  ldstr      ""Y""
-  IL_003e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_003e:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_0043:  ldloca.s   V_1
-  IL_0045:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0045:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_004a:  call       ""void System.Console.WriteLine(string)""
   IL_004f:  ret
 }
@@ -1396,38 +1396,38 @@ value:1,alignment:2:format:Y";
   // Code size       84 (0x54)
   .maxstack  4
   .locals init (int V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  ldc.i4.4
   IL_0005:  ldc.i4.4
-  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldstr      ""base""
-  IL_0012:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0012:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0017:  ldloca.s   V_1
   IL_0019:  ldloc.0
   IL_001a:  ldc.i4.0
   IL_001b:  ldnull
-  IL_001c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_001c:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_0021:  ldloca.s   V_1
   IL_0023:  ldloc.0
   IL_0024:  ldc.i4.1
   IL_0025:  ldnull
-  IL_0026:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0026:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_002b:  ldloca.s   V_1
   IL_002d:  ldloc.0
   IL_002e:  ldc.i4.0
   IL_002f:  ldstr      ""X""
-  IL_0034:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0034:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_0039:  ldloca.s   V_1
   IL_003b:  ldloc.0
   IL_003c:  ldc.i4.2
   IL_003d:  ldstr      ""Y""
-  IL_0042:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0042:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_0047:  ldloca.s   V_1
-  IL_0049:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0049:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_004e:  call       ""void System.Console.WriteLine(string)""
   IL_0053:  ret
 }
@@ -1437,41 +1437,41 @@ value:1,alignment:2:format:Y";
   // Code size       92 (0x5c)
   .maxstack  4
   .locals init (int V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  ldc.i4.4
   IL_0005:  ldc.i4.4
-  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldstr      ""base""
-  IL_0012:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0012:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0017:  brfalse.s  IL_004d
   IL_0019:  ldloca.s   V_1
   IL_001b:  ldloc.0
-  IL_001c:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+  IL_001c:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
   IL_0021:  brfalse.s  IL_004d
   IL_0023:  ldloca.s   V_1
   IL_0025:  ldloc.0
   IL_0026:  ldc.i4.1
-  IL_0027:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int)""
+  IL_0027:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int)""
   IL_002c:  brfalse.s  IL_004d
   IL_002e:  ldloca.s   V_1
   IL_0030:  ldloc.0
   IL_0031:  ldstr      ""X""
-  IL_0036:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, string)""
+  IL_0036:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, string)""
   IL_003b:  brfalse.s  IL_004d
   IL_003d:  ldloca.s   V_1
   IL_003f:  ldloc.0
   IL_0040:  ldc.i4.2
   IL_0041:  ldstr      ""Y""
-  IL_0046:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0046:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_004b:  br.s       IL_004e
   IL_004d:  ldc.i4.0
   IL_004e:  pop
   IL_004f:  ldloca.s   V_1
-  IL_0051:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0051:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_0056:  call       ""void System.Console.WriteLine(string)""
   IL_005b:  ret
 }
@@ -1481,45 +1481,45 @@ value:1,alignment:2:format:Y";
   // Code size       96 (0x60)
   .maxstack  4
   .locals init (int V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  ldc.i4.4
   IL_0005:  ldc.i4.4
-  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldstr      ""base""
-  IL_0012:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0012:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0017:  brfalse.s  IL_0051
   IL_0019:  ldloca.s   V_1
   IL_001b:  ldloc.0
   IL_001c:  ldc.i4.0
   IL_001d:  ldnull
-  IL_001e:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_001e:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_0023:  brfalse.s  IL_0051
   IL_0025:  ldloca.s   V_1
   IL_0027:  ldloc.0
   IL_0028:  ldc.i4.1
   IL_0029:  ldnull
-  IL_002a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_002a:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_002f:  brfalse.s  IL_0051
   IL_0031:  ldloca.s   V_1
   IL_0033:  ldloc.0
   IL_0034:  ldc.i4.0
   IL_0035:  ldstr      ""X""
-  IL_003a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_003a:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_003f:  brfalse.s  IL_0051
   IL_0041:  ldloca.s   V_1
   IL_0043:  ldloc.0
   IL_0044:  ldc.i4.2
   IL_0045:  ldstr      ""Y""
-  IL_004a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_004a:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int, int, string)""
   IL_004f:  br.s       IL_0052
   IL_0051:  ldc.i4.0
   IL_0052:  pop
   IL_0053:  ldloca.s   V_1
-  IL_0055:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0055:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_005a:  call       ""void System.Console.WriteLine(string)""
   IL_005f:  ret
 }
@@ -1535,11 +1535,11 @@ using System;
 ReadOnlySpan<char> span = stackalloc char[1];
 Console.WriteLine($""{span}"");";
 
-            var comp = CreateCompilation(new[] { source, GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false) }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation(new[] { source, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false) }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
-                // (4,22): error CS8652: The feature 'interpolated string builders' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (4,22): error CS8652: The feature 'interpolated string handlers' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // Console.WriteLine($"{span}");
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "span").WithArguments("interpolated string builders").WithLocation(4, 22)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "span").WithArguments("interpolated string handlers").WithLocation(4, 22)
                 );
         }
 
@@ -1553,7 +1553,7 @@ using System;
 ReadOnlySpan<char> a = ""1"";
 System.Console.WriteLine($""base{a}{a,1}{a:X}{a,2:Y}"");";
 
-            string interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters, useBoolReturns);
+            string interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: true, useDefaultParameters, useBoolReturns);
 
             string expectedOutput = useDefaultParameters ?
 @"base
@@ -1588,35 +1588,35 @@ value:1,alignment:2:format:Y";
   // Code size       89 (0x59)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldc.i4.4
   IL_000e:  ldc.i4.4
-  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000f:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_0014:  ldloca.s   V_1
   IL_0016:  ldstr      ""base""
-  IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_001b:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0020:  ldloca.s   V_1
   IL_0022:  ldloc.0
-  IL_0023:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+  IL_0023:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
   IL_0028:  ldloca.s   V_1
   IL_002a:  ldloc.0
   IL_002b:  ldc.i4.1
-  IL_002c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int)""
+  IL_002c:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int)""
   IL_0031:  ldloca.s   V_1
   IL_0033:  ldloc.0
   IL_0034:  ldstr      ""X""
-  IL_0039:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, string)""
+  IL_0039:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, string)""
   IL_003e:  ldloca.s   V_1
   IL_0040:  ldloc.0
   IL_0041:  ldc.i4.2
   IL_0042:  ldstr      ""Y""
-  IL_0047:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0047:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_004c:  ldloca.s   V_1
-  IL_004e:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_004e:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_0053:  call       ""void System.Console.WriteLine(string)""
   IL_0058:  ret
 }
@@ -1626,39 +1626,39 @@ value:1,alignment:2:format:Y";
   // Code size       93 (0x5d)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldc.i4.4
   IL_000e:  ldc.i4.4
-  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000f:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_0014:  ldloca.s   V_1
   IL_0016:  ldstr      ""base""
-  IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_001b:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0020:  ldloca.s   V_1
   IL_0022:  ldloc.0
   IL_0023:  ldc.i4.0
   IL_0024:  ldnull
-  IL_0025:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0025:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_002a:  ldloca.s   V_1
   IL_002c:  ldloc.0
   IL_002d:  ldc.i4.1
   IL_002e:  ldnull
-  IL_002f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_002f:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_0034:  ldloca.s   V_1
   IL_0036:  ldloc.0
   IL_0037:  ldc.i4.0
   IL_0038:  ldstr      ""X""
-  IL_003d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_003d:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_0042:  ldloca.s   V_1
   IL_0044:  ldloc.0
   IL_0045:  ldc.i4.2
   IL_0046:  ldstr      ""Y""
-  IL_004b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_004b:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_0050:  ldloca.s   V_1
-  IL_0052:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0052:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_0057:  call       ""void System.Console.WriteLine(string)""
   IL_005c:  ret
 }
@@ -1668,42 +1668,42 @@ value:1,alignment:2:format:Y";
   // Code size      101 (0x65)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldc.i4.4
   IL_000e:  ldc.i4.4
-  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000f:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_0014:  ldloca.s   V_1
   IL_0016:  ldstr      ""base""
-  IL_001b:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_001b:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0020:  brfalse.s  IL_0056
   IL_0022:  ldloca.s   V_1
   IL_0024:  ldloc.0
-  IL_0025:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+  IL_0025:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
   IL_002a:  brfalse.s  IL_0056
   IL_002c:  ldloca.s   V_1
   IL_002e:  ldloc.0
   IL_002f:  ldc.i4.1
-  IL_0030:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int)""
+  IL_0030:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int)""
   IL_0035:  brfalse.s  IL_0056
   IL_0037:  ldloca.s   V_1
   IL_0039:  ldloc.0
   IL_003a:  ldstr      ""X""
-  IL_003f:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, string)""
+  IL_003f:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, string)""
   IL_0044:  brfalse.s  IL_0056
   IL_0046:  ldloca.s   V_1
   IL_0048:  ldloc.0
   IL_0049:  ldc.i4.2
   IL_004a:  ldstr      ""Y""
-  IL_004f:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_004f:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_0054:  br.s       IL_0057
   IL_0056:  ldc.i4.0
   IL_0057:  pop
   IL_0058:  ldloca.s   V_1
-  IL_005a:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_005a:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_005f:  call       ""void System.Console.WriteLine(string)""
   IL_0064:  ret
 }
@@ -1713,46 +1713,46 @@ value:1,alignment:2:format:Y";
   // Code size      105 (0x69)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldc.i4.4
   IL_000e:  ldc.i4.4
-  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000f:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_0014:  ldloca.s   V_1
   IL_0016:  ldstr      ""base""
-  IL_001b:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_001b:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
   IL_0020:  brfalse.s  IL_005a
   IL_0022:  ldloca.s   V_1
   IL_0024:  ldloc.0
   IL_0025:  ldc.i4.0
   IL_0026:  ldnull
-  IL_0027:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0027:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_002c:  brfalse.s  IL_005a
   IL_002e:  ldloca.s   V_1
   IL_0030:  ldloc.0
   IL_0031:  ldc.i4.1
   IL_0032:  ldnull
-  IL_0033:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0033:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_0038:  brfalse.s  IL_005a
   IL_003a:  ldloca.s   V_1
   IL_003c:  ldloc.0
   IL_003d:  ldc.i4.0
   IL_003e:  ldstr      ""X""
-  IL_0043:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0043:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_0048:  brfalse.s  IL_005a
   IL_004a:  ldloca.s   V_1
   IL_004c:  ldloc.0
   IL_004d:  ldc.i4.2
   IL_004e:  ldstr      ""Y""
-  IL_0053:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0053:  call       ""bool System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
   IL_0058:  br.s       IL_005b
   IL_005a:  ldc.i4.0
   IL_005b:  pop
   IL_005c:  ldloca.s   V_1
-  IL_005e:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_005e:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_0063:  call       ""void System.Console.WriteLine(string)""
   IL_0068:  ret
 }
@@ -1770,7 +1770,7 @@ Console.Write($""base{Throw()}{a = 2}"");
 Console.WriteLine(a);
 string Throw() => throw new Exception();";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: true, returnExpression: "false");
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: true, returnExpression: "false");
 
             CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
 base
@@ -1780,7 +1780,7 @@ base
         [ConditionalFact(typeof(NoIOperationValidation))]
         public void AwaitInHoles_UsesFormat()
         {
-            // PROTOTYPE(interp-string): We could make this case use the builder as well by evaluating the holes ahead of time. For InterpolatedStringBuilder,
+            // PROTOTYPE(interp-string): We could make this case use the builder as well by evaluating the holes ahead of time. For DefaultInterpolatedStringHandler,
             // we know that the framework is never going to ship a version that short circuits, so it would be a valid optimization for us to make.
             var source = @"
 using System;
@@ -1789,7 +1789,7 @@ using System.Threading.Tasks;
 Console.WriteLine($""base{await Hole()}"");
 Task<int> Hole() => Task.FromResult(1);";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"base1");
 
@@ -1883,7 +1883,7 @@ var hole = await Hole();
 Console.WriteLine($""base{hole}"");
 Task<int> Hole() => Task.FromResult(1);";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
 base
@@ -1896,7 +1896,7 @@ value:1");
   .locals init (int V_0,
                 int V_1, //hole
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_3,
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_3,
                 System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
@@ -1941,16 +1941,16 @@ value:1");
     IL_0061:  stloc.1
     IL_0062:  ldc.i4.4
     IL_0063:  ldc.i4.1
-    IL_0064:  newobj     ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+    IL_0064:  newobj     ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
     IL_0069:  stloc.3
     IL_006a:  ldloca.s   V_3
     IL_006c:  ldstr      ""base""
-    IL_0071:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+    IL_0071:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
     IL_0076:  ldloca.s   V_3
     IL_0078:  ldloc.1
-    IL_0079:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+    IL_0079:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
     IL_007e:  ldloca.s   V_3
-    IL_0080:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+    IL_0080:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
     IL_0085:  call       ""void System.Console.WriteLine(string)""
     IL_008a:  leave.s    IL_00a5
   }
@@ -1993,7 +1993,7 @@ Task<int> M(int i)
     return Task.FromResult(1);
 }";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
 1
@@ -2008,7 +2008,7 @@ value:2");
   .locals init (int V_0,
                 int V_1,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_3,
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_3,
                 System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
@@ -2062,17 +2062,17 @@ value:2");
     IL_0079:  ldarg.0
     IL_007a:  ldc.i4.4
     IL_007b:  ldc.i4.1
-    IL_007c:  newobj     ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+    IL_007c:  newobj     ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
     IL_0081:  stloc.3
     IL_0082:  ldloca.s   V_3
     IL_0084:  ldstr      ""base""
-    IL_0089:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+    IL_0089:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
     IL_008e:  ldloca.s   V_3
     IL_0090:  ldarg.0
     IL_0091:  ldfld      ""int <Program>$.<<Main>$>d__0.<hole>5__2""
-    IL_0096:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+    IL_0096:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
     IL_009b:  ldloca.s   V_3
-    IL_009d:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+    IL_009d:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
     IL_00a2:  stfld      ""string <Program>$.<<Main>$>d__0.<>7__wrap3""
     IL_00a7:  ldc.i4.3
     IL_00a8:  call       ""System.Threading.Tasks.Task<int> <Program>$.<<Main>$>g__M|0_1(int)""
@@ -2151,7 +2151,7 @@ value:2");
             var interpolatedStringBuilder = @"
 namespace System.Runtime.CompilerServices
 {
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         public override string ToString() => throw null;
         public void Dispose() => throw null;
@@ -2163,9 +2163,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,5): error CS1729: 'InterpolatedStringBuilder' does not contain a constructor that takes 2 arguments
+                // (1,5): error CS1729: 'DefaultInterpolatedStringHandler' does not contain a constructor that takes 2 arguments
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "2").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler", "2").WithLocation(1, 5)
             );
         }
 
@@ -2177,9 +2177,9 @@ namespace System.Runtime.CompilerServices
             var interpolatedStringBuilder = @"
 namespace System.Runtime.CompilerServices
 {
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
-        public InterpolatedStringBuilder(int literalLength) => throw null;
+        public DefaultInterpolatedStringHandler(int literalLength) => throw null;
         public override string ToString() => throw null;
         public void Dispose() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2190,9 +2190,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,5): error CS1729: 'InterpolatedStringBuilder' does not contain a constructor that takes 2 arguments
+                // (1,5): error CS1729: 'DefaultInterpolatedStringHandler' does not contain a constructor that takes 2 arguments
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "2").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler", "2").WithLocation(1, 5)
             );
         }
 
@@ -2204,9 +2204,9 @@ namespace System.Runtime.CompilerServices
             var interpolatedStringBuilder = @"
 namespace System.Runtime.CompilerServices
 {
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
-        public InterpolatedStringBuilder(ref int literalLength, int formattedCount) => throw null;
+        public DefaultInterpolatedStringHandler(ref int literalLength, int formattedCount) => throw null;
         public override string ToString() => throw null;
         public void Dispose() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2236,9 +2236,9 @@ namespace System.Runtime.CompilerServices
             var interpolatedStringBuilder = @"
 namespace System.Runtime.CompilerServices
 {
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
-        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount) => throw null;
         " + toStringAndClearMethod + @"
         public override string ToString() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2250,9 +2250,9 @@ namespace System.Runtime.CompilerServices
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics();
             comp.VerifyEmitDiagnostics(
-                // (1,5): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear'
+                // (1,5): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear'
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "ToStringAndClear").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler", "ToStringAndClear").WithLocation(1, 5)
             );
         }
 
@@ -2264,10 +2264,10 @@ namespace System.Runtime.CompilerServices
             var interpolatedStringBuilder = @"
 namespace System.Runtime.CompilerServices
 {
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         [System.Obsolete(""Constructor is obsolete"", error: true)]
-        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount) => throw null;
         public void Dispose() => throw null;
         public override string ToString() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2278,9 +2278,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,5): error CS0619: 'InterpolatedStringBuilder.InterpolatedStringBuilder(int, int)' is obsolete: 'Constructor is obsolete'
+                // (1,5): error CS0619: 'DefaultInterpolatedStringHandler.DefaultInterpolatedStringHandler(int, int)' is obsolete: 'Constructor is obsolete'
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.InterpolatedStringBuilder(int, int)", "Constructor is obsolete").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.DefaultInterpolatedStringHandler(int, int)", "Constructor is obsolete").WithLocation(1, 5)
             );
         }
 
@@ -2292,9 +2292,9 @@ namespace System.Runtime.CompilerServices
             var interpolatedStringBuilder = @"
 namespace System.Runtime.CompilerServices
 {
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
-        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount) => throw null;
         public void Dispose() => throw null;
         public override string ToString() => throw null;
         [System.Obsolete(""AppendLiteral is obsolete"", error: true)]
@@ -2306,9 +2306,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,7): error CS0619: 'InterpolatedStringBuilder.AppendLiteral(string)' is obsolete: 'AppendLiteral is obsolete'
+                // (1,7): error CS0619: 'DefaultInterpolatedStringHandler.AppendLiteral(string)' is obsolete: 'AppendLiteral is obsolete'
                 // _ = $"base{(object)1}";
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "base").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)", "AppendLiteral is obsolete").WithLocation(1, 7)
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "base").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)", "AppendLiteral is obsolete").WithLocation(1, 7)
             );
         }
 
@@ -2320,9 +2320,9 @@ namespace System.Runtime.CompilerServices
             var interpolatedStringBuilder = @"
 namespace System.Runtime.CompilerServices
 {
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
-        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount) => throw null;
         public void Dispose() => throw null;
         public override string ToString() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2334,9 +2334,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,11): error CS0619: 'InterpolatedStringBuilder.AppendFormatted<T>(T, int, string)' is obsolete: 'AppendFormatted is obsolete'
+                // (1,11): error CS0619: 'DefaultInterpolatedStringHandler.AppendFormatted<T>(T, int, string)' is obsolete: 'AppendFormatted is obsolete'
                 // _ = $"base{(object)1}";
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "{(object)1}").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<T>(T, int, string)", "AppendFormatted is obsolete").WithLocation(1, 11)
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "{(object)1}").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<T>(T, int, string)", "AppendFormatted is obsolete").WithLocation(1, 11)
             );
         }
 
@@ -2364,7 +2364,7 @@ namespace System.Runtime.CompilerServices
             var code = @"_ = $""{(object)1}"";";
 
             var interpolatedStringBuilder = @"
-.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.InterpolatedStringBuilder
+.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.DefaultInterpolatedStringHandler
     extends [mscorlib]System.ValueType
 {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -2434,9 +2434,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilationWithIL(code, ilSource: interpolatedStringBuilder + UnmanagedCallersOnlyIl);
             comp.VerifyDiagnostics(
-                // (1,7): error CS0570: 'InterpolatedStringBuilder.AppendFormatted<T>(T, int, string)' is not supported by the language
+                // (1,7): error CS0570: 'DefaultInterpolatedStringHandler.AppendFormatted<T>(T, int, string)' is not supported by the language
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_BindToBogus, "{(object)1}").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<T>(T, int, string)").WithLocation(1, 7)
+                Diagnostic(ErrorCode.ERR_BindToBogus, "{(object)1}").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<T>(T, int, string)").WithLocation(1, 7)
             );
         }
 
@@ -2447,7 +2447,7 @@ namespace System.Runtime.CompilerServices
 
             var interpolatedStringBuilder = @"
 
-.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.InterpolatedStringBuilder
+.class public sequential ansi sealed beforefieldinit System.Runtime.CompilerServices.DefaultInterpolatedStringHandler
     extends [mscorlib]System.ValueType
 {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -2510,9 +2510,9 @@ namespace System.Runtime.CompilerServices
             var comp = CreateCompilationWithIL(code, ilSource: interpolatedStringBuilder + UnmanagedCallersOnlyIl);
             comp.VerifyDiagnostics();
             comp.VerifyEmitDiagnostics(
-                // (1,5): error CS0570: 'InterpolatedStringBuilder.ToStringAndClear()' is not supported by the language
+                // (1,5): error CS0570: 'DefaultInterpolatedStringHandler.ToStringAndClear()' is not supported by the language
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_BindToBogus, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_BindToBogus, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()").WithLocation(1, 5)
             );
         }
 
@@ -2530,7 +2530,7 @@ ref struct S
 {
 }";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: true, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: true, useDefaultParameters: true, useBoolReturns: false);
 
             var comp = CreateCompilation(new[] { source, interpolatedStringBuilder }, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseExe, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
@@ -2550,7 +2550,7 @@ ref struct S
 bool b = true;
 System.Console.WriteLine($""{b switch { true => 1, false => null }}{(!b ? null : 2)}{default}{null}"");";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
 value:1
@@ -2564,13 +2564,13 @@ value:");
   .maxstack  3
   .locals init (bool V_0, //b
                 object V_1,
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_2)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_2
   IL_0004:  ldc.i4.0
   IL_0005:  ldc.i4.4
-  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_000b:  ldloc.0
   IL_000c:  brfalse.s  IL_0017
   IL_000e:  ldc.i4.1
@@ -2581,7 +2581,7 @@ value:");
   IL_0018:  stloc.1
   IL_0019:  ldloca.s   V_2
   IL_001b:  ldloc.1
-  IL_001c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
+  IL_001c:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(object)""
   IL_0021:  ldloca.s   V_2
   IL_0023:  ldloc.0
   IL_0024:  brfalse.s  IL_002e
@@ -2589,15 +2589,15 @@ value:");
   IL_0027:  box        ""int""
   IL_002c:  br.s       IL_002f
   IL_002e:  ldnull
-  IL_002f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
+  IL_002f:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(object)""
   IL_0034:  ldloca.s   V_2
   IL_0036:  ldnull
-  IL_0037:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
+  IL_0037:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(string)""
   IL_003c:  ldloca.s   V_2
   IL_003e:  ldnull
-  IL_003f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
+  IL_003f:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(string)""
   IL_0044:  ldloca.s   V_2
-  IL_0046:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0046:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_004b:  call       ""void System.Console.WriteLine(string)""
   IL_0050:  ret
 }
@@ -2609,15 +2609,15 @@ value:");
         {
             var source = @"System.Console.WriteLine($""{(null, default)}{new()}"");";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
             var comp = CreateCompilation(new[] { source, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
                 // (1,29): error CS1503: Argument 1: cannot convert from '(<null>, default)' to 'object'
                 // System.Console.WriteLine($"{(null, default)}");
                 Diagnostic(ErrorCode.ERR_BadArgType, "(null, default)").WithArguments("1", "(<null>, default)", "object").WithLocation(1, 29),
-                // (1,29): error CS8652: The feature 'interpolated string builders' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (1,29): error CS8652: The feature 'interpolated string handlers' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // System.Console.WriteLine($"{(null, default)}");
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "(null, default)").WithArguments("interpolated string builders").WithLocation(1, 29),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "(null, default)").WithArguments("interpolated string handlers").WithLocation(1, 29),
                 // (1,46): error CS1729: 'string' does not contain a constructor that takes 0 arguments
                 // System.Console.WriteLine($"{(null, default)}{new()}");
                 // PROTOTYPE(interp-string): This is technically a break. Should we special case this?
@@ -2633,7 +2633,7 @@ bool b = true;
 int i = 1;
 System.Console.WriteLine($""{(!b ? ref i : ref i)}"");";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
 
             CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"value:1");
         }
@@ -2646,7 +2646,7 @@ System.Console.WriteLine($""{(!b ? ref i : ref i)}"");";
 int i = 1;
 System.Console.WriteLine($""{$""{i}""}"");";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"value:value:1");
 
@@ -2655,27 +2655,27 @@ System.Console.WriteLine($""{$""{i}""}"");";
   // Code size       55 (0x37)
   .maxstack  4
   .locals init (int V_0, //i
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1,
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1,
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_2)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  ldc.i4.0
   IL_0005:  ldc.i4.1
-  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_000b:  ldloca.s   V_1
   IL_000d:  ldloca.s   V_2
   IL_000f:  ldc.i4.0
   IL_0010:  ldc.i4.1
-  IL_0011:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0011:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_0016:  ldloca.s   V_2
   IL_0018:  ldloc.0
-  IL_0019:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+  IL_0019:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
   IL_001e:  ldloca.s   V_2
-  IL_0020:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0025:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
+  IL_0020:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
+  IL_0025:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(string)""
   IL_002a:  ldloca.s   V_1
-  IL_002c:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_002c:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_0031:  call       ""void System.Console.WriteLine(string)""
   IL_0036:  ret
 }
@@ -2694,7 +2694,7 @@ try
     Console.WriteLine(""Starting try"");
     throw new MyException { Prop = i };
 }
-// Test InterpolatedStringBuilder renders specially, so we're actually comparing to ""value:Prop"" plus some whitespace
+// Test DefaultInterpolatedStringHandler renders specially, so we're actually comparing to ""value:Prop"" plus some whitespace
 catch (MyException e) when (e.ToString() == $""{i}"".Trim())
 {
     Console.WriteLine(""Caught"");
@@ -2706,7 +2706,7 @@ class MyException : Exception
     public override string ToString() => ""value:"" + Prop.ToString();
 }";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"
 Starting try
@@ -2717,7 +2717,7 @@ Caught");
   // Code size       95 (0x5f)
   .maxstack  4
   .locals init (int V_0, //i
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   .try
@@ -2742,12 +2742,12 @@ Caught");
     IL_002a:  ldloca.s   V_1
     IL_002c:  ldc.i4.0
     IL_002d:  ldc.i4.1
-    IL_002e:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+    IL_002e:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
     IL_0033:  ldloca.s   V_1
     IL_0035:  ldloc.0
-    IL_0036:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+    IL_0036:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
     IL_003b:  ldloca.s   V_1
-    IL_003d:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+    IL_003d:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
     IL_0042:  callvirt   ""string string.Trim()""
     IL_0047:  call       ""bool string.op_Equality(string, string)""
     IL_004c:  ldc.i4.0
@@ -2777,7 +2777,7 @@ try
     Console.WriteLine(""Starting try"");
     throw new MyException { Prop = s.ToString() };
 }
-// Test InterpolatedStringBuilder renders specially, so we're actually comparing to ""value:Prop"" plus some whitespace
+// Test DefaultInterpolatedStringHandler renders specially, so we're actually comparing to ""value:Prop"" plus some whitespace
 catch (MyException e) when (e.ToString() == $""{s}"".Trim())
 {
     Console.WriteLine(""Caught"");
@@ -2789,7 +2789,7 @@ class MyException : Exception
     public override string ToString() => ""value:"" + Prop.ToString();
 }";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp, expectedOutput: @"
 Starting try
@@ -2801,7 +2801,7 @@ Caught");
   // Code size      122 (0x7a)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //s
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  newarr     ""char""
   IL_0006:  dup
@@ -2834,12 +2834,12 @@ Caught");
     IL_0045:  ldloca.s   V_1
     IL_0047:  ldc.i4.0
     IL_0048:  ldc.i4.1
-    IL_0049:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+    IL_0049:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
     IL_004e:  ldloca.s   V_1
     IL_0050:  ldloc.0
-    IL_0051:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+    IL_0051:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
     IL_0056:  ldloca.s   V_1
-    IL_0058:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+    IL_0058:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
     IL_005d:  callvirt   ""string string.Trim()""
     IL_0062:  call       ""bool string.op_Equality(string, string)""
     IL_0067:  ldc.i4.0
@@ -2876,7 +2876,7 @@ class C
     public static implicit operator ReadOnlySpan<char>(C s) => ""C converted"";
 }";
 
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
 
             var comp = CreateCompilation(new[] { source, interpolatedStringBuilder },
                 targetFramework: TargetFramework.NetCoreApp,
@@ -2891,7 +2891,7 @@ value:C");
   .maxstack  3
   .locals init (S V_0, //s
                 C V_1, //c
-                System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  newobj     ""C..ctor()""
@@ -2899,16 +2899,16 @@ value:C");
   IL_000e:  ldloca.s   V_2
   IL_0010:  ldc.i4.0
   IL_0011:  ldc.i4.2
-  IL_0012:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0012:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_0017:  ldloca.s   V_2
   IL_0019:  ldloc.0
   IL_001a:  call       ""System.ReadOnlySpan<char> S.op_Implicit(S)""
-  IL_001f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+  IL_001f:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
   IL_0024:  ldloca.s   V_2
   IL_0026:  ldloc.1
-  IL_0027:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<C>(C)""
+  IL_0027:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<C>(C)""
   IL_002c:  ldloca.s   V_2
-  IL_002e:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_002e:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_0033:  call       ""void System.Console.WriteLine(string)""
   IL_0038:  ret
 }
@@ -2929,7 +2929,7 @@ ref struct S
     public static explicit operator ReadOnlySpan<char>(S s) => ""S converted"";
 }
 ";
-            var interpolatedStringBuilder = GetInterpolatedStringBuilderDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: true, useDefaultParameters: false, useBoolReturns: false);
 
             var comp = CreateCompilation(new[] { source, interpolatedStringBuilder }, targetFramework: TargetFramework.NetCoreApp, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
@@ -2957,10 +2957,10 @@ public struct CustomStruct
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength, int formattedCount)
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -2977,21 +2977,21 @@ value:1");
 {
   // Code size       52 (0x34)
   .maxstack  3
-  .locals init (System.Runtime.CompilerServices.InterpolatedStringBuilder V_0)
+  .locals init (System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_0)
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldc.i4.4
   IL_0003:  ldc.i4.1
-  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0004:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_0009:  ldloca.s   V_0
   IL_000b:  ldstr      ""Text""
   IL_0010:  call       ""CustomStruct CustomStruct.op_Implicit(string)""
-  IL_0015:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(CustomStruct)""
+  IL_0015:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(CustomStruct)""
   IL_001a:  ldloca.s   V_0
   IL_001c:  ldc.i4.1
   IL_001d:  box        ""int""
-  IL_0022:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
+  IL_0022:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(object)""
   IL_0027:  ldloca.s   V_0
-  IL_0029:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0029:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
   IL_002e:  call       ""void System.Console.WriteLine(string)""
   IL_0033:  ret
 }
@@ -3016,10 +3016,10 @@ public struct CustomStruct
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength, int formattedCount)
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3048,10 +3048,10 @@ Console.WriteLine($""Text{1}"");
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength, int formattedCount)
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3063,12 +3063,12 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (4,21): error CS9001: Interpolated string builder method 'InterpolatedStringBuilder.AppendLiteral(string)' is malformed. It does not return 'void' or 'bool'.
+                // (4,21): error CS9001: Interpolated string handler method 'DefaultInterpolatedStringHandler.AppendLiteral(string)' is malformed. It does not return 'void' or 'bool'.
                 // Console.WriteLine($"Text{1}");
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnMalformed, "Text").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)").WithLocation(4, 21),
-                // (4,25): error CS9001: Interpolated string builder method 'InterpolatedStringBuilder.AppendFormatted(object)' is malformed. It does not return 'void' or 'bool'.
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnMalformed, "Text").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)").WithLocation(4, 21),
+                // (4,25): error CS9001: Interpolated string handler method 'DefaultInterpolatedStringHandler.AppendFormatted(object)' is malformed. It does not return 'void' or 'bool'.
                 // Console.WriteLine($"Text{1}");
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnMalformed, "{1}").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)").WithLocation(4, 25)
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnMalformed, "{1}").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(object)").WithLocation(4, 25)
             );
         }
 
@@ -3084,10 +3084,10 @@ Console.WriteLine($""{1}Text"");
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength, int formattedCount)
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3099,12 +3099,12 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (4,25): error CS9002: Interpolated string builder method 'InterpolatedStringBuilder.AppendFormatted(object)' has inconsistent return type. Expected to return 'bool'.
+                // (4,25): error CS9002: Interpolated string handler method 'DefaultInterpolatedStringHandler.AppendFormatted(object)' has inconsistent return type. Expected to return 'bool'.
                 // Console.WriteLine($"Text{1}");
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnInconsistent, "{1}").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)", "bool").WithLocation(4, 25),
-                // (5,24): error CS9002: Interpolated string builder method 'InterpolatedStringBuilder.AppendLiteral(string)' has inconsistent return type. Expected to return 'void'.
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnInconsistent, "{1}").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(object)", "bool").WithLocation(4, 25),
+                // (5,24): error CS9002: Interpolated string handler method 'DefaultInterpolatedStringHandler.AppendLiteral(string)' has inconsistent return type. Expected to return 'void'.
                 // Console.WriteLine($"{1}Text");
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnInconsistent, "Text").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)", "void").WithLocation(5, 24)
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnInconsistent, "Text").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)", "void").WithLocation(5, 24)
             );
         }
 
@@ -3120,10 +3120,10 @@ Console.WriteLine($""{1}Text"");
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength, int formattedCount)
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3135,12 +3135,12 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (4,25): error CS9002: Interpolated string builder method 'InterpolatedStringBuilder.AppendFormatted(object)' has inconsistent return type. Expected to return 'void'.
+                // (4,25): error CS9002: Interpolated string handler method 'DefaultInterpolatedStringHandler.AppendFormatted(object)' has inconsistent return type. Expected to return 'void'.
                 // Console.WriteLine($"Text{1}");
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnInconsistent, "{1}").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)", "void").WithLocation(4, 25),
-                // (5,24): error CS9002: Interpolated string builder method 'InterpolatedStringBuilder.AppendLiteral(string)' has inconsistent return type. Expected to return 'bool'.
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnInconsistent, "{1}").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(object)", "void").WithLocation(4, 25),
+                // (5,24): error CS9002: Interpolated string handler method 'DefaultInterpolatedStringHandler.AppendLiteral(string)' has inconsistent return type. Expected to return 'bool'.
                 // Console.WriteLine($"{1}Text");
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderMethodReturnInconsistent, "Text").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)", "bool").WithLocation(5, 24)
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnInconsistent, "Text").WithArguments("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)", "bool").WithLocation(5, 24)
             );
         }
 
@@ -3155,10 +3155,10 @@ Console.WriteLine($""{1}"");
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct InterpolatedStringBuilder
+    public ref struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength, int formattedCount)
+        public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -1210,9 +1210,8 @@ namespace System.Runtime.CompilerServices
     using System.Text;
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => new InterpolatedStringBuilder(literalLength);
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength)
+        public InterpolatedStringBuilder(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -1357,173 +1356,172 @@ value:1,alignment:2:format:Y";
             {
                 (useDefaultParameters: false, useBoolReturns: false) => @"
 {
-  // Code size       79 (0x4f)
+  // Code size       80 (0x50)
   .maxstack  4
   .locals init (int V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
-  IL_0002:  ldc.i4.4
-  IL_0003:  ldc.i4.4
-  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
-  IL_000c:  ldstr      ""base""
-  IL_0011:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_0016:  ldloca.s   V_1
-  IL_0018:  ldloc.0
-  IL_0019:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
-  IL_001e:  ldloca.s   V_1
-  IL_0020:  ldloc.0
-  IL_0021:  ldc.i4.1
-  IL_0022:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int)""
-  IL_0027:  ldloca.s   V_1
-  IL_0029:  ldloc.0
-  IL_002a:  ldstr      ""X""
-  IL_002f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, string)""
-  IL_0034:  ldloca.s   V_1
-  IL_0036:  ldloc.0
-  IL_0037:  ldc.i4.2
-  IL_0038:  ldstr      ""Y""
-  IL_003d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_0042:  ldloca.s   V_1
-  IL_0044:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0049:  call       ""void System.Console.WriteLine(string)""
-  IL_004e:  ret
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  ldc.i4.4
+  IL_0005:  ldc.i4.4
+  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldstr      ""base""
+  IL_0012:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0017:  ldloca.s   V_1
+  IL_0019:  ldloc.0
+  IL_001a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+  IL_001f:  ldloca.s   V_1
+  IL_0021:  ldloc.0
+  IL_0022:  ldc.i4.1
+  IL_0023:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int)""
+  IL_0028:  ldloca.s   V_1
+  IL_002a:  ldloc.0
+  IL_002b:  ldstr      ""X""
+  IL_0030:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, string)""
+  IL_0035:  ldloca.s   V_1
+  IL_0037:  ldloc.0
+  IL_0038:  ldc.i4.2
+  IL_0039:  ldstr      ""Y""
+  IL_003e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0043:  ldloca.s   V_1
+  IL_0045:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_004a:  call       ""void System.Console.WriteLine(string)""
+  IL_004f:  ret
 }
 ",
                 (useDefaultParameters: true, useBoolReturns: false) => @"
-
 {
-  // Code size       83 (0x53)
+  // Code size       84 (0x54)
   .maxstack  4
   .locals init (int V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
-  IL_0002:  ldc.i4.4
-  IL_0003:  ldc.i4.4
-  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
-  IL_000c:  ldstr      ""base""
-  IL_0011:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_0016:  ldloca.s   V_1
-  IL_0018:  ldloc.0
-  IL_0019:  ldc.i4.0
-  IL_001a:  ldnull
-  IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_0020:  ldloca.s   V_1
-  IL_0022:  ldloc.0
-  IL_0023:  ldc.i4.1
-  IL_0024:  ldnull
-  IL_0025:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_002a:  ldloca.s   V_1
-  IL_002c:  ldloc.0
-  IL_002d:  ldc.i4.0
-  IL_002e:  ldstr      ""X""
-  IL_0033:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_0038:  ldloca.s   V_1
-  IL_003a:  ldloc.0
-  IL_003b:  ldc.i4.2
-  IL_003c:  ldstr      ""Y""
-  IL_0041:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_0046:  ldloca.s   V_1
-  IL_0048:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_004d:  call       ""void System.Console.WriteLine(string)""
-  IL_0052:  ret
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  ldc.i4.4
+  IL_0005:  ldc.i4.4
+  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldstr      ""base""
+  IL_0012:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0017:  ldloca.s   V_1
+  IL_0019:  ldloc.0
+  IL_001a:  ldc.i4.0
+  IL_001b:  ldnull
+  IL_001c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0021:  ldloca.s   V_1
+  IL_0023:  ldloc.0
+  IL_0024:  ldc.i4.1
+  IL_0025:  ldnull
+  IL_0026:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_002b:  ldloca.s   V_1
+  IL_002d:  ldloc.0
+  IL_002e:  ldc.i4.0
+  IL_002f:  ldstr      ""X""
+  IL_0034:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0039:  ldloca.s   V_1
+  IL_003b:  ldloc.0
+  IL_003c:  ldc.i4.2
+  IL_003d:  ldstr      ""Y""
+  IL_0042:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0047:  ldloca.s   V_1
+  IL_0049:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_004e:  call       ""void System.Console.WriteLine(string)""
+  IL_0053:  ret
 }
 ",
                 (useDefaultParameters: false, useBoolReturns: true) => @"
 {
-  // Code size       91 (0x5b)
+  // Code size       92 (0x5c)
   .maxstack  4
   .locals init (int V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
-  IL_0002:  ldc.i4.4
-  IL_0003:  ldc.i4.4
-  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
-  IL_000c:  ldstr      ""base""
-  IL_0011:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_0016:  brfalse.s  IL_004c
-  IL_0018:  ldloca.s   V_1
-  IL_001a:  ldloc.0
-  IL_001b:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
-  IL_0020:  brfalse.s  IL_004c
-  IL_0022:  ldloca.s   V_1
-  IL_0024:  ldloc.0
-  IL_0025:  ldc.i4.1
-  IL_0026:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int)""
-  IL_002b:  brfalse.s  IL_004c
-  IL_002d:  ldloca.s   V_1
-  IL_002f:  ldloc.0
-  IL_0030:  ldstr      ""X""
-  IL_0035:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, string)""
-  IL_003a:  brfalse.s  IL_004c
-  IL_003c:  ldloca.s   V_1
-  IL_003e:  ldloc.0
-  IL_003f:  ldc.i4.2
-  IL_0040:  ldstr      ""Y""
-  IL_0045:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_004a:  br.s       IL_004d
-  IL_004c:  ldc.i4.0
-  IL_004d:  pop
-  IL_004e:  ldloca.s   V_1
-  IL_0050:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0055:  call       ""void System.Console.WriteLine(string)""
-  IL_005a:  ret
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  ldc.i4.4
+  IL_0005:  ldc.i4.4
+  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldstr      ""base""
+  IL_0012:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0017:  brfalse.s  IL_004d
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldloc.0
+  IL_001c:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+  IL_0021:  brfalse.s  IL_004d
+  IL_0023:  ldloca.s   V_1
+  IL_0025:  ldloc.0
+  IL_0026:  ldc.i4.1
+  IL_0027:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int)""
+  IL_002c:  brfalse.s  IL_004d
+  IL_002e:  ldloca.s   V_1
+  IL_0030:  ldloc.0
+  IL_0031:  ldstr      ""X""
+  IL_0036:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, string)""
+  IL_003b:  brfalse.s  IL_004d
+  IL_003d:  ldloca.s   V_1
+  IL_003f:  ldloc.0
+  IL_0040:  ldc.i4.2
+  IL_0041:  ldstr      ""Y""
+  IL_0046:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_004b:  br.s       IL_004e
+  IL_004d:  ldc.i4.0
+  IL_004e:  pop
+  IL_004f:  ldloca.s   V_1
+  IL_0051:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0056:  call       ""void System.Console.WriteLine(string)""
+  IL_005b:  ret
 }
 ",
                 (useDefaultParameters: true, useBoolReturns: true) => @"
 {
-  // Code size       95 (0x5f)
+  // Code size       96 (0x60)
   .maxstack  4
   .locals init (int V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
-  IL_0002:  ldc.i4.4
-  IL_0003:  ldc.i4.4
-  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
-  IL_000c:  ldstr      ""base""
-  IL_0011:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_0016:  brfalse.s  IL_0050
-  IL_0018:  ldloca.s   V_1
-  IL_001a:  ldloc.0
-  IL_001b:  ldc.i4.0
-  IL_001c:  ldnull
-  IL_001d:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_0022:  brfalse.s  IL_0050
-  IL_0024:  ldloca.s   V_1
-  IL_0026:  ldloc.0
-  IL_0027:  ldc.i4.1
-  IL_0028:  ldnull
-  IL_0029:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_002e:  brfalse.s  IL_0050
-  IL_0030:  ldloca.s   V_1
-  IL_0032:  ldloc.0
-  IL_0033:  ldc.i4.0
-  IL_0034:  ldstr      ""X""
-  IL_0039:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_003e:  brfalse.s  IL_0050
-  IL_0040:  ldloca.s   V_1
-  IL_0042:  ldloc.0
-  IL_0043:  ldc.i4.2
-  IL_0044:  ldstr      ""Y""
-  IL_0049:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
-  IL_004e:  br.s       IL_0051
-  IL_0050:  ldc.i4.0
-  IL_0051:  pop
-  IL_0052:  ldloca.s   V_1
-  IL_0054:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0059:  call       ""void System.Console.WriteLine(string)""
-  IL_005e:  ret
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  ldc.i4.4
+  IL_0005:  ldc.i4.4
+  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldstr      ""base""
+  IL_0012:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0017:  brfalse.s  IL_0051
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldloc.0
+  IL_001c:  ldc.i4.0
+  IL_001d:  ldnull
+  IL_001e:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_0023:  brfalse.s  IL_0051
+  IL_0025:  ldloca.s   V_1
+  IL_0027:  ldloc.0
+  IL_0028:  ldc.i4.1
+  IL_0029:  ldnull
+  IL_002a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_002f:  brfalse.s  IL_0051
+  IL_0031:  ldloca.s   V_1
+  IL_0033:  ldloc.0
+  IL_0034:  ldc.i4.0
+  IL_0035:  ldstr      ""X""
+  IL_003a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_003f:  brfalse.s  IL_0051
+  IL_0041:  ldloca.s   V_1
+  IL_0043:  ldloc.0
+  IL_0044:  ldc.i4.2
+  IL_0045:  ldstr      ""Y""
+  IL_004a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int, int, string)""
+  IL_004f:  br.s       IL_0052
+  IL_0051:  ldc.i4.0
+  IL_0052:  pop
+  IL_0053:  ldloca.s   V_1
+  IL_0055:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_005a:  call       ""void System.Console.WriteLine(string)""
+  IL_005f:  ret
 }
 ",
             };
@@ -1587,177 +1585,176 @@ value:1,alignment:2:format:Y";
             {
                 (useDefaultParameters: false, useBoolReturns: false) => @"
 {
-  // Code size       88 (0x58)
+  // Code size       89 (0x59)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
-  IL_000b:  ldc.i4.4
-  IL_000c:  ldc.i4.4
-  IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0012:  stloc.1
-  IL_0013:  ldloca.s   V_1
-  IL_0015:  ldstr      ""base""
-  IL_001a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_001f:  ldloca.s   V_1
-  IL_0021:  ldloc.0
-  IL_0022:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
-  IL_0027:  ldloca.s   V_1
-  IL_0029:  ldloc.0
-  IL_002a:  ldc.i4.1
-  IL_002b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int)""
-  IL_0030:  ldloca.s   V_1
-  IL_0032:  ldloc.0
-  IL_0033:  ldstr      ""X""
-  IL_0038:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, string)""
-  IL_003d:  ldloca.s   V_1
-  IL_003f:  ldloc.0
-  IL_0040:  ldc.i4.2
-  IL_0041:  ldstr      ""Y""
-  IL_0046:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_004b:  ldloca.s   V_1
-  IL_004d:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0052:  call       ""void System.Console.WriteLine(string)""
-  IL_0057:  ret
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldc.i4.4
+  IL_000e:  ldc.i4.4
+  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0014:  ldloca.s   V_1
+  IL_0016:  ldstr      ""base""
+  IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0020:  ldloca.s   V_1
+  IL_0022:  ldloc.0
+  IL_0023:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+  IL_0028:  ldloca.s   V_1
+  IL_002a:  ldloc.0
+  IL_002b:  ldc.i4.1
+  IL_002c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int)""
+  IL_0031:  ldloca.s   V_1
+  IL_0033:  ldloc.0
+  IL_0034:  ldstr      ""X""
+  IL_0039:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, string)""
+  IL_003e:  ldloca.s   V_1
+  IL_0040:  ldloc.0
+  IL_0041:  ldc.i4.2
+  IL_0042:  ldstr      ""Y""
+  IL_0047:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_004c:  ldloca.s   V_1
+  IL_004e:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0053:  call       ""void System.Console.WriteLine(string)""
+  IL_0058:  ret
 }
 ",
                 (useDefaultParameters: true, useBoolReturns: false) => @"
 {
-  // Code size       92 (0x5c)
+  // Code size       93 (0x5d)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
-  IL_000b:  ldc.i4.4
-  IL_000c:  ldc.i4.4
-  IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0012:  stloc.1
-  IL_0013:  ldloca.s   V_1
-  IL_0015:  ldstr      ""base""
-  IL_001a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_001f:  ldloca.s   V_1
-  IL_0021:  ldloc.0
-  IL_0022:  ldc.i4.0
-  IL_0023:  ldnull
-  IL_0024:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_0029:  ldloca.s   V_1
-  IL_002b:  ldloc.0
-  IL_002c:  ldc.i4.1
-  IL_002d:  ldnull
-  IL_002e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_0033:  ldloca.s   V_1
-  IL_0035:  ldloc.0
-  IL_0036:  ldc.i4.0
-  IL_0037:  ldstr      ""X""
-  IL_003c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_0041:  ldloca.s   V_1
-  IL_0043:  ldloc.0
-  IL_0044:  ldc.i4.2
-  IL_0045:  ldstr      ""Y""
-  IL_004a:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_004f:  ldloca.s   V_1
-  IL_0051:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0056:  call       ""void System.Console.WriteLine(string)""
-  IL_005b:  ret
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldc.i4.4
+  IL_000e:  ldc.i4.4
+  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0014:  ldloca.s   V_1
+  IL_0016:  ldstr      ""base""
+  IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0020:  ldloca.s   V_1
+  IL_0022:  ldloc.0
+  IL_0023:  ldc.i4.0
+  IL_0024:  ldnull
+  IL_0025:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_002a:  ldloca.s   V_1
+  IL_002c:  ldloc.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  ldnull
+  IL_002f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0034:  ldloca.s   V_1
+  IL_0036:  ldloc.0
+  IL_0037:  ldc.i4.0
+  IL_0038:  ldstr      ""X""
+  IL_003d:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0042:  ldloca.s   V_1
+  IL_0044:  ldloc.0
+  IL_0045:  ldc.i4.2
+  IL_0046:  ldstr      ""Y""
+  IL_004b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0050:  ldloca.s   V_1
+  IL_0052:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0057:  call       ""void System.Console.WriteLine(string)""
+  IL_005c:  ret
 }
 ",
                 (useDefaultParameters: false, useBoolReturns: true) => @"
 {
-  // Code size      100 (0x64)
+  // Code size      101 (0x65)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
-  IL_000b:  ldc.i4.4
-  IL_000c:  ldc.i4.4
-  IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0012:  stloc.1
-  IL_0013:  ldloca.s   V_1
-  IL_0015:  ldstr      ""base""
-  IL_001a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_001f:  brfalse.s  IL_0055
-  IL_0021:  ldloca.s   V_1
-  IL_0023:  ldloc.0
-  IL_0024:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
-  IL_0029:  brfalse.s  IL_0055
-  IL_002b:  ldloca.s   V_1
-  IL_002d:  ldloc.0
-  IL_002e:  ldc.i4.1
-  IL_002f:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int)""
-  IL_0034:  brfalse.s  IL_0055
-  IL_0036:  ldloca.s   V_1
-  IL_0038:  ldloc.0
-  IL_0039:  ldstr      ""X""
-  IL_003e:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, string)""
-  IL_0043:  brfalse.s  IL_0055
-  IL_0045:  ldloca.s   V_1
-  IL_0047:  ldloc.0
-  IL_0048:  ldc.i4.2
-  IL_0049:  ldstr      ""Y""
-  IL_004e:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_0053:  br.s       IL_0056
-  IL_0055:  ldc.i4.0
-  IL_0056:  pop
-  IL_0057:  ldloca.s   V_1
-  IL_0059:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_005e:  call       ""void System.Console.WriteLine(string)""
-  IL_0063:  ret
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldc.i4.4
+  IL_000e:  ldc.i4.4
+  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0014:  ldloca.s   V_1
+  IL_0016:  ldstr      ""base""
+  IL_001b:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0020:  brfalse.s  IL_0056
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  ldloc.0
+  IL_0025:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+  IL_002a:  brfalse.s  IL_0056
+  IL_002c:  ldloca.s   V_1
+  IL_002e:  ldloc.0
+  IL_002f:  ldc.i4.1
+  IL_0030:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int)""
+  IL_0035:  brfalse.s  IL_0056
+  IL_0037:  ldloca.s   V_1
+  IL_0039:  ldloc.0
+  IL_003a:  ldstr      ""X""
+  IL_003f:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, string)""
+  IL_0044:  brfalse.s  IL_0056
+  IL_0046:  ldloca.s   V_1
+  IL_0048:  ldloc.0
+  IL_0049:  ldc.i4.2
+  IL_004a:  ldstr      ""Y""
+  IL_004f:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0054:  br.s       IL_0057
+  IL_0056:  ldc.i4.0
+  IL_0057:  pop
+  IL_0058:  ldloca.s   V_1
+  IL_005a:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_005f:  call       ""void System.Console.WriteLine(string)""
+  IL_0064:  ret
 }
 ",
                 (useDefaultParameters: true, useBoolReturns: true) => @"
-
 {
-  // Code size      104 (0x68)
+  // Code size      105 (0x69)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //a
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldstr      ""1""
   IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
-  IL_000b:  ldc.i4.4
-  IL_000c:  ldc.i4.4
-  IL_000d:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0012:  stloc.1
-  IL_0013:  ldloca.s   V_1
-  IL_0015:  ldstr      ""base""
-  IL_001a:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
-  IL_001f:  brfalse.s  IL_0059
-  IL_0021:  ldloca.s   V_1
-  IL_0023:  ldloc.0
-  IL_0024:  ldc.i4.0
-  IL_0025:  ldnull
-  IL_0026:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_002b:  brfalse.s  IL_0059
-  IL_002d:  ldloca.s   V_1
-  IL_002f:  ldloc.0
-  IL_0030:  ldc.i4.1
-  IL_0031:  ldnull
-  IL_0032:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_0037:  brfalse.s  IL_0059
-  IL_0039:  ldloca.s   V_1
-  IL_003b:  ldloc.0
-  IL_003c:  ldc.i4.0
-  IL_003d:  ldstr      ""X""
-  IL_0042:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_0047:  brfalse.s  IL_0059
-  IL_0049:  ldloca.s   V_1
-  IL_004b:  ldloc.0
-  IL_004c:  ldc.i4.2
-  IL_004d:  ldstr      ""Y""
-  IL_0052:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
-  IL_0057:  br.s       IL_005a
-  IL_0059:  ldc.i4.0
-  IL_005a:  pop
-  IL_005b:  ldloca.s   V_1
-  IL_005d:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0062:  call       ""void System.Console.WriteLine(string)""
-  IL_0067:  ret
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldc.i4.4
+  IL_000e:  ldc.i4.4
+  IL_000f:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0014:  ldloca.s   V_1
+  IL_0016:  ldstr      ""base""
+  IL_001b:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(string)""
+  IL_0020:  brfalse.s  IL_005a
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  ldloc.0
+  IL_0025:  ldc.i4.0
+  IL_0026:  ldnull
+  IL_0027:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_002c:  brfalse.s  IL_005a
+  IL_002e:  ldloca.s   V_1
+  IL_0030:  ldloc.0
+  IL_0031:  ldc.i4.1
+  IL_0032:  ldnull
+  IL_0033:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0038:  brfalse.s  IL_005a
+  IL_003a:  ldloca.s   V_1
+  IL_003c:  ldloc.0
+  IL_003d:  ldc.i4.0
+  IL_003e:  ldstr      ""X""
+  IL_0043:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0048:  brfalse.s  IL_005a
+  IL_004a:  ldloca.s   V_1
+  IL_004c:  ldloc.0
+  IL_004d:  ldc.i4.2
+  IL_004e:  ldstr      ""Y""
+  IL_0053:  call       ""bool System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>, int, string)""
+  IL_0058:  br.s       IL_005b
+  IL_005a:  ldc.i4.0
+  IL_005b:  pop
+  IL_005c:  ldloca.s   V_1
+  IL_005e:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0063:  call       ""void System.Console.WriteLine(string)""
+  IL_0068:  ret
 }
 ",
             };
@@ -1796,25 +1793,81 @@ Task<int> Hole() => Task.FromResult(1);";
 
             var verifier = CompileAndVerify(new[] { source, interpolatedStringBuilder }, expectedOutput: @"base1");
 
-            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+            verifier.VerifyIL("<Program>$.<<Main>$>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size       47 (0x2f)
-  .maxstack  2
-  .locals init (<Program>$.<<Main>$>d__0 V_0)
-  IL_0000:  ldloca.s   V_0
-  IL_0002:  call       ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Create()""
-  IL_0007:  stfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
-  IL_000c:  ldloca.s   V_0
-  IL_000e:  ldc.i4.m1
-  IL_000f:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
-  IL_0014:  ldloca.s   V_0
-  IL_0016:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
-  IL_001b:  ldloca.s   V_0
-  IL_001d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start<<Program>$.<<Main>$>d__0>(ref <Program>$.<<Main>$>d__0)""
-  IL_0022:  ldloca.s   V_0
-  IL_0024:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
-  IL_0029:  call       ""System.Threading.Tasks.Task System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Task.get""
-  IL_002e:  ret
+  // Code size      164 (0xa4)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
+                System.Exception V_3)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_003e
+    IL_000a:  call       ""System.Threading.Tasks.Task<int> <Program>$.<<Main>$>g__Hole|0_0()""
+    IL_000f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0014:  stloc.2
+    IL_0015:  ldloca.s   V_2
+    IL_0017:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_001c:  brtrue.s   IL_005a
+    IL_001e:  ldarg.0
+    IL_001f:  ldc.i4.0
+    IL_0020:  dup
+    IL_0021:  stloc.0
+    IL_0022:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_0027:  ldarg.0
+    IL_0028:  ldloc.2
+    IL_0029:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_002e:  ldarg.0
+    IL_002f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+    IL_0034:  ldloca.s   V_2
+    IL_0036:  ldarg.0
+    IL_0037:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, <Program>$.<<Main>$>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref <Program>$.<<Main>$>d__0)""
+    IL_003c:  leave.s    IL_00a3
+    IL_003e:  ldarg.0
+    IL_003f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_0044:  stloc.2
+    IL_0045:  ldarg.0
+    IL_0046:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> <Program>$.<<Main>$>d__0.<>u__1""
+    IL_004b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0051:  ldarg.0
+    IL_0052:  ldc.i4.m1
+    IL_0053:  dup
+    IL_0054:  stloc.0
+    IL_0055:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_005a:  ldloca.s   V_2
+    IL_005c:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0061:  stloc.1
+    IL_0062:  ldstr      ""base{0}""
+    IL_0067:  ldloc.1
+    IL_0068:  box        ""int""
+    IL_006d:  call       ""string string.Format(string, object)""
+    IL_0072:  call       ""void System.Console.WriteLine(string)""
+    IL_0077:  leave.s    IL_0090
+  }
+  catch System.Exception
+  {
+    IL_0079:  stloc.3
+    IL_007a:  ldarg.0
+    IL_007b:  ldc.i4.s   -2
+    IL_007d:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+    IL_0082:  ldarg.0
+    IL_0083:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+    IL_0088:  ldloc.3
+    IL_0089:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_008e:  leave.s    IL_00a3
+  }
+  IL_0090:  ldarg.0
+  IL_0091:  ldc.i4.s   -2
+  IL_0093:  stfld      ""int <Program>$.<<Main>$>d__0.<>1__state""
+  IL_0098:  ldarg.0
+  IL_0099:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder <Program>$.<<Main>$>d__0.<>t__builder""
+  IL_009e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00a3:  ret
 }
 ");
         }
@@ -1888,7 +1941,7 @@ value:1");
     IL_0061:  stloc.1
     IL_0062:  ldc.i4.4
     IL_0063:  ldc.i4.1
-    IL_0064:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_0064:  newobj     ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
     IL_0069:  stloc.3
     IL_006a:  ldloca.s   V_3
     IL_006c:  ldstr      ""base""
@@ -2009,7 +2062,7 @@ value:2");
     IL_0079:  ldarg.0
     IL_007a:  ldc.i4.4
     IL_007b:  ldc.i4.1
-    IL_007c:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
+    IL_007c:  newobj     ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
     IL_0081:  stloc.3
     IL_0082:  ldloca.s   V_3
     IL_0084:  ldstr      ""base""
@@ -2100,7 +2153,6 @@ namespace System.Runtime.CompilerServices
 {
     public ref struct InterpolatedStringBuilder
     {
-        public InterpolatedStringBuilder(int literalLength) => throw null;
         public override string ToString() => throw null;
         public void Dispose() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2111,12 +2163,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,5): error CS0117: 'InterpolatedStringBuilder' does not contain a definition for 'Create'
+                // (1,5): error CS1729: 'InterpolatedStringBuilder' does not contain a constructor that takes 2 arguments
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_NoSuchMember, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "Create").WithLocation(1, 5),
-                // (1,5): error CS9003: Interpolated string builder type 'InterpolatedStringBuilder' does not have a valid 'Create' method.
-                // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderInvalidCreateMethod, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "2").WithLocation(1, 5)
             );
         }
 
@@ -2130,7 +2179,6 @@ namespace System.Runtime.CompilerServices
 {
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength) => throw null;
         public InterpolatedStringBuilder(int literalLength) => throw null;
         public override string ToString() => throw null;
         public void Dispose() => throw null;
@@ -2142,9 +2190,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,5): error CS1501: No overload for method 'Create' takes 2 arguments
+                // (1,5): error CS1729: 'InterpolatedStringBuilder' does not contain a constructor that takes 2 arguments
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_BadArgCount, @"$""{(object)1}""").WithArguments("Create", "2").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder", "2").WithLocation(1, 5)
             );
         }
 
@@ -2158,8 +2206,7 @@ namespace System.Runtime.CompilerServices
 {
     public ref struct InterpolatedStringBuilder
     {
-        public static void Create(int literalLength) => throw null;
-        public InterpolatedStringBuilder(int literalLength) => throw null;
+        public InterpolatedStringBuilder(ref int literalLength, int formattedCount) => throw null;
         public override string ToString() => throw null;
         public void Dispose() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2169,41 +2216,11 @@ namespace System.Runtime.CompilerServices
 ";
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
+            // PROTOTYPE(interp-string): Better error here?
             comp.VerifyDiagnostics(
-                // (1,5): error CS1501: No overload for method 'Create' takes 2 arguments
+                // (1,5): error CS1620: Argument 1 must be passed with the 'ref' keyword
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_BadArgCount, @"$""{(object)1}""").WithArguments("Create", "2").WithLocation(1, 5),
-                // (1,5): error CS9003: Interpolated string builder type 'InterpolatedStringBuilder' does not have a valid 'Create' method.
-                // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_InterpolatedStringBuilderInvalidCreateMethod, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder").WithLocation(1, 5)
-            );
-        }
-
-        [ConditionalFact(typeof(NoIOperationValidation))]
-        public void MissingCreate_04()
-        {
-            var code = @"_ = $""{(object)1}"";";
-
-            var interpolatedStringBuilder = @"
-namespace System.Runtime.CompilerServices
-{
-    public ref struct InterpolatedStringBuilder
-    {
-        public InterpolatedStringBuilder Create(int literalLength, int formattedCount) => throw null;
-        public InterpolatedStringBuilder(int literalLength) => throw null;
-        public override string ToString() => throw null;
-        public void Dispose() => throw null;
-        public void AppendLiteral(string value) => throw null;
-        public void AppendFormatted<T>(T hole, int alignment = 0, string format = null) => throw null;
-    }
-}
-";
-
-            var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
-            comp.VerifyDiagnostics(
-                // (1,5): error CS0120: An object reference is required for the non-static field, method, or property 'InterpolatedStringBuilder.Create(int, int)'
-                // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_ObjectRequired, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_BadArgRef, @"$""{(object)1}""").WithArguments("1", "ref").WithLocation(1, 5)
             );
         }
 
@@ -2221,8 +2238,7 @@ namespace System.Runtime.CompilerServices
 {
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => throw null;
-        public InterpolatedStringBuilder(int literalLength) => throw null;
+        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
         " + toStringAndClearMethod + @"
         public override string ToString() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2240,8 +2256,6 @@ namespace System.Runtime.CompilerServices
             );
         }
 
-        // PROTOTYPE(interp-string): Should we hard error on malformed Append... methods in the well-known InterpolatedStringBuilder as well?
-
         [ConditionalFact(typeof(NoIOperationValidation))]
         public void ObsoleteCreateMethod()
         {
@@ -2252,9 +2266,8 @@ namespace System.Runtime.CompilerServices
 {
     public ref struct InterpolatedStringBuilder
     {
-        [System.Obsolete(""Create is obsolete"", error: true)]
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => throw null;
-        public InterpolatedStringBuilder(int baseLength) => throw null;
+        [System.Obsolete(""Constructor is obsolete"", error: true)]
+        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
         public void Dispose() => throw null;
         public override string ToString() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2265,9 +2278,9 @@ namespace System.Runtime.CompilerServices
 
             var comp = CreateCompilation(new[] { code, interpolatedStringBuilder });
             comp.VerifyDiagnostics(
-                // (1,5): error CS0619: 'InterpolatedStringBuilder.Create(int, int)' is obsolete: 'Create is obsolete'
+                // (1,5): error CS0619: 'InterpolatedStringBuilder.InterpolatedStringBuilder(int, int)' is obsolete: 'Constructor is obsolete'
                 // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)", "Create is obsolete").WithLocation(1, 5)
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.InterpolatedStringBuilder(int, int)", "Constructor is obsolete").WithLocation(1, 5)
             );
         }
 
@@ -2281,8 +2294,7 @@ namespace System.Runtime.CompilerServices
 {
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => throw null;
-        public InterpolatedStringBuilder(int literalLength) => throw null;
+        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
         public void Dispose() => throw null;
         public override string ToString() => throw null;
         [System.Obsolete(""AppendLiteral is obsolete"", error: true)]
@@ -2310,8 +2322,7 @@ namespace System.Runtime.CompilerServices
 {
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => throw null;
-        public InterpolatedStringBuilder(int literalLength) => throw null;
+        public InterpolatedStringBuilder(int literalLength, int formattedCount) => throw null;
         public void Dispose() => throw null;
         public override string ToString() => throw null;
         public void AppendLiteral(string value) => throw null;
@@ -2326,49 +2337,6 @@ namespace System.Runtime.CompilerServices
                 // (1,11): error CS0619: 'InterpolatedStringBuilder.AppendFormatted<T>(T, int, string)' is obsolete: 'AppendFormatted is obsolete'
                 // _ = $"base{(object)1}";
                 Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "{(object)1}").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<T>(T, int, string)", "AppendFormatted is obsolete").WithLocation(1, 11)
-            );
-        }
-
-        [ConditionalFact(typeof(NoIOperationValidation))]
-        public void UnmanagedCallersOnlyCreateMethod()
-        {
-            var code = @"_ = $""{(object)1}"";";
-
-            var interpolatedStringBuilder = @"
-namespace System.Runtime.CompilerServices
-{
-    public ref struct InterpolatedStringBuilder
-    {
-        [System.Runtime.InteropServices.UnmanagedCallersOnly]
-        public static InterpolatedStringBuilder Create(int baseLength, int numFormatHoles) => throw null;
-        public InterpolatedStringBuilder(int baseLength) => throw null;
-        public string ToStringAndClear() => throw null;
-        public void AppendLiteral(string value) => throw null;
-        public void AppendFormatted<T>(T hole, int alignment = 0, string format = null) => throw null;
-    }
-}
-namespace System.Runtime.InteropServices
-{
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    public sealed class UnmanagedCallersOnlyAttribute : Attribute
-    {
-        public UnmanagedCallersOnlyAttribute()
-        {
-        }
-
-        public Type[] CallConvs;
-        public string EntryPoint;
-    }
-}
-";
-
-            var comp1 = CreateCompilation(interpolatedStringBuilder, targetFramework: TargetFramework.NetCoreApp);
-
-            var comp = CreateCompilation(new[] { code }, references: new[] { comp1.EmitToImageReference() });
-            comp.VerifyDiagnostics(
-                // (1,5): error CS8901: 'InterpolatedStringBuilder.Create(int, int)' is attributed with 'UnmanagedCallersOnly' and cannot be called directly. Obtain a function pointer to this method.
-                // _ = $"{(object)1}";
-                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeCalledDirectly, @"$""{(object)1}""").WithArguments("System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)").WithLocation(1, 5)
             );
         }
 
@@ -2413,24 +2381,10 @@ namespace System.Runtime.InteropServices
     .pack 0
     .size 1
 
-    // Methods
-    .method public hidebysig static 
-        valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder Create (
-            int32 literalLength,
-            int32 formattedCount
-        ) cil managed 
-    {
-        .locals init (
-            [0] valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder
-        )
-
-        ldnull
-        throw
-    }
-
     .method public hidebysig specialname rtspecialname 
         instance void .ctor (
-            int32 literalLength
+            int32 literalLength,
+            int32 formattedCount
         ) cil managed 
     {
         ldnull
@@ -2510,24 +2464,10 @@ namespace System.Runtime.InteropServices
     .pack 0
     .size 1
 
-    // Methods
-    .method public hidebysig static 
-        valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder Create (
-            int32 literalLength,
-            int32 formattedCount
-        ) cil managed 
-    {
-        .locals init (
-            [0] valuetype System.Runtime.CompilerServices.InterpolatedStringBuilder
-        )
-
-        ldnull
-        throw
-    }
-
     .method public hidebysig specialname rtspecialname 
         instance void .ctor (
-            int32 literalLength
+            int32 literalLength,
+            int32 formattedCount
         ) cil managed 
     {
         ldnull
@@ -2620,46 +2560,46 @@ value:");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size       80 (0x50)
-  .maxstack  2
+  // Code size       81 (0x51)
+  .maxstack  3
   .locals init (bool V_0, //b
                 object V_1,
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
-  IL_0002:  ldc.i4.0
-  IL_0003:  ldc.i4.4
-  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0009:  stloc.2
-  IL_000a:  ldloc.0
-  IL_000b:  brfalse.s  IL_0016
-  IL_000d:  ldc.i4.1
-  IL_000e:  box        ""int""
-  IL_0013:  stloc.1
-  IL_0014:  br.s       IL_0018
-  IL_0016:  ldnull
-  IL_0017:  stloc.1
-  IL_0018:  ldloca.s   V_2
-  IL_001a:  ldloc.1
-  IL_001b:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
-  IL_0020:  ldloca.s   V_2
-  IL_0022:  ldloc.0
-  IL_0023:  brfalse.s  IL_002d
-  IL_0025:  ldc.i4.2
-  IL_0026:  box        ""int""
-  IL_002b:  br.s       IL_002e
-  IL_002d:  ldnull
-  IL_002e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
-  IL_0033:  ldloca.s   V_2
-  IL_0035:  ldnull
-  IL_0036:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
-  IL_003b:  ldloca.s   V_2
-  IL_003d:  ldnull
-  IL_003e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
-  IL_0043:  ldloca.s   V_2
-  IL_0045:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_004a:  call       ""void System.Console.WriteLine(string)""
-  IL_004f:  ret
+  IL_0002:  ldloca.s   V_2
+  IL_0004:  ldc.i4.0
+  IL_0005:  ldc.i4.4
+  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000b:  ldloc.0
+  IL_000c:  brfalse.s  IL_0017
+  IL_000e:  ldc.i4.1
+  IL_000f:  box        ""int""
+  IL_0014:  stloc.1
+  IL_0015:  br.s       IL_0019
+  IL_0017:  ldnull
+  IL_0018:  stloc.1
+  IL_0019:  ldloca.s   V_2
+  IL_001b:  ldloc.1
+  IL_001c:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
+  IL_0021:  ldloca.s   V_2
+  IL_0023:  ldloc.0
+  IL_0024:  brfalse.s  IL_002e
+  IL_0026:  ldc.i4.2
+  IL_0027:  box        ""int""
+  IL_002c:  br.s       IL_002f
+  IL_002e:  ldnull
+  IL_002f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
+  IL_0034:  ldloca.s   V_2
+  IL_0036:  ldnull
+  IL_0037:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
+  IL_003c:  ldloca.s   V_2
+  IL_003e:  ldnull
+  IL_003f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
+  IL_0044:  ldloca.s   V_2
+  IL_0046:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_004b:  call       ""void System.Console.WriteLine(string)""
+  IL_0050:  ret
 }
 ");
         }
@@ -2712,32 +2652,32 @@ System.Console.WriteLine($""{$""{i}""}"");";
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size       53 (0x35)
-  .maxstack  3
+  // Code size       55 (0x37)
+  .maxstack  4
   .locals init (int V_0, //i
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1,
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
-  IL_0002:  ldc.i4.0
-  IL_0003:  ldc.i4.1
-  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
-  IL_000c:  ldc.i4.0
-  IL_000d:  ldc.i4.1
-  IL_000e:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0013:  stloc.2
-  IL_0014:  ldloca.s   V_2
-  IL_0016:  ldloc.0
-  IL_0017:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
-  IL_001c:  ldloca.s   V_2
-  IL_001e:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0023:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
-  IL_0028:  ldloca.s   V_1
-  IL_002a:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_002f:  call       ""void System.Console.WriteLine(string)""
-  IL_0034:  ret
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  ldc.i4.0
+  IL_0005:  ldc.i4.1
+  IL_0006:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldc.i4.0
+  IL_0010:  ldc.i4.1
+  IL_0011:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0016:  ldloca.s   V_2
+  IL_0018:  ldloc.0
+  IL_0019:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+  IL_001e:  ldloca.s   V_2
+  IL_0020:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0025:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(string)""
+  IL_002a:  ldloca.s   V_1
+  IL_002c:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0031:  call       ""void System.Console.WriteLine(string)""
+  IL_0036:  ret
 }
 ");
         }
@@ -2774,8 +2714,8 @@ Caught");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size       94 (0x5e)
-  .maxstack  3
+  // Code size       95 (0x5f)
+  .maxstack  4
   .locals init (int V_0, //i
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
   IL_0000:  ldc.i4.1
@@ -2797,30 +2737,30 @@ Caught");
     IL_001f:  brtrue.s   IL_0025
     IL_0021:  pop
     IL_0022:  ldc.i4.0
-    IL_0023:  br.s       IL_004e
+    IL_0023:  br.s       IL_004f
     IL_0025:  callvirt   ""string object.ToString()""
-    IL_002a:  ldc.i4.0
-    IL_002b:  ldc.i4.1
-    IL_002c:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-    IL_0031:  stloc.1
-    IL_0032:  ldloca.s   V_1
-    IL_0034:  ldloc.0
-    IL_0035:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
-    IL_003a:  ldloca.s   V_1
-    IL_003c:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-    IL_0041:  callvirt   ""string string.Trim()""
-    IL_0046:  call       ""bool string.op_Equality(string, string)""
-    IL_004b:  ldc.i4.0
-    IL_004c:  cgt.un
-    IL_004e:  endfilter
+    IL_002a:  ldloca.s   V_1
+    IL_002c:  ldc.i4.0
+    IL_002d:  ldc.i4.1
+    IL_002e:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+    IL_0033:  ldloca.s   V_1
+    IL_0035:  ldloc.0
+    IL_0036:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<int>(int)""
+    IL_003b:  ldloca.s   V_1
+    IL_003d:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+    IL_0042:  callvirt   ""string string.Trim()""
+    IL_0047:  call       ""bool string.op_Equality(string, string)""
+    IL_004c:  ldc.i4.0
+    IL_004d:  cgt.un
+    IL_004f:  endfilter
   }  // end filter
   {  // handler
-    IL_0050:  pop
-    IL_0051:  ldstr      ""Caught""
-    IL_0056:  call       ""void System.Console.WriteLine(string)""
-    IL_005b:  leave.s    IL_005d
+    IL_0051:  pop
+    IL_0052:  ldstr      ""Caught""
+    IL_0057:  call       ""void System.Console.WriteLine(string)""
+    IL_005c:  leave.s    IL_005e
   }
-  IL_005d:  ret
+  IL_005e:  ret
 }
 ");
         }
@@ -2858,7 +2798,7 @@ Caught");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size      121 (0x79)
+  // Code size      122 (0x7a)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //s
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_1)
@@ -2889,30 +2829,30 @@ Caught");
     IL_003a:  brtrue.s   IL_0040
     IL_003c:  pop
     IL_003d:  ldc.i4.0
-    IL_003e:  br.s       IL_0069
+    IL_003e:  br.s       IL_006a
     IL_0040:  callvirt   ""string object.ToString()""
-    IL_0045:  ldc.i4.0
-    IL_0046:  ldc.i4.1
-    IL_0047:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-    IL_004c:  stloc.1
-    IL_004d:  ldloca.s   V_1
-    IL_004f:  ldloc.0
-    IL_0050:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
-    IL_0055:  ldloca.s   V_1
-    IL_0057:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-    IL_005c:  callvirt   ""string string.Trim()""
-    IL_0061:  call       ""bool string.op_Equality(string, string)""
-    IL_0066:  ldc.i4.0
-    IL_0067:  cgt.un
-    IL_0069:  endfilter
+    IL_0045:  ldloca.s   V_1
+    IL_0047:  ldc.i4.0
+    IL_0048:  ldc.i4.1
+    IL_0049:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+    IL_004e:  ldloca.s   V_1
+    IL_0050:  ldloc.0
+    IL_0051:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+    IL_0056:  ldloca.s   V_1
+    IL_0058:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+    IL_005d:  callvirt   ""string string.Trim()""
+    IL_0062:  call       ""bool string.op_Equality(string, string)""
+    IL_0067:  ldc.i4.0
+    IL_0068:  cgt.un
+    IL_006a:  endfilter
   }  // end filter
   {  // handler
-    IL_006b:  pop
-    IL_006c:  ldstr      ""Caught""
-    IL_0071:  call       ""void System.Console.WriteLine(string)""
-    IL_0076:  leave.s    IL_0078
+    IL_006c:  pop
+    IL_006d:  ldstr      ""Caught""
+    IL_0072:  call       ""void System.Console.WriteLine(string)""
+    IL_0077:  leave.s    IL_0079
   }
-  IL_0078:  ret
+  IL_0079:  ret
 }
 ");
         }
@@ -2947,8 +2887,8 @@ value:C");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size       56 (0x38)
-  .maxstack  2
+  // Code size       57 (0x39)
+  .maxstack  3
   .locals init (S V_0, //s
                 C V_1, //c
                 System.Runtime.CompilerServices.InterpolatedStringBuilder V_2)
@@ -2956,21 +2896,21 @@ value:C");
   IL_0002:  initobj    ""S""
   IL_0008:  newobj     ""C..ctor()""
   IL_000d:  stloc.1
-  IL_000e:  ldc.i4.0
-  IL_000f:  ldc.i4.2
-  IL_0010:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0015:  stloc.2
-  IL_0016:  ldloca.s   V_2
-  IL_0018:  ldloc.0
-  IL_0019:  call       ""System.ReadOnlySpan<char> S.op_Implicit(S)""
-  IL_001e:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
-  IL_0023:  ldloca.s   V_2
-  IL_0025:  ldloc.1
-  IL_0026:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<C>(C)""
-  IL_002b:  ldloca.s   V_2
-  IL_002d:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_0032:  call       ""void System.Console.WriteLine(string)""
-  IL_0037:  ret
+  IL_000e:  ldloca.s   V_2
+  IL_0010:  ldc.i4.0
+  IL_0011:  ldc.i4.2
+  IL_0012:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0017:  ldloca.s   V_2
+  IL_0019:  ldloc.0
+  IL_001a:  call       ""System.ReadOnlySpan<char> S.op_Implicit(S)""
+  IL_001f:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(System.ReadOnlySpan<char>)""
+  IL_0024:  ldloca.s   V_2
+  IL_0026:  ldloc.1
+  IL_0027:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted<C>(C)""
+  IL_002c:  ldloca.s   V_2
+  IL_002e:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_0033:  call       ""void System.Console.WriteLine(string)""
+  IL_0038:  ret
 }
 ");
         }
@@ -3019,9 +2959,8 @@ namespace System.Runtime.CompilerServices
     using System.Text;
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => new InterpolatedStringBuilder(literalLength);
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength)
+        public InterpolatedStringBuilder(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3036,25 +2975,25 @@ literal:Text
 value:1");
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size       51 (0x33)
-  .maxstack  2
+  // Code size       52 (0x34)
+  .maxstack  3
   .locals init (System.Runtime.CompilerServices.InterpolatedStringBuilder V_0)
-  IL_0000:  ldc.i4.4
-  IL_0001:  ldc.i4.1
-  IL_0002:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder System.Runtime.CompilerServices.InterpolatedStringBuilder.Create(int, int)""
-  IL_0007:  stloc.0
-  IL_0008:  ldloca.s   V_0
-  IL_000a:  ldstr      ""Text""
-  IL_000f:  call       ""CustomStruct CustomStruct.op_Implicit(string)""
-  IL_0014:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(CustomStruct)""
-  IL_0019:  ldloca.s   V_0
-  IL_001b:  ldc.i4.1
-  IL_001c:  box        ""int""
-  IL_0021:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
-  IL_0026:  ldloca.s   V_0
-  IL_0028:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
-  IL_002d:  call       ""void System.Console.WriteLine(string)""
-  IL_0032:  ret
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.4
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""System.Runtime.CompilerServices.InterpolatedStringBuilder..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldstr      ""Text""
+  IL_0010:  call       ""CustomStruct CustomStruct.op_Implicit(string)""
+  IL_0015:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendLiteral(CustomStruct)""
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  ldc.i4.1
+  IL_001d:  box        ""int""
+  IL_0022:  call       ""void System.Runtime.CompilerServices.InterpolatedStringBuilder.AppendFormatted(object)""
+  IL_0027:  ldloca.s   V_0
+  IL_0029:  call       ""string System.Runtime.CompilerServices.InterpolatedStringBuilder.ToStringAndClear()""
+  IL_002e:  call       ""void System.Console.WriteLine(string)""
+  IL_0033:  ret
 }
 ");
         }
@@ -3079,9 +3018,8 @@ namespace System.Runtime.CompilerServices
     using System.Text;
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => new InterpolatedStringBuilder(literalLength);
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength)
+        public InterpolatedStringBuilder(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3112,9 +3050,8 @@ namespace System.Runtime.CompilerServices
     using System.Text;
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => new InterpolatedStringBuilder(literalLength);
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength)
+        public InterpolatedStringBuilder(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3149,9 +3086,8 @@ namespace System.Runtime.CompilerServices
     using System.Text;
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => new InterpolatedStringBuilder(literalLength);
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength)
+        public InterpolatedStringBuilder(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3186,9 +3122,8 @@ namespace System.Runtime.CompilerServices
     using System.Text;
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => new InterpolatedStringBuilder(literalLength);
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength)
+        public InterpolatedStringBuilder(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }
@@ -3222,9 +3157,8 @@ namespace System.Runtime.CompilerServices
     using System.Text;
     public ref struct InterpolatedStringBuilder
     {
-        public static InterpolatedStringBuilder Create(int literalLength, int formattedCount) => new InterpolatedStringBuilder(literalLength);
         private readonly StringBuilder _builder;
-        public InterpolatedStringBuilder(int literalLength)
+        public InterpolatedStringBuilder(int literalLength, int formattedCount)
         {
             _builder = new StringBuilder();
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -608,7 +608,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException:
                     case WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute:
                     case WellKnownType.System_Runtime_CompilerServices_IsExternalInit:
-                    case WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder:
+                    case WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler:
                         // Not yet in the platform.
                         continue;
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
@@ -962,7 +962,7 @@ namespace System
                     case WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject:
                     case WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags:
-                    case WellKnownMember.System_Runtime_CompilerServices_InterpolatedStringBuilder__ToStringAndClear:
+                    case WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis
         /// The interpoled string builder, when the interpolated string is being lowered through the builder pattern
         /// or the interpolated string expression is being converted directly to System.String.
         /// </summary>
-        InterpolatedStringBuilder = 0x102,
+        InterpolatedStringHandler = 0x102,
     }
 
     internal static class SynthesizedLocalKindExtensions

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis
         System_Text_StringBuilder__AppendObject,
         System_Text_StringBuilder__ctor,
 
-        System_Runtime_CompilerServices_InterpolatedStringBuilder__ToStringAndClear,
+        System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
 
         Count
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3505,9 +3505,9 @@ namespace Microsoft.CodeAnalysis
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                     
-                // System_Runtime_CompilerServices_InterpolatedStringBuilder__ToStringAndClear
+                // System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear
                 (byte)MemberFlags.Method,                                                                                   // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder - WellKnownType.ExtSentinel), // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler - WellKnownType.ExtSentinel), // DeclaringTypeId
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String, // Return Type
@@ -3951,7 +3951,7 @@ namespace Microsoft.CodeAnalysis
                 "Append",                                   // System_Text_StringBuilder__AppendString
                 "Append",                                   // System_Text_StringBuilder__AppendObject
                 ".ctor",                                    // System_Text_StringBuilder__ctor
-                "ToStringAndClear",                         // System_Runtime_CompilerServices_InterpolatedStringBuilder__ToStringAndClear
+                "ToStringAndClear",                         // System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis
 
         System_Text_StringBuilder,
 
-        System_Runtime_CompilerServices_InterpolatedStringBuilder,
+        System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
 
         NextAvailable,
 
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.InteropServices.OutAttribute",
 
             "System.Text.StringBuilder",
-            "System.Runtime.CompilerServices.InterpolatedStringBuilder",
+            "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler",
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -543,7 +543,7 @@ End Namespace
                          WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException,
                          WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute,
                          WellKnownType.System_Runtime_CompilerServices_IsExternalInit,
-                         WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder
+                         WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -609,7 +609,7 @@ End Namespace
                          WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException,
                          WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute,
                          WellKnownType.System_Runtime_CompilerServices_IsExternalInit,
-                         WellKnownType.System_Runtime_CompilerServices_InterpolatedStringBuilder
+                         WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -695,7 +695,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T,
                          WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags,
-                         WellKnownMember.System_Runtime_CompilerServices_InterpolatedStringBuilder__ToStringAndClear
+                         WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -837,7 +837,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T,
                          WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags,
-                         WellKnownMember.System_Runtime_CompilerServices_InterpolatedStringBuilder__ToStringAndClear
+                         WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,


### PR DESCRIPTION
Couple of smaller changes:

1. Call a constructor, rather than a create method.
2. Move from calling types builders to handlers, to keep in sync with https://github.com/dotnet/runtime/issues/51962.