### PR TITLE
Update LSP tooltips to better support markdown

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
@@ -49,6 +49,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             while (index < taggedTexts.Length)
             {
                 var part = taggedTexts[index];
+
+                // These tags can be ignored - they are for markdown formatting only.
+                if (part.Tag is TextTags.CodeBlockStart or TextTags.CodeBlockEnd)
+                {
+                    index++;
+                    continue;
+                }
+
                 if (part.Tag == TextTags.ContainerStart)
                 {
                     if (currentRuns.Count > 0)

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -235,6 +235,8 @@ namespace Microsoft.CodeAnalysis
 
                 case TextTags.ContainerStart:
                 case TextTags.ContainerEnd:
+                case TextTags.CodeBlockStart:
+                case TextTags.CodeBlockEnd:
                     // These tags are not visible so classify them as whitespace
                     return ClassificationTypeNames.WhiteSpace;
 

--- a/src/Features/Core/Portable/Common/TextTags.cs
+++ b/src/Features/Core/Portable/Common/TextTags.cs
@@ -59,5 +59,13 @@ namespace Microsoft.CodeAnalysis
         /// Indicates the end of a text container. See <see cref="ContainerStart"/>.
         /// </summary>
         internal const string ContainerEnd = nameof(ContainerEnd);
+
+        /// <summary>
+        /// Indicates the start of a code block.  The elements after <see cref="CodeBlockStart"/>
+        /// through (but not including) the matching <see cref="CodeBlockEnd"/> are rendered as
+        /// a codeblock in LSP markup.
+        /// </summary>
+        internal const string CodeBlockStart = nameof(CodeBlockStart);
+        internal const string CodeBlockEnd = nameof(CodeBlockEnd);
     }
 }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                     if (group == SymbolDescriptionGroups.MainDescription)
                     {
                         // Mark the main description as a code block.
-                        taggedText = parts.ToTaggedText(_getNavigationHint)
+                        taggedText = taggedText
                             .Insert(0, new TaggedText(TextTags.CodeBlockStart, string.Empty))
                             .Add(new TaggedText(TextTags.CodeBlockEnd, string.Empty));
                     }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -437,7 +437,18 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 // Merge the two maps into one final result.
                 var result = new Dictionary<SymbolDescriptionGroups, ImmutableArray<TaggedText>>(_documentationMap);
                 foreach (var (group, parts) in _groupMap)
-                    result[group] = parts.ToTaggedText(_getNavigationHint);
+                {
+                    var taggedText = parts.ToTaggedText(_getNavigationHint);
+                    if (group == SymbolDescriptionGroups.MainDescription)
+                    {
+                        // Mark the main description as a code block.
+                        taggedText = parts.ToTaggedText(_getNavigationHint)
+                            .Insert(0, new TaggedText(TextTags.CodeBlockStart, string.Empty))
+                            .Add(new TaggedText(TextTags.CodeBlockEnd, string.Empty));
+                    }
+
+                    result[group] = taggedText;
+                }
 
                 return result;
             }

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -3,12 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.QuickInfo;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -47,17 +51,42 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return null;
             }
 
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var supportsVSExtensions = context.ClientCapabilities.HasVisualStudioLspCapability() == true;
 
-            // TODO - Switch to markup content once it supports classifications.
-            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
-            return new VSHover
+            var hover = await GetHoverAsync(info, document, supportsVSExtensions, cancellationToken).ConfigureAwait(false);
+            return hover;
+
+            static async Task<Hover> GetHoverAsync(QuickInfoItem info, Document document, bool supportsVSExtensions, CancellationToken cancellationToken)
             {
-                Range = ProtocolConversions.TextSpanToRange(info.Span, text),
-                Contents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(string.Empty),
-                // Build the classified text without navigation actions - they are not serializable.
-                RawContent = await IntellisenseQuickInfoBuilder.BuildContentWithoutNavigationActionsAsync(info, document, cancellationToken).ConfigureAwait(false)
-            };
+                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                if (supportsVSExtensions)
+                {
+                    return new VSHover
+                    {
+                        Range = ProtocolConversions.TextSpanToRange(info.Span, text),
+                        Contents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(string.Empty),
+                        // Build the classified text without navigation actions - they are not serializable.
+                        // TODO - Switch to markup content once it supports classifications.
+                        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
+                        RawContent = await IntellisenseQuickInfoBuilder.BuildContentWithoutNavigationActionsAsync(info, document, cancellationToken).ConfigureAwait(false)
+                    };
+                }
+                else
+                {
+                    return new Hover
+                    {
+                        Range = ProtocolConversions.TextSpanToRange(info.Span, text),
+                        Contents = GetContents(info),
+                    };
+                }
+            }
+
+            static MarkupContent GetContents(QuickInfoItem info)
+            {
+                // Insert line breaks in between sections to ensure we get double spacing between sections.
+                var tags = info.Sections.SelectMany(section => section.TaggedParts.Add(new TaggedText(TextTags.LineBreak, Environment.NewLine))).ToImmutableArray();
+                return ProtocolConversions.GetDocumentationMarkdown(tags);
+            }
         }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -362,7 +362,7 @@ link text";
                 new ClassifiedTextRun("class name", className)
             };
 
