### PR TITLE
Add API Review Process Documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,7 @@ src/VisualStudio/ @dotnet/roslyn-ide
 src/VisualStudio/LiveShare @dotnet/roslyn-ide @daytonellwanger @srivatsn @aletsdelarosa
 src/Workspaces/ @dotnet/roslyn-ide
 
+src/Compilers/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners
+src/Workspaces/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners
+src/Features/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners
+src/EditorFeatures/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners

--- a/.github/ISSUE_TEMPLATE/api-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/api-suggestion.md
@@ -10,14 +10,14 @@ assignees: ''
 ## Background and Motivation
 
 <!--
-We welcome API proposals! We have a process to evaluate the value and shape of new API. There is an overview of our process [here](https://github.com/dotnet/roslyn/blob/main/docs/contrbuting/API%20Review%20Process.md). This template will help us gather the information we need to start the review process.
+We welcome API proposals! We have a process to evaluate the value and shape of new APIs. There is an overview of our process [here](https://github.com/dotnet/roslyn/blob/main/docs/contributing/API%20Review%20Process.md). This template will help us gather the information we need to start the review process.
 First, please describe the purpose and value of the new API here.
 -->
 
 ## Proposed API
 
 <!--
-Please provide the specific public API signature diff that you are proposing. For example:
+Please provide a sketch of public API signature diff that you are proposing. Be as specific as you can: the more specific the proposal, the easier the process will be. For example:
 ```diff
 namespace Microsoft.CodeAnalysis.Operations
 {
@@ -27,6 +27,8 @@ namespace Microsoft.CodeAnalysis.Operations
      }
 ```
 You may find the [Framework Design Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/framework-design-guidelines-digest.md) helpful.
+
+https://github.com/dotnet/roslyn/issues/53410 is a good example issue.
 -->
 
 ## Usage Examples

--- a/.github/ISSUE_TEMPLATE/api-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/api-suggestion.md
@@ -1,0 +1,54 @@
+---
+name: API proposal
+about: Propose a change to the public API surface
+title: ''
+labels: [Feature Request, Concept-API]
+assignees: ''
+
+---
+
+## Background and Motivation
+
+<!--
+We welcome API proposals! We have a process to evaluate the value and shape of new API. There is an overview of our process [here](https://github.com/dotnet/roslyn/blob/main/docs/contrbuting/API%20Review%20Process.md). This template will help us gather the information we need to start the review process.
+First, please describe the purpose and value of the new API here.
+-->
+
+## Proposed API
+
+<!--
+Please provide the specific public API signature diff that you are proposing. For example:
+```diff
+namespace Microsoft.CodeAnalysis.Operations
+{
+     public class ISwitchExpressionOperation
+     {
++        public bool IsExhaustive { get; }
+     }
+```
+You may find the [Framework Design Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/framework-design-guidelines-digest.md) helpful.
+-->
+
+## Usage Examples
+
+<!--
+Please provide code examples that highlight how the proposed API additions are meant to be consumed.
+This will help suggest whether the API has the right shape to be functional, performant and useable.
+You can use code blocks like this:
+``` C#
+// some lines of code here
+```
+-->
+
+## Alternative Designs
+
+<!--
+Were there other options you considered, such as alternative API shapes?
+How does this compare to analogous APIs in other ecosystems and libraries?
+-->
+
+## Risks
+
+<!--
+Please mention any risks that to your knowledge the API proposal might entail, such as breaking changes, performance regressions, etc.
+-->

--- a/.github/ISSUE_TEMPLATE/api-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/api-suggestion.md
@@ -17,7 +17,11 @@ First, please describe the purpose and value of the new API here.
 ## Proposed API
 
 <!--
-Please provide a sketch of public API signature diff that you are proposing. Be as specific as you can: the more specific the proposal, the easier the process will be. For example:
+Please provide a sketch of the public API signature diff that you are proposing. Be as specific as you can: the more specific the proposal, the easier the process will be. An example diff is below.
+You may find the [Framework Design Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/framework-design-guidelines-digest.md) helpful.
+https://github.com/dotnet/roslyn/issues/53410 is a good example issue.
+-->
+
 ```diff
 namespace Microsoft.CodeAnalysis.Operations
 {
@@ -26,10 +30,6 @@ namespace Microsoft.CodeAnalysis.Operations
 +        public bool IsExhaustive { get; }
      }
 ```
-You may find the [Framework Design Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/framework-design-guidelines-digest.md) helpful.
-
-https://github.com/dotnet/roslyn/issues/53410 is a good example issue.
--->
 
 ## Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you are interested in fixing issues and contributing directly to the code bas
 - [Submitting pull requests](https://github.com/dotnet/roslyn/blob/main/CONTRIBUTING.md)
 - Finding a bug to fix in the [IDE](https://aka.ms/roslyn-ide-bugs-help-wanted) or [Compiler](https://aka.ms/roslyn-compiler-bugs-help-wanted)
 - Finding a feature to implement in the [IDE](https://aka.ms/roslyn-ide-feature-help-wanted) or [Compiler](https://aka.ms/roslyn-compiler-feature-help-wanted)
+- Roslyn API suggestions should go through the [API review process](<docs/contributing/API Review Process.md>)
 
 ### Community
 

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -1,0 +1,14 @@
+# Pull Requests Tagging
+
+If you need to tag folks on an issue or PR, you will generally want to tag the owners (not the lead) for [area](#areas) to which the change or issue is closest to.
+
+# Areas
+
+| Area               | Lead    | Owners                 |
+|--------------------|---------|------------------------|
+|api-Syntax          |@jaredpar|@CyrusNajmabadi @333fred|
+|api-Symbols         |@jaredpar|@AlekseyTs              |
+|api-SemanticModel   |@jaredpar|@AlekseyTs @333fred     |
+|api-IOperation      |@jaredpar|@333fred                |
+|api-SourceGenerators|@jaredpar|@chsienki               |
+|api-Analyzers       |@jaredpar|@mavasani @333fred      |

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -2,7 +2,7 @@
 
 If you need to tag folks on an issue or PR, you will generally want to tag the owners (not the lead) for [area](#areas) to which the change or issue is closest to.
 
-# Areas
+## Areas
 
 | Area               | Lead    | Owners                 |
 |--------------------|---------|------------------------|

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -31,7 +31,7 @@ The rule of thumb is that we (**dotnet/roslyn**) review every public API that is
 
  There are three methods to get an API review (this section applies to API area owners, but is included for transparency into the process):
 
-* **Get into the backlog**. Generally speaking, filing an issue in `dotnet/roslyn` and applying the label `api-ready-for-review` on it will make your issue show up during API reviews. The downside is that we generally walk the backlog oldest-newest, so your issue might not be looked at for a while. Progress of issues can be tracked via https://apireview.net/backlog/roslyn (PROTOTYPE: make this link actually work).
+* **Get into the backlog**. Generally speaking, filing an issue in `dotnet/roslyn` and applying the label `api-ready-for-review` on it will make your issue show up during API reviews. The downside is that we generally walk the backlog oldest-newest, so your issue might not be looked at for a while. Progress of issues can be tracked via https://apireview.net/backlog?g=Roslyn.
 * **Fast track**. If you need to bypass the backlog apply both `api-ready-for-review` and `blocking`. All blocking issues are looked at before we walk the backlog.
 * **Dedicated review**. If an issue you are the area owner for needs an hour or longer, send an email to roslynapiowners and we book dedicated time. We also book dedicated time for language feature APIs: any APIs added as part of a new language feature need to have a dedicated review session. Rule of thumb: if the API proposal has more than a dozen APIs, the APIs have complex policy, or the APIs are part of a feature branch, then you need 60 min or more. When in doubt, send mail to roslynapiowners.
 

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -23,11 +23,9 @@ The rule of thumb is that we (**dotnet/roslyn**) review every public API that is
 
 5. **API gets reviewed**. The group conducting the review is called *RAR*, which stands for *Roslyn API Reviewers*. In the review, we'll take notes and provide feedback. After the review, we'll publish the notes in the [API Review repository](https://github.com/dotnet/apireviews) and at the end of the relevant issue. Multiple outcomes are possible:
 
-    * **Approved**. In this case the label `api-ready-for-review` is replaced
-    with `api-approved`.
-    * **Needs work**. In case we believe the proposal isn't ready yet, we'll
-    replace the label `api-ready-for-review` with `api-needs-work`.
-    * **Rejected**. In case we believe the proposal isn't a direction we want pursue, we simply write a comment and close the issue.
+    * **Approved**. In this case the label `api-ready-for-review` is replaced with `api-approved`.
+    * **Needs work**. If we believe the proposal isn't ready yet, we'll replace the label `api-ready-for-review` with `api-needs-work`.
+    * **Rejected**. If we believe the proposal isn't a direction we want to pursue, we'll simply write a comment and close the issue.
 
 ## Review schedule
 

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -35,7 +35,7 @@ The rule of thumb is that we (**dotnet/roslyn**) review every public API that is
 * **Fast track**. If you need to bypass the backlog apply both `api-ready-for-review` and `blocking`. All blocking issues are looked at before we walk the backlog.
 * **Dedicated review**. If an issue you are the area owner for needs an hour or longer, send an email to roslynapiowners and we book dedicated time. We also book dedicated time for language feature APIs: any APIs added as part of a new language feature need to have a dedicated review session. Rule of thumb: if the API proposal has more than a dozen APIs, the APIs have complex policy, or the APIs are part of a feature branch, then you need 60 min or more. When in doubt, send mail to roslynapiowners.
 
-The API review board currently meets biweekly.
+The API review board currently meets every 2 weeks.
 
 ## Pull requests
 

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -39,7 +39,7 @@ The API review board currently meets biweekly.
 
 ## Pull requests
 
-Pull requests against **dotnet/roslyn** that adds new public API shouldn't be submitted before getting approval. Also, we don't want to get work in progress (WIP) PR's. The reason being that we want to reduce the number pending PRs so that we can focus on the work the community expects we take action on.
+Pull requests against **dotnet/roslyn** that add new public API shouldn't be submitted before getting approval. Also, we don't want to get work in progress (WIP) PR's. The reason being that we want to reduce the number pending PRs so that we can focus on the work the community expects we take action on.
 
 If you want to collaborate with other people on the design, feel free to perform the work in a branch in your own fork. If you want to track your TODOs in the description of a PR, you can always submit a PR against your own fork. Also, feel free to advertise your PR by linking it from the issue you filed against **dotnet/roslyn** in the first step above.
 

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -1,0 +1,48 @@
+# API Review Process
+
+.NET has a long standing history of taking API usability extremely seriously. Thus, we generally review every single API that is added to the product. This page discusses how we conduct design reviews for the Roslyn components.
+
+## Which APIs should be reviewed?
+
+The rule of thumb is that we (**dotnet/roslyn**) review every public API that is being added to this repository in the CodeAnalysis (compiler), Workspaces, Features, and EditorFeatures libraries. APIs in the LanguageServices dlls are not usually reviewed as they are not intended for general consumption; they are for use in Visual Studio, and we don't have a compat bar for these APIs.
+
+## Steps
+
+1. **Requester files an issue**. The issue description should contain a speclet that represents a sketch of the new APIs, including samples on how the APIs are being used. The goal isn't to get a complete API list, but a good handle on how the new APIs would roughly look like and in what scenarios they are being used. Please use [this template](https://github.com/dotnet/roslyn/issues/new?template=api-suggestion.md). The issue should have the labels `Feature Request` and `Concept-API`.
+
+2. **We assign an owner**. We'll assign a dedicated owner from our side that sponsors the issue. This is usually [the area owner](../area-owners.md#areas) for which the API proposal or design change request was filed for.
+
+3. **Discussion**. The goal of the discussion is to help the assignee to make a decision whether we want to pursue the proposal or not. In this phase, the goal isn't necessarily to perform an in-depth review; rather, we want to make sure that the proposal is actionable, i.e. has a concrete design, a sketch of the APIs and some code samples that show how it should be used. If changes are necessary, the owner will set the label `api-needs-work`. To make the changes, the requester should edit the top-most issue description. This allows folks joining later to understand the most recent proposal. To avoid confusion, the requester can maintain a tiny change log, like a bolded "Updates:" followed by a bullet point list of the updates that were being made. When you the feedback is addressed, the requester should notify the owner to re-review the changes.
+
+4. **Owner makes decision**. When the owner believes enough information is available to make a decision, they will update the issue accordingly:
+
+    * **Mark for review**. If the owner believes the proposal is actionable, they will label the issue with `api-ready-for-review`.
+    * **Close as not actionable**. In case the issue didn't get enough traction to be distilled into a concrete proposal, the owner will close the issue.
+    * **Close as won't fix as proposed**. Sometimes, the issue that is raised is a good one but the owner thinks the concrete proposal is not the right way to tackle the problem. In most cases, the owner will try to steer the discussion in a direction that results in a design that we believe is appropriate. However, for some proposals the problem is at the heart of the design which can't easily be changed without starting a new proposal. In those cases, the owner will close the issue and explain the issue the design has.
+    * **Close as won't fix**. Similarly, if proposal is taking the product in a direction we simply don't want to go, the issue might also get closed. In that case, the problem isn't the proposed design but in the issue itself.
+
+5. **API gets reviewed**. The group conducting the review is called *RAR*, which stands for *roslyn api reviewers*. In the review, we'll take notes and provide feedback. After the review, we'll publish the notes in the [API Review repository](https://github.com/dotnet/apireviews) and at the end of the relevant issue. Multiple outcomes are possible:
+
+    * **Approved**. In this case the label `api-ready-for-review` is replaced
+    with `api-approved`.
+    * **Needs work**. In case we believe the proposal isn't ready yet, we'll
+    replace the label `api-ready-for-review` with `api-needs-work`.
+    * **Rejected**. In case we believe the proposal isn't a direction we want to go after, we simply write a comment and close the issue.
+
+## Review schedule
+
+ There are three methods to get an API review:
+
+* **Get into the backlog**. Generally speaking, filing an issue in `dotnet/roslyn` and applying the label `api-ready-for-review` on it will make your issue show up during API reviews. The downside is that we generally walk the backlog oldest-newest, so your issue might not be looked at for a while. Progress of issues can be tracked via https://apireview.net/backlog/roslyn (PROTOTYPE: make this link actually work).
+* **Fast track**. If you need to bypass the backlog apply both `api-ready-for-review` and `blocking`. All blocking issues are looked at before we walk the backlog.
+* **Dedicated review**. This only applies to area owners. If an issue you are the area owner for needs an hour or longer, send an email to roslynapiowners and we book dedicated time. We also book dedicated time for language feature APIs: any APIs added as part of a new language feature need to have a dedicated review session. Rule of thumb: if the API proposal has more than a dozen APIs, the APIs have complex policy, or the APIs are part of a feature branch, then you need 60 min or more. When in doubt, send mail to roslynapiowners.
+
+The API review board currently meets biweekly.
+
+## Pull requests
+
+Pull requests against **dotnet/roslyn** shouldn't be submitted before getting approval. Also, we don't want to get work in progress (WIP) PR's. The reason being that we want to reduce the number pending PRs so that we can focus on the work the community expects we take action on.
+
+If you want to collaborate with other people on the design, feel free to perform the work in a branch in your own fork. If you want to track your TODOs in the description of a PR, you can always submit a PR against your own fork. Also, feel free to advertise your PR by linking it from the issue you filed against **dotnet/roslyn** in the first step above.
+
+For **dotnet/roslyn** team members, PRs are allowed to be submitted and merged before a full API review session, but you should have sign-off from the area owner, and the API is expected to be covered in a formal review session before being shipped.

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -31,7 +31,7 @@ The rule of thumb is that we (**dotnet/roslyn**) review every public API that is
 
  There are three methods to get an API review (this section applies to API area owners, but is included for transparency into the process):
 
-* **Get into the backlog**. Generally speaking, filing an issue in `dotnet/roslyn` and applying the label `api-ready-for-review` on it will make your issue show up during API reviews. The downside is that we generally walk the backlog oldest-newest, so your issue might not be looked at for a while. Progress of issues can be tracked via https://apireview.net/backlog?g=Roslyn.
+* **Get into the backlog**. Generally speaking, filing an issue in `dotnet/roslyn` and applying the label `api-ready-for-review` on it will make your issue show up during API reviews. The downside is that we generally walk the backlog oldest-newest, so your issue might not be looked at for a while. Progress of issues can be tracked via <https://apireview.net/backlog?g=Roslyn>.
 * **Fast track**. If you need to bypass the backlog apply both `api-ready-for-review` and `blocking`. All blocking issues are looked at before we walk the backlog.
 * **Dedicated review**. If an issue you are the area owner for needs an hour or longer, send an email to roslynapiowners and we book dedicated time. We also book dedicated time for language feature APIs: any APIs added as part of a new language feature need to have a dedicated review session. Rule of thumb: if the API proposal has more than a dozen APIs, the APIs have complex policy, or the APIs are part of a feature branch, then you need 60 min or more. When in doubt, send mail to roslynapiowners.
 

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -8,7 +8,7 @@ The rule of thumb is that we (**dotnet/roslyn**) review every public API that is
 
 ## Steps
 
-1. **Requester files an issue**. The issue description should contain a speclet that represents a sketch of the new APIs, including samples on how the APIs are being used. The goal isn't to get a complete API list, but a good handle on how the new APIs would roughly look like and in what scenarios they are being used. Please use [this template](https://github.com/dotnet/roslyn/issues/new?template=api-suggestion.md). The issue should have the labels `Feature Request` and `Concept-API`.
+1. **Requester files an issue**. The issue description should contain a speclet that represents a sketch of the new APIs, including samples on how the APIs are being used. The goal isn't to get a complete API list, but a good handle on how the new APIs would roughly look like and in what scenarios they are being used. Please use [this template](https://github.com/dotnet/roslyn/issues/new?template=api-suggestion.md). The issue should have the labels `Feature Request` and `Concept-API`. [Here](https://github.com/dotnet/roslyn/issues/53410) is a good example of a strong API proposal.
 
 2. **We assign an owner**. We'll assign a dedicated owner from our side that sponsors the issue. This is usually [the area owner](../area-owners.md#areas) for which the API proposal or design change request was filed.
 
@@ -21,21 +21,21 @@ The rule of thumb is that we (**dotnet/roslyn**) review every public API that is
     * **Close as won't fix as proposed**. Sometimes, the issue that is raised is a good one but the owner thinks the concrete proposal is not the right way to tackle the problem. In most cases, the owner will try to steer the discussion in a direction that results in a design that we believe is appropriate. However, for some proposals the problem is at the heart of the design which can't easily be changed without starting a new proposal. In those cases, the owner will close the issue and explain the issue the design has.
     * **Close as won't fix**. Similarly, if proposal is taking the product in a direction we simply don't want to go, the issue might also get closed. In that case, the problem isn't the proposed design but in the issue itself.
 
-5. **API gets reviewed**. The group conducting the review is called *RAR*, which stands for *roslyn api reviewers*. In the review, we'll take notes and provide feedback. After the review, we'll publish the notes in the [API Review repository](https://github.com/dotnet/apireviews) and at the end of the relevant issue. Multiple outcomes are possible:
+5. **API gets reviewed**. The group conducting the review is called *RAR*, which stands for *Roslyn API Reviewers*. In the review, we'll take notes and provide feedback. After the review, we'll publish the notes in the [API Review repository](https://github.com/dotnet/apireviews) and at the end of the relevant issue. Multiple outcomes are possible:
 
     * **Approved**. In this case the label `api-ready-for-review` is replaced
     with `api-approved`.
     * **Needs work**. In case we believe the proposal isn't ready yet, we'll
     replace the label `api-ready-for-review` with `api-needs-work`.
-    * **Rejected**. In case we believe the proposal isn't a direction we want to go after, we simply write a comment and close the issue.
+    * **Rejected**. In case we believe the proposal isn't a direction we want pursue, we simply write a comment and close the issue.
 
 ## Review schedule
 
- There are three methods to get an API review:
+ There are three methods to get an API review (this section applies to API area owners, but is included for transparency into the process):
 
 * **Get into the backlog**. Generally speaking, filing an issue in `dotnet/roslyn` and applying the label `api-ready-for-review` on it will make your issue show up during API reviews. The downside is that we generally walk the backlog oldest-newest, so your issue might not be looked at for a while. Progress of issues can be tracked via https://apireview.net/backlog/roslyn (PROTOTYPE: make this link actually work).
 * **Fast track**. If you need to bypass the backlog apply both `api-ready-for-review` and `blocking`. All blocking issues are looked at before we walk the backlog.
-* **Dedicated review**. This only applies to area owners. If an issue you are the area owner for needs an hour or longer, send an email to roslynapiowners and we book dedicated time. We also book dedicated time for language feature APIs: any APIs added as part of a new language feature need to have a dedicated review session. Rule of thumb: if the API proposal has more than a dozen APIs, the APIs have complex policy, or the APIs are part of a feature branch, then you need 60 min or more. When in doubt, send mail to roslynapiowners.
+* **Dedicated review**. If an issue you are the area owner for needs an hour or longer, send an email to roslynapiowners and we book dedicated time. We also book dedicated time for language feature APIs: any APIs added as part of a new language feature need to have a dedicated review session. Rule of thumb: if the API proposal has more than a dozen APIs, the APIs have complex policy, or the APIs are part of a feature branch, then you need 60 min or more. When in doubt, send mail to roslynapiowners.
 
 The API review board currently meets biweekly.
 
@@ -45,4 +45,4 @@ Pull requests against **dotnet/roslyn** that adds new public API shouldn't be su
 
 If you want to collaborate with other people on the design, feel free to perform the work in a branch in your own fork. If you want to track your TODOs in the description of a PR, you can always submit a PR against your own fork. Also, feel free to advertise your PR by linking it from the issue you filed against **dotnet/roslyn** in the first step above.
 
-For **dotnet/roslyn** team members, PRs are allowed to be submitted and merged before a full API review session, but you should have sign-off from the area owner, and the API is expected to be covered in a formal review session before being shipped.
+For **dotnet/roslyn** team members, PRs are allowed to be submitted and merged before a full API review session, but you should have sign-off from the area owner, and the API is expected to be covered in a formal review session before being shipped. For such issues, please work with the API area owner to make sure that the issue is marked blocking appropriately so it will be covered in short order.

--- a/docs/contributing/API Review Process.md
+++ b/docs/contributing/API Review Process.md
@@ -1,6 +1,6 @@
 # API Review Process
 
-.NET has a long standing history of taking API usability extremely seriously. Thus, we generally review every single API that is added to the product. This page discusses how we conduct design reviews for the Roslyn components.
+.NET has a long-standing history of taking API usability extremely seriously. Thus, we generally review every single API that is added to the product. This page discusses how we conduct design reviews for the Roslyn components.
 
 ## Which APIs should be reviewed?
 
@@ -10,9 +10,9 @@ The rule of thumb is that we (**dotnet/roslyn**) review every public API that is
 
 1. **Requester files an issue**. The issue description should contain a speclet that represents a sketch of the new APIs, including samples on how the APIs are being used. The goal isn't to get a complete API list, but a good handle on how the new APIs would roughly look like and in what scenarios they are being used. Please use [this template](https://github.com/dotnet/roslyn/issues/new?template=api-suggestion.md). The issue should have the labels `Feature Request` and `Concept-API`.
 
-2. **We assign an owner**. We'll assign a dedicated owner from our side that sponsors the issue. This is usually [the area owner](../area-owners.md#areas) for which the API proposal or design change request was filed for.
+2. **We assign an owner**. We'll assign a dedicated owner from our side that sponsors the issue. This is usually [the area owner](../area-owners.md#areas) for which the API proposal or design change request was filed.
 
-3. **Discussion**. The goal of the discussion is to help the assignee to make a decision whether we want to pursue the proposal or not. In this phase, the goal isn't necessarily to perform an in-depth review; rather, we want to make sure that the proposal is actionable, i.e. has a concrete design, a sketch of the APIs and some code samples that show how it should be used. If changes are necessary, the owner will set the label `api-needs-work`. To make the changes, the requester should edit the top-most issue description. This allows folks joining later to understand the most recent proposal. To avoid confusion, the requester can maintain a tiny change log, like a bolded "Updates:" followed by a bullet point list of the updates that were being made. When you the feedback is addressed, the requester should notify the owner to re-review the changes.
+3. **Discussion**. The goal of the discussion is to help the assignee to decide whether we want to pursue the proposal or not. In this phase, the goal isn't necessarily to perform an in-depth review; rather, we want to make sure that the proposal is actionable, i.e. has a concrete design, a sketch of the APIs and some code samples that show how it should be used. If changes are necessary, the owner will set the label `api-needs-work`. To make the changes, the requester should edit the top-most issue description. This allows folks joining later to understand the most recent proposal. To avoid confusion, the requester can maintain a tiny change log, like a bolded "Updates:" followed by a bullet point list of the updates that were being made. When you the feedback is addressed, the requester should notify the owner to re-review the changes.
 
 4. **Owner makes decision**. When the owner believes enough information is available to make a decision, they will update the issue accordingly:
 
@@ -41,7 +41,7 @@ The API review board currently meets biweekly.
 
 ## Pull requests
 
-Pull requests against **dotnet/roslyn** shouldn't be submitted before getting approval. Also, we don't want to get work in progress (WIP) PR's. The reason being that we want to reduce the number pending PRs so that we can focus on the work the community expects we take action on.
+Pull requests against **dotnet/roslyn** that adds new public API shouldn't be submitted before getting approval. Also, we don't want to get work in progress (WIP) PR's. The reason being that we want to reduce the number pending PRs so that we can focus on the work the community expects we take action on.
 
 If you want to collaborate with other people on the design, feel free to perform the work in a branch in your own fork. If you want to track your TODOs in the description of a PR, you can always submit a PR against your own fork. Also, feel free to advertise your PR by linking it from the issue you filed against **dotnet/roslyn** in the first step above.
 


### PR DESCRIPTION
We're currently working on making a more formal API review process for Roslyn. This PR adds documentation to the repo on how that process works, and the general expectations for how the process should work. Much of this documentation is copied from dotnet/runtime, and modified to fit the repo. Still to be done:

* [x] Get a board on apireviews.net/backlog (cc @terrajobst).
* [x] List areas and owners for the IDE layers (cc @jasonmalinowski and @JoeRobich).
* [x] Set up the email aliases and meeting schedules.
* [x] Add labels to the repo.
* [x] Add examples of a good API request (this may come later).
* [x] Broad messaging to the roslyn team.
