### PR TITLE
Correctly find enum members in case labels

### DIFF
--- a/src/EditorFeatures/Test/SymbolFinder/FindSymbolAtPositionTests.cs
+++ b/src/EditorFeatures/Test/SymbolFinder/FindSymbolAtPositionTests.cs
@@ -2,22 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 {
     [UseExportProvider]
-    public class ISemanticSnapshotExtensionTests
+    public class FindSymbolAtPositionTests
     {
         [Fact]
-        public async Task TryGetSymbolTouchingPositionOnLeadingTrivia()
+        public async Task PositionOnLeadingTrivia()
         {
             using var workspace = TestWorkspace.CreateCSharp(
                 @"using System;
@@ -30,11 +29,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                         #pragma warning restore 612
                     }
                 }");
-            var position = workspace.Documents.Single(d => d.CursorPosition.HasValue).CursorPosition.Value;
-            var snapshot = workspace.Documents.Single().GetTextBuffer().CurrentSnapshot;
+            var position = workspace.Documents.Single(d => d.CursorPosition.HasValue).CursorPosition!.Value;
 
-            var document = workspace.CurrentSolution.GetDocument(workspace.Documents.Single().Id);
-            Assert.NotNull(document);
+            var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.Single().Id);
 
             var symbol = await SymbolFinder.FindSymbolAtPositionAsync(document, position);
             Assert.Null(symbol);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
@@ -60,10 +60,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var symbol = semanticModel.GetDeclaredSymbol(ancestor, cancellationToken);
                 if (symbol != null)
                 {
-                    // The token may be part of a larger name (for example, `int` in `public static operator int[](Goo g);`.
-                    // So check if the symbol's location encompasses the span of the token we're asking about.
-                    if (symbol.Locations.Any(loc => loc.SourceTree == location.SourceTree && loc.SourceSpan.Contains(location.SourceSpan)))
-                        return symbol;
+                    if (symbol is IMethodSymbol { MethodKind: MethodKind.Conversion })
+                    {
+                        // The token may be part of a larger name (for example, `int` in `public static operator int[](Goo g);`.
+                        // So check if the symbol's location encompasses the span of the token we're asking about.
+                        if (symbol.Locations.Any(loc => loc.SourceTree == location.SourceTree && loc.SourceSpan.Contains(location.SourceSpan)))
+                            return symbol;
+                    }
+                    else
+                    {
+                        // For any other symbols, we only care if the name directly matches the span of the token
+                        if (symbol.Locations.Contains(location))
+                            return symbol;
+                    }
 
                     // We found some symbol, but it defined something else. We're not going to have a higher node defining _another_ symbol with this token, so we can stop now.
                     return null;


### PR DESCRIPTION
When we changed the logic for finding declared symbols in ca2505a08c8974dde3243bd9fdb6a159c3d83cd7, we now would see the case label as declaring the symbol which we don't want. As a conservative choice, we'll do the expanded logic only for operators where it was originally intended.

Fixes #53269