### PR TITLE
Revert "Revert "Require partial method signatures to match" (47576) (#47879)"

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6329,7 +6329,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Partial method declarations '{0}' and '{1}' have signature differences.</value>
   </data>
   <data name="WRN_PartialMethodTypeDifference_Title" xml:space="preserve">
-    <value>Partial method declarations have differences in parameter names, parameter types, or return types.</value>
+    <value>Partial method declarations have signature differences.</value>
   </data>
   <data name="IDS_TopLevelStatements" xml:space="preserve">
     <value>top-level statements</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6326,10 +6326,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Partial method declarations must have matching ref return values.</value>
   </data>
   <data name="WRN_PartialMethodTypeDifference" xml:space="preserve">
-    <value>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</value>
+    <value>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</value>
   </data>
   <data name="WRN_PartialMethodTypeDifference_Title" xml:space="preserve">
-    <value>Partial method declarations have differences in parameter or return types.</value>
+    <value>Partial method declarations have differences in parameter names, parameter types, or return types.</value>
   </data>
   <data name="IDS_TopLevelStatements" xml:space="preserve">
     <value>top-level statements</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6325,6 +6325,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_PartialMethodRefReturnDifference" xml:space="preserve">
     <value>Partial method declarations must have matching ref return values.</value>
   </data>
+  <data name="WRN_PartialMethodTypeDifference" xml:space="preserve">
+    <value>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</value>
+  </data>
+  <data name="WRN_PartialMethodTypeDifference_Title" xml:space="preserve">
+    <value>Partial method declarations have differences in parameter or return types.</value>
+  </data>
   <data name="IDS_TopLevelStatements" xml:space="preserve">
     <value>top-level statements</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6326,7 +6326,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Partial method declarations must have matching ref return values.</value>
   </data>
   <data name="WRN_PartialMethodTypeDifference" xml:space="preserve">
-    <value>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</value>
+    <value>Partial method declarations '{0}' and '{1}' have signature differences.</value>
   </data>
   <data name="WRN_PartialMethodTypeDifference_Title" xml:space="preserve">
     <value>Partial method declarations have differences in parameter names, parameter types, or return types.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1835,8 +1835,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_StaticAnonymousFunctionCannotCaptureThis = 8821,
         ERR_OverrideDefaultConstraintNotSatisfied = 8822,
         ERR_DefaultConstraintOverrideOnly = 8823,
+<<<<<<< HEAD
         WRN_ParameterNotNullIfNotNull = 8824,
         WRN_ReturnNotNullIfNotNull = 8825,
+=======
+        WRN_PartialMethodTypeDifference = 8824,
+>>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
 
         ERR_RuntimeDoesNotSupportCovariantReturnsOfClasses = 8830,
         ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses = 8831,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1835,12 +1835,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_StaticAnonymousFunctionCannotCaptureThis = 8821,
         ERR_OverrideDefaultConstraintNotSatisfied = 8822,
         ERR_DefaultConstraintOverrideOnly = 8823,
-<<<<<<< HEAD
         WRN_ParameterNotNullIfNotNull = 8824,
         WRN_ReturnNotNullIfNotNull = 8825,
-=======
-        WRN_PartialMethodTypeDifference = 8824,
->>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
+        WRN_PartialMethodTypeDifference = 8826,
 
         ERR_RuntimeDoesNotSupportCovariantReturnsOfClasses = 8830,
         ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses = 8831,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -218,6 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_SyncAndAsyncEntryPoints:
                 case ErrorCode.WRN_ParameterIsStaticClass:
                 case ErrorCode.WRN_ReturnTypeIsStaticClass:
+                case ErrorCode.WRN_PartialMethodTypeDifference:
                     // Warning level 5 is exclusively for warnings introduced in the compiler
                     // shipped with dotnet 5 (C# 9) and that can be reported for pre-existing code.
                     return 5;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -204,6 +204,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             switch (code)
             {
+                case ErrorCode.WRN_PartialMethodTypeDifference:
+                    // Warning level 6 is exclusively for warnings introduced in the compiler
+                    // shipped with dotnet 6 (C# 10) and that can be reported for pre-existing code.
+                    return 6;
                 case ErrorCode.WRN_NubExprIsConstBool2:
                 case ErrorCode.WRN_StaticInAsOrIs:
                 case ErrorCode.WRN_PrecedenceInversion:
@@ -218,7 +222,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_SyncAndAsyncEntryPoints:
                 case ErrorCode.WRN_ParameterIsStaticClass:
                 case ErrorCode.WRN_ReturnTypeIsStaticClass:
-                case ErrorCode.WRN_PartialMethodTypeDifference:
                     // Warning level 5 is exclusively for warnings introduced in the compiler
                     // shipped with dotnet 5 (C# 9) and that can be reported for pre-existing code.
                     return 5;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -247,12 +247,9 @@
                 case ErrorCode.WRN_GivenExpressionAlwaysMatchesPattern:
                 case ErrorCode.WRN_IsPatternAlways:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial:
-<<<<<<< HEAD
                 case ErrorCode.WRN_ParameterNotNullIfNotNull:
                 case ErrorCode.WRN_ReturnNotNullIfNotNull:
-=======
                 case ErrorCode.WRN_PartialMethodTypeDifference:
->>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
                 case ErrorCode.WRN_SwitchExpressionNotExhaustiveWithWhen:
                 case ErrorCode.WRN_SwitchExpressionNotExhaustiveForNullWithWhen:
                 case ErrorCode.WRN_PrecedenceInversion:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -247,8 +247,12 @@
                 case ErrorCode.WRN_GivenExpressionAlwaysMatchesPattern:
                 case ErrorCode.WRN_IsPatternAlways:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial:
+<<<<<<< HEAD
                 case ErrorCode.WRN_ParameterNotNullIfNotNull:
                 case ErrorCode.WRN_ReturnNotNullIfNotNull:
+=======
+                case ErrorCode.WRN_PartialMethodTypeDifference:
+>>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
                 case ErrorCode.WRN_SwitchExpressionNotExhaustiveWithWhen:
                 case ErrorCode.WRN_SwitchExpressionNotExhaustiveForNullWithWhen:
                 case ErrorCode.WRN_PrecedenceInversion:

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -129,6 +129,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
+        /// This instance is used to determine if a partial method implementation matches the definition,
+        /// including differences ignored by the runtime.
+        /// </summary>
+        public static readonly MemberSignatureComparer PartialMethodsStrictComparer = new MemberSignatureComparer(
+            considerName: true,
+            considerExplicitlyImplementedInterfaces: true,
+            considerReturnType: true,
+            considerTypeConstraints: false,
+            considerCallingConvention: false,
+            considerRefKindDifferences: true,
+            typeComparison: TypeCompareKind.ObliviousNullableModifierMatchesAny);
+
+        /// <summary>
         /// This instance is used to check whether one member overrides another, according to the C# definition.
         /// </summary>
         public static readonly MemberSignatureComparer CSharpOverrideComparer = new MemberSignatureComparer(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3059,13 +3059,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodMustHaveLatent, method.Locations[0], method);
                     }
-<<<<<<< HEAD
-                    else if (method.OtherPartOfPartial is MethodSymbol otherPart && MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(method, otherPart))
-                    {
-                        diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentTupleNames, method.Locations[0], method, method.OtherPartOfPartial);
-                    }
-=======
->>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
                     else if (method is { IsPartialDefinition: true, OtherPartOfPartial: null, HasExplicitAccessModifier: true })
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodWithAccessibilityModsMustHaveImplementation, method.Locations[0], method);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3059,10 +3059,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodMustHaveLatent, method.Locations[0], method);
                     }
+<<<<<<< HEAD
                     else if (method.OtherPartOfPartial is MethodSymbol otherPart && MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(method, otherPart))
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentTupleNames, method.Locations[0], method, method.OtherPartOfPartial);
                     }
+=======
+>>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
                     else if (method is { IsPartialDefinition: true, OtherPartOfPartial: null, HasExplicitAccessModifier: true })
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodWithAccessibilityModsMustHaveImplementation, method.Locations[0], method);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1169,7 +1169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 location,
                 new FormattedSymbol(overridingParameter, SymbolDisplayFormat.ShortFormat));
 
-        internal static void CheckValidNullableMethodOverride<TArg>(
+        internal static bool CheckValidNullableMethodOverride<TArg>(
             CSharpCompilation compilation,
             MethodSymbol baseMethod,
             MethodSymbol overrideMethod,
@@ -1181,13 +1181,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (!PerformValidNullableOverrideCheck(compilation, baseMethod, overrideMethod))
             {
-                return;
+                return false;
             }
+
+            bool hasErrors = false;
 
             if ((baseMethod.FlowAnalysisAnnotations & FlowAnalysisAnnotations.DoesNotReturn) == FlowAnalysisAnnotations.DoesNotReturn &&
                 (overrideMethod.FlowAnalysisAnnotations & FlowAnalysisAnnotations.DoesNotReturn) != FlowAnalysisAnnotations.DoesNotReturn)
             {
                 diagnostics.Add(ErrorCode.WRN_DoesNotReturnMismatch, overrideMethod.Locations[0], new FormattedSymbol(overrideMethod, SymbolDisplayFormat.MinimallyQualifiedFormat));
+                hasErrors = true;
             }
 
             var conversions = compilation.Conversions.WithNullability(true);
@@ -1206,7 +1209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         baseMethod.ReturnTypeWithAnnotations.Type))
                 {
                     reportMismatchInReturnType(diagnostics, baseMethod, overrideMethod, false, extraArgument);
-                    return;
+                    return true;
                 }
 
                 // check top-level nullability including flow analysis annotations
@@ -1218,41 +1221,43 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         overrideMethod.ReturnTypeFlowAnalysisAnnotations))
                 {
                     reportMismatchInReturnType(diagnostics, baseMethod, overrideMethod, true, extraArgument);
-                    return;
+                    return true;
                 }
             }
 
-            if (reportMismatchInParameterType == null)
+            if (reportMismatchInParameterType != null)
             {
-                return;
+                for (int i = 0; i < baseParameters.Length; i++)
+                {
+                    var baseParameter = baseParameters[i];
+                    var baseParameterType = baseParameter.TypeWithAnnotations;
+                    var overrideParameter = overrideParameters[i + overrideParameterOffset];
+                    var overrideParameterType = getNotNullIfNotNullOutputType(overrideParameter.TypeWithAnnotations, overrideParameter.NotNullIfParameterNotNull);
+                    // check nested nullability
+                    if (!isValidNullableConversion(
+                            conversions,
+                            overrideParameter.RefKind,
+                            baseParameterType.Type,
+                            overrideParameterType.Type))
+                    {
+                        reportMismatchInParameterType(diagnostics, baseMethod, overrideMethod, overrideParameter, false, extraArgument);
+                        hasErrors = true;
+                    }
+                    // check top-level nullability including flow analysis annotations
+                    else if (!NullableWalker.AreParameterAnnotationsCompatible(
+                            overrideParameter.RefKind,
+                            baseParameterType,
+                            baseParameter.FlowAnalysisAnnotations,
+                            overrideParameterType,
+                            overrideParameter.FlowAnalysisAnnotations))
+                    {
+                        reportMismatchInParameterType(diagnostics, baseMethod, overrideMethod, overrideParameter, true, extraArgument);
+                        hasErrors = true;
+                    }
+                }
             }
 
-            for (int i = 0; i < baseParameters.Length; i++)
-            {
-                var baseParameter = baseParameters[i];
-                var baseParameterType = baseParameter.TypeWithAnnotations;
-                var overrideParameter = overrideParameters[i + overrideParameterOffset];
-                var overrideParameterType = getNotNullIfNotNullOutputType(overrideParameter.TypeWithAnnotations, overrideParameter.NotNullIfParameterNotNull);
-                // check nested nullability
-                if (!isValidNullableConversion(
-                        conversions,
-                        overrideParameter.RefKind,
-                        baseParameterType.Type,
-                        overrideParameterType.Type))
-                {
-                    reportMismatchInParameterType(diagnostics, baseMethod, overrideMethod, overrideParameter, false, extraArgument);
-                }
-                // check top-level nullability including flow analysis annotations
-                else if (!NullableWalker.AreParameterAnnotationsCompatible(
-                        overrideParameter.RefKind,
-                        baseParameterType,
-                        baseParameter.FlowAnalysisAnnotations,
-                        overrideParameterType,
-                        overrideParameter.FlowAnalysisAnnotations))
-                {
-                    reportMismatchInParameterType(diagnostics, baseMethod, overrideMethod, overrideParameter, true, extraArgument);
-                }
-            }
+            return hasErrors;
 
             TypeWithAnnotations getNotNullIfNotNullOutputType(TypeWithAnnotations outputType, ImmutableHashSet<string> notNullIfParameterNotNull)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1169,6 +1169,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 location,
                 new FormattedSymbol(overridingParameter, SymbolDisplayFormat.ShortFormat));
 
