### PR TITLE
State Table Cleanup

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1517,7 +1517,7 @@ class C { }
             Assert.Equal(1, textsCalledFor.Count);
             Assert.Equal(text1, textsCalledFor[0]);
 
-            // clear the results, add an aditional text, but keep the compilation the same
+            // clear the results, add an additional text, but keep the compilation the same
             compilationsCalledFor.Clear();
             textsCalledFor.Clear();
             driver = driver.AddAdditionalTexts(ImmutableArray.Create<AdditionalText>(text2));
@@ -1572,7 +1572,7 @@ class C { }
             Assert.Equal(1, compilationsCalledFor.Count);
             Assert.Equal(compilation, compilationsCalledFor[0]);
 
-            // now edit the compilation, run the generator, and confim that the output was not called again this time
+            // now edit the compilation, run the generator, and confirm that the output was not called again this time
             Compilation newCompilation = compilation.WithOptions(compilation.Options.WithModuleName("newCompilation"));
             driver = driver.RunGenerators(newCompilation);
             Assert.Equal(1, compilationsCalledFor.Count);

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1442,5 +1442,141 @@ class C { }
             Assert.Throws<OperationCanceledException>(() => timeoutFunc(30));
             Assert.Throws<OperationCanceledException>(() => userTimeoutFunc(30));
         }
+
+        [Fact]
+        public void IncrementalGenerator_Doesnt_Run_For_Same_Input()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            List<Compilation> compilationsCalledFor = new List<Compilation>();
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterOutput(ctx.Sources.Compilation.GenerateSource((spc, c) =>
+                {
+                    compilationsCalledFor.Add(c);
+                }));
+            }));
+
+            // run the generator once, and check it was passed the compilation
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions);
+            driver = driver.RunGenerators(compilation);
+            Assert.Equal(1, compilationsCalledFor.Count);
+            Assert.Equal(compilation, compilationsCalledFor[0]);
+
+            // run the same compilation through again, and confirm the output wasn't called
+            driver = driver.RunGenerators(compilation);
+            Assert.Equal(1, compilationsCalledFor.Count);
+            Assert.Equal(compilation, compilationsCalledFor[0]);
+        }
+
+        [Fact]
+        public void IncrementalGenerator_Runs_Only_For_Changed_Inputs()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            var text1 = new InMemoryAdditionalText("Text1", "content1");
+            var text2 = new InMemoryAdditionalText("Text2", "content2");
+
+            List<Compilation> compilationsCalledFor = new List<Compilation>();
+            List<AdditionalText> textsCalledFor = new List<AdditionalText>();
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterOutput(ctx.Sources.Compilation.GenerateSource((spc, c) =>
+                {
+                    compilationsCalledFor.Add(c);
+                }));
+
+                ctx.RegisterOutput(ctx.Sources.AdditionalTexts.GenerateSource((spc, c) =>
+                {
+                    textsCalledFor.Add(c);
+                }));
+            }));
+
+
+            // run the generator once, and check it was passed the compilation
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, additionalTexts: new[] { text1 }, parseOptions: parseOptions);
+            driver = driver.RunGenerators(compilation);
+            Assert.Equal(1, compilationsCalledFor.Count);
+            Assert.Equal(compilation, compilationsCalledFor[0]);
+            Assert.Equal(1, textsCalledFor.Count);
+            Assert.Equal(text1, textsCalledFor[0]);
+
+            // clear the results, add an aditional text, but keep the compilation the same
+            compilationsCalledFor.Clear();
+            textsCalledFor.Clear();
+            driver = driver.AddAdditionalTexts(ImmutableArray.Create<AdditionalText>(text2));
+            driver = driver.RunGenerators(compilation);
+            Assert.Equal(0, compilationsCalledFor.Count);
+            Assert.Equal(1, textsCalledFor.Count);
+            Assert.Equal(text2, textsCalledFor[0]);
+
+            // now edit the compilation
+            compilationsCalledFor.Clear();
+            textsCalledFor.Clear();
+            var newCompilation = compilation.WithOptions(compilation.Options.WithModuleName("newComp"));
+            driver = driver.RunGenerators(newCompilation);
+            Assert.Equal(1, compilationsCalledFor.Count);
+            Assert.Equal(newCompilation, compilationsCalledFor[0]);
+            Assert.Equal(0, textsCalledFor.Count);
+
+            // re run without changing anything
+            compilationsCalledFor.Clear();
+            textsCalledFor.Clear();
+            driver = driver.RunGenerators(newCompilation);
+            Assert.Equal(0, compilationsCalledFor.Count);
+            Assert.Equal(0, textsCalledFor.Count);
+        }
+
+        [Fact]
+        public void IncrementalGenerator_Can_Add_Comparer_To_Input_Node()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            List<Compilation> compilationsCalledFor = new List<Compilation>();
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                var compilationSource = ctx.Sources.Compilation.WithComparer(new LambdaComparer<Compilation>((c1, c2) => true, 0));
+                ctx.RegisterOutput(compilationSource.GenerateSource((spc, c) =>
+                {
+                    compilationsCalledFor.Add(c);
+                }));
+            }));
+
+            // run the generator once, and check it was passed the compilation
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions);
+            driver = driver.RunGenerators(compilation);
+            Assert.Equal(1, compilationsCalledFor.Count);
+            Assert.Equal(compilation, compilationsCalledFor[0]);
+
+            // now edit the compilation, run the generator, and confim that the output was not called again this time
+            Compilation newCompilation = compilation.WithOptions(compilation.Options.WithModuleName("newCompilation"));
+            driver = driver.RunGenerators(newCompilation);
+            Assert.Equal(1, compilationsCalledFor.Count);
+            Assert.Equal(compilation, compilationsCalledFor[0]);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Entries_Can_Be_Enumerated()
         {
-            var builder = new NodeStateTable<int>.Builder();
+            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(1), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(2), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(3), EntryState.Added);
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Entries_Are_Flattened_When_Enumerated()
         {
-            var builder = new NodeStateTable<int>.Builder();
+            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         {
             var o = new object();
 
-            var builder = new NodeStateTable<object>.Builder();
+            var builder = NodeStateTable<object>.Empty.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(o, o, o), EntryState.Added);
             var table = builder.ToImmutableAndFree();
 
@@ -54,18 +54,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Builder_Can_Add_Entries_From_Previous_Table()
         {
-            var builder = new NodeStateTable<int>.Builder();
+            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(1), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(2, 3), EntryState.Cached);
             builder.AddEntries(ImmutableArray.Create(4, 5), EntryState.Modified);
             builder.AddEntries(ImmutableArray.Create(6), EntryState.Added);
             var previousTable = builder.ToImmutableAndFree();
 
-            builder = new NodeStateTable<int>.Builder();
+            builder = previousTable.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(10, 11), EntryState.Added);
-            builder.AddEntriesFromPreviousTable(previousTable, EntryState.Cached); // ((2, EntryState.Cached), (3, EntryState.Cached))
+            builder.AddEntriesFromPreviousTable(EntryState.Cached); // ((2, EntryState.Cached), (3, EntryState.Cached))
             builder.AddEntries(ImmutableArray.Create(20, 21, 22), EntryState.Modified);
