### PR TITLE
Fix collapse to definitions for top-level statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
@@ -411,6 +412,24 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [WorkItem(52493, "https://github.com/dotnet/roslyn/issues/")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task LocalFunctionInTopLevelStatement_AutoCollapse()
+        {
+            const string code = @"
+Foo();
+Bar();
+
+{|hint:static void Foo(){|textspan:
+{$$
+   // ...
+}|}|}
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -40,7 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                         isCollapsible: true,
                         textSpan: GetTextSpan(node),
                         hintSpan: GetHintSpan(node),
-                        type: type));
+                        type: type,
+                        autoCollapse: parentKind == SyntaxKind.LocalFunctionStatement && node.Parent.IsParentKind(SyntaxKind.GlobalStatement)));
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/52493

Thanks to who wrote this comment :)

https://github.com/dotnet/roslyn/blob/c337aead326a96751c2be4aeca4652c2b8015b20/src/Features/Core/Portable/Structure/BlockSpan.cs#L35-L38