### PR TITLE
Fix OOP tests around Find References and Rename

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.FieldSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.FieldSymbols.vb
@@ -533,7 +533,7 @@ class Definition:Program
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestField_UsedInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestField_UsedInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -556,7 +556,7 @@ class Definition:Program
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
@@ -294,7 +294,7 @@ End Class
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharp_IndexerInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestCSharp_IndexerInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -317,7 +317,7 @@ class D
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LabelSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LabelSymbols.vb
@@ -88,7 +88,7 @@ End Module
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestLabelInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestLabelInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -105,7 +105,7 @@ End Module
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LocalFunctions.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LocalFunctions.vb
@@ -197,7 +197,7 @@ class Test
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestLocalFunctionUsedInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestLocalFunctionUsedInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -214,7 +214,7 @@ class Test
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
@@ -2533,7 +2533,7 @@ namespace N
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestNamedTypeUsedInSourceGeneratedOutput(kind As TestKind) As Task
+        Public Async Function TestNamedTypeUsedInSourceGeneratedOutput(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -2541,7 +2541,7 @@ namespace N
         <DocumentFromSourceGenerator>class D : [|C|] { }</DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
@@ -458,7 +458,7 @@ class A
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpFindOperatorUsedInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestCSharpFindOperatorUsedInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -480,7 +480,7 @@ class B
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
 
     End Class

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -3577,7 +3577,7 @@ End Class
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestOrdinaryMethodUsedInSourceGenerator(kind As TestKind) As Task
+        Public Async Function TestOrdinaryMethodUsedInSourceGenerator(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -3604,7 +3604,7 @@ End Class
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ParameterSymbol.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ParameterSymbol.vb
@@ -673,7 +673,7 @@ end class
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestParameterReferencedInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestParameterReferencedInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -697,11 +697,11 @@ end class
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestParameterDefinedInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestParameterDefinedInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -725,7 +725,7 @@ end class
         </Document>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -1047,7 +1047,7 @@ namespace N
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharp_PropertyUseInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestCSharp_PropertyUseInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1082,7 +1082,7 @@ namespace ConsoleApplication22
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.RangeVariableSymbol.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.RangeVariableSymbol.vb
@@ -239,7 +239,7 @@ End Namespace
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpRangeVariableUseInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestCSharpRangeVariableUseInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -255,7 +255,7 @@ class C
     </Project>
 </Workspace>
 
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
 
     End Class

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
@@ -378,7 +378,7 @@ class Program
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestTuplesUseInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestTuplesUseInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferencesNetCoreApp="true">
@@ -409,7 +409,7 @@ partial class Program
         </DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
@@ -1618,7 +1618,7 @@ End Class]]>
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCrefReferenceInSourceGeneratedDocument(kind As TestKind) As Task
+        Public Async Function TestCrefReferenceInSourceGeneratedDocument(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1641,7 +1641,7 @@ End Class]]>
         ]]></DocumentFromSourceGenerator>
     </Project>
 </Workspace>
-            Await TestAPIAndFeature(input, kind, TestHost.InProcess) ' TODO: support out of proc in tests: https://github.com/dotnet/roslyn/issues/50494
+            Await TestAPIAndFeature(input, kind, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
@@ -53,7 +53,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 Optional changedOptionSet As Dictionary(Of OptionKey, Object) = Nothing,
                 Optional expectFailure As Boolean = False,
                 Optional sourceGenerator As ISourceGenerator = Nothing) As RenameEngineResult
-            Dim workspace = TestWorkspace.CreateWorkspace(workspaceXml, composition:=EditorTestCompositions.EditorFeatures.AddParts(GetType(NoCompilationContentTypeLanguageService), GetType(NoCompilationContentTypeDefinitions)))
+
+            Dim composition = EditorTestCompositions.EditorFeatures.AddParts(GetType(NoCompilationContentTypeLanguageService), GetType(NoCompilationContentTypeDefinitions))
+
+            If host = RenameTestHost.OutOfProcess_SingleCall OrElse host = RenameTestHost.OutOfProcess_SplitCall Then
+                composition = composition.WithTestHostParts(Remote.Testing.TestHost.OutOfProcess)
+            End If
+
+            Dim workspace = TestWorkspace.CreateWorkspace(workspaceXml, composition:=composition)
             workspace.SetTestLogger(AddressOf helper.WriteLine)
 
             If sourceGenerator IsNot Nothing Then

