### PR TITLE
Don't attempt to edit source generated files during rename

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
@@ -51,9 +51,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 renameTo As String,
                 host As RenameTestHost,
                 Optional changedOptionSet As Dictionary(Of OptionKey, Object) = Nothing,
-                Optional expectFailure As Boolean = False) As RenameEngineResult
+                Optional expectFailure As Boolean = False,
+                Optional sourceGenerator As ISourceGenerator = Nothing) As RenameEngineResult
             Dim workspace = TestWorkspace.CreateWorkspace(workspaceXml, composition:=EditorTestCompositions.EditorFeatures.AddParts(GetType(NoCompilationContentTypeLanguageService), GetType(NoCompilationContentTypeDefinitions)))
             workspace.SetTestLogger(AddressOf helper.WriteLine)
+
+            If sourceGenerator IsNot Nothing Then
+                workspace.OnAnalyzerReferenceAdded(workspace.CurrentSolution.ProjectIds.Single(), New TestGeneratorReference(sourceGenerator))
+            End If
 
             Dim engineResult As RenameEngineResult = Nothing
             Try


### PR DESCRIPTION
We don't let a user rename symbols that are defined in source generated files, but in some scenarios we may cascade to them. This prevents us from updating those cascaded definitions either. The assumption in such a change is that the names in generated files are being generated from some of the original definitions that are being renamed, and so everything will refresh.

Fixes https://github.com/dotnet/roslyn/issues/51537