### PR TITLE
Change node equivalency calculation in SyntaxDiffer

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
@@ -505,7 +505,17 @@ namespace Microsoft.CodeAnalysis
 
         private static bool AreIdentical(in SyntaxNodeOrToken node1, in SyntaxNodeOrToken node2)
         {
-            return node1.UnderlyingNode == node2.UnderlyingNode;
+            if (node1.UnderlyingNode == null && node2.UnderlyingNode == null)
+            {
+                return true;
+            }
+
+            if (node1.UnderlyingNode == null && node2.UnderlyingNode != null)
+            {
+                return false;
+            }
+
+            return node1.UnderlyingNode!.IsEquivalentTo(node2.UnderlyingNode);
         }
 
         private static bool AreSimilar(in SyntaxNodeOrToken node1, in SyntaxNodeOrToken node2)


### PR DESCRIPTION
It appears that the equivalency check for nodes in SyntaxDiffer was not using the correct equality checker. This was causing rename issues in the new Razor editor (https://github.com/dotnet/aspnetcore/issues/31369) since many more nodes than necessary were being replaced due to not being deemed equivalent. This PR switches the method to using the correct check.

@jasonmalinowski If this fix seems incorrect, please let me know, although it seems to have fixed the issue in Razor.