### PR TITLE
Expose AnalysisContext.MinimumReportedSeverity

### DIFF
--- a/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
@@ -32,11 +32,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal static DiagnosticSeverity GetMinimumUnfilteredSeverity(this SeverityFilter severityFilter)
         {
-            if (!severityFilter.Contains(SeverityFilter.Hidden))
+            if (!severityFilter.Contains(ReportDiagnostic.Hidden))
             {
                 return DiagnosticSeverity.Hidden;
             }
-            else if (!severityFilter.Contains(SeverityFilter.Info))
+            else if (!severityFilter.Contains(ReportDiagnostic.Info))
             {
                 return DiagnosticSeverity.Info;
             }

--- a/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
@@ -29,5 +29,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 _ => false
             };
         }
+
+        internal static DiagnosticSeverity GetMinimumUnfilteredSeverity(this SeverityFilter severityFilter)
+        {
+            if ((severityFilter & SeverityFilter.Hidden) == 0)
+            {
+                return DiagnosticSeverity.Hidden;
+            }
+
+            if ((severityFilter & SeverityFilter.Info) == 0)
+            {
+                return DiagnosticSeverity.Info;
+            }
+
+            return DiagnosticSeverity.Warning;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
@@ -32,12 +32,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal static DiagnosticSeverity GetMinimumUnfilteredSeverity(this SeverityFilter severityFilter)
         {
-            if ((severityFilter & SeverityFilter.Hidden) == 0)
+            if (!severityFilter.Contains(SeverityFilter.Hidden))
             {
                 return DiagnosticSeverity.Hidden;
             }
-
-            if ((severityFilter & SeverityFilter.Info) == 0)
+            else if (!severityFilter.Contains(SeverityFilter.Info))
             {
                 return DiagnosticSeverity.Info;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var analyzerExecutor = AnalyzerExecutor.Create(
                 compilation, analysisOptions.Options ?? AnalyzerOptions.Empty, addNotCategorizedDiagnostic, newOnAnalyzerException, analysisOptions.AnalyzerExceptionFilter,
                 IsCompilerAnalyzer, AnalyzerManager, ShouldSkipAnalysisOnGeneratedCode, ShouldSuppressGeneratedCodeDiagnostic, IsGeneratedOrHiddenCodeLocation, IsAnalyzerSuppressedForTree, GetAnalyzerGate,
-                getSemanticModel: GetOrCreateSemanticModel,
+                getSemanticModel: GetOrCreateSemanticModel, _severityFilter,
                 analysisOptions.LogAnalyzerExecutionTime, addCategorizedLocalDiagnostic, addCategorizedNonLocalDiagnostic, s => _programmaticSuppressions!.Add(s), cancellationToken);
 
             Initialize(analyzerExecutor, diagnosticQueue, compilationData, cancellationToken);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         return Task.Run(() =>
                         {
                             var sessionScope = new HostSessionStartAnalysisScope();
-                            executor.ExecuteInitializeMethod(context._analyzer, sessionScope);
+                            executor.ExecuteInitializeMethod(context._analyzer, sessionScope, executor.SeverityFilter);
                             return sessionScope;
                         }, executor.CancellationToken);
                     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -222,6 +222,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         /// <summary>
+        /// Indicates the minimum reported diagnostic severity for this analysis context.
+        /// Analyzer diagnostics with severity lesser than this severity are not reported.
+        /// </summary>
+        public virtual DiagnosticSeverity MinimumReportedSeverity => throw new NotImplementedException();
+
+        /// <summary>
         /// Attempts to compute or get the cached value provided by the given <paramref name="valueProvider"/> for the given <paramref name="text"/>.
         /// Note that the pair {<paramref name="valueProvider"/>, <paramref name="text"/>} acts as the key.
         /// Reusing the same <paramref name="valueProvider"/> instance across analyzer actions and/or analyzer instances can improve the overall analyzer performance by avoiding recomputation of the values.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -21,10 +21,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly DiagnosticAnalyzer _analyzer;
         private readonly HostSessionStartAnalysisScope _scope;
 
-        public AnalyzerAnalysisContext(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope scope)
+        public AnalyzerAnalysisContext(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope scope, SeverityFilter severityFilter)
         {
             _analyzer = analyzer;
             _scope = scope;
+            MinimumReportedSeverity = severityFilter.GetMinimumUnfilteredSeverity();
         }
 
         public override void RegisterCompilationStartAction(Action<CompilationStartAnalysisContext> action)
@@ -114,6 +115,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             _scope.ConfigureGeneratedCodeAnalysis(_analyzer, mode);
         }
+
+        public override DiagnosticSeverity MinimumReportedSeverity { get; }
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -36,6 +36,7 @@ override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGenerators(
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGeneratorsForAllLanguages() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator!>
 override Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.DefaultVisit(Microsoft.CodeAnalysis.IOperation! operation, TArgument argument) -> object?
 override Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.Visit(Microsoft.CodeAnalysis.IOperation? operation, TArgument argument) -> object?
+virtual Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.MinimumReportedSeverity.get -> Microsoft.CodeAnalysis.DiagnosticSeverity
 virtual Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetGenerators(string! language) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator!>
 virtual Microsoft.CodeAnalysis.Diagnostics.AnalyzerReference.GetGeneratorsForAllLanguages() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator!>
 abstract Microsoft.CodeAnalysis.Compilation.GetUsedAssemblyReferences(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.MetadataReference!>

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -2364,5 +2364,27 @@ namespace Microsoft.CodeAnalysis
                 });
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public class MinimumReportedSeverityAnalyzer : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor _descriptor = new DiagnosticDescriptor(
+                "ID1",
+                "Title1",
+                "Message1",
+                "Category1",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public DiagnosticSeverity MinimumReportedSeverity { get; private set; }
+            public bool AnalyzerInvoked { get; private set; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                MinimumReportedSeverity = context.MinimumReportedSeverity;
+                AnalyzerInvoked = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Implements the compiler/analyzer driver change from https://github.com/dotnet/roslyn/issues/52991#issuecomment-840407508
This flag indicates the minimum reported diagnostic severity for analyzer execution context. For command line builds, this will be warning, while for the IDE case this will be hidden.
Analyzer diagnostics with severity lesser than this severity are not reported by the driver.

This flag will allow the IDE code style analyzers to turn on/off in command line builds based on `option_name = option_value:severity` entries in editorconfig.