-            builder.AddEntriesFromPreviousTable(previousTable, EntryState.Removed); //((6, EntryState.Removed))); 
+            builder.AddEntriesFromPreviousTable(EntryState.Removed); //((6, EntryState.Removed))); 
             var newTable = builder.ToImmutableAndFree();
 
             var expected = ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Cached), (20, EntryState.Modified), (21, EntryState.Modified), (22, EntryState.Modified), (6, EntryState.Removed));
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Entries_Are_Cached_Or_Removed_When_Compacted()
         {
-            var builder = new NodeStateTable<int>.Builder();
+            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Removed);
             builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Compaction_Occurs_Only_Once()
         {
-            var builder = new NodeStateTable<int>.Builder();
+            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Removed);
             builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Driver_Table_Calls_Into_Node_With_PreviousTable()
         {
-            var nodeBuilder = new NodeStateTable<int>.Builder();
+            var nodeBuilder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
             nodeBuilder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Cached);
             var newTable = nodeBuilder.ToImmutableAndFree();
 
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Driver_Table_Compacts_State_Tables_When_Made_Immutable()
         {
-            var nodeBuilder = new NodeStateTable<int>.Builder();
+            var nodeBuilder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
             nodeBuilder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             nodeBuilder.AddEntries(ImmutableArray.Create(4), EntryState.Removed);
             nodeBuilder.AddEntries(ImmutableArray.Create(5, 6), EntryState.Modified);

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -63,9 +63,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             builder = previousTable.ToBuilderWithABetterName();
             builder.AddEntries(ImmutableArray.Create(10, 11), EntryState.Added);
-            builder.AddEntriesFromPreviousTable(EntryState.Cached); // ((2, EntryState.Cached), (3, EntryState.Cached))
+            builder.TryUseCachedEntries(); // ((2, EntryState.Cached), (3, EntryState.Cached))
             builder.AddEntries(ImmutableArray.Create(20, 21, 22), EntryState.Modified);
-            builder.AddEntriesFromPreviousTable(EntryState.Removed); //((6, EntryState.Removed))); 
+            builder.RemoveEntries(); //((6, EntryState.Removed))); 
             var newTable = builder.ToImmutableAndFree();
 
             var expected = ImmutableArray.Create((10, EntryState.Added), (11, EntryState.Added), (2, EntryState.Cached), (3, EntryState.Cached), (20, EntryState.Modified), (21, EntryState.Modified), (22, EntryState.Modified), (6, EntryState.Removed));

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Entries_Can_Be_Enumerated()
         {
-            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
+            var builder = NodeStateTable<int>.Empty.ToBuilder();
             builder.AddEntries(ImmutableArray.Create(1), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(2), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(3), EntryState.Added);
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Entries_Are_Flattened_When_Enumerated()
         {
-            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
+            var builder = NodeStateTable<int>.Empty.ToBuilder();
             builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         {
             var o = new object();
 
-            var builder = NodeStateTable<object>.Empty.ToBuilderWithABetterName();
+            var builder = NodeStateTable<object>.Empty.ToBuilder();
             builder.AddEntries(ImmutableArray.Create(o, o, o), EntryState.Added);
             var table = builder.ToImmutableAndFree();
 
@@ -54,14 +54,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Builder_Can_Add_Entries_From_Previous_Table()
         {
-            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
+            var builder = NodeStateTable<int>.Empty.ToBuilder();
             builder.AddEntries(ImmutableArray.Create(1), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(2, 3), EntryState.Cached);
             builder.AddEntries(ImmutableArray.Create(4, 5), EntryState.Modified);
             builder.AddEntries(ImmutableArray.Create(6), EntryState.Added);
             var previousTable = builder.ToImmutableAndFree();
 
-            builder = previousTable.ToBuilderWithABetterName();
+            builder = previousTable.ToBuilder();
             builder.AddEntries(ImmutableArray.Create(10, 11), EntryState.Added);
             builder.TryUseCachedEntries(); // ((2, EntryState.Cached), (3, EntryState.Cached))
             builder.AddEntries(ImmutableArray.Create(20, 21, 22), EntryState.Modified);
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Entries_Are_Cached_Or_Removed_When_Compacted()
         {
-            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
+            var builder = NodeStateTable<int>.Empty.ToBuilder();
             builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Removed);
             builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Node_Table_Compaction_Occurs_Only_Once()
         {
-            var builder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
+            var builder = NodeStateTable<int>.Empty.ToBuilder();
             builder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             builder.AddEntries(ImmutableArray.Create(4, 5, 6), EntryState.Removed);
             builder.AddEntries(ImmutableArray.Create(7, 8, 9), EntryState.Added);
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Driver_Table_Calls_Into_Node_With_PreviousTable()
         {
-            var nodeBuilder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
+            var nodeBuilder = NodeStateTable<int>.Empty.ToBuilder();
             nodeBuilder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Cached);
             var newTable = nodeBuilder.ToImmutableAndFree();
 
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Fact]
         public void Driver_Table_Compacts_State_Tables_When_Made_Immutable()
         {
-            var nodeBuilder = NodeStateTable<int>.Empty.ToBuilderWithABetterName();
+            var nodeBuilder = NodeStateTable<int>.Empty.ToBuilder();
             nodeBuilder.AddEntries(ImmutableArray.Create(1, 2, 3), EntryState.Added);
             nodeBuilder.AddEntries(ImmutableArray.Create(4), EntryState.Removed);
             nodeBuilder.AddEntries(ImmutableArray.Create(5, 6), EntryState.Modified);

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -260,7 +260,6 @@ namespace Microsoft.CodeAnalysis
             }
             constantSourcesBuilder.Free();
 
-
             var driverStateBuilder = new DriverStateTable.Builder(compilation, _state, syntaxInputNodes.ToImmutableAndFree(), cancellationToken);
 
             for (int i = 0; i < state.IncrementalGenerators.Length; i++)

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -295,13 +295,16 @@ namespace Microsoft.CodeAnalysis
             driverStateBuilder.AddInput(SharedInputNodes.ParseOptions, _state.ParseOptions);
             driverStateBuilder.AddInput(SharedInputNodes.AdditionalTexts, _state.AdditionalTexts);
 
+            // PROTOTYPE(source-generators): we should probably just pass these at creation, and need to handle syntax rx's too
+            driverStateBuilder.AddSyntaxNodes(syntaxInputNodes.ToImmutable());
+
             // If we have syntax inputs, or receivers, bring them up to date
             if (syntaxInputNodes.Count > 0 || walkerCount > 0)
             {
                 var builders = ArrayBuilder<ISyntaxTransformBuilder>.GetInstance(syntaxInputNodes.Count);
                 foreach (var node in syntaxInputNodes)
                 {
-                    builders.Add(node.GetBuilder(_state.StateTable));
+                   // builders.Add(node.GetBuilder(_state.StateTable));
                 }
 
                 foreach ((var tree, var treeState) in driverStateBuilder.GetLatestStateTableForNode(SharedInputNodes.SyntaxTrees))
@@ -311,8 +314,7 @@ namespace Microsoft.CodeAnalysis
                         // we need to keep the removed tree entries, but can skip everything else
                         foreach (var b in builders)
                         {
-                            // PROTOTYPE(source-generators): we know we don't use the model in this case
-                            b.AddFilterFromPreviousTable(null!, EntryState.Removed);
+                          //  b.AddFilterFromPreviousTable(null, EntryState.Removed);
                         }
                         continue;
                     }
@@ -325,13 +327,13 @@ namespace Microsoft.CodeAnalysis
                     {
                         foreach (var b in builders)
                         {
-                            b.AddFilterFromPreviousTable(semanticModel, treeState);
+                           // b.AddFilterFromPreviousTable(semanticModel, treeState);
                         }
                     }
                     else
                     {
                         // run a walk for each filter and apply the results
-                        IncrementalGeneratorSyntaxWalker.VisitNodeForBuilders(tree.GetRoot(cancellationToken), semanticModel, builders);
+                        //IncrementalGeneratorSyntaxWalker.VisitNodeForBuilders(tree.GetRoot(cancellationToken), semanticModel, builders);
                     }
 
                     // back compat, run this tree over any ISyntaxContextReceivers
@@ -360,7 +362,7 @@ namespace Microsoft.CodeAnalysis
                 // add the updated nodes as inputs to the new graph
                 foreach (var builder in builders)
                 {
-                    builder.AddInputs(driverStateBuilder);
+                    //builder.AddInputs(driverStateBuilder);
                 }
 
                 builders.Free();

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis
             constantSourcesBuilder.Free();
 
 
-            var driverStateBuilder = new DriverStateTable.Builder(compilation, _state, syntaxInputNodes.ToImmutable(), cancellationToken);
+            var driverStateBuilder = new DriverStateTable.Builder(compilation, _state, syntaxInputNodes.ToImmutableAndFree(), cancellationToken);
 
             for (int i = 0; i < state.IncrementalGenerators.Length; i++)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis
             var stateBuilder = ArrayBuilder<GeneratorState>.GetInstance(state.Generators.Length);
             var constantSourcesBuilder = ArrayBuilder<SyntaxTree>.GetInstance();
             var walkerBuilder = ArrayBuilder<GeneratorSyntaxWalker?>.GetInstance(state.Generators.Length, fillWithValue: null); // we know there is at max 1 per generator
-            var syntaxInputNodes = ArrayBuilder<ISyntaxTransformNode>.GetInstance();
+            var syntaxInputNodes = ArrayBuilder<ISyntaxInputNode>.GetInstance();
             int walkerCount = 0;
 
             for (int i = 0; i < state.IncrementalGenerators.Length; i++)

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -94,14 +94,7 @@ namespace Microsoft.CodeAnalysis
 
         public GeneratorDriver AddAdditionalTexts(ImmutableArray<AdditionalText> additionalTexts)
         {
-            var builder = _state.StateTable.GetStateTable(SharedInputNodes.AdditionalTexts).ToBuilder(extraCapacity: additionalTexts.Length);
-            foreach (var text in additionalTexts)
-            {
-                builder.AddEntries(ImmutableArray.Create(text), EntryState.Added);
-            }
-            var stateTable = _state.StateTable.SetStateTable(SharedInputNodes.AdditionalTexts, builder.ToImmutableAndFree());
-
-            var newState = _state.With(additionalTexts: _state.AdditionalTexts.AddRange(additionalTexts), stateTable: stateTable);
+            var newState = _state.With(additionalTexts: _state.AdditionalTexts.AddRange(additionalTexts));
             return FromState(newState);
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -382,9 +382,8 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
-                if (generatorState.SyntaxReceiver is object)
+                if (generatorState.Sources.ReceiverNode is object)
                 {
-                    Debug.Assert(generatorState.Sources.ReceiverNode is object);
                     driverStateBuilder.AddInput(generatorState.Sources.ReceiverNode, generatorState.SyntaxReceiver);
                 }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new generator state that contains information, constant trees and an execution pipeline
         /// </summary>
         public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, PerGeneratorInputNodes sources, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes)
-            : this(info, postInitTrees, sources, outputNodes, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, syntaxReceiver: null, exception: null)
+            : this(info, postInitTrees, sources, outputNodes, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, exception: null)
         {
         }
 
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new generator state that contains an exception and the associated diagnostic
         /// </summary>
         public GeneratorState(GeneratorInfo info, Exception e, Diagnostic error)
-            : this(info, ImmutableArray<GeneratedSyntaxTree>.Empty, PerGeneratorInputNodes.Empty, ImmutableArray<IIncrementalGeneratorOutputNode>.Empty, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray.Create(error), syntaxReceiver: null, exception: e)
+            : this(info, ImmutableArray<GeneratedSyntaxTree>.Empty, PerGeneratorInputNodes.Empty, ImmutableArray<IIncrementalGeneratorOutputNode>.Empty, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray.Create(error), exception: e)
         {
         }
 
@@ -53,11 +53,11 @@ namespace Microsoft.CodeAnalysis
         /// Creates a generator state that contains results
         /// </summary>
         public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, PerGeneratorInputNodes sources, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics)
-            : this(info, postInitTrees, sources, outputNodes, generatedTrees, diagnostics, syntaxReceiver: null, exception: null)
+            : this(info, postInitTrees, sources, outputNodes, generatedTrees, diagnostics, exception: null)
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, PerGeneratorInputNodes sources, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, ISyntaxContextReceiver? syntaxReceiver, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, PerGeneratorInputNodes sources, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, Exception? exception)
         {
             this.PostInitTrees = postInitTrees;
             this.Sources = sources;
@@ -65,7 +65,6 @@ namespace Microsoft.CodeAnalysis
             this.GeneratedTrees = generatedTrees;
             this.Info = info;
             this.Diagnostics = diagnostics;
-            this.SyntaxReceiver = syntaxReceiver;
             this.Exception = exception;
         }
 
@@ -79,26 +78,8 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorInfo Info { get; }
 
-        internal ISyntaxContextReceiver? SyntaxReceiver { get; }
-
         internal Exception? Exception { get; }
 
         internal ImmutableArray<Diagnostic> Diagnostics { get; }
-
-        /// <summary>
-        /// Adds a syntax receiver to this generator state
-        /// </summary>
-        internal GeneratorState WithReceiver(ISyntaxContextReceiver syntaxReceiver)
-        {
-            Debug.Assert(this.Exception is null);
-            return new GeneratorState(this.Info,
-                                      postInitTrees: this.PostInitTrees,
-                                      sources: this.Sources,
-                                      outputNodes: this.OutputNodes,
-                                      generatedTrees: this.GeneratedTrees,
-                                      diagnostics: this.Diagnostics,
-                                      syntaxReceiver: syntaxReceiver,
-                                      exception: null);
-        }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -29,15 +29,15 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new generator state that contains information and constant trees
         /// </summary>
         public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees)
-            : this(info, postInitTrees, PerGeneratorInputNodes.Empty, ImmutableArray<IIncrementalGeneratorOutputNode>.Empty)
+            : this(info, postInitTrees, ImmutableArray<ISyntaxInputNode>.Empty, ImmutableArray<IIncrementalGeneratorOutputNode>.Empty)
         {
         }
 
         /// <summary>
         /// Creates a new generator state that contains information, constant trees and an execution pipeline
         /// </summary>
-        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, PerGeneratorInputNodes sources, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes)
-            : this(info, postInitTrees, sources, outputNodes, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, exception: null)
+        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<ISyntaxInputNode> inputNodes, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes)
+            : this(info, postInitTrees, inputNodes, outputNodes, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<Diagnostic>.Empty, exception: null)
         {
         }
 