+        /// <returns>
+        /// Returns true if there is:
+        /// <list type="bullet">
+        /// <item><description>DoesNotReturn mismatch.</description></item>
+        /// <item><description>Parameter type mismatch.</description></item>
+        /// <item><description>Return type mismatch.</description></item>
+        /// </list>
+        /// </returns>
         internal static bool CheckValidNullableMethodOverride<TArg>(
             CSharpCompilation compilation,
             MethodSymbol baseMethod,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1170,12 +1170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 new FormattedSymbol(overridingParameter, SymbolDisplayFormat.ShortFormat));
 
         /// <returns>
-        /// Returns true if there is:
-        /// <list type="bullet">
-        /// <item><description>DoesNotReturn mismatch.</description></item>
-        /// <item><description>Parameter type mismatch.</description></item>
-        /// <item><description>Return type mismatch.</description></item>
-        /// </list>
+        /// <see langword="true"/> if a diagnostic was added. Otherwise, <see langword="false"/>.
         /// </returns>
         internal static bool CheckValidNullableMethodOverride<TArg>(
             CSharpCompilation compilation,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -700,6 +700,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             PartialMethodConstraintsChecks(definition, implementation, diagnostics);
 
+            if (definition.Parameters.Length == implementation.Parameters.Length)
+            {
+                for (int i = 0; i < definition.Parameters.Length; i++)
+                {
+                    if (definition.Parameters[i].Name != implementation.Parameters[i].Name)
+                    {
+                        diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
+                            new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),
+                            new FormattedSymbol(implementation, SymbolDisplayFormat.MinimallyQualifiedFormat));
+                        break;
+                    }
+                }
+            }
+
             if (SourceMemberContainerTypeSymbol.CheckValidNullableMethodOverride(
                 implementation.DeclaringCompilation,
                 constructedDefinition,
@@ -720,7 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if (!hasTypeDifferences &&
-                !MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation))
+                (!MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation)))
             {
                 diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
                     new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),
@@ -751,6 +765,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var typeParameter1 = typeParameters1[i];
                 var typeParameter2 = typeParameters2[i];
+
+                // TODO: Should report on type parameter name differences?
+                /*
+                if (typeParameter1.Name != typeParameter2.Name)
+                {
+                    diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
+                        new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        new FormattedSymbol(implementation, SymbolDisplayFormat.MinimallyQualifiedFormat));
+                }
+                */
 
                 if (!MemberSignatureComparer.HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -757,6 +757,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var typeParameter1 = typeParameters1[i];
                 var typeParameter2 = typeParameters2[i];
+
                 if (!MemberSignatureComparer.HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
                 {
                     diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentConstraints, implementation.Locations[0], implementation, typeParameter2.Name);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -642,7 +642,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(!ReferenceEquals(definition, implementation));
 
-            MethodSymbol constructedDefinition = definition.ConstructIfGeneric(implementation.TypeArgumentsWithAnnotations);
+            MethodSymbol constructedDefinition = definition.ConstructIfGeneric(TypeMap.TypeParametersAsTypeSymbolsWithIgnoredAnnotations(implementation.TypeParameters));
             bool hasTypeDifferences = !constructedDefinition.ReturnTypeWithAnnotations.Equals(implementation.ReturnTypeWithAnnotations, TypeCompareKind.AllIgnoreOptions);
             if (hasTypeDifferences)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -720,11 +720,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if ((!hasTypeDifferences && !MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation)) ||
-                !definition.Parameters.SequenceEqual(implementation.Parameters, (a, b) => a.Name == b.Name))
+                hasDifferencesInParameterOrTypeParameterName(definition, implementation))
             {
                 diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
                     new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),
                     new FormattedSymbol(implementation, SymbolDisplayFormat.MinimallyQualifiedFormat));
+            }
+
+            static bool hasDifferencesInParameterOrTypeParameterName(SourceOrdinaryMethodSymbol definition, SourceOrdinaryMethodSymbol implementation)
+            {
+                return !definition.Parameters.SequenceEqual(implementation.Parameters, (a, b) => a.Name == b.Name) ||
+                    !definition.TypeParameters.SequenceEqual(implementation.TypeParameters, (a, b) => a.Name == b.Name);
             }
         }
 
@@ -751,17 +757,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var typeParameter1 = typeParameters1[i];
                 var typeParameter2 = typeParameters2[i];
-
-                // TODO: Should report on type parameter name differences?
-                /*
-                if (typeParameter1.Name != typeParameter2.Name)
-                {
-                    diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
-                        new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        new FormattedSymbol(implementation, SymbolDisplayFormat.MinimallyQualifiedFormat));
-                }
-                */
-
                 if (!MemberSignatureComparer.HaveSameConstraints(typeParameter1, typeMap1, typeParameter2, typeMap2))
                 {
                     diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentConstraints, implementation.Locations[0], implementation, typeParameter2.Name);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -700,20 +700,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             PartialMethodConstraintsChecks(definition, implementation, diagnostics);
 
-            if (definition.Parameters.Length == implementation.Parameters.Length)
-            {
-                for (int i = 0; i < definition.Parameters.Length; i++)
-                {
-                    if (definition.Parameters[i].Name != implementation.Parameters[i].Name)
-                    {
-                        diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
-                            new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),
-                            new FormattedSymbol(implementation, SymbolDisplayFormat.MinimallyQualifiedFormat));
-                        break;
-                    }
-                }
-            }
-
             if (SourceMemberContainerTypeSymbol.CheckValidNullableMethodOverride(
                 implementation.DeclaringCompilation,
                 constructedDefinition,
@@ -733,8 +719,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 hasTypeDifferences = true;
             }
 
-            if (!hasTypeDifferences &&
-                (!MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation)))
+            if ((!hasTypeDifferences && !MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation)) ||
+                !definition.Parameters.SequenceEqual(implementation.Parameters, (a, b) => a.Name == b.Name))
             {
                 diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
                     new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -642,17 +642,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(!ReferenceEquals(definition, implementation));
 
-<<<<<<< HEAD
-            MethodSymbol constructedDefinition = definition.ConstructIfGeneric(TypeMap.TypeParametersAsTypeSymbolsWithIgnoredAnnotations(implementation.TypeParameters));
-            bool returnTypesEqual = constructedDefinition.ReturnTypeWithAnnotations.Equals(implementation.ReturnTypeWithAnnotations, TypeCompareKind.AllIgnoreOptions);
-            if (!returnTypesEqual
-                && !SourceMemberContainerTypeSymbol.IsOrContainsErrorType(implementation.ReturnType)
-                && !SourceMemberContainerTypeSymbol.IsOrContainsErrorType(definition.ReturnType))
-=======
             MethodSymbol constructedDefinition = definition.ConstructIfGeneric(implementation.TypeArgumentsWithAnnotations);
             bool hasTypeDifferences = !constructedDefinition.ReturnTypeWithAnnotations.Equals(implementation.ReturnTypeWithAnnotations, TypeCompareKind.AllIgnoreOptions);
             if (hasTypeDifferences)
->>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
             {
                 diagnostics.Add(ErrorCode.ERR_PartialMethodReturnTypeDifference, implementation.Locations[0]);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -642,13 +642,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(!ReferenceEquals(definition, implementation));
 
+<<<<<<< HEAD
             MethodSymbol constructedDefinition = definition.ConstructIfGeneric(TypeMap.TypeParametersAsTypeSymbolsWithIgnoredAnnotations(implementation.TypeParameters));
             bool returnTypesEqual = constructedDefinition.ReturnTypeWithAnnotations.Equals(implementation.ReturnTypeWithAnnotations, TypeCompareKind.AllIgnoreOptions);
             if (!returnTypesEqual
                 && !SourceMemberContainerTypeSymbol.IsOrContainsErrorType(implementation.ReturnType)
                 && !SourceMemberContainerTypeSymbol.IsOrContainsErrorType(definition.ReturnType))
+=======
+            MethodSymbol constructedDefinition = definition.ConstructIfGeneric(implementation.TypeArgumentsWithAnnotations);
+            bool hasTypeDifferences = !constructedDefinition.ReturnTypeWithAnnotations.Equals(implementation.ReturnTypeWithAnnotations, TypeCompareKind.AllIgnoreOptions);
+            if (hasTypeDifferences)
+>>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
             {
                 diagnostics.Add(ErrorCode.ERR_PartialMethodReturnTypeDifference, implementation.Locations[0]);
+            }
+            else if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(definition, implementation))
+            {
+                hasTypeDifferences = true;
+                diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentTupleNames, implementation.Locations[0], definition, implementation);
             }
 
             if (definition.RefKind != implementation.RefKind)
@@ -697,24 +708,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             PartialMethodConstraintsChecks(definition, implementation, diagnostics);
 
