### PR TITLE
Add endpoint for public semantic tokens LSP API

### DIFF
--- a/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
@@ -333,6 +333,18 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 semanticTokensRangeParams, _clientCapabilities, ClientName, cancellationToken);
         }
 
+        // Temporary workaround to specify the actual public LSP method name until the LSP protocol package updates.
+        // Tracked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1249055
+        [JsonRpcMethod("textDocument/semanticTokens/full", UseSingleObjectParameterDeserialization = true)]
+        public Task<SemanticTokens> GetTextDocumentSemanticTokensPublicAsync(SemanticTokensParams semanticTokensParams, CancellationToken cancellationToken)
+            => GetTextDocumentSemanticTokensAsync(semanticTokensParams, cancellationToken);
+
+        // Temporary workaround to specify the actual public LSP method name until the LSP protocol package updates.
+        // Tracked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1249055
+        [JsonRpcMethod("textDocument/semanticTokens/full/delta", UseSingleObjectParameterDeserialization = true)]
+        public Task<SumType<SemanticTokens, SemanticTokensEdits>> GetTextDocumentSemanticTokensEditsPublicAsync(SemanticTokensEditsParams semanticTokensEditsParams, CancellationToken cancellationToken)
+            => GetTextDocumentSemanticTokensEditsAsync(semanticTokensEditsParams, cancellationToken);
+
         [JsonRpcMethod(Methods.TextDocumentDidChangeName, UseSingleObjectParameterDeserialization = true)]
         public Task<object> HandleDocumentDidChangeAsync(DidChangeTextDocumentParams didChangeParams, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
The semantic tokens version in the VS LSP dlls was created before the actual public LSP api shipped, so some of the names are outdated.  For now to allow semantic tokens in VSCode, we can just implement the correct method names until the VS LSP client updates their protocol packages.  This is tracked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1249055