@@ -45,22 +45,22 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new generator state that contains an exception and the associated diagnostic
         /// </summary>
         public GeneratorState(GeneratorInfo info, Exception e, Diagnostic error)
-            : this(info, ImmutableArray<GeneratedSyntaxTree>.Empty, PerGeneratorInputNodes.Empty, ImmutableArray<IIncrementalGeneratorOutputNode>.Empty, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray.Create(error), exception: e)
+            : this(info, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray<ISyntaxInputNode>.Empty, ImmutableArray<IIncrementalGeneratorOutputNode>.Empty, ImmutableArray<GeneratedSyntaxTree>.Empty, ImmutableArray.Create(error), exception: e)
         {
         }
 
         /// <summary>
         /// Creates a generator state that contains results
         /// </summary>
-        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, PerGeneratorInputNodes sources, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics)
-            : this(info, postInitTrees, sources, outputNodes, generatedTrees, diagnostics, exception: null)
+        public GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<ISyntaxInputNode> inputNodes, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics)
+            : this(info, postInitTrees, inputNodes, outputNodes, generatedTrees, diagnostics, exception: null)
         {
         }
 
-        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, PerGeneratorInputNodes sources, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, Exception? exception)
+        private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<ISyntaxInputNode> inputNodes, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, Exception? exception)
         {
             this.PostInitTrees = postInitTrees;
-            this.Sources = sources;
+            this.InputNodes = inputNodes;
             this.OutputNodes = outputNodes;
             this.GeneratedTrees = generatedTrees;
             this.Info = info;
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
 
         internal ImmutableArray<GeneratedSyntaxTree> PostInitTrees { get; }
 
-        internal PerGeneratorInputNodes Sources { get; }
+        internal ImmutableArray<ISyntaxInputNode> InputNodes { get; }
 
         internal ImmutableArray<IIncrementalGeneratorOutputNode> OutputNodes { get; }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -60,9 +60,9 @@ namespace Microsoft.CodeAnalysis
 
         public IncrementalValueSources Sources { get; }
 
-        internal IncrementalGeneratorPipelineContext(PerGeneratorInputNodes.Builder sourcesBuilder, ArrayBuilder<IIncrementalGeneratorOutputNode> outputBuilder)
+        internal IncrementalGeneratorPipelineContext(ArrayBuilder<ISyntaxInputNode> syntaxInputBuilder, ArrayBuilder<IIncrementalGeneratorOutputNode> outputBuilder)
         {
-            Sources = new IncrementalValueSources(sourcesBuilder);
+            Sources = new IncrementalValueSources(syntaxInputBuilder);
             _outputBuilder = outputBuilder;
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
@@ -5,10 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis
             var transformed = _func(source);
 
             // update the table 
-            var newTable = new NodeStateTable<TOutput>.Builder();
+            var newTable = previousTable.ToBuilderWithABetterName();
             if (previousTable.IsEmpty)
             {
                 newTable.AddEntries(transformed, EntryState.Added);
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
             else
             {
                 Debug.Assert(previousTable.Count == 1);
-                newTable.ModifyEntriesFromPreviousTable(previousTable, transformed, _comparer);
+                newTable.ModifyEntriesFromPreviousTable(transformed, _comparer);
             }
             return newTable.ToImmutableAndFree();
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis
             var transformed = _func(source);
 
             // update the table 
-            var newTable = previousTable.ToBuilderWithABetterName();
+            var newTable = previousTable.ToBuilder();
             if (!newTable.TryModifyEntries(transformed, _comparer))
             {
                 newTable.AddEntries(transformed, EntryState.Added);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchTransformNode.cs
@@ -59,15 +59,11 @@ namespace Microsoft.CodeAnalysis
 
             // update the table 
             var newTable = previousTable.ToBuilderWithABetterName();
-            if (previousTable.IsEmpty)
+            if (!newTable.TryModifyEntries(transformed, _comparer))
             {
                 newTable.AddEntries(transformed, EntryState.Added);
             }
-            else
-            {
-                Debug.Assert(previousTable.Count == 1);
-                newTable.ModifyEntriesFromPreviousTable(transformed, _comparer);
-            }
+
             return newTable.ToImmutableAndFree();
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -49,10 +50,12 @@ namespace Microsoft.CodeAnalysis
                 _cancellationToken = cancellationToken;
             }
 
-            public IStateTable GetSyntaxInputTable(ISyntaxInputNode syntaxTransform)
+            public IStateTable GetSyntaxInputTable(ISyntaxInputNode syntaxInputNode)
             {
+                Debug.Assert(_syntaxInputNodes.Contains(syntaxInputNode));
+
                 // when we don't have a value for this node, we update all the syntax inputs at once
-                if (!_tableBuilder.ContainsKey(syntaxTransform))
+                if (!_tableBuilder.ContainsKey(syntaxInputNode))
                 {
                     // get a builder for each input node
                     var builders = ArrayBuilder<ISyntaxInputBuilder>.GetInstance(_syntaxInputNodes.Length);
@@ -80,7 +83,7 @@ namespace Microsoft.CodeAnalysis
                     builders.Free();
                 }
 
-                return _tableBuilder[syntaxTransform];
+                return _tableBuilder[syntaxInputNode];
             }
 
             public NodeStateTable<T> GetLatestStateTableForNode<T>(IIncrementalGeneratorNode<T> source)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis
                     foreach (var builder in builders)
                     {
                         builder.SaveStateAndFree(_tableBuilder);
+                        Debug.Assert(_tableBuilder.ContainsKey(builder.SyntaxInputNode));
                     }
                     builders.Free();
                 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -41,25 +41,27 @@ namespace Microsoft.CodeAnalysis
 
             private readonly CancellationToken _cancellationToken;
 
-            public Builder(DriverStateTable previousTable, CancellationToken cancellationToken = default)
+            public Builder(DriverStateTable previousTable)
+            {
+                _previousTable = previousTable;
+            }
+
+            public Builder(DriverStateTable previousTable, Compilation compilation, GeneratorDriverState driverState, ImmutableArray<ISyntaxTransformNode> syntaxTransformNodes, ImmutableArray<(object, object)> otherInputs, CancellationToken cancellationToken = default)
             {
                 _previousTable = previousTable;
                 _cancellationToken = cancellationToken;
-            }
 
-            public void AddInput<T>(InputNode<T> source, T value)
-            {
-                _inputBuilder[source] = ImmutableArray.Create(value);
-            }
+                _inputBuilder[SharedInputNodes.Compilation] = ImmutableArray.Create(compilation);
+                _inputBuilder[SharedInputNodes.SyntaxTrees] = compilation.SyntaxTrees.ToImmutableArray();
+                _inputBuilder[SharedInputNodes.AdditionalTexts] = driverState.AdditionalTexts;
+                _inputBuilder[SharedInputNodes.AnalyzerConfigOptions] = ImmutableArray.Create(driverState.OptionsProvider);
+                _inputBuilder[SharedInputNodes.ParseOptions] = ImmutableArray.Create(driverState.ParseOptions);
+                foreach ((var key, var value) in otherInputs)
+                {
+                    _inputBuilder[key] = value;
+                }
 
-            public void AddInput<T>(InputNode<T> source, IEnumerable<T> value)
-            {
-                _inputBuilder[source] = value.ToImmutableArray();
-            }
-
-            public void AddSyntaxNodes(ImmutableArray<ISyntaxTransformNode> nodes)
-            {
-                _syntaxNodes.AddRange(nodes);
+                _syntaxNodes.AddRange(syntaxTransformNodes);
             }
 
             public ImmutableArray<T> GetInputValue<T>(InputNode<T> source)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -32,6 +32,8 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly ImmutableDictionary<object, IStateTable>.Builder _tableBuilder = ImmutableDictionary.CreateBuilder<object, IStateTable>();
 
+            private readonly ImmutableDictionary<object, object>.Builder _inputBuilder = ImmutableDictionary.CreateBuilder<object, object>();
+
             private readonly DriverStateTable _previousTable;
 
             private readonly CancellationToken _cancellationToken;
@@ -49,13 +51,19 @@ namespace Microsoft.CodeAnalysis
 
             public void AddInput<T>(InputNode<T> source, T value)
             {
-                _tableBuilder[source] = source.CreateInputTable(_previousTable.GetStateTable(source), value);
+                _inputBuilder[source] = ImmutableArray.Create(value);
             }
 
             public void AddInput<T>(InputNode<T> source, IEnumerable<T> value)
             {
-                _tableBuilder[source] = source.CreateInputTable(_previousTable.GetStateTable(source), value);
+                _inputBuilder[source] = value.ToImmutableArray();
             }
+
+            public ImmutableArray<T> GetInputValue<T>(InputNode<T> source)
+            {
+                return (ImmutableArray<T>)_inputBuilder[source];
+            }
+
 
             public NodeStateTable<T> GetLatestStateTableForNode<T>(IIncrementalGeneratorNode<T> source)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ISyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ISyntaxInputNode.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis
 
     internal interface ISyntaxInputBuilder
     {
+        ISyntaxInputNode SyntaxInputNode { get; }
+
         void VisitTree(SyntaxNode root, EntryState state, SemanticModel? model);
 
         void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ISyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ISyntaxInputNode.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal interface ISyntaxInputNode
+    {
+        ISyntaxInputBuilder GetBuilder(DriverStateTable table);
+    }
+
+    internal interface ISyntaxInputBuilder
+    {
+        void VisitTree(SyntaxNode root, EntryState state, SemanticModel? model);
+
+        void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables);
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
@@ -57,15 +57,15 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal sealed class PerGeneratorInputNodes
     {
-        public static readonly PerGeneratorInputNodes Empty = new PerGeneratorInputNodes(receiverNode: null, ImmutableArray<ISyntaxTransformNode>.Empty);
+        public static readonly PerGeneratorInputNodes Empty = new PerGeneratorInputNodes(receiverNode: null, ImmutableArray<ISyntaxInputNode>.Empty);
 
-        private PerGeneratorInputNodes(InputNode<ISyntaxContextReceiver?>? receiverNode, ImmutableArray<ISyntaxTransformNode> transformNodes)
+        private PerGeneratorInputNodes(InputNode<ISyntaxContextReceiver?>? receiverNode, ImmutableArray<ISyntaxInputNode> transformNodes)
         {
             this.ReceiverNode = receiverNode;
             this.TransformNodes = transformNodes;
         }
 
-        public ImmutableArray<ISyntaxTransformNode> TransformNodes { get; }
+        public ImmutableArray<ISyntaxInputNode> TransformNodes { get; }
 
         public InputNode<ISyntaxContextReceiver?>? ReceiverNode { get; }
 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis
         {
             private InputNode<ISyntaxContextReceiver?>? _receiverNode;
 
-            private ArrayBuilder<ISyntaxTransformNode>? _transformNodes;
+            private ArrayBuilder<ISyntaxInputNode>? _transformNodes;
 
             bool _disposed = false;
 
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis
                 return _receiverNode;
             }
 
-            public ArrayBuilder<ISyntaxTransformNode> SyntaxTransformNodes
+            public ArrayBuilder<ISyntaxInputNode> SyntaxTransformNodes
             {
                 get
                 {
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis
                         // but the rest of the structure isn't. We should decide if we want to support that or 
                         // just say this whole thing isn't thread safe.
 
-                        var newNodes = ArrayBuilder<ISyntaxTransformNode>.GetInstance();
+                        var newNodes = ArrayBuilder<ISyntaxInputNode>.GetInstance();
                         InterlockedOperations.Initialize(ref _transformNodes, newNodes);
 
                         // in the case another thread beat us to initialization, we will see that threads arraybuilder.
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(!_disposed);
                 return _receiverNode is null && _transformNodes is null
                     ? Empty
-                    : new PerGeneratorInputNodes(_receiverNode, _transformNodes?.ToImmutable() ?? ImmutableArray<ISyntaxTransformNode>.Empty);
+                    : new PerGeneratorInputNodes(_receiverNode, _transformNodes?.ToImmutable() ?? ImmutableArray<ISyntaxInputNode>.Empty);
             }
 
             public void Free()

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis
     {
         public static readonly PerGeneratorInputNodes Empty = new PerGeneratorInputNodes(receiverNode: null, ImmutableArray<ISyntaxTransformNode>.Empty);
 
-        private PerGeneratorInputNodes(InputNode<ISyntaxContextReceiver>? receiverNode, ImmutableArray<ISyntaxTransformNode> transformNodes)
+        private PerGeneratorInputNodes(InputNode<ISyntaxContextReceiver?>? receiverNode, ImmutableArray<ISyntaxTransformNode> transformNodes)
         {
             this.ReceiverNode = receiverNode;
             this.TransformNodes = transformNodes;
@@ -67,23 +67,23 @@ namespace Microsoft.CodeAnalysis
 
         public ImmutableArray<ISyntaxTransformNode> TransformNodes { get; }
 
-        public InputNode<ISyntaxContextReceiver>? ReceiverNode { get; }
+        public InputNode<ISyntaxContextReceiver?>? ReceiverNode { get; }
 
         public sealed class Builder
         {
-            private InputNode<ISyntaxContextReceiver>? _receiverNode;
+            private InputNode<ISyntaxContextReceiver?>? _receiverNode;
 
             private ArrayBuilder<ISyntaxTransformNode>? _transformNodes;
 
             bool _disposed = false;
 
-            public InputNode<ISyntaxContextReceiver> GetOrCreateReceiverNode()
+            public InputNode<ISyntaxContextReceiver?> GetOrCreateReceiverNode()
             {
                 Debug.Assert(!_disposed);
                 if (_receiverNode is null)
                 {
                     // this is called by only internal code which we know to be thread safe
-                    _receiverNode = new InputNode<ISyntaxContextReceiver>();
+                    _receiverNode = new InputNode<ISyntaxContextReceiver?>();
                 }
                 return _receiverNode;
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IncrementalValueSources.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
         public IncrementalValueSource<AnalyzerConfigOptionsProvider> AnalyzerConfigOptions => new IncrementalValueSource<AnalyzerConfigOptionsProvider>(SharedInputNodes.AnalyzerConfigOptions);
 
         //only used for back compat in the adaptor
-        internal IncrementalValueSource<ISyntaxContextReceiver> CreateSyntaxReceiver() => new IncrementalValueSource<ISyntaxContextReceiver>(_perGeneratorBuilder.GetOrCreateReceiverNode());
+        internal IncrementalValueSource<ISyntaxContextReceiver?> CreateSyntaxReceiver() => new IncrementalValueSource<ISyntaxContextReceiver?>(_perGeneratorBuilder.GetOrCreateReceiverNode());
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis
@@ -32,7 +33,8 @@ namespace Microsoft.CodeAnalysis
             HashSet<T> itemsSet = new HashSet<T>(_comparer);
             foreach (var item in inputItems)
             {
-                itemsSet.Add(item);
+                var added = itemsSet.Add(item);
+                Debug.Assert(added);
             }
 
             var builder = previousTable.ToBuilder();
@@ -43,7 +45,8 @@ namespace Microsoft.CodeAnalysis
                 if (itemsSet.Remove(oldItem))
                 {
                     // we're iterating the table, so know that it has entries
-                    builder.TryUseCachedEntries();
+                    var usedCache = builder.TryUseCachedEntries();
+                    Debug.Assert(usedCache);
                 }
                 else
                 {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -17,18 +17,18 @@ namespace Microsoft.CodeAnalysis
     /// <typeparam name="T">The type of the input</typeparam>
     internal sealed class InputNode<T> : IIncrementalGeneratorNode<T>
     {
-        private readonly InputNode<T> _inputSource;
+        private readonly Func<DriverStateTable.Builder, ImmutableArray<T>> _getInput;
         private readonly IEqualityComparer<T>? _comparer;
 
-        public InputNode(InputNode<T>? inputSource = null, IEqualityComparer<T>? comparer = null)
+        public InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, IEqualityComparer<T>? comparer = null)
         {
-            _inputSource = inputSource ?? this;
+            _getInput = getInput;
             _comparer = comparer;
         }
 
         public NodeStateTable<T> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<T> previousTable, CancellationToken cancellationToken)
         {
-            var inputItems = graphState.GetInputValue(_inputSource);
+            var inputItems = _getInput(graphState);
 
             // create a mutable hashset of the new items we can check against
             HashSet<T> itemsSet = new HashSet<T>(_comparer);
@@ -62,6 +62,6 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
-        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_inputSource, comparer);
+        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, comparer);
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
             var inputItems = graphState.GetInputValue(_inputSource);
 
             // create a mutable hashset of the new items we can check against
-            PooledHashSet<T> itemsSet = PooledHashSet<T>.GetInstance();
+            HashSet<T> itemsSet = new HashSet<T>(_comparer);
             foreach (var item in inputItems)
             {
                 itemsSet.Add(item);
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis
             {
                 builder.AddEntries(ImmutableArray.Create(newItem), EntryState.Added);
             }
-            itemsSet.Free();
+
             return builder.ToImmutableAndFree();
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -17,9 +17,18 @@ namespace Microsoft.CodeAnalysis
     /// <typeparam name="T"></typeparam>
     internal sealed class InputNode<T> : IIncrementalGeneratorNode<T>
     {
+        private readonly InputNode<T> _inputSource;
+        private readonly IEqualityComparer<T>? _comparer;
+
+        public InputNode(InputNode<T>? inputSource = null, IEqualityComparer<T>? comparer = null)
+        {
+            _inputSource = inputSource ?? this;
+            _comparer = comparer;
+        }
+
         public NodeStateTable<T> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<T> previousTable, CancellationToken cancellationToken)
         {
-            var inputItems = graphState.GetInputValue(this);
+            var inputItems = graphState.GetInputValue(_inputSource);
 
             // create a mutable hashset of the new items we can check against
             PooledHashSet<T> itemsSet = PooledHashSet<T>.GetInstance();
@@ -46,8 +55,6 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
-        // PROTOTYPE(source-generators): how does this work? we definitely want to be able to add custom comparers to the input nodes
-        // I guess its just a 'compare only' node with this as the input?
-        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => this;
+        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_inputSource, comparer);
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -19,27 +19,11 @@ namespace Microsoft.CodeAnalysis
     {
         public NodeStateTable<T> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<T> previousTable, CancellationToken cancellationToken)
         {
-            // the input node doesn't change the table. 
-            // instead the driver manipulates the previous table to contain the current state of the node.
-            // we can just return that state, as it's already up to date.
-            return previousTable;
-        }
+            var inputItems = graphState.GetInputValue(this);
 
-        // PROTOTYPE(source-generators): how does this work? we definitely want to be able to add custom comparers to the input nodes
-        // I guess its just a 'compare only' node with this as the input?
-        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => this;
-
-        public NodeStateTable<T> CreateInputTable(NodeStateTable<T> previousTable, T item)
-        {
-            // PROTOTYPE(source-generators): we should compare the values, not just assume they were added
-            return NodeStateTable<T>.WithSingleItem(item, EntryState.Added);
-        }
-
-        public NodeStateTable<T> CreateInputTable(NodeStateTable<T> previousTable, IEnumerable<T> items)
-        {
             // create a mutable hashset of the new items we can check against
             PooledHashSet<T> itemsSet = PooledHashSet<T>.GetInstance();
-            foreach (var item in items)
+            foreach (var item in inputItems)
             {
                 itemsSet.Add(item);
             }
@@ -61,5 +45,9 @@ namespace Microsoft.CodeAnalysis
             itemsSet.Free();
             return builder.ToImmutableAndFree();
         }
+
+        // PROTOTYPE(source-generators): how does this work? we definitely want to be able to add custom comparers to the input nodes
+        // I guess its just a 'compare only' node with this as the input?
+        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => this;
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -12,9 +12,9 @@ using Microsoft.CodeAnalysis.PooledObjects;
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
-    /// Input nodes don't actually do anything. They are just placeholders for the value sources
+    /// Input nodes are the 'root' nodes in the graph, and get their values from the inputs of the driver state table
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of the input</typeparam>
     internal sealed class InputNode<T> : IIncrementalGeneratorNode<T>
     {
         private readonly InputNode<T> _inputSource;
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
                 itemsSet.Add(item);
             }
 
-            var builder = previousTable.ToBuilderWithABetterName();
+            var builder = previousTable.ToBuilder();
 
             // for each item in the previous table, check if its still in the new items
             foreach ((var oldItem, _) in previousTable)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -44,13 +44,13 @@ namespace Microsoft.CodeAnalysis
                 itemsSet.Add(item);
             }
 
-            var builder = new NodeStateTable<T>.Builder();
+            var builder = previousTable.ToBuilderWithABetterName();
 
             // for each item in the previous table, check if its still in the new items
             foreach ((var oldItem, _) in previousTable)
             {
                 bool inItemSet = itemsSet.Remove(oldItem);
-                builder.AddEntriesFromPreviousTable(previousTable, inItemSet ? EntryState.Cached : EntryState.Removed);
+                builder.AddEntriesFromPreviousTable(inItemSet ? EntryState.Cached : EntryState.Removed);
             }
 
             // any remaining new items are added

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -42,8 +42,15 @@ namespace Microsoft.CodeAnalysis
             // for each item in the previous table, check if its still in the new items
             foreach ((var oldItem, _) in previousTable)
             {
-                bool inItemSet = itemsSet.Remove(oldItem);
-                builder.AddEntriesFromPreviousTable(inItemSet ? EntryState.Cached : EntryState.Removed);
+                if (itemsSet.Remove(oldItem))
+                {
+                    // we're iterating the table, so know that it has entries
+                    builder.TryUseCachedEntries();
+                }
+                else
+                {
+                    builder.RemoveEntries();
+                }
             }
 
             // any remaining new items are added

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/JoinNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/JoinNode.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/JoinNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/JoinNode.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                 return NodeStateTable<(TInput1, ImmutableArray<TInput2>)>.FromFaultedTable(input2Table);
             }
 
-            var builder = previousTable.ToBuilderWithABetterName();
+            var builder = previousTable.ToBuilder();
 
             // Semantics of a join:
             //

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/JoinNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/JoinNode.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis
 
         private readonly IIncrementalGeneratorNode<TInput2> _input2;
 
-
         public JoinNode(IIncrementalGeneratorNode<TInput1> input1, IIncrementalGeneratorNode<TInput2> input2)
         {
             _input1 = input1;
@@ -43,7 +42,7 @@ namespace Microsoft.CodeAnalysis
                 return NodeStateTable<(TInput1, ImmutableArray<TInput2>)>.FromFaultedTable(input2Table);
             }
 
-            var builder = new NodeStateTable<(TInput1, ImmutableArray<TInput2>)>.Builder();
+            var builder = previousTable.ToBuilderWithABetterName();
 
             // Semantics of a join:
             //

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -68,8 +68,7 @@ namespace Microsoft.CodeAnalysis
         private NodeStateTable(ImmutableArray<ImmutableArray<(T, EntryState)>> states, bool isCompacted, Exception? exception)
         {
             Debug.Assert(exception is object && !isCompacted
-                        || exception is null && isCompacted && states.All(s => s.All(e => e.Item2 == EntryState.Cached))
-                        || exception is null);
+                         || exception is null && (!isCompacted || isCompacted && states.All(s => s.All(e => e.Item2 == EntryState.Cached))));
 
             _states = states;
             _exception = exception;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -242,6 +242,11 @@ namespace Microsoft.CodeAnalysis
                 var hasNonCached = _states.Any(s => s.Any(i => i.Item2 != EntryState.Cached));
                 return new NodeStateTable<T>(_states.ToImmutableAndFree(), isCompacted: !hasNonCached, exception: _exception);
             }
+
+            internal ImmutableArray<T> GetLastEntries()
+            {
+                return _states[_states.Count - 1].SelectAsArray(t => t.Item1);
+            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
         private NodeStateTable(ImmutableArray<ImmutableArray<(T, EntryState)>> states, bool isCompacted, Exception? exception)
         {
             Debug.Assert(exception is object && !isCompacted
-                         || exception is null && (!isCompacted || isCompacted && states.All(s => s.All(e => e.Item2 == EntryState.Cached))));
+                         || exception is null && (!isCompacted || states.All(s => s.All(e => e.Item2 == EntryState.Cached))));
 
             _states = states;
             _exception = exception;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -175,7 +175,9 @@ namespace Microsoft.CodeAnalysis
                     return false;
                 }
 
-                var previousEntries = _previous._states[_states.Count].SelectAsArray(s => (s.item, EntryState.Cached));
+                var previousEntries = _previous._states[_states.Count];
+                Debug.Assert(previousEntries.All(e => e.state == EntryState.Cached));
+
                 _states.Add(previousEntries);
                 return true;
             }
@@ -257,7 +259,7 @@ namespace Microsoft.CodeAnalysis
                     return NodeStateTable<T>.Empty;
                 }
 
-                var hasNonCached = _states.Any(s => s.Any(i => i.Item2 != EntryState.Cached));
+                var hasNonCached = _states.Any(static s => s.Any(static i => i.Item2 != EntryState.Cached));
                 return new NodeStateTable<T>(_states.ToImmutableAndFree(), isCompacted: !hasNonCached, exception: null);
 
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -188,6 +188,13 @@ namespace Microsoft.CodeAnalysis
                     return false;
                 }
 
+                // Semantics:
+                // For every slot in the previous table, we compare the new value.
+                // - Cached when the same
+                // - Modified when different
+                // - Removed when i > outputs.length
+                // - Added when i < previousTable.length
+
                 var previousEntries = _previous._states[_states.Count];
                 var modifiedEntries = ArrayBuilder<(T item, EntryState state)>.GetInstance();
 
@@ -230,7 +237,7 @@ namespace Microsoft.CodeAnalysis
 
             public void AddEntries(ImmutableArray<T> values, EntryState state)
             {
-                _states.Add(values.SelectAsArray(v => (v, state)));
+                _states.Add(values.SelectAsArray((v, state) => (v, state), state));
             }
 
             public void SetFaulted(Exception e)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -124,14 +124,7 @@ namespace Microsoft.CodeAnalysis
             return sourceBuilder.ToImmutableAndFree();
         }
 
-        public Builder ToBuilder(int? extraCapacity = null)
-        {
-            Debug.Assert(!this.IsFaulted);
-            int? capacity = extraCapacity.HasValue ? this._states.Length + extraCapacity.Value : null;
-            return new Builder(this, copyPrevious: true, capacity);
-        }
-
-        public Builder ToBuilderWithABetterName()
+        public Builder ToBuilder()
         {
             Debug.Assert(!this.IsFaulted);
             return new Builder(this, copyPrevious: false);
@@ -143,30 +136,21 @@ namespace Microsoft.CodeAnalysis
             return new NodeStateTable<T>(Empty._states, isCompacted: true, table._exception);
         }
 
-        public static NodeStateTable<T> WithSingleItem(T item, EntryState state)
-        {
-            return new NodeStateTable<T>(ImmutableArray.Create(ImmutableArray.Create((item, state))), isCompacted: false, exception: null);
-        }
-
         public sealed class Builder
         {
             private readonly ArrayBuilder<ImmutableArray<(T, EntryState)>> _states;
             private readonly NodeStateTable<T> _previous;
             private Exception? _exception = null;
 
-            internal Builder(NodeStateTable<T> previous, bool copyPrevious = false, int? capacity = null)
+            internal Builder(NodeStateTable<T> previous, bool copyPrevious = false)
             {
-                _states = capacity.HasValue
-                          ? ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance(capacity.Value)
-                          : ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance();
-
+                _states = ArrayBuilder<ImmutableArray<(T, EntryState)>>.GetInstance();
+                _previous = previous;
                 if (copyPrevious)
                 {
                     _states.AddRange(previous._states);
                 }
-                _previous = previous;
             }
-
 
             public void RemoveEntries()
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -80,6 +80,13 @@ namespace Microsoft.CodeAnalysis
             // get our own state table
             var table = context.TableBuilder.GetLatestStateTableForNode(this);
 
+            if (table.IsFaulted)
+            {
+                // PROTOTYPE (source-generators): we're essentially using exceptions as control flow here.
+                //                                instead we should append the exceptions to the context and allow the driver to handle it there
+                throw table.GetException();
+            }
+
             // add each non-removed entry to the context
             foreach (var ((sources, diagnostics), state) in table)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -4,12 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-
 using TOutput = System.ValueTuple<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.GeneratedSourceText>, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Diagnostic>>;
 
 namespace Microsoft.CodeAnalysis

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -41,11 +41,11 @@ namespace Microsoft.CodeAnalysis
             var nodeTable = previousTable.ToBuilderWithABetterName();
             foreach (var entry in sourceTable)
             {
-                if (entry.state == EntryState.Cached || entry.state == EntryState.Removed)
+                if (entry.state == EntryState.Removed)
                 {
-                    nodeTable.AddEntriesFromPreviousTable(entry.state);
+                    nodeTable.RemoveEntries();
                 }
-                else if (entry.state == EntryState.Added || entry.state == EntryState.Modified)
+                else if (entry.state != EntryState.Cached || !nodeTable.TryUseCachedEntries())
                 {
                     // we don't currently handle modified any differently than added at the output
                     // we just run the action and mark the new source as added. In theory we could compare
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis
                         sourcesBuilder.Free();
                         diagnostics.Free();
                     }
+
                 }
             }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -38,12 +38,12 @@ namespace Microsoft.CodeAnalysis
                 return NodeStateTable<TOutput>.FromFaultedTable(sourceTable);
             }
 
-            var nodeTable = new NodeStateTable<TOutput>.Builder();
+            var nodeTable = previousTable.ToBuilderWithABetterName();
             foreach (var entry in sourceTable)
             {
                 if (entry.state == EntryState.Cached || entry.state == EntryState.Removed)
                 {
-                    nodeTable.AddEntriesFromPreviousTable(previousTable, entry.state);
+                    nodeTable.AddEntriesFromPreviousTable(entry.state);
                 }
                 else if (entry.state == EntryState.Added || entry.state == EntryState.Modified)
                 {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis
                 return NodeStateTable<TOutput>.FromFaultedTable(sourceTable);
             }
 
-            var nodeTable = previousTable.ToBuilderWithABetterName();
+            var nodeTable = previousTable.ToBuilder();
             foreach (var entry in sourceTable)
             {
                 if (entry.state == EntryState.Removed)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
@@ -48,6 +48,8 @@ namespace Microsoft.CodeAnalysis
                 _transformTable = table.GetStateTableOrEmpty<T>(_owner).ToBuilder();
             }
 
+            public ISyntaxInputNode SyntaxInputNode { get => _owner; }
+
             public void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables)
             {
                 tables[_owner._filterKey] = _filterTable.ToImmutableAndFree();

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
@@ -6,24 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Text;
 using System.Threading;
-using System.Linq;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal interface ISyntaxInputNode
-    {
-        ISyntaxInputBuilder GetBuilder(DriverStateTable table);
-    }
-
-    internal interface ISyntaxInputBuilder
-    {
-        void VisitTree(SyntaxNode root, EntryState state, SemanticModel? model);
-
-        void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables);
-    }
-
     internal sealed class SyntaxInputNode<T> : IIncrementalGeneratorNode<T>, ISyntaxInputNode
     {
         private readonly Func<GeneratorSyntaxContext, T> _func;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -60,6 +60,8 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
+            public ISyntaxInputNode SyntaxInputNode { get => _owner; }
+
             public void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables)
             {
                 if (_exception is object)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed class SyntaxReceiverInputNode : ISyntaxInputNode, IIncrementalGeneratorNode<ISyntaxContextReceiver>
+    {
+        private readonly SyntaxContextReceiverCreator _receiverCreator;
+
+        public SyntaxReceiverInputNode(SyntaxContextReceiverCreator receiverCreator)
+        {
+            _receiverCreator = receiverCreator;
+        }
+
+        public NodeStateTable<ISyntaxContextReceiver> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<ISyntaxContextReceiver> previousTable, CancellationToken cancellationToken)
+        {
+            return (NodeStateTable<ISyntaxContextReceiver>)graphState.GetSyntaxInputTable(this);
+        }
+
+        public IIncrementalGeneratorNode<ISyntaxContextReceiver> WithComparer(IEqualityComparer<ISyntaxContextReceiver> comparer)
+        {
+            // we don't publically expose this node to end users
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public ISyntaxInputBuilder GetBuilder(DriverStateTable table) => new Builder(this, table);
+
+        public class Builder : ISyntaxInputBuilder
+        {
+            private readonly SyntaxReceiverInputNode _owner;
+            private readonly NodeStateTable<ISyntaxContextReceiver>.Builder _nodeStateTable;
+            private readonly ISyntaxContextReceiver? _receiver;
+            private readonly GeneratorSyntaxWalker? _walker;
+            private Exception? _exception;
+
+            public Builder(SyntaxReceiverInputNode owner, DriverStateTable driverStateTable)
+            {
+                _owner = owner;
+                _nodeStateTable = driverStateTable.GetStateTableOrEmpty<ISyntaxContextReceiver>(_owner).ToBuilder();
+                try
+                {
+                    _receiver = owner._receiverCreator();
+                }
+                catch (Exception e)
+                {
+                    _exception = e;
+                }
+
+                if (_receiver is object)
+                {
+                    _walker = new GeneratorSyntaxWalker(_receiver);
+                }
+            }
+
+            public void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables)
+            {
+                if (_exception is object)
+                {
+                    _nodeStateTable.SetFaulted(_exception);
+                }
+                else if (_receiver is object)
+                {
+                    _nodeStateTable.AddEntries(ImmutableArray.Create(_receiver), EntryState.Modified);
+                }
+                tables[_owner] = _nodeStateTable.ToImmutableAndFree();
+            }
+
+            public void VisitTree(SyntaxNode root, EntryState state, SemanticModel? model)
+            {
+                if (_walker is object && _exception is null && state != EntryState.Removed)
+                {
+                    Debug.Assert(model is object);
+                    try
+                    {
+                        _walker.VisitWithModel(model, root);
+                    }
+                    catch (Exception e)
+                    {
+                        _exception = e;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Text;
 using System.Threading;
 using Roslyn.Utilities;
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
 
         public ISyntaxInputBuilder GetBuilder(DriverStateTable table) => new Builder(this, table);
 
-        public class Builder : ISyntaxInputBuilder
+        private sealed class Builder : ISyntaxInputBuilder
         {
             private readonly SyntaxReceiverInputNode _owner;
             private readonly NodeStateTable<ISyntaxContextReceiver>.Builder _nodeStateTable;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis
 
         public IIncrementalGeneratorNode<ISyntaxContextReceiver> WithComparer(IEqualityComparer<ISyntaxContextReceiver> comparer)
         {
-            // we don't publically expose this node to end users
+            // we don't expose this node to end users
             throw ExceptionUtilities.Unreachable;
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxTransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxTransformNode.cs
@@ -64,10 +64,10 @@ namespace Microsoft.CodeAnalysis
                 _owner = owner;
 
                 _previousFilterTable = previousFilter;
-                _filterTable = new NodeStateTable<SyntaxNode>.Builder();
+                _filterTable = _previousFilterTable.ToBuilderWithABetterName();
 
                 _previousTransformTable = previousTransform;
-                _transformTable = new NodeStateTable<T>.Builder();
+                _transformTable = _previousTransformTable.ToBuilderWithABetterName();
             }
 
             public bool Filter(SyntaxNode syntaxNode) => _owner._filterFunc(syntaxNode);
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis
             public void AddFilterFromPreviousTable(SemanticModel? model, EntryState state)
             {
                 Debug.Assert(model is object || state == EntryState.Removed);
-                var nodes = _filterTable.AddEntriesFromPreviousTable(_previousFilterTable, state);
+                var nodes = _filterTable.AddEntriesFromPreviousTable(state);
                 UpdateTransformTable(nodes, model, state);
             }
 
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (state == EntryState.Removed)
                     {
-                        _transformTable.AddEntriesFromPreviousTable(_previousTransformTable, EntryState.Removed);
+                        _transformTable.AddEntriesFromPreviousTable(EntryState.Removed);
                     }
                     else
                     {
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis
                         }
                         else
                         {
-                            _transformTable.ModifyEntriesFromPreviousTable(_previousTransformTable, transformed, _owner._comparer);
+                            _transformTable.ModifyEntriesFromPreviousTable(transformed, _owner._comparer);
                         }
                     }
                 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxTransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxTransformNode.cs
@@ -64,10 +64,10 @@ namespace Microsoft.CodeAnalysis
                 _owner = owner;
 
                 _previousFilterTable = previousFilter;
-                _filterTable = _previousFilterTable.ToBuilderWithABetterName();
+                _filterTable = _previousFilterTable.ToBuilder();
 
                 _previousTransformTable = previousTransform;
-                _transformTable = _previousTransformTable.ToBuilderWithABetterName();
+                _transformTable = _previousTransformTable.ToBuilder();
             }
 
             public bool Filter(SyntaxNode syntaxNode) => _owner._filterFunc(syntaxNode);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxTransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxTransformNode.cs
@@ -75,8 +75,9 @@ namespace Microsoft.CodeAnalysis
             public void AddFilterFromPreviousTable(SemanticModel? model, EntryState state)
             {
                 Debug.Assert(model is object || state == EntryState.Removed);
-                var nodes = _filterTable.AddEntriesFromPreviousTable(state);
-                UpdateTransformTable(nodes, model, state);
+                // FIX ME
+               // var nodes = _filterTable.AddEntriesFromPreviousTable(state);
+                //UpdateTransformTable(nodes, model, state);
             }
 
             public void AddFilterEntries(ImmutableArray<SyntaxNode> nodes, SemanticModel model)
@@ -91,20 +92,24 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (state == EntryState.Removed)
                     {
-                        _transformTable.AddEntriesFromPreviousTable(EntryState.Removed);
+                        _transformTable.RemoveEntries();
                     }
                     else
                     {
                         Debug.Assert(model is object);
                         var value = new GeneratorSyntaxContext(node, model);
                         var transformed = ImmutableArray.Create(_owner._func(value));
-                        if (_previousTransformTable.IsEmpty || state == EntryState.Added)
+
+                        if (state != EntryState.Added)
                         {
-                            _transformTable.AddEntries(transformed, EntryState.Added);
+                            if (!_transformTable.TryModifyEntries(transformed, _owner._comparer))
+                            {
+                                _transformTable.AddEntries(transformed, EntryState.Added);
+                            }
                         }
                         else
                         {
-                            _transformTable.ModifyEntriesFromPreviousTable(transformed, _owner._comparer);
+                            _transformTable.AddEntries(transformed, EntryState.Added);
                         }
                     }
                 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueSources.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueSources.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public readonly struct SyntaxValueSources
     {
-        private readonly ArrayBuilder<ISyntaxTransformNode> _nodes;
+        private readonly ArrayBuilder<ISyntaxInputNode> _nodes;
 
-        internal SyntaxValueSources(ArrayBuilder<ISyntaxTransformNode> nodes)
+        internal SyntaxValueSources(ArrayBuilder<ISyntaxInputNode> nodes)
         {
             _nodes = nodes;
         }
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis
         // PROTOTYPE(source-generators): Minimum exposed, low-level API for now, we can add more as needed
         public IncrementalValueSource<T> Transform<T>(Func<SyntaxNode, bool> filterFunc, Func<GeneratorSyntaxContext, T> transformFunc)
         {
-            var node = new SyntaxTransformNode<T>(filterFunc, transformFunc);
+            var node = new SyntaxInputNode<T>(filterFunc, transformFunc);
             _nodes.Add(node);
             return new IncrementalValueSource<T>(node);
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueSources.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueSources.cs
@@ -12,18 +12,18 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public readonly struct SyntaxValueSources
     {
-        private readonly ArrayBuilder<ISyntaxInputNode> _nodes;
+        private readonly ArrayBuilder<ISyntaxInputNode> _inputNodes;
 
-        internal SyntaxValueSources(ArrayBuilder<ISyntaxInputNode> nodes)
+        internal SyntaxValueSources(ArrayBuilder<ISyntaxInputNode> inputNodes)
         {
-            _nodes = nodes;
+            _inputNodes = inputNodes;
         }
 
         // PROTOTYPE(source-generators): Minimum exposed, low-level API for now, we can add more as needed
         public IncrementalValueSource<T> Transform<T>(Func<SyntaxNode, bool> filterFunc, Func<GeneratorSyntaxContext, T> transformFunc)
         {
             var node = new SyntaxInputNode<T>(filterFunc, transformFunc);
-            _nodes.Add(node);
+            _inputNodes.Add(node);
             return new IncrementalValueSource<T>(node);
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
         internal IncrementalValueSource<ISyntaxContextReceiver> CreateSyntaxReceiverInput(SyntaxContextReceiverCreator creator)
         {
             var node = new SyntaxReceiverInputNode(creator);
-            _nodes.Add(node);
+            _inputNodes.Add(node);
             return new IncrementalValueSource<ISyntaxContextReceiver>(node);
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueSources.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueSources.cs
@@ -26,5 +26,15 @@ namespace Microsoft.CodeAnalysis
             _nodes.Add(node);
             return new IncrementalValueSource<T>(node);
         }
+
+        /// <summary>
+        /// Creates a syntax receiver input node. Only used for back compat in <see cref="SourceGeneratorAdaptor"/>
+        /// </summary>
+        internal IncrementalValueSource<ISyntaxContextReceiver> CreateSyntaxReceiverInput(SyntaxContextReceiverCreator creator)
+        {
+            var node = new SyntaxReceiverInputNode(creator);
+            _nodes.Add(node);
+            return new IncrementalValueSource<ISyntaxContextReceiver>(node);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
             // - Added: perform transform and add
             // - Modified: perform transform and do element wise comparison with previous results
 
-            var newTable = new NodeStateTable<TOutput>.Builder();
+            var newTable = previousTable.ToBuilderWithABetterName();
 
             foreach (var entry in sourceTable)
             {
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis
                 // if that fails, try modifying, then finally, just add them.
                 if ((entry.state == EntryState.Cached || entry.state == EntryState.Removed) && !previousTable.IsEmpty)
                 {
-                    newTable.AddEntriesFromPreviousTable(previousTable, entry.state);
+                    newTable.AddEntriesFromPreviousTable(entry.state);
                 }
                 else
                 {
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
 
                     if (entry.state == EntryState.Modified && !previousTable.IsEmpty)
                     {
-                        newTable.ModifyEntriesFromPreviousTable(previousTable, newOutputs, _comparer);
+                        newTable.ModifyEntriesFromPreviousTable(newOutputs, _comparer);
                     }
                     else
                     {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
             // - Added: perform transform and add
             // - Modified: perform transform and do element wise comparison with previous results
 
-            var newTable = previousTable.ToBuilderWithABetterName();
+            var newTable = previousTable.ToBuilder();
 
             foreach (var entry in sourceTable)
             {

--- a/src/Compilers/Test/Core/SourceGeneration/LambdaComparer.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/LambdaComparer.cs
@@ -5,14 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Roslyn.Utilities;
 
 namespace Roslyn.Test.Utilities.TestGenerators
 {
-    public class LambdaComparer<T> : IEqualityComparer<T>
+    public sealed class LambdaComparer<T> : IEqualityComparer<T>
     {
         private readonly Func<T?, T?, bool> _equal;
         private readonly int? _hashCode;

--- a/src/Compilers/Test/Core/SourceGeneration/LambdaComparer.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/LambdaComparer.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+
+namespace Roslyn.Test.Utilities.TestGenerators
+{
+    public class LambdaComparer<T> : IEqualityComparer<T>
+    {
+        private readonly Func<T?, T?, bool> _equal;
+        private readonly int? _hashCode;
+
+        public LambdaComparer(Func<T?, T?, bool> equal, int? hashCode = null)
+        {
+            _equal = equal;
+            _hashCode = hashCode;
+        }
+
+        public bool Equals(T? x, T? y) => _equal(x, y);
+
+        public int GetHashCode([DisallowNull] T obj) => _hashCode.HasValue ? _hashCode.Value : EqualityComparer<T>.Default.GetHashCode(obj);
+    }
+}


### PR DESCRIPTION
This doesn't really add a lot of new functionality, but does clean up a lot of the existing code.

Refactors the state tables and input nodes to be cleaner:
- State table builder contain the previous table
- State tables have a set of 'Try...' methods that callers can progressively fall back against
- Take the input values as part of creating the generator driver builder
- Have inputs node use a lambda to retrieve their input values
- Inputs calculate their value on demand when updated using the lambda to get the new input value
- Syntax nodes are calculated on demand:
  - We still need to calculate the syntax nodes at the same time
  - As soon as one syntax input needs updating the driver will update them all together, allowing model sharing
-  Implement legacy ISyntaxReceiver on top of syntax node inputs