-            SourceMemberContainerTypeSymbol.CheckValidNullableMethodOverride(
+            if (SourceMemberContainerTypeSymbol.CheckValidNullableMethodOverride(
                 implementation.DeclaringCompilation,
                 constructedDefinition,
                 implementation,
                 diagnostics,
-                (diagnostics, implementedMethod, implementingMethod, topLevel, returnTypesEqual) =>
+                static (diagnostics, implementedMethod, implementingMethod, topLevel, arg) =>
                 {
-                    if (returnTypesEqual)
-                    {
-                        // report only if this is an unsafe *nullability* difference
-                        diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, implementingMethod.Locations[0]);
-                    }
+                    // report only if this is an unsafe *nullability* difference
+                    diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, implementingMethod.Locations[0]);
                 },
-                (diagnostics, implementedMethod, implementingMethod, implementingParameter, blameAttributes, arg) =>
+                static (diagnostics, implementedMethod, implementingMethod, implementingParameter, blameAttributes, arg) =>
                 {
                     diagnostics.Add(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, implementingMethod.Locations[0], new FormattedSymbol(implementingParameter, SymbolDisplayFormat.ShortFormat));
                 },
-                extraArgument: returnTypesEqual);
+                extraArgument: (object)null))
+            {
+                hasTypeDifferences = true;
+            }
+
+            if (!hasTypeDifferences &&
+                !MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation))
+            {
+                diagnostics.Add(ErrorCode.WRN_PartialMethodTypeDifference, implementation.Locations[0],
+                    new FormattedSymbol(definition, SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    new FormattedSymbol(implementation, SymbolDisplayFormat.MinimallyQualifiedFormat));
+            }
         }
 
         private static void PartialMethodConstraintsChecks(SourceOrdinaryMethodSymbol definition, SourceOrdinaryMethodSymbol implementation, BindingDiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Typy a aliasy by neměly mít název record.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Typen und Aliase dürfen nicht den Namen "record" aufweisen.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Los tipos y los alias no deben denominarse "record".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Les types et les alias ne doivent pas porter le nom 'record'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Il nome di tipi e alias non deve essere 'record'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">型およびエイリアスに 'record' という名前を指定することはできません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">형식 및 별칭의 이름은 'record'로 지정할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Typy i aliasy nie powinny mieć nazwy „record”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Os tipos e os aliases não devem ser nomeados como 'registro'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Типы и псевдонимы не могут иметь имя "record"</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">Türler ve diğer adlar 'record' olarak adlandırılmamalıdır.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">类型和别名不应命名为 "record"。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations have signature differences.</source>
+        <target state="new">Partial method declarations have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1083,13 +1083,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">
-        <source>Partial method declarations have differences in parameter or return types.</source>
-        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <source>Partial method declarations have differences in parameter names, parameter types, or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter names, parameter types, or return types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1083,8 +1083,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference">
-        <source>Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</source>
-        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter names, parameter types, or return types.</target>
+        <source>Partial method declarations '{0}' and '{1}' have signature differences.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have signature differences.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PartialMethodTypeDifference_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1082,6 +1082,16 @@
         <target state="new">Mixed declarations and expressions in deconstruction</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference">
+        <source>Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations '{0}' and '{1}' have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialMethodTypeDifference_Title">
+        <source>Partial method declarations have differences in parameter or return types.</source>
+        <target state="new">Partial method declarations have differences in parameter or return types.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RecordNamedDisallowed">
         <source>Types and aliases should not be named 'record'.</source>
         <target state="translated">類型與別名不應命名為 'record'。</target>

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -1272,10 +1272,10 @@ public class C : IA, IB<(nint, object, nuint[], object, nint, object, (System.In
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.Regular9);
             comp.VerifyEmitDiagnostics(
-                // (4,25): warning CS8824: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have differences in parameter or return types.
+                // (4,25): warning CS8826: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have signature differences.
                 //     static partial void F2(System.UIntPtr x) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2").WithArguments("void Program.F2(nuint x)", "void Program.F2(UIntPtr x)").WithLocation(4, 25),
-                // (5,25): warning CS8824: Partial method declarations 'void Program.F1(IntPtr x)' and 'void Program.F1(nint x)' have differences in parameter or return types.
+                // (5,25): warning CS8826: Partial method declarations 'void Program.F1(IntPtr x)' and 'void Program.F1(nint x)' have signature differences.
                 //     static partial void F1(nint x) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("void Program.F1(IntPtr x)", "void Program.F1(nint x)").WithLocation(5, 25));
         }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -1270,7 +1270,7 @@ public class C : IA, IB<(nint, object, nuint[], object, nint, object, (System.In
 ";
             AssertNativeIntegerAttributes(comp, expected);
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.Regular9);
             comp.VerifyEmitDiagnostics(
                 // (4,25): warning CS8824: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have differences in parameter or return types.
                 //     static partial void F2(System.UIntPtr x) { }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -1251,6 +1251,7 @@ public class C : IA, IB<(nint, object, nuint[], object, nint, object, (System.In
         }
 
         [Fact]
+        [WorkItem(45519, "https://github.com/dotnet/roslyn/issues/45519")]
         public void EmitAttribute_PartialMethods()
         {
             var source =
@@ -1262,13 +1263,21 @@ public class C : IA, IB<(nint, object, nuint[], object, nint, object, (System.In
     static partial void F2(nuint x);
 }";
             var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All), parseOptions: TestOptions.Regular9);
-            // Ideally should not emit any attributes. Compare with dynamic/object.
             var expected =
 @"Program
     void F2(System.UIntPtr x)
         [NativeInteger] System.UIntPtr x
 ";
             AssertNativeIntegerAttributes(comp, expected);
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.Regular9);
+            comp.VerifyEmitDiagnostics(
+                // (4,25): warning CS8824: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have differences in parameter or return types.
+                //     static partial void F2(System.UIntPtr x) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2").WithArguments("void Program.F2(nuint x)", "void Program.F2(UIntPtr x)").WithLocation(4, 25),
+                // (5,25): warning CS8824: Partial method declarations 'void Program.F1(IntPtr x)' and 'void Program.F1(nint x)' have differences in parameter or return types.
+                //     static partial void F1(nint x) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("void Program.F1(IntPtr x)", "void Program.F1(nint x)").WithLocation(5, 25));
         }
 
         // Shouldn't depend on [NullablePublicOnly].

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -20548,16 +20548,16 @@ public partial class C
                 // (10,18): error CS8142: Both partial method declarations, 'C.M1((int a, int b))' and 'C.M1((int notA, int notB))', must use the same tuple element names.
                 //     partial void M1((int notA, int notB) y) { }
                 Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M1").WithArguments("C.M1((int a, int b))", "C.M1((int notA, int notB))").WithLocation(10, 18),
-                // (10,18): warning CS8826: Partial method declarations 'void C.M1((int a, int b) x)' and 'void C.M1((int notA, int notB) y)' have differences in parameter names, parameter types, or return types.
+                // (10,18): warning CS8826: Partial method declarations 'void C.M1((int a, int b) x)' and 'void C.M1((int notA, int notB) y)' have signature differences.
                 //     partial void M1((int notA, int notB) y) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("void C.M1((int a, int b) x)", "void C.M1((int notA, int notB) y)").WithLocation(10, 18),
                 // (11,18): error CS8142: Both partial method declarations, 'C.M2((int a, int b))' and 'C.M2((int, int))', must use the same tuple element names.
                 //     partial void M2((int, int) y) { }
                 Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M2").WithArguments("C.M2((int a, int b))", "C.M2((int, int))").WithLocation(11, 18),
-                // (11,18): warning CS8826: Partial method declarations 'void C.M2((int a, int b) x)' and 'void C.M2((int, int) y)' have differences in parameter names, parameter types, or return types.
+                // (11,18): warning CS8826: Partial method declarations 'void C.M2((int a, int b) x)' and 'void C.M2((int, int) y)' have signature differences.
                 //     partial void M2((int, int) y) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("void C.M2((int a, int b) x)", "void C.M2((int, int) y)").WithLocation(11, 18),
-                // (12,18): warning CS8826: Partial method declarations 'void C.M3((int a, int b) x)' and 'void C.M3((int a, int b) y)' have differences in parameter names, parameter types, or return types.
+                // (12,18): warning CS8826: Partial method declarations 'void C.M3((int a, int b) x)' and 'void C.M3((int a, int b) y)' have signature differences.
                 //     partial void M3((int a, int b) y) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M3").WithArguments("void C.M3((int a, int b) x)", "void C.M3((int a, int b) y)").WithLocation(12, 18)
                 );

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -20548,9 +20548,18 @@ public partial class C
                 // (10,18): error CS8142: Both partial method declarations, 'C.M1((int a, int b))' and 'C.M1((int notA, int notB))', must use the same tuple element names.
                 //     partial void M1((int notA, int notB) y) { }
                 Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M1").WithArguments("C.M1((int a, int b))", "C.M1((int notA, int notB))").WithLocation(10, 18),
+                // (10,18): warning CS8826: Partial method declarations 'void C.M1((int a, int b) x)' and 'void C.M1((int notA, int notB) y)' have differences in parameter names, parameter types, or return types.
+                //     partial void M1((int notA, int notB) y) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("void C.M1((int a, int b) x)", "void C.M1((int notA, int notB) y)").WithLocation(10, 18),
                 // (11,18): error CS8142: Both partial method declarations, 'C.M2((int a, int b))' and 'C.M2((int, int))', must use the same tuple element names.
                 //     partial void M2((int, int) y) { }
-                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M2").WithArguments("C.M2((int a, int b))", "C.M2((int, int))").WithLocation(11, 18)
+                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M2").WithArguments("C.M2((int a, int b))", "C.M2((int, int))").WithLocation(11, 18),
+                // (11,18): warning CS8826: Partial method declarations 'void C.M2((int a, int b) x)' and 'void C.M2((int, int) y)' have differences in parameter names, parameter types, or return types.
+                //     partial void M2((int, int) y) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("void C.M2((int a, int b) x)", "void C.M2((int, int) y)").WithLocation(11, 18),
+                // (12,18): warning CS8826: Partial method declarations 'void C.M3((int a, int b) x)' and 'void C.M3((int a, int b) y)' have differences in parameter names, parameter types, or return types.
+                //     partial void M3((int a, int b) y) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M3").WithArguments("void C.M3((int a, int b) x)", "void C.M3((int a, int b) y)").WithLocation(12, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -20545,12 +20545,12 @@ public partial class C
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (4,18): error CS8142: Both partial method declarations, 'C.M1((int a, int b))' and 'C.M1((int notA, int notB))', must use the same tuple element names.
-                //     partial void M1((int a, int b) x);
-                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M1").WithArguments("C.M1((int a, int b))", "C.M1((int notA, int notB))").WithLocation(4, 18),
-                // (5,18): error CS8142: Both partial method declarations, 'C.M2((int a, int b))' and 'C.M2((int, int))', must use the same tuple element names.
-                //     partial void M2((int a, int b) x);
-                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M2").WithArguments("C.M2((int a, int b))", "C.M2((int, int))").WithLocation(5, 18)
+                // (10,18): error CS8142: Both partial method declarations, 'C.M1((int a, int b))' and 'C.M1((int notA, int notB))', must use the same tuple element names.
+                //     partial void M1((int notA, int notB) y) { }
+                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M1").WithArguments("C.M1((int a, int b))", "C.M1((int notA, int notB))").WithLocation(10, 18),
+                // (11,18): error CS8142: Both partial method declarations, 'C.M2((int a, int b))' and 'C.M2((int, int))', must use the same tuple element names.
+                //     partial void M2((int, int) y) { }
+                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M2").WithArguments("C.M2((int a, int b))", "C.M2((int, int))").WithLocation(11, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/CompilationEventTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/CompilationEventTests.cs
@@ -94,8 +94,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var q = new AsyncQueue<CompilationEvent>();
             CreateCompilationWithMscorlib45(source)
                 .WithEventQueue(q)
-                .VerifyDiagnostics()  // force diagnostics twice
-                .VerifyDiagnostics();
+                .VerifyDiagnostics(
+                    // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                    //     partial void M(int x2) {}
+                    Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
+
+                )  // force diagnostics twice
+                .VerifyDiagnostics(
+                    // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                    //     partial void M(int x2) {}
+                    Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
+                );
             VerifyEvents(q);
         }
 
@@ -143,14 +152,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             q = new AsyncQueue<CompilationEvent>();
             comp = CreateCompilationWithMscorlib45(source).WithEventQueue(q);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                //     partial void M(int x2) {}
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
+                );
             comp.GetUsedAssemblyReferences();
             VerifyEvents(q);
 
             q = new AsyncQueue<CompilationEvent>();
             comp = CreateCompilationWithMscorlib45(source).WithEventQueue(q);
             comp.GetUsedAssemblyReferences();
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                //     partial void M(int x2) {}
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
+                );
             VerifyEvents(q);
 
             q = new AsyncQueue<CompilationEvent>();

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/CompilationEventTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/CompilationEventTests.cs
@@ -95,13 +95,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             CreateCompilationWithMscorlib45(source)
                 .WithEventQueue(q)
                 .VerifyDiagnostics(
-                    // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                    // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have signature differences.
                     //     partial void M(int x2) {}
                     Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
 
                 )  // force diagnostics twice
                 .VerifyDiagnostics(
-                    // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                    // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have signature differences.
                     //     partial void M(int x2) {}
                     Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
                 );
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             q = new AsyncQueue<CompilationEvent>();
             comp = CreateCompilationWithMscorlib45(source).WithEventQueue(q);
             comp.VerifyDiagnostics(
-                // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have signature differences.
                 //     partial void M(int x2) {}
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
                 );
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp = CreateCompilationWithMscorlib45(source).WithEventQueue(q);
             comp.GetUsedAssemblyReferences();
             comp.VerifyDiagnostics(
-                // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have differences in parameter names, parameter types, or return types.
+                // (12,18): warning CS8826: Partial method declarations 'void C<T1>.M(int x1)' and 'void C<T1>.M(int x2)' have signature differences.
                 //     partial void M(int x2) {}
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C<T1>.M(int x1)", "void C<T1>.M(int x2)").WithLocation(12, 18)
                 );

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -739,7 +739,7 @@ partial class C
 }";
 
             CreateCompilation(source).VerifyDiagnostics(
-                // (9,25): warning CS8826: Partial method declarations 'void C.PartialMethod(int x)' and 'void C.PartialMethod(int y)' have differences in parameter names, parameter types, or return types.
+                // (9,25): warning CS8826: Partial method declarations 'void C.PartialMethod(int x)' and 'void C.PartialMethod(int y)' have signature differences.
                 //     static partial void PartialMethod(int y) { Console.WriteLine(y); }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "PartialMethod").WithArguments("void C.PartialMethod(int x)", "void C.PartialMethod(int y)").WithLocation(9, 25),
                 // (13,23): error CS1739: The best overload for 'PartialMethod' does not have a parameter named 'y'

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -739,9 +739,12 @@ partial class C
 }";
 
             CreateCompilation(source).VerifyDiagnostics(
-// (13,23): error CS1739: The best overload for 'PartialMethod' does not have a parameter named 'y'
-//         PartialMethod(y:123);
-Diagnostic(ErrorCode.ERR_BadNamedArgument, "y").WithArguments("PartialMethod", "y")
+                // (9,25): warning CS8826: Partial method declarations 'void C.PartialMethod(int x)' and 'void C.PartialMethod(int y)' have differences in parameter names, parameter types, or return types.
+                //     static partial void PartialMethod(int y) { Console.WriteLine(y); }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "PartialMethod").WithArguments("void C.PartialMethod(int x)", "void C.PartialMethod(int y)").WithLocation(9, 25),
+                // (13,23): error CS1739: The best overload for 'PartialMethod' does not have a parameter named 'y'
+                //         PartialMethod(y:123);
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "y").WithArguments("PartialMethod", "y").WithLocation(13, 23)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -3319,7 +3319,7 @@ class C2 : IA, IB
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics();
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics(
                 // (4,25): warning CS8824: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have differences in parameter or return types.
                 //     static partial void F2(System.UIntPtr x) { }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -3316,7 +3316,7 @@ class C2 : IA, IB
     static partial void F1(nint x) { }
     static partial void F2(nuint x);
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.Regular9);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -3321,10 +3321,10 @@ class C2 : IA, IB
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics(
-                // (4,25): warning CS8824: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have differences in parameter or return types.
+                // (4,25): warning CS8826: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have signature differences.
                 //     static partial void F2(System.UIntPtr x) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2").WithArguments("void Program.F2(nuint x)", "void Program.F2(UIntPtr x)").WithLocation(4, 25),
-                // (5,25): warning CS8824: Partial method declarations 'void Program.F1(IntPtr x)' and 'void Program.F1(nint x)' have differences in parameter or return types.
+                // (5,25): warning CS8826: Partial method declarations 'void Program.F1(IntPtr x)' and 'void Program.F1(nint x)' have signature differences.
                 //     static partial void F1(nint x) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("void Program.F1(IntPtr x)", "void Program.F1(nint x)").WithLocation(5, 25));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -3305,6 +3305,7 @@ class C2 : IA, IB
         }
 
         [Fact]