-        private async Task<T> GetCompletionItemToResolveAsync<T>(
+        private static async Task<T> GetCompletionItemToResolveAsync<T>(
             TestLspServer testLspServer,
             Dictionary<string, IList<LSP.Location>> locations,
             string label,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -35,10 +36,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
     }
 }";
             using var testLspServer = CreateTestLspServer(markup, out var locations);
-            var tags = new string[] { "Class", "Internal" };
-            var completionParams = CreateCompletionParams(
-                locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
-
             var clientCapabilities = new LSP.VSClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
@@ -53,21 +50,18 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
                     }
                 }
             };
-            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities);
-            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "A");
-            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
-            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
-            var clientCompletionItem = ConvertToClientCompletionItem(serverCompletionItem);
+            var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.VSCompletionItem>(
+                testLspServer,
+                locations,
+                label: "A",
+                clientCapabilities).ConfigureAwait(false);
 
             var description = new ClassifiedTextElement(CreateClassifiedTextRunForClass("A"));
-
             var expected = CreateResolvedCompletionItem(clientCompletionItem, description, "class A", null);
 
             var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
                 testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
             AssertJsonEquals(expected, results);
-            var vsCompletionList = Assert.IsAssignableFrom<VSCompletionList>(completionList);
-            Assert.NotNull(vsCompletionList.Data);
         }
 
         [Fact]
@@ -82,23 +76,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
     }
 }";
             using var testLspServer = CreateTestLspServer(markup, out var locations);
-            var tags = new string[] { "Class", "Internal" };
-            var completionParams = CreateCompletionParams(
-                locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
-
-            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams);
-            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "A");
-            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
-            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
-            var clientCompletionItem = ConvertToClientCompletionItem(serverCompletionItem);
+            var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.VSCompletionItem>(testLspServer, locations, label: "A").ConfigureAwait(false);
 
             var description = new ClassifiedTextElement(CreateClassifiedTextRunForClass("A"));
-            var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
-
             var expected = CreateResolvedCompletionItem(clientCompletionItem, description, "class A", null);
 
             var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
-                testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
+                testLspServer, clientCompletionItem).ConfigureAwait(false);
             AssertJsonEquals(expected, results);
         }
 
@@ -117,18 +101,9 @@ class B : A
     override {|caret:|}
 }";
             using var testLspServer = CreateTestLspServer(markup, out var locations);
-            var tags = new string[] { "Method", "Public" };
-            var completionParams = CreateCompletionParams(
-                locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
-            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams);
-            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "M()");
-            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
-            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
-            var clientCompletionItem = ConvertToClientCompletionItem(serverCompletionItem);
-            var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
-
+            var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.VSCompletionItem>(testLspServer, locations, label: "M()").ConfigureAwait(false);
             var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
-                testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
+                testLspServer, clientCompletionItem).ConfigureAwait(false);
 
             Assert.NotNull(results.TextEdit);
             Assert.Null(results.InsertText);
@@ -153,15 +128,6 @@ class B : A
     override {|caret:|}
 }";
             using var testLspServer = CreateTestLspServer(markup, out var locations);
-            var tags = new string[] { "Method", "Public" };
-            var completionParams = CreateCompletionParams(
-                locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
-            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams);
-            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == "M()");
-            var completionResultId = ((CompletionResolveData)serverCompletionItem.Data).ResultId.Value;
-            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
-            var clientCompletionItem = ConvertToClientCompletionItem(serverCompletionItem);
-
             // Explicitly enable snippets. This allows us to set the cursor with $0. Currently only applies to C# in Razor docs.
             var clientCapabilities = new LSP.VSClientCapabilities
             {
@@ -177,6 +143,11 @@ class B : A
                     }
                 }
             };
+            var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.VSCompletionItem>(
+                testLspServer,
+                locations,
+                label: "M()",
+                clientCapabilities).ConfigureAwait(false);
 
             var results = (LSP.VSCompletionItem)await RunResolveCompletionItemAsync(
                 testLspServer, clientCompletionItem, clientCapabilities).ConfigureAwait(false);