--- a/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<ReferenceLocation> RehydrateAsync(
             Solution solution, CancellationToken cancellationToken)
         {
-            var document = solution.GetDocument(this.Document);
+            var document = await solution.GetDocumentAsync(this.Document, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var aliasSymbol = await RehydrateAliasAsync(solution, cancellationToken).ConfigureAwait(false);
             var additionalProperties = this.AdditionalProperties;

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         public void SerializeAnalyzerReference(AnalyzerReference reference, ObjectWriter writer, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            WriteTo(reference, writer, cancellationToken);
+            WriteAnalyzerReferenceTo(reference, writer, cancellationToken);
         }
 
         private AnalyzerReference DeserializeAnalyzerReference(ObjectReader reader, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             throw ExceptionUtilities.UnexpectedValue(type);
         }
 
-        public static void WriteTo(AnalyzerReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        public virtual void WriteAnalyzerReferenceTo(AnalyzerReference reference, ObjectWriter writer, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             }
         }
 
-        public AnalyzerReference ReadAnalyzerReferenceFrom(ObjectReader reader, CancellationToken cancellationToken)
+        public virtual AnalyzerReference ReadAnalyzerReferenceFrom(ObjectReader reader, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemoteHostClientProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -11,7 +12,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.UnitTests.Remote;
+using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote.Testing
@@ -34,11 +38,19 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
         private sealed class WorkspaceManager : RemoteWorkspaceManager
         {
-            public WorkspaceManager(SolutionAssetCache assetStorage, Type[]? additionalRemoteParts)
+            public WorkspaceManager(SolutionAssetCache assetStorage, ConcurrentDictionary<Guid, TestGeneratorReference> sharedTestGeneratorReferences, Type[]? additionalRemoteParts)
                 : base(assetStorage)
             {
                 LazyWorkspace = new Lazy<RemoteWorkspace>(
-                    () => new RemoteWorkspace(FeaturesTestCompositions.RemoteHost.AddParts(additionalRemoteParts).GetHostServices(), WorkspaceKind.RemoteWorkspace));
+                    () =>
+                    {
+                        var hostServices = FeaturesTestCompositions.RemoteHost.AddParts(additionalRemoteParts).GetHostServices();
+
+                        // We want to allow references to source generators to be shared between the "in proc" and "remote" workspaces and
+                        // MEF compositions, so tell the serializer service to use the same map for this "remote" workspace as the in-proc one.
+                        ((IMefHostExportProvider)hostServices).GetExportedValue<TestSerializerService.Factory>().SharedTestGeneratorReferences = sharedTestGeneratorReferences;
+                        return new RemoteWorkspace(hostServices, WorkspaceKind.RemoteWorkspace);
+                    });
             }
 
             public Lazy<RemoteWorkspace> LazyWorkspace { get; }
@@ -59,7 +71,13 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         {
             _services = services;
 
-            _lazyManager = new Lazy<WorkspaceManager>(() => new WorkspaceManager(RemoteAssetStorage ?? new SolutionAssetCache(), AdditionalRemoteParts));
+            var testSerializerServiceFactory = ((IMefHostExportProvider)services.HostServices).GetExportedValue<TestSerializerService.Factory>();
+
+            _lazyManager = new Lazy<WorkspaceManager>(
+                () => new WorkspaceManager(
+                    RemoteAssetStorage ?? new SolutionAssetCache(),
+                    testSerializerServiceFactory.SharedTestGeneratorReferences,
+                    AdditionalRemoteParts));
             _lazyClient = new AsyncLazy<RemoteHostClient>(
                 cancellationToken => InProcRemoteHostClient.CreateAsync(
                     _services,

--- a/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/TestSerializerService.cs
@@ -5,11 +5,13 @@
 #nullable disable
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Serialization;
@@ -30,10 +32,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.Remote
         private static readonly ImmutableDictionary<string, MetadataReference> s_wellKnownReferences = ImmutableDictionary.Create<string, MetadataReference>()
             .AddRange(s_wellKnownReferenceNames.Select(pair => KeyValuePairUtil.Create(pair.Value, pair.Key)));
 
+        private readonly ConcurrentDictionary<Guid, TestGeneratorReference> _sharedTestGeneratorReferences;
+
         [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
-        public TestSerializerService(HostWorkspaceServices workspaceServices)
+        public TestSerializerService(ConcurrentDictionary<Guid, TestGeneratorReference> sharedTestGeneratorReferences, HostWorkspaceServices workspaceServices)
             : base(workspaceServices)
         {
+            _sharedTestGeneratorReferences = sharedTestGeneratorReferences;
         }
 
         public override void WriteMetadataReferenceTo(MetadataReference reference, ObjectWriter writer, SolutionReplicationContext context, CancellationToken cancellationToken)
@@ -64,9 +69,82 @@ namespace Microsoft.CodeAnalysis.UnitTests.Remote
             }
         }
 
+        public override void WriteAnalyzerReferenceTo(AnalyzerReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        {
+            if (reference is TestGeneratorReference generatorReference)
+            {
+                // It's a test reference, we'll just store it in a map and then just write out our GUID
+                _sharedTestGeneratorReferences.TryAdd(generatorReference.Guid, generatorReference);
+                writer.WriteGuid(generatorReference.Guid);
+            }
+            else
+            {
+                writer.WriteGuid(Guid.Empty);
+                base.WriteAnalyzerReferenceTo(reference, writer, cancellationToken);
+            }
+        }
+
+        public override AnalyzerReference ReadAnalyzerReferenceFrom(ObjectReader reader, CancellationToken cancellationToken)
+        {
+            var testGeneratorReferenceGuid = reader.ReadGuid();
+
+            if (testGeneratorReferenceGuid != Guid.Empty)
+            {
+                Contract.ThrowIfFalse(_sharedTestGeneratorReferences.TryGetValue(testGeneratorReferenceGuid, out var generatorReference));
+                return generatorReference;
+            }
+            else
+            {
+                return base.ReadAnalyzerReferenceFrom(reader, cancellationToken);
+            }
+        }
+
         [ExportWorkspaceServiceFactory(typeof(ISerializerService), layer: ServiceLayer.Test), Shared, PartNotDiscoverable]
+        [Export(typeof(Factory))]
         internal new sealed class Factory : IWorkspaceServiceFactory
         {
+            private ConcurrentDictionary<Guid, TestGeneratorReference> _sharedTestGeneratorReferences;
+
+            /// <summary>
+            /// Gate to serialize reads/writes to <see cref="_sharedTestGeneratorReferences"/>.
+            /// </summary>
+            private readonly object _gate = new object();
+
+            /// <summary>
+            /// In unit tests that are testing OOP, we want to be able to share test generator references directly
+            /// from one side to another. We'll create multiple instances of the TestSerializerService -- one for each
+            /// workspace and in different MEF compositions, but we'll share the generator references across them. This
+            /// property allows the shared dictionary to be read/set.
+            /// </summary>
+            public ConcurrentDictionary<Guid, TestGeneratorReference> SharedTestGeneratorReferences
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        if (_sharedTestGeneratorReferences == null)
+                            _sharedTestGeneratorReferences = new ConcurrentDictionary<Guid, TestGeneratorReference>();
+
+                        return _sharedTestGeneratorReferences;
+                    }
+                }
+
+                set
+                {
+                    lock (_gate)
+                    {
+                        // If we're already being assigned the same set of references as before, we're fine as that won't change anything.
+                        // Ideally, every time we created a new RemoteWorkspace we'd have a new MEF container; this would ensure that
+                        // the assignment earlier before we create the RemoteWorkspace was always the first assignment. However the
+                        // ExportProviderCache.cs in our unit tests hands out the same MEF container multpile times instead of implementing the expected
+                        // contract. See https://github.com/dotnet/roslyn/issues/25863 for further details.
+                        Contract.ThrowIfFalse(_sharedTestGeneratorReferences == null ||
+                            _sharedTestGeneratorReferences == value, "We already have a shared set of references, we shouldn't be getting another one.");
+                        _sharedTestGeneratorReferences = value;
+                    }
+                }
+            }
+
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
             public Factory()
@@ -75,7 +153,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Remote
 
             [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
             public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-                => new TestSerializerService(workspaceServices);
+                => new TestSerializerService(SharedTestGeneratorReferences, workspaceServices);
         }
     }
 }

--- a/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
+++ b/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -12,17 +13,31 @@ namespace Roslyn.Test.Utilities
     /// A simple deriviation of <see cref="AnalyzerReference"/> that returns the source generator
     /// passed, for ease in unit tests.
     /// </summary>
-    public sealed class TestGeneratorReference : AnalyzerReference
+    public sealed class TestGeneratorReference : AnalyzerReference, IChecksummedObject
     {
         private readonly ISourceGenerator _generator;
+        private readonly Checksum _checksum;
 
         public TestGeneratorReference(ISourceGenerator generator)
         {
             _generator = generator;
+            Guid = Guid.NewGuid();
+
+            // In unit tests, we often simulate OOP interactions by interacting with a in-process remote host, but
+            // still going through our serialization pathways. In real OOP cases we only support serializing
+            // AnalyzerFileReferences, since we load the file in both places. In unit tests however we often directly
+            // create instances of ISourceGenerators so we can test generator support for various features.
+            // We'll make up a checksum here so we can "serialize" it to our unit test in-proc "remote" host.
+            var checksumArray = Guid.ToByteArray();
+            Array.Resize(ref checksumArray, Checksum.HashSize);
+            _checksum = Checksum.From(checksumArray);
         }
 
         public override string? FullPath => null;
         public override object Id => this;
+        public Guid Guid { get; }
+
+        Checksum IChecksummedObject.Checksum => _checksum;
 
         public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => ImmutableArray<DiagnosticAnalyzer>.Empty;
         public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => ImmutableArray<DiagnosticAnalyzer>.Empty;


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/50494. Commit at a time strongly recommended; explanations are in each commit message.

This does also fix one product bug where the non-streaming OOP API for find references would throw exceptions if references were found in a source generated document. I don't know if that has any direct outcome, but I want these changes in 16.11 since otherwise we had some test gaps. Specifically it ensures that https://github.com/dotnet/roslyn/pull/53380 has good coverage.