+        [WorkItem(45519, "https://github.com/dotnet/roslyn/issues/45519")]
         public void Partial_01()
         {
             var source =
@@ -3317,6 +3318,15 @@ class C2 : IA, IB
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (4,25): warning CS8824: Partial method declarations 'void Program.F2(nuint x)' and 'void Program.F2(UIntPtr x)' have differences in parameter or return types.
+                //     static partial void F2(System.UIntPtr x) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2").WithArguments("void Program.F2(nuint x)", "void Program.F2(UIntPtr x)").WithLocation(4, 25),
+                // (5,25): warning CS8824: Partial method declarations 'void Program.F1(IntPtr x)' and 'void Program.F1(nint x)' have differences in parameter or return types.
+                //     static partial void F1(nint x) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("void Program.F1(IntPtr x)", "void Program.F1(nint x)").WithLocation(5, 25));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -3626,49 +3626,51 @@ partial class P
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
-                // (4,22): warning CS1572: XML comment has a param tag for 'q', but there is no parameter by that name
-                //     /// <param name="q"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "q").WithArguments("q"),
-                // (5,22): warning CS1572: XML comment has a param tag for 'value', but there is no parameter by that name
-                //     /// <param name="value"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "value").WithArguments("value"),
-                // (6,16): warning CS1573: Parameter 'x' has no matching param tag in the XML comment for 'C.M(int)' (but other parameters do)
-                //     void M(int x) { }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "C.M(int)"),
-                // (8,22): warning CS1572: XML comment has a param tag for 'x', but there is no parameter by that name
-                //     /// <param name="x"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "x").WithArguments("x"),
-                // (11,22): warning CS1572: XML comment has a param tag for 'q', but there is no parameter by that name
-                //     /// <param name="q"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "q").WithArguments("q"),
-                // (12,18): warning CS1573: Parameter 'x' has no matching param tag in the XML comment for 'C.this[int, int]' (but other parameters do)
-                //     int this[int x, int y] { get { return 0; } set { } }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "C.this[int, int]"),
-                // (12,25): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'C.this[int, int]' (but other parameters do)
-                //     int this[int x, int y] { get { return 0; } set { } }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "C.this[int, int]"),
-                // (14,22): warning CS1572: XML comment has a param tag for 'q', but there is no parameter by that name
-                //     /// <param name="q"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "q").WithArguments("q"),
-                // (15,22): warning CS1572: XML comment has a param tag for 'value', but there is no parameter by that name
-                //     /// <param name="value"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "value").WithArguments("value"),
-                // (21,22): warning CS1572: XML comment has a param tag for 'x', but there is no parameter by that name
-                //     /// <param name="x"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "x").WithArguments("x"),
-                // (22,24): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'P.M(int)' (but other parameters do)
-                //     partial void M(int y);
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "P.M(int)"),
-                // (27,22): warning CS1572: XML comment has a param tag for 'y', but there is no parameter by that name
-                //     /// <param name="y"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "y").WithArguments("y"),
-                // (28,24): warning CS1573: Parameter 'x' has no matching param tag in the XML comment for 'P.M(int)' (but other parameters do)
+                // (28,18): warning CS8826: Partial method declarations 'void P.M(int y)' and 'void P.M(int x)' have differences in parameter names, parameter types, or return types.
                 //     partial void M(int x) { }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "P.M(int)"),
-
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void P.M(int y)", "void P.M(int x)").WithLocation(28, 18),
                 // (16,25): warning CS0067: The event 'C.E' is never used
                 //     event System.Action E;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E"));
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(16, 25),
+                // (4,22): warning CS1572: XML comment has a param tag for 'q', but there is no parameter by that name
+                //     /// <param name="q"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "q").WithArguments("q").WithLocation(4, 22),
+                // (5,22): warning CS1572: XML comment has a param tag for 'value', but there is no parameter by that name
+                //     /// <param name="value"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "value").WithArguments("value").WithLocation(5, 22),
+                // (6,16): warning CS1573: Parameter 'x' has no matching param tag in the XML comment for 'C.M(int)' (but other parameters do)
+                //     void M(int x) { }
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "C.M(int)").WithLocation(6, 16),
+                // (8,22): warning CS1572: XML comment has a param tag for 'x', but there is no parameter by that name
+                //     /// <param name="x"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "x").WithArguments("x").WithLocation(8, 22),
+                // (11,22): warning CS1572: XML comment has a param tag for 'q', but there is no parameter by that name
+                //     /// <param name="q"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "q").WithArguments("q").WithLocation(11, 22),
+                // (12,18): warning CS1573: Parameter 'x' has no matching param tag in the XML comment for 'C.this[int, int]' (but other parameters do)
+                //     int this[int x, int y] { get { return 0; } set { } }
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "C.this[int, int]").WithLocation(12, 18),
+                // (12,25): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'C.this[int, int]' (but other parameters do)
+                //     int this[int x, int y] { get { return 0; } set { } }
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "C.this[int, int]").WithLocation(12, 25),
+                // (14,22): warning CS1572: XML comment has a param tag for 'q', but there is no parameter by that name
+                //     /// <param name="q"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "q").WithArguments("q").WithLocation(14, 22),
+                // (15,22): warning CS1572: XML comment has a param tag for 'value', but there is no parameter by that name
+                //     /// <param name="value"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "value").WithArguments("value").WithLocation(15, 22),
+                // (27,22): warning CS1572: XML comment has a param tag for 'y', but there is no parameter by that name
+                //     /// <param name="y"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "y").WithArguments("y").WithLocation(27, 22),
+                // (28,24): warning CS1573: Parameter 'x' has no matching param tag in the XML comment for 'P.M(int)' (but other parameters do)
+                //     partial void M(int x) { }
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "P.M(int)").WithLocation(28, 24),
+                // (21,22): warning CS1572: XML comment has a param tag for 'x', but there is no parameter by that name
+                //     /// <param name="x"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamTag, "x").WithArguments("x").WithLocation(21, 22),
+                // (22,24): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'P.M(int)' (but other parameters do)
+                //     partial void M(int y);
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "P.M(int)").WithLocation(22, 24));
         }
 
         [Fact]
@@ -3700,21 +3702,24 @@ partial class P
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
+                // (23,18): warning CS8826: Partial method declarations 'void P.M(int q, int r)' and 'void P.M(int x, int y)' have differences in parameter names, parameter types, or return types.
+                //     partial void M(int x, int y) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void P.M(int q, int r)", "void P.M(int x, int y)").WithLocation(23, 18),
                 // (5,23): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'C.M(int, int)' (but other parameters do)
                 //     void M(int x, int y) { }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "C.M(int, int)"),
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "C.M(int, int)").WithLocation(5, 23),
                 // (8,25): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'C.this[int, int]' (but other parameters do)
                 //     int this[int x, int y] { get { return 0; } set { } }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "C.this[int, int]"),
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "C.this[int, int]").WithLocation(8, 25),
                 // (11,18): warning CS1573: Parameter 'x' has no matching param tag in the XML comment for 'C.this[int]' (but other parameters do)
                 //     int this[int x] { get { return 0; } set { } }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "C.this[int]"),
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "x").WithArguments("x", "C.this[int]").WithLocation(11, 18),
                 // (23,31): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'P.M(int, int)' (but other parameters do)
                 //     partial void M(int x, int y) { }
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "P.M(int, int)"),
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "y").WithArguments("y", "P.M(int, int)").WithLocation(23, 31),
                 // (17,31): warning CS1573: Parameter 'r' has no matching param tag in the XML comment for 'P.M(int, int)' (but other parameters do)
                 //     partial void M(int q, int r);
-                Diagnostic(ErrorCode.WRN_MissingParamTag, "r").WithArguments("r", "P.M(int, int)"));
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "r").WithArguments("r", "P.M(int, int)").WithLocation(17, 31));
         }
 
         [Fact]
@@ -3804,34 +3809,36 @@ partial class P
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
-                // (4,25): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'q', but there is no parameter by that name
-                //     /// <paramref name="q"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "q").WithArguments("q", "C.M(int)"),
-                // (5,25): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'value', but there is no parameter by that name
-                //     /// <paramref name="value"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "value").WithArguments("value", "C.M(int)"),
-                // (8,25): warning CS1734: XML comment on 'C.P' has a paramref tag for 'x', but there is no parameter by that name
-                //     /// <paramref name="x"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "x").WithArguments("x", "C.P"),
-                // (11,25): warning CS1734: XML comment on 'C.this[int, int]' has a paramref tag for 'q', but there is no parameter by that name
-                //     /// <paramref name="q"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "q").WithArguments("q", "C.this[int, int]"),
-                // (14,25): warning CS1734: XML comment on 'C.E' has a paramref tag for 'q', but there is no parameter by that name
-                //     /// <paramref name="q"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "q").WithArguments("q", "C.E"),
-                // (15,25): warning CS1734: XML comment on 'C.E' has a paramref tag for 'value', but there is no parameter by that name
-                //     /// <paramref name="value"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "value").WithArguments("value", "C.E"),
-                // (27,25): warning CS1734: XML comment on 'P.M(int)' has a paramref tag for 'y', but there is no parameter by that name
-                //     /// <paramref name="y"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "y").WithArguments("y", "P.M(int)"),
-                // (21,25): warning CS1734: XML comment on 'P.M(int)' has a paramref tag for 'x', but there is no parameter by that name
-                //     /// <paramref name="x"/>
-                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "x").WithArguments("x", "P.M(int)"),
-
+                // (28,18): warning CS8826: Partial method declarations 'void P.M(int y)' and 'void P.M(int x)' have differences in parameter names, parameter types, or return types.
+                //     partial void M(int x) { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void P.M(int y)", "void P.M(int x)").WithLocation(28, 18),
                 // (16,25): warning CS0067: The event 'C.E' is never used
                 //     event System.Action E;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E"));
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(16, 25),
+                // (4,25): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'q', but there is no parameter by that name
+                //     /// <paramref name="q"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "q").WithArguments("q", "C.M(int)").WithLocation(4, 25),
+                // (5,25): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'value', but there is no parameter by that name
+                //     /// <paramref name="value"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "value").WithArguments("value", "C.M(int)").WithLocation(5, 25),
+                // (8,25): warning CS1734: XML comment on 'C.P' has a paramref tag for 'x', but there is no parameter by that name
+                //     /// <paramref name="x"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "x").WithArguments("x", "C.P").WithLocation(8, 25),
+                // (11,25): warning CS1734: XML comment on 'C.this[int, int]' has a paramref tag for 'q', but there is no parameter by that name
+                //     /// <paramref name="q"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "q").WithArguments("q", "C.this[int, int]").WithLocation(11, 25),
+                // (14,25): warning CS1734: XML comment on 'C.E' has a paramref tag for 'q', but there is no parameter by that name
+                //     /// <paramref name="q"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "q").WithArguments("q", "C.E").WithLocation(14, 25),
+                // (15,25): warning CS1734: XML comment on 'C.E' has a paramref tag for 'value', but there is no parameter by that name
+                //     /// <paramref name="value"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "value").WithArguments("value", "C.E").WithLocation(15, 25),
+                // (27,25): warning CS1734: XML comment on 'P.M(int)' has a paramref tag for 'y', but there is no parameter by that name
+                //     /// <paramref name="y"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "y").WithArguments("y", "P.M(int)").WithLocation(27, 25),
+                // (21,25): warning CS1734: XML comment on 'P.M(int)' has a paramref tag for 'x', but there is no parameter by that name
+                //     /// <paramref name="x"/>
+                Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "x").WithArguments("x", "P.M(int)").WithLocation(21, 25));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -3626,7 +3626,7 @@ partial class P
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
-                // (28,18): warning CS8826: Partial method declarations 'void P.M(int y)' and 'void P.M(int x)' have differences in parameter names, parameter types, or return types.
+                // (28,18): warning CS8826: Partial method declarations 'void P.M(int y)' and 'void P.M(int x)' have signature differences.
                 //     partial void M(int x) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void P.M(int y)", "void P.M(int x)").WithLocation(28, 18),
                 // (16,25): warning CS0067: The event 'C.E' is never used