@@ -204,7 +175,6 @@ class B : A
     override {|caret:|}
 }";
             using var testLspServer = CreateTestLspServer(markup, out _);
-            var tags = new string[] { "Method", "Public" };
 
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
@@ -218,8 +188,73 @@ class B : A
     }", textEdit.NewText);
         }
 
-        private static async Task<object> RunResolveCompletionItemAsync(TestLspServer testLspServer, LSP.CompletionItem completionItem, LSP.ClientCapabilities clientCapabilities = null)
+        
+        [Fact]
+        public async Task TestResolveCompletionItemWithMarkupContentAsync()
         {
+            var markup =
+@"
+class A
+{
+    /// <summary>
+    /// A cref <see cref=""AMethod""/>
+    /// <br/>
+    /// <strong>strong text</strong>
+    /// <br/>
+    /// <em>italic text</em>
+    /// <br/>
+    /// <u>underline text</u>
+    /// <para>
+    /// <list type='bullet'>
+    /// <item>
+    /// <description>Item 1.</description>
+    /// </item>
+    /// <item>
+    /// <description>Item 2.</description>
+    /// </item>
+    /// </list>
+    /// <a href = ""https://google.com"" > link text</a>
+    /// </para>
+    /// </summary>
+    void AMethod(int i)
+    {
+    }
+
+    void M()
+    {
+        AMet{|caret:|}
+    }
+}";
+            using var testLspServer = CreateTestLspServer(markup, out var locations);
+            var clientCompletionItem = await GetCompletionItemToResolveAsync<LSP.CompletionItem>(
+                testLspServer,
+                locations,
+                label: "AMethod",
+                new ClientCapabilities()).ConfigureAwait(false);
+            Assert.True(clientCompletionItem is not VSCompletionItem);
+
+            var expected = @"```csharp
+void A.AMethod(int i)
+```
+  
+A&nbsp;cref&nbsp;A.AMethod(int)  
+**strong&nbsp;text**  
+_italic&nbsp;text_  
+<u>underline&nbsp;text</u>  
+  
+•&nbsp;Item&nbsp;1.  
+•&nbsp;Item&nbsp;2.  
+  
+[link text](https://google.com)";
+
+            var results = await RunResolveCompletionItemAsync(
+                testLspServer, clientCompletionItem, new ClientCapabilities()).ConfigureAwait(false);
+            Assert.Equal(expected, results.Documentation.Value.Second.Value);
+        }
+
+        private static async Task<LSP.CompletionItem> RunResolveCompletionItemAsync(TestLspServer testLspServer, LSP.CompletionItem completionItem, LSP.ClientCapabilities clientCapabilities = null)
+        {
+            clientCapabilities ??= new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
             return await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName,
                            completionItem, clientCapabilities, null, CancellationToken.None);
         }
@@ -252,16 +287,33 @@ class B : A
                 new ClassifiedTextRun("class name", className)
             };
 
-        private static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
+        private async Task<T> GetCompletionItemToResolveAsync<T>(
+            TestLspServer testLspServer,
+            Dictionary<string, IList<LSP.Location>> locations,
+            string label,
+            LSP.ClientCapabilities clientCapabilities = null) where T : LSP.CompletionItem
         {
-            var clientCapabilities = new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
-            return RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities);
+            var completionParams = CreateCompletionParams(
+                locations["caret"].Single(), LSP.VSCompletionInvokeKind.Explicit, "\0", LSP.CompletionTriggerKind.Invoked);
+
+            clientCapabilities ??= new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
+            var completionList = await RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities);
+
+            if (clientCapabilities.HasCompletionListDataCapability())
+            {
+                var vsCompletionList = Assert.IsAssignableFrom<VSCompletionList>(completionList);
+                Assert.NotNull(vsCompletionList.Data);
+            }
+
+            var serverCompletionItem = completionList.Items.FirstOrDefault(item => item.Label == label);
+            var clientCompletionItem = ConvertToClientCompletionItem((T)serverCompletionItem);
+            return clientCompletionItem;
         }
 
         private static async Task<LSP.CompletionList> RunGetCompletionsAsync(
             TestLspServer testLspServer,
             LSP.CompletionParams completionParams,
-            LSP.VSClientCapabilities clientCapabilities)
+            LSP.ClientCapabilities clientCapabilities)
         {
             var completionList = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,
                 completionParams, clientCapabilities, null, CancellationToken.None);
@@ -281,10 +333,10 @@ class B : A
             return completionList;
         }
 
-        private static LSP.VSCompletionItem ConvertToClientCompletionItem(LSP.CompletionItem serverCompletionItem)
+        private static T ConvertToClientCompletionItem<T>(T serverCompletionItem) where T : LSP.CompletionItem
         {
             var serializedItem = JsonConvert.SerializeObject(serverCompletionItem);
-            var clientCompletionItem = JsonConvert.DeserializeObject<LSP.VSCompletionItem>(serializedItem);
+            var clientCompletionItem = JsonConvert.DeserializeObject<T>(serializedItem);
             return clientCompletionItem;
         }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -236,13 +236,13 @@ class A
 void A.AMethod(int i)
 ```
   
-A&nbsp;cref&nbsp;A.AMethod(int)  
+A&nbsp;cref&nbsp;A\.AMethod\(int\)  
 **strong&nbsp;text**  
 _italic&nbsp;text_  
 <u>underline&nbsp;text</u>  
   
-•&nbsp;Item&nbsp;1.  
-•&nbsp;Item&nbsp;2.  
+•&nbsp;Item&nbsp;1\.  
+•&nbsp;Item&nbsp;2\.  
   
 [link text](https://google.com)";
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -232,7 +232,7 @@ $@"<Workspace>
             using var testLspServer = CreateTestLspServer(markup, out var locations);
             var expectedLocation = locations["caret"].Single();
 
-            var expectedMarkdown = @"```csharp
+            var expectedMarkdown = @$"```csharp
 void A.AMethod(int i)
 ```
   
@@ -248,10 +248,10 @@ _italic&nbsp;text_
   
 Remarks&nbsp;are&nbsp;cool&nbsp;too\.  
   
-Returns:  
+{FeaturesResources.Returns_colon}  
 &nbsp;&nbsp;a&nbsp;string  
   
-Exceptions:  
+{FeaturesResources.Exceptions_colon}  
 &nbsp;&nbsp;System\.NullReferenceException  
 ";
 
@@ -306,7 +306,7 @@ Exceptions:
             using var testLspServer = CreateTestLspServer(markup, out var locations);
             var expectedLocation = locations["caret"].Single();
 
-            var expectedText = @"void A.AMethod(int i)
+            var expectedText = @$"void A.AMethod(int i)
 A cref A.AMethod(int)
 strong text
 italic text
@@ -319,10 +319,10 @@ link text
 
 Remarks are cool too.
 
-Returns:
+{FeaturesResources.Returns_colon}
   a string
 
-Exceptions:
+{FeaturesResources.Exceptions_colon}
   System.NullReferenceException
 ";
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
 
             var results = await RunGetHoverAsync(testLspServer, expectedLocation).ConfigureAwait(false);
 
-            VerifyContent(results, $"string A.Method(int i)|A great method|{FeaturesResources.Returns_colon}|  |a string");
+            VerifyVSContent(results, $"string A.Method(int i)|A great method|{FeaturesResources.Returns_colon}|  |a string");
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
             var expectedLocation = locations["caret"].Single();
 
             var results = await RunGetHoverAsync(testLspServer, expectedLocation).ConfigureAwait(false);
-            VerifyContent(results, $"string A.Method(int i)|A great method|{FeaturesResources.Exceptions_colon}|  System.NullReferenceException");
+            VerifyVSContent(results, $"string A.Method(int i)|A great method|{FeaturesResources.Exceptions_colon}|  System.NullReferenceException");
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
             var expectedLocation = locations["caret"].Single();
 
             var results = await RunGetHoverAsync(testLspServer, expectedLocation).ConfigureAwait(false);
-            VerifyContent(results, "string A.Method(int i)|A great method|Remarks are cool too.");
+            VerifyVSContent(results, "string A.Method(int i)|A great method|Remarks are cool too.");
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Hover
             var expectedLocation = locations["caret"].Single();
 
             var results = await RunGetHoverAsync(testLspServer, expectedLocation).ConfigureAwait(false);
-            VerifyContent(results, "string A.Method(int i)|A great method|• |Item 1.|• |Item 2.");
+            VerifyVSContent(results, "string A.Method(int i)|A great method|• |Item 1.|• |Item 2.");
         }
 
         [Fact]
@@ -187,19 +187,93 @@ $@"<Workspace>
                 var result = await RunGetHoverAsync(testLspServer, location, project.Id);
 
                 var expectedConstant = project.Name == "Net472" ? "Target in net472" : "Target in netcoreapp3.1";
-                VerifyContent(result, $"({FeaturesResources.constant}) string WithConstant.Target = \"{expectedConstant}\"");
+                VerifyVSContent(result, $"({FeaturesResources.constant}) string WithConstant.Target = \"{expectedConstant}\"");
             }
         }
 
-        private static async Task<LSP.VSHover> RunGetHoverAsync(TestLspServer testLspServer, LSP.Location caret, ProjectId projectContext = null)
+        [Fact]
+        public async Task TestGetHoverAsync_UsingMarkupContent()
         {
-            return (LSP.VSHover)await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Hover>(LSP.Methods.TextDocumentHoverName,
-                           CreateTextDocumentPositionParams(caret, projectContext), new LSP.ClientCapabilities(), null, CancellationToken.None);
+            var markup =
+@"class A
+{
+    /// <summary>
+    /// A cref <see cref=""AMethod""/>
+    /// <br/>
+    /// <strong>strong text</strong>
+    /// <br/>
+    /// <em>italic text</em>
+    /// <br/>
+    /// <u>underline text</u>
+    /// <para>
+    /// <list type='bullet'>
+    /// <item>
+    /// <description>Item 1.</description>
+    /// </item>
+    /// <item>
+    /// <description>Item 2.</description>
+    /// </item>
+    /// </list>
+    /// <a href = ""https://google.com"" > link text</a>
+    /// </para>
+    /// </summary>
+    /// <exception cref='System.NullReferenceException'>
+    /// Oh no!
+    /// </exception>
+    /// <param name='i'>an int</param>
+    /// <returns>a string</returns>
+    /// <remarks>
+    /// Remarks are cool too.
+    /// </remarks>
+    void {|caret:AMethod|}(int i)
+    {
+    }
+}";
+            using var testLspServer = CreateTestLspServer(markup, out var locations);
+            var expectedLocation = locations["caret"].Single();
+
+            var expectedMarkdown = @"```csharp
+void A.AMethod(int i)
+```
+  
+A&nbsp;cref&nbsp;A.AMethod(int)  
+**strong&nbsp;text**  
+_italic&nbsp;text_  
+<u>underline&nbsp;text</u>  
+  
+•&nbsp;Item&nbsp;1.  
+•&nbsp;Item&nbsp;2.  
+  
+[link text](https://google.com)  
+  
+Remarks&nbsp;are&nbsp;cool&nbsp;too.  
+  
+Returns:  
+&nbsp;&nbsp;a&nbsp;string  
+  
+Exceptions:  
+&nbsp;&nbsp;System.NullReferenceException  
+";
+
+            var results = await RunGetHoverAsync(testLspServer, expectedLocation, clientCapabilities: new LSP.ClientCapabilities()).ConfigureAwait(false);
+            Assert.Equal(expectedMarkdown, results.Contents.Third.Value);
         }
 
-        private void VerifyContent(LSP.VSHover result, string expectedContent)
+        private static async Task<LSP.Hover> RunGetHoverAsync(
+            TestLspServer testLspServer,
+            LSP.Location caret,
+            ProjectId projectContext = null,
+            LSP.ClientCapabilities clientCapabilities = null)
         {
-            var containerElement = (ContainerElement)result.RawContent;
+            clientCapabilities ??= new LSP.VSClientCapabilities { SupportsVisualStudioExtensions = true };
+            return await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Hover>(LSP.Methods.TextDocumentHoverName,
+                           CreateTextDocumentPositionParams(caret, projectContext), clientCapabilities, null, CancellationToken.None);
+        }
+
+        private void VerifyVSContent(LSP.Hover hover, string expectedContent)
+        {
+            var vsHover = Assert.IsType<LSP.VSHover>(hover);
+            var containerElement = (ContainerElement)vsHover.RawContent;
             using var _ = ArrayBuilder<ClassifiedTextElement>.GetInstance(out var classifiedTextElements);
             GetClassifiedTextElements(containerElement, classifiedTextElements);
             Assert.False(classifiedTextElements.SelectMany(classifiedTextElements => classifiedTextElements.Runs).Any(run => run.NavigationAction != null));


### PR DESCRIPTION
This adds better support for tooltips in Hover and completion by converting TaggedText into Markdown content which vscode can read.

Also fixed a bug in completionresolve which was picking the wrong completion item to resolve when the label was a subset of another label (e.g. "A" is a subset of "AMethod").

Pics:
![vscode_hover](https://user-images.githubusercontent.com/5749229/117534347-d8ff3280-afa5-11eb-9e9c-36eea31fe1b7.png)
![vscode_sighelp](https://user-images.githubusercontent.com/5749229/117534348-db618c80-afa5-11eb-9f8d-dd3e993e8783.png)
