### PR TITLE
Reduce nestingLevel in EndToEndTests.DeeplyNestedGeneric

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -149,22 +149,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOrLinuxOnly))]
         [WorkItem(33909, "https://github.com/dotnet/roslyn/issues/33909")]
         [WorkItem(34880, "https://github.com/dotnet/roslyn/issues/34880")]
+        [WorkItem(53361, "https://github.com/dotnet/roslyn/issues/53361")]
         public void DeeplyNestedGeneric()
         {
             int nestingLevel = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
             {
                 // Legacy baselines are indicated by comments
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) when ExecutionConditionUtil.IsMacOS => 200, // 100
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) when ExecutionConditionUtil.IsMacOS => 540, // 100
-                _ when ExecutionConditionUtil.IsCoreClrUnix => 1240, // 1200
-                _ when ExecutionConditionUtil.IsMonoDesktop => 750, // 730
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 470, // 270
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1310, // 1290
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 290, // 170
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 770, // 730
+                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 370, // 270
+                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1290, // 1290
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 270, // 170
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 730, // 730
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 
@@ -178,7 +175,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             //    Console.WriteLine($" - {DateTime.UtcNow - start}");
             //}
 
-            runDeeplyNestedGenericTest(nestingLevel);
+            for (int i = 0; i < 20; i++) // PROTOTYPE: Remove this.
+            {
+                runDeeplyNestedGenericTest(nestingLevel);
+            }
 
             void runDeeplyNestedGenericTest(int nestingLevel)
             {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -175,10 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             //    Console.WriteLine($" - {DateTime.UtcNow - start}");
             //}
 
-            for (int i = 0; i < 20; i++) // PROTOTYPE: Remove this.
-            {
-                runDeeplyNestedGenericTest(nestingLevel);
-            }
+            runDeeplyNestedGenericTest(nestingLevel);
 
             void runDeeplyNestedGenericTest(int nestingLevel)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/53361.

`EndToEndTests.DeeplyNestedGeneric()` tests deeply nested types: `MyStruct0<T0> { MyStruct1<T1> { ... MyStructN<TN> { } ... } }` and the `StackOverflowException` in https://github.com/dotnet/roslyn/issues/53361 occurs when getting the `Binder` for a nested `struct`.

The failure happens only occasionally because `BinderFactoryVisitor` caches a `Binder` for each declaration `SyntaxNode` in `BinderFactory._binderCache`, and the cache is small (50 items) and uses `Object.GetHashCode()` for the `SyntaxNode` key, so each `ParsedSyntaxTree` is likely to have a different set of 50 items in the cache when visiting the same syntax.

In the worst case, getting the `Binder` for the inner most `MyStructN<TN> { }` might recurse through all containing types to get the containing `Binder` instances without any cache hits.