@@ -3702,7 +3702,7 @@ partial class P
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
-                // (23,18): warning CS8826: Partial method declarations 'void P.M(int q, int r)' and 'void P.M(int x, int y)' have differences in parameter names, parameter types, or return types.
+                // (23,18): warning CS8826: Partial method declarations 'void P.M(int q, int r)' and 'void P.M(int x, int y)' have signature differences.
                 //     partial void M(int x, int y) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void P.M(int q, int r)", "void P.M(int x, int y)").WithLocation(23, 18),
                 // (5,23): warning CS1573: Parameter 'y' has no matching param tag in the XML comment for 'C.M(int, int)' (but other parameters do)
@@ -3809,7 +3809,7 @@ partial class P
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
-                // (28,18): warning CS8826: Partial method declarations 'void P.M(int y)' and 'void P.M(int x)' have differences in parameter names, parameter types, or return types.
+                // (28,18): warning CS8826: Partial method declarations 'void P.M(int y)' and 'void P.M(int x)' have signature differences.
                 //     partial void M(int x) { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void P.M(int y)", "void P.M(int x)").WithLocation(28, 18),
                 // (16,25): warning CS0067: The event 'C.E' is never used
@@ -4032,7 +4032,7 @@ partial class P<T>
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
-                // (29,18): warning CS8826: Partial method declarations 'void P<T>.M1<U>()' and 'void P<T>.M1<V>()' have differences in parameter names, parameter types, or return types.
+                // (29,18): warning CS8826: Partial method declarations 'void P<T>.M1<U>()' and 'void P<T>.M1<V>()' have signature differences.
                 //     partial void M1<V>() { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("void P<T>.M1<U>()", "void P<T>.M1<V>()").WithLocation(29, 18),
                 // (2,22): warning CS1711: XML comment has a typeparam tag for 'T', but there is no type parameter by that name
@@ -4168,7 +4168,7 @@ partial class P<T>
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
-                // (29,18): warning CS8826: Partial method declarations 'void P<T>.M1<U>()' and 'void P<T>.M1<V>()' have differences in parameter names, parameter types, or return types.
+                // (29,18): warning CS8826: Partial method declarations 'void P<T>.M1<U>()' and 'void P<T>.M1<V>()' have signature differences.
                 //     partial void M1<V>() { }
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("void P<T>.M1<U>()", "void P<T>.M1<V>()").WithLocation(29, 18),
                 // (2,25): warning CS1735: XML comment on 'C' has a typeparamref tag for 'T', but there is no type parameter by that name

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -4032,6 +4032,9 @@ partial class P<T>
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
+                // (29,18): warning CS8826: Partial method declarations 'void P<T>.M1<U>()' and 'void P<T>.M1<V>()' have differences in parameter names, parameter types, or return types.
+                //     partial void M1<V>() { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("void P<T>.M1<U>()", "void P<T>.M1<V>()").WithLocation(29, 18),
                 // (2,22): warning CS1711: XML comment has a typeparam tag for 'T', but there is no type parameter by that name
                 // /// <typeparam name="T"/> -- warning
                 Diagnostic(ErrorCode.WRN_UnmatchedTypeParamTag, "T").WithArguments("T"),
@@ -4165,6 +4168,9 @@ partial class P<T>
 }
 ";
             CreateCompilationWithMscorlib40AndDocumentationComments(source).VerifyDiagnostics(
+                // (29,18): warning CS8826: Partial method declarations 'void P<T>.M1<U>()' and 'void P<T>.M1<V>()' have differences in parameter names, parameter types, or return types.
+                //     partial void M1<V>() { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("void P<T>.M1<U>()", "void P<T>.M1<V>()").WithLocation(29, 18),
                 // (2,25): warning CS1735: XML comment on 'C' has a typeparamref tag for 'T', but there is no type parameter by that name
                 // /// <typeparamref name="T"/> -- warning
                 Diagnostic(ErrorCode.WRN_UnmatchedTypeParamRefTag, "T").WithArguments("T", "C"),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
@@ -2817,13 +2817,13 @@ partial class C
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
-                // (7,22): warning CS8826: Partial method declarations 'U C.M1<U>()' and 'V C.M1<V>()' have differences in parameter names, parameter types, or return types.
+                // (7,22): warning CS8826: Partial method declarations 'U C.M1<U>()' and 'V C.M1<V>()' have signature differences.
                 //     public partial V M1<V>() => default;
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("U C.M1<U>()", "V C.M1<V>()").WithLocation(7, 22),
-                // (13,22): warning CS8826: Partial method declarations 'U C.M3<U>()' and 'V C.M3<V>()' have differences in parameter names, parameter types, or return types.
+                // (13,22): warning CS8826: Partial method declarations 'U C.M3<U>()' and 'V C.M3<V>()' have signature differences.
                 //     public partial V M3<V>() => default;
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M3").WithArguments("U C.M3<U>()", "V C.M3<V>()").WithLocation(13, 22),
-                // (16,35): warning CS8826: Partial method declarations 'IEnumerable<U> C.M4<U>()' and 'IEnumerable<V> C.M4<V>()' have differences in parameter names, parameter types, or return types.
+                // (16,35): warning CS8826: Partial method declarations 'IEnumerable<U> C.M4<U>()' and 'IEnumerable<V> C.M4<V>()' have signature differences.
                 //     public partial IEnumerable<V> M4<V>() => default;
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M4").WithArguments("IEnumerable<U> C.M4<U>()", "IEnumerable<V> C.M4<V>()").WithLocation(16, 35)
             );
@@ -2930,13 +2930,13 @@ partial class C
                 // (5,24): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial int M1() => throw null!; // 1
                 Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M1").WithLocation(5, 24),
-                // (5,24): warning CS8826: Partial method declarations 'ref int C.M1()' and 'int C.M1()' have differences in parameter names, parameter types, or return types.
+                // (5,24): warning CS8826: Partial method declarations 'ref int C.M1()' and 'int C.M1()' have signature differences.
                 //     public partial int M1() => throw null!; // 1
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("ref int C.M1()", "int C.M1()").WithLocation(5, 24),
                 // (8,28): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial ref int M2() => throw null!; // 2
                 Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M2").WithLocation(8, 28),
-                // (8,28): warning CS8826: Partial method declarations 'int C.M2()' and 'ref int C.M2()' have differences in parameter names, parameter types, or return types.
+                // (8,28): warning CS8826: Partial method declarations 'int C.M2()' and 'ref int C.M2()' have signature differences.
                 //     public partial ref int M2() => throw null!; // 2
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("int C.M2()", "ref int C.M2()").WithLocation(8, 28));
         }
@@ -3031,10 +3031,10 @@ partial class C
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
-                // (5,28): warning CS8824: Partial method declarations 'object C.M1()' and 'dynamic C.M1()' have differences in parameter or return types.
+                // (5,28): warning CS8826: Partial method declarations 'object C.M1()' and 'dynamic C.M1()' have signature differences.
                 //     public partial dynamic M1() => null;
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("object C.M1()", "dynamic C.M1()").WithLocation(5, 28),
-                // (8,27): warning CS8824: Partial method declarations 'dynamic C.M2()' and 'object C.M2()' have differences in parameter or return types.
+                // (8,27): warning CS8826: Partial method declarations 'dynamic C.M2()' and 'object C.M2()' have signature differences.
                 //     public partial object M2() => null;
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("dynamic C.M2()", "object C.M2()").WithLocation(8, 27));
         }
@@ -3058,10 +3058,10 @@ partial class C
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
-                // (7,25): warning CS8824: Partial method declarations 'IntPtr C.M1()' and 'nint C.M1()' have differences in parameter or return types.
+                // (7,25): warning CS8826: Partial method declarations 'IntPtr C.M1()' and 'nint C.M1()' have signature differences.
                 //     public partial nint M1() => 0;
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("IntPtr C.M1()", "nint C.M1()").WithLocation(7, 25),
-                // (10,27): warning CS8824: Partial method declarations 'nint C.M2()' and 'IntPtr C.M2()' have differences in parameter or return types.
+                // (10,27): warning CS8826: Partial method declarations 'nint C.M2()' and 'IntPtr C.M2()' have signature differences.
                 //     public partial IntPtr M2() => default;
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("nint C.M2()", "IntPtr C.M2()").WithLocation(10, 27));
         }
@@ -3083,13 +3083,13 @@ partial class C
                 // (5,37): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial ref readonly int M1() => throw null!; // 1
                 Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M1").WithLocation(5, 37),
-                // (5,37): warning CS8826: Partial method declarations 'ref int C.M1()' and 'ref readonly int C.M1()' have differences in parameter names, parameter types, or return types.
+                // (5,37): warning CS8826: Partial method declarations 'ref int C.M1()' and 'ref readonly int C.M1()' have signature differences.
                 //     public partial ref readonly int M1() => throw null!; // 1
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("ref int C.M1()", "ref readonly int C.M1()").WithLocation(5, 37),
                 // (8,28): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial ref int M2() => throw null!; // 2
                 Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M2").WithLocation(8, 28),
-                // (8,28): warning CS8826: Partial method declarations 'ref readonly int C.M2()' and 'ref int C.M2()' have differences in parameter names, parameter types, or return types.
+                // (8,28): warning CS8826: Partial method declarations 'ref readonly int C.M2()' and 'ref int C.M2()' have signature differences.
                 //     public partial ref int M2() => throw null!; // 2
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("ref readonly int C.M2()", "ref int C.M2()").WithLocation(8, 28));
         }
@@ -3163,7 +3163,7 @@ partial class C
                 // (6,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
                 //     public partial string? M1() => null; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M1").WithLocation(6, 28),
-                // (9,27): warning CS8824: Partial method declarations 'string? C.M2()' and 'string C.M2()' have differences in parameter or return types.
+                // (9,27): warning CS8826: Partial method declarations 'string? C.M2()' and 'string C.M2()' have signature differences.
                 //     public partial string M2() => "hello"; // 2
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("string? C.M2()", "string C.M2()").WithLocation(9, 27),
                 // (13,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
@@ -3172,7 +3172,7 @@ partial class C
                 // (15,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
                 //     public partial string? M4(); // 4
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(15, 26),
-                // (22,27): warning CS8824: Partial method declarations 'string? C.M8()' and 'string C.M8()' have differences in parameter or return types.
+                // (22,27): warning CS8826: Partial method declarations 'string? C.M8()' and 'string C.M8()' have signature differences.
                 //     public partial string M8() => null!; // 5
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M8").WithArguments("string? C.M8()", "string C.M8()").WithLocation(22, 27),
                 // (31,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
@@ -3222,7 +3222,7 @@ partial class C
                     // (4,31): error CS8818: Partial method declarations must have matching ref return values.
                     //     public partial (int, int) F1() => default;
                     Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "F1").WithLocation(4, 31),
-                    // (4,31): warning CS8826: Partial method declarations 'ref (int x, int y) C.F1()' and '(int, int) C.F1()' have differences in parameter names, parameter types, or return types.
+                    // (4,31): warning CS8826: Partial method declarations 'ref (int x, int y) C.F1()' and '(int, int) C.F1()' have signature differences.
                     //     public partial (int, int) F1() => default;
                     Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("ref (int x, int y) C.F1()", "(int, int) C.F1()").WithLocation(4, 31));
         }
@@ -3246,13 +3246,13 @@ partial class C
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
             comp.VerifyDiagnostics(
-                // (4,18): warning CS8824: Partial method declarations 'void C.F1(object o)' and 'void C.F1(dynamic o)' have differences in parameter or return types.
+                // (4,18): warning CS8826: Partial method declarations 'void C.F1(object o)' and 'void C.F1(dynamic o)' have signature differences.
                 //     partial void F1(dynamic o) { } // 1
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1", isSuppressed: false).WithArguments("void C.F1(object o)", "void C.F1(dynamic o)").WithLocation(4, 18),
-                // (6,27): warning CS8824: Partial method declarations 'void C.F2(object o)' and 'void C.F2(dynamic o)' have differences in parameter or return types.
+                // (6,27): warning CS8826: Partial method declarations 'void C.F2(object o)' and 'void C.F2(dynamic o)' have signature differences.
                 //     internal partial void F2(dynamic o) { } // 2
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2", isSuppressed: false).WithArguments("void C.F2(object o)", "void C.F2(dynamic o)").WithLocation(6, 27),
-                // (8,29): warning CS8824: Partial method declarations 'dynamic C.F3()' and 'object C.F3()' have differences in parameter or return types.
+                // (8,29): warning CS8826: Partial method declarations 'dynamic C.F3()' and 'object C.F3()' have signature differences.
                 //     internal partial object F3() => null; // 3
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F3", isSuppressed: false).WithArguments("dynamic C.F3()", "object C.F3()").WithLocation(8, 29));
         }
@@ -3311,7 +3311,7 @@ partial class C
                 // (12,27): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
                 //     internal partial void F4(IEnumerable<string> s) { } // 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F4").WithArguments("s").WithLocation(12, 27),
-                // (14,29): warning CS8824: Partial method declarations 'string? C.F5()' and 'string C.F5()' have differences in parameter or return types.
+                // (14,29): warning CS8826: Partial method declarations 'string? C.F5()' and 'string C.F5()' have signature differences.
                 //     internal partial string F5() => null!; // 5
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F5").WithArguments("string? C.F5()", "string C.F5()").WithLocation(14, 29),
                 // (16,43): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
@@ -3386,16 +3386,16 @@ partial class C
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
             comp.VerifyDiagnostics(
-                // (5,18): warning CS8824: Partial method declarations 'void C.F1(nint i)' and 'void C.F1(IntPtr i)' have differences in parameter or return types.
+                // (5,18): warning CS8826: Partial method declarations 'void C.F1(nint i)' and 'void C.F1(IntPtr i)' have signature differences.
                 //     partial void F1(System.IntPtr i) { } // 1
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("void C.F1(nint i)", "void C.F1(IntPtr i)").WithLocation(5, 18),
-                // (7,18): warning CS8824: Partial method declarations 'void C.F2(dynamic x, nint y)' and 'void C.F2(object x, IntPtr y)' have differences in parameter or return types.
+                // (7,18): warning CS8826: Partial method declarations 'void C.F2(dynamic x, nint y)' and 'void C.F2(object x, IntPtr y)' have signature differences.
                 //     partial void F2(object x, System.IntPtr y) { } // 2
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2").WithArguments("void C.F2(dynamic x, nint y)", "void C.F2(object x, IntPtr y)").WithLocation(7, 18),
-                // (9,27): warning CS8824: Partial method declarations 'void C.F3(nint i)' and 'void C.F3(IntPtr i)' have differences in parameter or return types.
+                // (9,27): warning CS8826: Partial method declarations 'void C.F3(nint i)' and 'void C.F3(IntPtr i)' have signature differences.
                 //     internal partial void F3(System.IntPtr i) { } // 3
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F3").WithArguments("void C.F3(nint i)", "void C.F3(IntPtr i)").WithLocation(9, 27),
-                // (11,40): warning CS8824: Partial method declarations 'IEnumerable<IntPtr> C.F4()' and 'IEnumerable<nint> C.F4()' have differences in parameter or return types.
+                // (11,40): warning CS8826: Partial method declarations 'IEnumerable<IntPtr> C.F4()' and 'IEnumerable<nint> C.F4()' have signature differences.
                 //     internal partial IEnumerable<nint> F4() => null; // 4
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F4").WithArguments("IEnumerable<IntPtr> C.F4()", "IEnumerable<nint> C.F4()").WithLocation(11, 40));
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
@@ -2816,7 +2816,17 @@ partial class C
     public partial IEnumerable<V> M4<V>() => default;
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (7,22): warning CS8826: Partial method declarations 'U C.M1<U>()' and 'V C.M1<V>()' have differences in parameter names, parameter types, or return types.
+                //     public partial V M1<V>() => default;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("U C.M1<U>()", "V C.M1<V>()").WithLocation(7, 22),
+                // (13,22): warning CS8826: Partial method declarations 'U C.M3<U>()' and 'V C.M3<V>()' have differences in parameter names, parameter types, or return types.
+                //     public partial V M3<V>() => default;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M3").WithArguments("U C.M3<U>()", "V C.M3<V>()").WithLocation(13, 22),
+                // (16,35): warning CS8826: Partial method declarations 'IEnumerable<U> C.M4<U>()' and 'IEnumerable<V> C.M4<V>()' have differences in parameter names, parameter types, or return types.
+                //     public partial IEnumerable<V> M4<V>() => default;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M4").WithArguments("IEnumerable<U> C.M4<U>()", "IEnumerable<V> C.M4<V>()").WithLocation(16, 35)
+            );
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
@@ -2656,7 +2656,7 @@ partial class C
                 //     public partial long M() => 42; // 1
                 Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M").WithLocation(5, 25));
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (5,25): error CS8817: Both partial method declarations must have the same return type.
                 //     public partial long M() => 42; // 1
@@ -2697,7 +2697,7 @@ partial class C
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (8,27): warning CS8825: Partial method declarations 'string? C.M1()' and 'string C.M1()' must have identical nullability for parameter types and return types.
                 //     public partial string M1() => "hello";
@@ -2731,7 +2731,7 @@ partial class C
                 //     public partial IEnumerable<string?> M2() => null!; // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M2").WithLocation(11, 41));
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (8,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
                 //     public partial string? M1() => null; // 1
@@ -3013,7 +3013,7 @@ partial class C
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (5,28): warning CS8824: Partial method declarations 'object C.M1()' and 'dynamic C.M1()' have differences in parameter or return types.
                 //     public partial dynamic M1() => null;
@@ -3040,7 +3040,7 @@ partial class C
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (7,25): warning CS8824: Partial method declarations 'IntPtr C.M1()' and 'nint C.M1()' have differences in parameter or return types.
                 //     public partial nint M1() => 0;
@@ -3136,7 +3136,7 @@ partial class C
                 //     public partial string? M12(); // 9
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(36, 26));
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (6,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
                 //     public partial string? M1() => null; // 1
@@ -3219,7 +3219,7 @@ partial class C
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
             comp.VerifyDiagnostics(
                 // (4,18): warning CS8824: Partial method declarations 'void C.F1(object o)' and 'void C.F1(dynamic o)' have differences in parameter or return types.
                 //     partial void F1(dynamic o) { } // 1
@@ -3272,7 +3272,7 @@ partial class C
                 //     internal partial IEnumerable<string?> F6() => null!; // 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "F6").WithLocation(16, 43));
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
             comp.VerifyDiagnostics(
                 // (6,18): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
                 //     partial void F1(string s) { } // 1
@@ -3318,7 +3318,7 @@ partial class C
             var comp = CreateCompilation(source);
             verifyDiagnostics(comp);
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
             verifyDiagnostics(comp);
 
             static void verifyDiagnostics(CSharpCompilation comp)
@@ -3359,7 +3359,7 @@ partial class C
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
 
-            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
             comp.VerifyDiagnostics(
                 // (5,18): warning CS8824: Partial method declarations 'void C.F1(nint i)' and 'void C.F1(IntPtr i)' have differences in parameter or return types.
                 //     partial void F1(System.IntPtr i) { } // 1

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
@@ -2655,6 +2655,12 @@ partial class C
                 // (5,25): error CS8817: Both partial method declarations must have the same return type.
                 //     public partial long M() => 42; // 1
                 Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M").WithLocation(5, 25));
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp.VerifyDiagnostics(
+                // (5,25): error CS8817: Both partial method declarations must have the same return type.
+                //     public partial long M() => 42; // 1
+                Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M").WithLocation(5, 25));
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]
@@ -2690,6 +2696,15 @@ partial class C
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp.VerifyDiagnostics(
+                // (8,27): warning CS8825: Partial method declarations 'string? C.M1()' and 'string C.M1()' must have identical nullability for parameter types and return types.
+                //     public partial string M1() => "hello";
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("string? C.M1()", "string C.M1()").WithLocation(8, 27),
+                // (11,40): warning CS8825: Partial method declarations 'IEnumerable<string?> C.M2()' and 'IEnumerable<string> C.M2()' must have identical nullability for parameter types and return types.
+                //     public partial IEnumerable<string> M2() => null!;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("IEnumerable<string?> C.M2()", "IEnumerable<string> C.M2()").WithLocation(11, 40));
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]
@@ -2708,6 +2723,15 @@ partial class C
     public partial IEnumerable<string?> M2() => null!; // 2
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp.VerifyDiagnostics(
+                // (8,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
+                //     public partial string? M1() => null; // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M1").WithLocation(8, 28),
+                // (11,41): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
+                //     public partial IEnumerable<string?> M2() => null!; // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M2").WithLocation(11, 41));
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (8,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
                 //     public partial string? M1() => null; // 1
@@ -2832,21 +2856,39 @@ partial class C
                 // (7,20): error CS0246: The type or namespace name 'ERROR' could not be found (are you missing a using directive or an assembly reference?)
                 //     public partial ERROR M1() => throw null!; // 1
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ERROR").WithArguments("ERROR").WithLocation(7, 20),
+                // (7,26): error CS8817: Both partial method declarations must have the same return type.
+                //     public partial ERROR M1() => throw null!; // 1
+                Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M1").WithLocation(7, 26),
                 // (10,32): error CS0246: The type or namespace name 'ERROR' could not be found (are you missing a using directive or an assembly reference?)
                 //     public partial IEnumerable<ERROR> M2() => throw null!; // 2
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ERROR").WithArguments("ERROR").WithLocation(10, 32),
+                // (10,39): error CS8817: Both partial method declarations must have the same return type.
+                //     public partial IEnumerable<ERROR> M2() => throw null!; // 2
+                Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M2").WithLocation(10, 39),
                 // (13,32): error CS0246: The type or namespace name 'ERROR' could not be found (are you missing a using directive or an assembly reference?)
                 //     public partial IEnumerable<ERROR> M3() => throw null!; // 3
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ERROR").WithArguments("ERROR").WithLocation(13, 32),
+                // (13,39): error CS8817: Both partial method declarations must have the same return type.
+                //     public partial IEnumerable<ERROR> M3() => throw null!; // 3
+                Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M3").WithLocation(13, 39),
                 // (15,20): error CS0246: The type or namespace name 'ERROR' could not be found (are you missing a using directive or an assembly reference?)
                 //     public partial ERROR M4(); // 4
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ERROR").WithArguments("ERROR").WithLocation(15, 20),
+                // (16,24): error CS8817: Both partial method declarations must have the same return type.
+                //     public partial int M4() => throw null!;
+                Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M4").WithLocation(16, 24),
                 // (18,32): error CS0246: The type or namespace name 'ERROR' could not be found (are you missing a using directive or an assembly reference?)
                 //     public partial IEnumerable<ERROR> M5(); // 5
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ERROR").WithArguments("ERROR").WithLocation(18, 32),
+                // (19,37): error CS8817: Both partial method declarations must have the same return type.
+                //     public partial IEnumerable<int> M5() => throw null!;
+                Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M5").WithLocation(19, 37),
                 // (21,32): error CS0246: The type or namespace name 'ERROR' could not be found (are you missing a using directive or an assembly reference?)
                 //     public partial IEnumerable<ERROR> M6(); // 6
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ERROR").WithArguments("ERROR").WithLocation(21, 32),
+                // (22,24): error CS8817: Both partial method declarations must have the same return type.
+                //     public partial int M6() => throw null!;
+                Diagnostic(ErrorCode.ERR_PartialMethodReturnTypeDifference, "M6").WithLocation(22, 24),
                 // (24,20): error CS0246: The type or namespace name 'ERROR' could not be found (are you missing a using directive or an assembly reference?)
                 //     public partial ERROR M7(); // 7
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ERROR").WithArguments("ERROR").WithLocation(24, 20),
@@ -2935,9 +2977,9 @@ partial class C
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
-                // (4,35): error CS8142: Both partial method declarations, 'C.M1()' and 'C.M1()', must use the same tuple element names.
-                //     public partial (int x, int y) M1();
-                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M1").WithArguments("C.M1()", "C.M1()").WithLocation(4, 35));
+                // (5,37): error CS8142: Both partial method declarations, 'C.M1()' and 'C.M1()', must use the same tuple element names.
+                //     public partial (int x1, int y1) M1() => default; // 1
+                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M1").WithArguments("C.M1()", "C.M1()").WithLocation(5, 37));
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]
@@ -2970,6 +3012,15 @@ partial class C
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp.VerifyDiagnostics(
+                // (5,28): warning CS8824: Partial method declarations 'object C.M1()' and 'dynamic C.M1()' have differences in parameter or return types.
+                //     public partial dynamic M1() => null;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("object C.M1()", "dynamic C.M1()").WithLocation(5, 28),
+                // (8,27): warning CS8824: Partial method declarations 'dynamic C.M2()' and 'object C.M2()' have differences in parameter or return types.
+                //     public partial object M2() => null;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("dynamic C.M2()", "object C.M2()").WithLocation(8, 27));
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]
@@ -2988,6 +3039,15 @@ partial class C
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp.VerifyDiagnostics(
+                // (7,25): warning CS8824: Partial method declarations 'IntPtr C.M1()' and 'nint C.M1()' have differences in parameter or return types.
+                //     public partial nint M1() => 0;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("IntPtr C.M1()", "nint C.M1()").WithLocation(7, 25),
+                // (10,27): warning CS8824: Partial method declarations 'nint C.M2()' and 'IntPtr C.M2()' have differences in parameter or return types.
+                //     public partial IntPtr M2() => default;
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("nint C.M2()", "IntPtr C.M2()").WithLocation(10, 27));
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]
@@ -3023,20 +3083,20 @@ partial class C
     public partial string? M1() => null; // 1
     
     public partial string? M2();
-    public partial string M2() => ""hello"";
+    public partial string M2() => ""hello""; // 2
     
 #nullable disable
     public partial string M3();
-    public partial string? M3() => null; // 2
+    public partial string? M3() => null; // 3
     
-    public partial string? M4(); // 3
+    public partial string? M4(); // 4
     public partial string M4() => ""hello"";
 
 #nullable enable
     public partial string M5();
     public partial string M6() => null!;
     public partial string M7();
-    public partial string M8() => null!;
+    public partial string M8() => null!; // 5
     public partial string? M9();
     public partial string? M10() => null;
     public partial string? M11();
@@ -3045,12 +3105,12 @@ partial class C
 #nullable disable
     public partial string M5() => null;
     public partial string M6();
-    public partial string? M7() => null; // 4
-    public partial string? M8(); // 5
+    public partial string? M7() => null; // 6
+    public partial string? M8(); // 7
     public partial string M9() => null;
     public partial string M10();
-    public partial string? M11() => null; // 6
-    public partial string? M12(); // 7
+    public partial string? M11() => null; // 8
+    public partial string? M12(); // 9
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
@@ -3058,22 +3118,52 @@ partial class C
                 //     public partial string? M1() => null; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M1").WithLocation(6, 28),
                 // (13,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
-                //     public partial string? M3() => null; // 2
+                //     public partial string? M3() => null; // 3
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(13, 26),
                 // (15,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
-                //     public partial string? M4(); // 3
+                //     public partial string? M4(); // 4
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(15, 26),
                 // (31,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
-                //     public partial string? M7() => null; // 4
+                //     public partial string? M7() => null; // 6
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(31, 26),
                 // (32,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
-                //     public partial string? M8(); // 5
+                //     public partial string? M8(); // 7
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(32, 26),
                 // (35,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
-                //     public partial string? M11() => null; // 6
+                //     public partial string? M11() => null; // 8
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(35, 26),
                 // (36,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
-                //     public partial string? M12(); // 7
+                //     public partial string? M12(); // 9
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(36, 26));
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            comp.VerifyDiagnostics(
+                // (6,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
+                //     public partial string? M1() => null; // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M1").WithLocation(6, 28),
+                // (9,27): warning CS8824: Partial method declarations 'string? C.M2()' and 'string C.M2()' have differences in parameter or return types.
+                //     public partial string M2() => "hello"; // 2
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("string? C.M2()", "string C.M2()").WithLocation(9, 27),
+                // (13,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+                //     public partial string? M3() => null; // 3
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(13, 26),
+                // (15,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+                //     public partial string? M4(); // 4
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(15, 26),
+                // (22,27): warning CS8824: Partial method declarations 'string? C.M8()' and 'string C.M8()' have differences in parameter or return types.
+                //     public partial string M8() => null!; // 5
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M8").WithArguments("string? C.M8()", "string C.M8()").WithLocation(22, 27),
+                // (31,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+                //     public partial string? M7() => null; // 6
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(31, 26),
+                // (32,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+                //     public partial string? M8(); // 7
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(32, 26),
+                // (35,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+                //     public partial string? M11() => null; // 8
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(35, 26),
+                // (36,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+                //     public partial string? M12(); // 9
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(36, 26));
         }
 
@@ -3110,6 +3200,179 @@ partial class C
                 // (4,31): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial (int, int) F1() => default;
                 Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "F1").WithLocation(4, 31));
+        }
+
+        [Fact]
+        [WorkItem(45519, "https://github.com/dotnet/roslyn/issues/45519")]
+        public void DifferentSignatures_Dynamic()
+        {
+            var source =
+@"partial class C
+{
+    partial void F1(object o);
+    partial void F1(dynamic o) { } // 1
+    internal partial void F2(object o);
+    internal partial void F2(dynamic o) { } // 2
+    internal partial dynamic F3();
+    internal partial object F3() => null; // 3
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            comp.VerifyDiagnostics(
+                // (4,18): warning CS8824: Partial method declarations 'void C.F1(object o)' and 'void C.F1(dynamic o)' have differences in parameter or return types.
+                //     partial void F1(dynamic o) { } // 1
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1", isSuppressed: false).WithArguments("void C.F1(object o)", "void C.F1(dynamic o)").WithLocation(4, 18),
+                // (6,27): warning CS8824: Partial method declarations 'void C.F2(object o)' and 'void C.F2(dynamic o)' have differences in parameter or return types.
+                //     internal partial void F2(dynamic o) { } // 2
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2", isSuppressed: false).WithArguments("void C.F2(object o)", "void C.F2(dynamic o)").WithLocation(6, 27),
+                // (8,29): warning CS8824: Partial method declarations 'dynamic C.F3()' and 'object C.F3()' have differences in parameter or return types.
+                //     internal partial object F3() => null; // 3
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F3", isSuppressed: false).WithArguments("dynamic C.F3()", "object C.F3()").WithLocation(8, 29));
+        }
+
+        [Fact]
+        [WorkItem(45519, "https://github.com/dotnet/roslyn/issues/45519")]
+        public void DifferentSignatures_Nullable()
+        {
+            var source =
+@"using System.Collections.Generic;
+#nullable enable
+partial class C
+{
+    partial void F1(string? s);
+    partial void F1(string s) { } // 1
+    partial void F2(IEnumerable<string?> s);
+    partial void F2(IEnumerable<string> s) { } // 2
+    internal partial void F3(string? s);
+    internal partial void F3(string s) { } // 3
+    internal partial void F4(IEnumerable<string?> s);
+    internal partial void F4(IEnumerable<string> s) { } // 4
+    internal partial string? F5();
+    internal partial string F5() => null!; // 5
+    internal partial IEnumerable<string> F6();
+    internal partial IEnumerable<string?> F6() => null!; // 6
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,18): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     partial void F1(string s) { } // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F1").WithArguments("s").WithLocation(6, 18),
+                // (8,18): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     partial void F2(IEnumerable<string> s) { } // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F2").WithArguments("s").WithLocation(8, 18),
+                // (10,27): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     internal partial void F3(string s) { } // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F3").WithArguments("s").WithLocation(10, 27),
+                // (12,27): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     internal partial void F4(IEnumerable<string> s) { } // 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F4").WithArguments("s").WithLocation(12, 27),
+                // (16,43): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
+                //     internal partial IEnumerable<string?> F6() => null!; // 6
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "F6").WithLocation(16, 43));
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            comp.VerifyDiagnostics(
+                // (6,18): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     partial void F1(string s) { } // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F1").WithArguments("s").WithLocation(6, 18),
+                // (8,18): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     partial void F2(IEnumerable<string> s) { } // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F2").WithArguments("s").WithLocation(8, 18),
+                // (10,27): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     internal partial void F3(string s) { } // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F3").WithArguments("s").WithLocation(10, 27),
+                // (12,27): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
+                //     internal partial void F4(IEnumerable<string> s) { } // 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial, "F4").WithArguments("s").WithLocation(12, 27),
+                // (14,29): warning CS8824: Partial method declarations 'string? C.F5()' and 'string C.F5()' have differences in parameter or return types.
+                //     internal partial string F5() => null!; // 5
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F5").WithArguments("string? C.F5()", "string C.F5()").WithLocation(14, 29),
+                // (16,43): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
+                //     internal partial IEnumerable<string?> F6() => null!; // 6
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "F6").WithLocation(16, 43));
+        }
+
+        // Errors reported for all differences.
+        [Fact]
+        [WorkItem(45519, "https://github.com/dotnet/roslyn/issues/45519")]
+        public void DifferentSignatures_Tuples()
+        {
+            var source =
+@"partial class C
+{
+    partial void F1<T, U>((T x, U y) t) { }
+    partial void F1<T, U>((T x, U y) t);
+    partial void F2<T, U>((T x, U y) t) { } // 1
+    partial void F2<T, U>((T, U) t);
+    partial void F3((dynamic, object) t);
+    partial void F3((object x, dynamic y) t) { } // 2
+    internal partial void F4<T, U>((T x, U y) t);
+    internal partial void F4<T, U>((T, U) t) { } // 3
+    internal partial (T, U) F5<T, U>() => default;
+    internal partial (T, U) F5<T, U>();
+    internal partial (T, U) F6<T, U>() => default; // 4
+    internal partial (T x, U y) F6<T, U>();
+}";
+            var comp = CreateCompilation(source);
+            verifyDiagnostics(comp);
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            verifyDiagnostics(comp);
+
+            static void verifyDiagnostics(CSharpCompilation comp)
+            {
+                comp.VerifyDiagnostics(
+                    // (5,18): error CS8142: Both partial method declarations, 'C.F2<T, U>((T, U))' and 'C.F2<T, U>((T x, U y))', must use the same tuple element names.
+                    //     partial void F2<T, U>((T x, U y) t) { } // 1
+                    Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "F2").WithArguments("C.F2<T, U>((T, U))", "C.F2<T, U>((T x, U y))").WithLocation(5, 18),
+                    // (8,18): error CS8142: Both partial method declarations, 'C.F3((dynamic, object))' and 'C.F3((object x, dynamic y))', must use the same tuple element names.
+                    //     partial void F3((object x, dynamic y) t) { } // 2
+                    Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "F3").WithArguments("C.F3((dynamic, object))", "C.F3((object x, dynamic y))").WithLocation(8, 18),
+                    // (10,27): error CS8142: Both partial method declarations, 'C.F4<T, U>((T x, U y))' and 'C.F4<T, U>((T, U))', must use the same tuple element names.
+                    //     internal partial void F4<T, U>((T, U) t) { } // 3
+                    Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "F4").WithArguments("C.F4<T, U>((T x, U y))", "C.F4<T, U>((T, U))").WithLocation(10, 27),
+                    // (13,29): error CS8142: Both partial method declarations, 'C.F6<T, U>()' and 'C.F6<T, U>()', must use the same tuple element names.
+                    //     internal partial (T, U) F6<T, U>() => default; // 4
+                    Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "F6").WithArguments("C.F6<T, U>()", "C.F6<T, U>()").WithLocation(13, 29));
+            }
+        }
+
+        [Fact]
+        [WorkItem(45519, "https://github.com/dotnet/roslyn/issues/45519")]
+        public void DifferentSignatures_NativeIntegers()
+        {
+            var source =
+@"using System.Collections.Generic;
+partial class C
+{
+    partial void F1(nint i);
+    partial void F1(System.IntPtr i) { } // 1
+    partial void F2(dynamic x, nint y);
+    partial void F2(object x, System.IntPtr y) { } // 2
+    internal partial void F3(nint i);
+    internal partial void F3(System.IntPtr i) { } // 3
+    internal partial IEnumerable<System.IntPtr> F4();
+    internal partial IEnumerable<nint> F4() => null; // 4
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithWarningLevel5);
+            comp.VerifyDiagnostics(
+                // (5,18): warning CS8824: Partial method declarations 'void C.F1(nint i)' and 'void C.F1(IntPtr i)' have differences in parameter or return types.
+                //     partial void F1(System.IntPtr i) { } // 1
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("void C.F1(nint i)", "void C.F1(IntPtr i)").WithLocation(5, 18),
+                // (7,18): warning CS8824: Partial method declarations 'void C.F2(dynamic x, nint y)' and 'void C.F2(object x, IntPtr y)' have differences in parameter or return types.
+                //     partial void F2(object x, System.IntPtr y) { } // 2
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F2").WithArguments("void C.F2(dynamic x, nint y)", "void C.F2(object x, IntPtr y)").WithLocation(7, 18),
+                // (9,27): warning CS8824: Partial method declarations 'void C.F3(nint i)' and 'void C.F3(IntPtr i)' have differences in parameter or return types.
+                //     internal partial void F3(System.IntPtr i) { } // 3
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F3").WithArguments("void C.F3(nint i)", "void C.F3(IntPtr i)").WithLocation(9, 27),
+                // (11,40): warning CS8824: Partial method declarations 'IEnumerable<IntPtr> C.F4()' and 'IEnumerable<nint> C.F4()' have differences in parameter or return types.
+                //     internal partial IEnumerable<nint> F4() => null; // 4
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F4").WithArguments("IEnumerable<IntPtr> C.F4()", "IEnumerable<nint> C.F4()").WithLocation(11, 40));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
@@ -2650,7 +2650,7 @@ partial class C
     public partial int M();
     public partial long M() => 42; // 1
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (5,25): error CS8817: Both partial method declarations must have the same return type.
                 //     public partial long M() => 42; // 1
@@ -2694,7 +2694,7 @@ partial class C
     public partial IEnumerable<string?> M2();
     public partial IEnumerable<string> M2() => null!;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
@@ -2722,7 +2722,7 @@ partial class C
     public partial IEnumerable<string> M2();
     public partial IEnumerable<string?> M2() => null!; // 2
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (8,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
                 //     public partial string? M1() => null; // 1
@@ -2920,9 +2920,15 @@ partial class C
                 // (5,24): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial int M1() => throw null!; // 1
                 Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M1").WithLocation(5, 24),
+                // (5,24): warning CS8826: Partial method declarations 'ref int C.M1()' and 'int C.M1()' have differences in parameter names, parameter types, or return types.
+                //     public partial int M1() => throw null!; // 1
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("ref int C.M1()", "int C.M1()").WithLocation(5, 24),
                 // (8,28): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial ref int M2() => throw null!; // 2
-                Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M2").WithLocation(8, 28));
+                Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M2").WithLocation(8, 28),
+                // (8,28): warning CS8826: Partial method declarations 'int C.M2()' and 'ref int C.M2()' have differences in parameter names, parameter types, or return types.
+                //     public partial ref int M2() => throw null!; // 2
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("int C.M2()", "ref int C.M2()").WithLocation(8, 28));
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]
@@ -3010,7 +3016,7 @@ partial class C
     public partial dynamic M2();
     public partial object M2() => null;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
@@ -3037,7 +3043,7 @@ partial class C
     public partial nint M2();
     public partial IntPtr M2() => default;
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
@@ -3067,9 +3073,15 @@ partial class C
                 // (5,37): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial ref readonly int M1() => throw null!; // 1
                 Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M1").WithLocation(5, 37),
+                // (5,37): warning CS8826: Partial method declarations 'ref int C.M1()' and 'ref readonly int C.M1()' have differences in parameter names, parameter types, or return types.
+                //     public partial ref readonly int M1() => throw null!; // 1
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M1").WithArguments("ref int C.M1()", "ref readonly int C.M1()").WithLocation(5, 37),
                 // (8,28): error CS8818: Partial method declarations must have matching ref return values.
                 //     public partial ref int M2() => throw null!; // 2
-                Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M2").WithLocation(8, 28));
+                Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "M2").WithLocation(8, 28),
+                // (8,28): warning CS8826: Partial method declarations 'ref readonly int C.M2()' and 'ref int C.M2()' have differences in parameter names, parameter types, or return types.
+                //     public partial ref int M2() => throw null!; // 2
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M2").WithArguments("ref readonly int C.M2()", "ref int C.M2()").WithLocation(8, 28));
         }
 
         [Fact, WorkItem(44930, "https://github.com/dotnet/roslyn/issues/44930")]
@@ -3112,7 +3124,7 @@ partial class C
     public partial string? M11() => null; // 8
     public partial string? M12(); // 9
 }";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
                 // (6,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
                 //     public partial string? M1() => null; // 1
@@ -3197,9 +3209,12 @@ partial class C
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
             comp.VerifyDiagnostics(
-                // (4,31): error CS8818: Partial method declarations must have matching ref return values.
-                //     public partial (int, int) F1() => default;
-                Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "F1").WithLocation(4, 31));
+                    // (4,31): error CS8818: Partial method declarations must have matching ref return values.
+                    //     public partial (int, int) F1() => default;
+                    Diagnostic(ErrorCode.ERR_PartialMethodRefReturnDifference, "F1").WithLocation(4, 31),
+                    // (4,31): warning CS8826: Partial method declarations 'ref (int x, int y) C.F1()' and '(int, int) C.F1()' have differences in parameter names, parameter types, or return types.
+                    //     public partial (int, int) F1() => default;
+                    Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F1").WithArguments("ref (int x, int y) C.F1()", "(int, int) C.F1()").WithLocation(4, 31));
         }
 
         [Fact]
@@ -3216,7 +3231,7 @@ partial class C
     internal partial dynamic F3();
     internal partial object F3() => null; // 3
 }";
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5));
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
@@ -3254,7 +3269,7 @@ partial class C
     internal partial IEnumerable<string> F6();
     internal partial IEnumerable<string?> F6() => null!; // 6
 }";
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5));
             comp.VerifyDiagnostics(
                 // (6,18): warning CS8611: Nullability of reference types in type of parameter 's' doesn't match partial method declaration.
                 //     partial void F1(string s) { } // 1
@@ -3315,7 +3330,7 @@ partial class C
     internal partial (T, U) F6<T, U>() => default; // 4
     internal partial (T x, U y) F6<T, U>();
 }";
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5));
             verifyDiagnostics(comp);
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));
@@ -3356,7 +3371,7 @@ partial class C
     internal partial IEnumerable<System.IntPtr> F4();
     internal partial IEnumerable<nint> F4() => null; // 4
 }";
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5));
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -3227,7 +3227,7 @@ partial class C
         where T2 : I<T1>;
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (7,18): warning CS8826: Partial method declarations 'void C.M<T, U>(T t, U u)' and 'void C.M<X, Y>(X x, Y y)' have differences in parameter names, parameter types, or return types.
+                // (7,18): warning CS8826: Partial method declarations 'void C.M<T, U>(T t, U u)' and 'void C.M<X, Y>(X x, Y y)' have signature differences.
                 //     partial void M<X, Y>(X x, Y y)
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C.M<T, U>(T t, U u)", "void C.M<X, Y>(X x, Y y)").WithLocation(7, 18),
                 // (13,9): error CS0103: The name 't' does not exist in the current context

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -3227,6 +3227,9 @@ partial class C
         where T2 : I<T1>;
 }";
             CreateCompilation(source).VerifyDiagnostics(
+                // (7,18): warning CS8826: Partial method declarations 'void C.M<T, U>(T t, U u)' and 'void C.M<X, Y>(X x, Y y)' have differences in parameter names, parameter types, or return types.
+                //     partial void M<X, Y>(X x, Y y)
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("void C.M<T, U>(T t, U u)", "void C.M<X, Y>(X x, Y y)").WithLocation(7, 18),
                 // (13,9): error CS0103: The name 't' does not exist in the current context
                 //         t.ToString();
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "t").WithArguments("t").WithLocation(13, 9),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -3672,11 +3672,7 @@ class BAttribute : System.Attribute { }
             var type1 = ns.GetTypeMembers("MyClass").Single() as NamedTypeSymbol;
             Assert.Equal(0, type1.TypeParameters.Length);
             var f = type1.GetMembers("F").Single() as MethodSymbol;
-            Assert.Equal(2, f.TypeParameters.Length);
-            var param1 = f.TypeParameters[0];
-            var param2 = f.TypeParameters[1];
-            Assert.Equal("T", param1.Name);
-            Assert.Equal("U", param2.Name);
+            Assert.Equal("T t", f.Parameters[0].ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -3663,7 +3663,7 @@ class BAttribute : System.Attribute { }
 }";
             var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
-                // (6,22): warning CS8826: Partial method declarations 'void MyClass.F<T, U>(T t)' and 'void MyClass.F<T, U>(T tt)' have differences in parameter names, parameter types, or return types.
+                // (6,22): warning CS8826: Partial method declarations 'void MyClass.F<T, U>(T t)' and 'void MyClass.F<T, U>(T tt)' have signature differences.
                 //         partial void F<T, U>(T tt) where T : class {}
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F").WithArguments("void MyClass.F<T, U>(T t)", "void MyClass.F<T, U>(T tt)").WithLocation(6, 22)
                 );
@@ -3692,7 +3692,7 @@ class BAttribute : System.Attribute { }
 }";
             var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
-                // (6,22): warning CS8826: Partial method declarations 'void MyClass.F<T, U>(T t)' and 'void MyClass.F<U, T>(U u)' have differences in parameter names, parameter types, or return types.
+                // (6,22): warning CS8826: Partial method declarations 'void MyClass.F<T, U>(T t)' and 'void MyClass.F<U, T>(U u)' have signature differences.
                 //         partial void F<U, T>(U u) where U : class {}
                 Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F").WithArguments("void MyClass.F<T, U>(T t)", "void MyClass.F<U, T>(U u)").WithLocation(6, 22)
                 );

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -14052,6 +14052,12 @@ partial class C<X>
                 // (32,18): error CS0761: Partial method declarations of 'C<X>.K1<T, U>()' have inconsistent constraints for type parameter 'U'
                 //     partial void K1<T, U>() where T : class where U : IA<T> { }
                 Diagnostic(ErrorCode.ERR_PartialMethodInconsistentConstraints, "K1").WithArguments("C<X>.K1<T, U>()", "U").WithLocation(32, 18),
+                // (32,18): warning CS8826: Partial method declarations 'void C<X>.K1<U, T>()' and 'void C<X>.K1<T, U>()' have differences in parameter names, parameter types, or return types.
+                //     partial void K1<T, U>() where T : class where U : IA<T> { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "K1").WithArguments("void C<X>.K1<U, T>()", "void C<X>.K1<T, U>()").WithLocation(32, 18),
+                // (33,18): warning CS8826: Partial method declarations 'void C<X>.K2<T1, T2>()' and 'void C<X>.K2<T, U>()' have differences in parameter names, parameter types, or return types.
+                //     partial void K2<T, U>() where T : class where U : T, IA<U> { }
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "K2").WithArguments("void C<X>.K2<T1, T2>()", "void C<X>.K2<T, U>()").WithLocation(33, 18),
                 // (38,18): error CS0761: Partial method declarations of 'C<X>.A1<T>()' have inconsistent constraints for type parameter 'T'
                 //     partial void A1<T>() where T : class { }
                 Diagnostic(ErrorCode.ERR_PartialMethodInconsistentConstraints, "A1").WithArguments("C<X>.A1<T>()", "T").WithLocation(38, 18));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -3661,7 +3661,12 @@ class BAttribute : System.Attribute { }
         partial void F<U, T>(U u) where U : class {}
     }
 }";
-            var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(
+                // (6,22): warning CS8826: Partial method declarations 'void MyClass.F<T, U>(T t)' and 'void MyClass.F<U, T>(U u)' have differences in parameter names, parameter types, or return types.
+                //         partial void F<U, T>(U u) where U : class {}
+                Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "F").WithArguments("void MyClass.F<T, U>(T t)", "void MyClass.F<U, T>(U u)").WithLocation(6, 22)
+                );
 
             var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
             var type1 = ns.GetTypeMembers("MyClass").Single() as NamedTypeSymbol;

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -416,14 +416,11 @@ class X
                     ErrorCode.WRN_ParameterIsStaticClass,
                     ErrorCode.WRN_ReturnTypeIsStaticClass,
                     ErrorCode.WRN_RecordNamedDisallowed,
-<<<<<<< HEAD
                     ErrorCode.WRN_RecordEqualsWithoutGetHashCode,
                     ErrorCode.WRN_AnalyzerReferencesFramework,
                     ErrorCode.WRN_UnreadRecordParameter,
                     ErrorCode.WRN_DoNotCompareFunctionPointers,
-=======
                     ErrorCode.WRN_PartialMethodTypeDifference,
->>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
                 };
 
                 Assert.Contains(error, nullableUnrelatedWarnings);

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -356,9 +356,12 @@ class X
                         case ErrorCode.WRN_SyncAndAsyncEntryPoints:
                         case ErrorCode.WRN_ParameterIsStaticClass:
                         case ErrorCode.WRN_ReturnTypeIsStaticClass:
-                        case ErrorCode.WRN_PartialMethodTypeDifference:
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 5 and C# 9.
                             Assert.Equal(5, ErrorFacts.GetWarningLevel(errorCode));
+                            break;
+                        case ErrorCode.WRN_PartialMethodTypeDifference:
+                            // These are the warnings introduced with the warning "wave" shipped with dotnet 6 and C# 10.
+                            Assert.Equal(6, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         default:
                             // If a new warning is added, this test will fail

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -356,6 +356,7 @@ class X
                         case ErrorCode.WRN_SyncAndAsyncEntryPoints:
                         case ErrorCode.WRN_ParameterIsStaticClass:
                         case ErrorCode.WRN_ReturnTypeIsStaticClass:
+                        case ErrorCode.WRN_PartialMethodTypeDifference:
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 5 and C# 9.
                             Assert.Equal(5, ErrorFacts.GetWarningLevel(errorCode));
                             break;
@@ -415,10 +416,14 @@ class X
                     ErrorCode.WRN_ParameterIsStaticClass,
                     ErrorCode.WRN_ReturnTypeIsStaticClass,
                     ErrorCode.WRN_RecordNamedDisallowed,
+<<<<<<< HEAD
                     ErrorCode.WRN_RecordEqualsWithoutGetHashCode,
                     ErrorCode.WRN_AnalyzerReferencesFramework,
                     ErrorCode.WRN_UnreadRecordParameter,
                     ErrorCode.WRN_DoNotCompareFunctionPointers,
+=======
+                    ErrorCode.WRN_PartialMethodTypeDifference,
+>>>>>>> parent of c785833f734 (Revert "Require partial method signatures to match" (47576) (#47879))
                 };
 
                 Assert.Contains(error, nullableUnrelatedWarnings);


### PR DESCRIPTION
This PR brings back #47576, and changes the warning level to 6, and also extend the warning for parameter name differences.

Fixes #47838
Fixes #52520