### PR TITLE
Fix dead test code

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -1114,8 +1114,10 @@ class Test
             var comp = CompileAndVerify(source, expectedOutput: @"2545571191011111114151617");
         }
 
-        [Fact]
-        public void TestAmbiguousOverridesRefOut()
+        [Theory]
+        [InlineData(TargetFramework.NetCoreApp)]
+        [InlineData(TargetFramework.Standard)]
+        public void TestAmbiguousOverridesRefOut(TargetFramework targetFramework)
         {
             var method1 = @"public virtual void Method(ref List<T> x, out List<U> y) { y = null; Console.WriteLine(""Base<T, U>.Method(ref List<T> x, out List<U> y)""); }";
             var method2 = @"public virtual void Method(out List<U> y, ref List<T> x) { y = null; Console.WriteLine(""Base<T, U>.Method(out List<U> y, ref List<T> x)""); }";
@@ -1190,7 +1192,7 @@ class Program
                     };
 
                     var substitutedSource = subst(substitutedSource0);
-                    var compilation = CreateCompilation(substitutedSource, options: TestOptions.ReleaseExe);
+                    var compilation = CreateCompilation(substitutedSource, options: TestOptions.ReleaseExe, targetFramework: targetFramework);
                     string expectedOutput;
                     if (compilation.Assembly.RuntimeSupportsCovariantReturnsOfClasses)
                     {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -1114,10 +1114,8 @@ class Test
             var comp = CompileAndVerify(source, expectedOutput: @"2545571191011111114151617");
         }
 
-        [Theory]
-        [InlineData(TargetFramework.NetCoreApp)]
-        [InlineData(TargetFramework.Standard)]
-        public void TestAmbiguousOverridesRefOut(TargetFramework targetFramework)
+        [Fact]
+        public void TestAmbiguousOverridesRefOut()
         {
             var method1 = @"public virtual void Method(ref List<T> x, out List<U> y) { y = null; Console.WriteLine(""Base<T, U>.Method(ref List<T> x, out List<U> y)""); }";
             var method2 = @"public virtual void Method(out List<U> y, ref List<T> x) { y = null; Console.WriteLine(""Base<T, U>.Method(out List<U> y, ref List<T> x)""); }";
@@ -1192,8 +1190,9 @@ class Program
                     };
 
                     var substitutedSource = subst(substitutedSource0);
-                    var compilation = CreateCompilation(substitutedSource, options: TestOptions.ReleaseExe, targetFramework: targetFramework);
+                    var compilation = CreateCompilation(substitutedSource, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.StandardLatest);
                     string expectedOutput;
+                    Assert.Equal(RuntimeUtilities.IsCoreClrRuntime, compilation.Assembly.RuntimeSupportsCovariantReturnsOfClasses);
                     if (compilation.Assembly.RuntimeSupportsCovariantReturnsOfClasses)
                     {
                         // Correct runtime behavior with no warning

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -4922,10 +4922,8 @@ public class Derived2 : Derived
             CreateCompilation(text).VerifyDiagnostics();
         }
 
-        [Theory]
-        [InlineData(TargetFramework.NetCoreApp)]
-        [InlineData(TargetFramework.Standard)]
-        public void TestAmbiguousOverrideMethod(TargetFramework targetFramework)
+        [Fact]
+        public void TestAmbiguousOverrideMethod()
         {
             var text = @"
 public class Base<TShort, TInt>
@@ -4939,7 +4937,8 @@ public class Derived : Base<short, int>
     public override void Method(short s, int i) { }
 }
 ";
-            CSharpCompilation comp = CreateCompilation(text, targetFramework: targetFramework);
+            CSharpCompilation comp = CreateCompilation(text, targetFramework: TargetFramework.StandardLatest);
+            Assert.Equal(RuntimeUtilities.IsCoreClrRuntime, comp.Assembly.RuntimeSupportsCovariantReturnsOfClasses);
             if (comp.Assembly.RuntimeSupportsDefaultInterfaceImplementation)
             {
                 comp.VerifyDiagnostics(
@@ -4981,10 +4980,8 @@ public class Derived : Base<short, int>
                 Diagnostic(ErrorCode.ERR_AmbigOverride, "this").WithArguments("Base<TShort, TInt>.this[TShort, int]", "Base<TShort, TInt>.this[short, TInt]", "Derived"));
         }
 
-        [Theory]
-        [InlineData(TargetFramework.NetCoreApp)]
-        [InlineData(TargetFramework.Standard)]
-        public void TestRuntimeAmbiguousOverride(TargetFramework targetFramework)
+        [Fact]
+        public void TestRuntimeAmbiguousOverride()
         {
             var text = @"
 class Base<TInt>
@@ -4999,7 +4996,8 @@ class Derived : Base<int>
     public override void Method(int @in, ref int @ref) { }
 }
 ";
-            var compilation = CreateCompilation(text, targetFramework: targetFramework);
+            var compilation = CreateCompilation(text, targetFramework: TargetFramework.StandardLatest);
+            Assert.Equal(RuntimeUtilities.IsCoreClrRuntime, compilation.Assembly.RuntimeSupportsCovariantReturnsOfClasses);
             if (compilation.Assembly.RuntimeSupportsCovariantReturnsOfClasses)
             {
                 // We no longer report a runtime ambiguous override because the compiler

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -4922,8 +4922,10 @@ public class Derived2 : Derived
             CreateCompilation(text).VerifyDiagnostics();
         }
 
-        [Fact]
-        public void TestAmbiguousOverrideMethod()
+        [Theory]
+        [InlineData(TargetFramework.NetCoreApp)]
+        [InlineData(TargetFramework.Standard)]
+        public void TestAmbiguousOverrideMethod(TargetFramework targetFramework)
         {
             var text = @"
 public class Base<TShort, TInt>
@@ -4937,7 +4939,7 @@ public class Derived : Base<short, int>
     public override void Method(short s, int i) { }
 }
 ";
-            CSharpCompilation comp = CreateCompilation(text);
+            CSharpCompilation comp = CreateCompilation(text, targetFramework: targetFramework);
             if (comp.Assembly.RuntimeSupportsDefaultInterfaceImplementation)
             {
                 comp.VerifyDiagnostics(
@@ -4979,8 +4981,10 @@ public class Derived : Base<short, int>
                 Diagnostic(ErrorCode.ERR_AmbigOverride, "this").WithArguments("Base<TShort, TInt>.this[TShort, int]", "Base<TShort, TInt>.this[short, TInt]", "Derived"));
         }
 
-        [Fact]
-        public void TestRuntimeAmbiguousOverride()
+        [Theory]
+        [InlineData(TargetFramework.NetCoreApp)]
+        [InlineData(TargetFramework.Standard)]
+        public void TestRuntimeAmbiguousOverride(TargetFramework targetFramework)
         {
             var text = @"
 class Base<TInt>
@@ -4995,7 +4999,7 @@ class Derived : Base<int>
     public override void Method(int @in, ref int @ref) { }
 }
 ";
-            var compilation = CreateCompilation(text);
+            var compilation = CreateCompilation(text, targetFramework: targetFramework);
             if (compilation.Assembly.RuntimeSupportsCovariantReturnsOfClasses)
             {
                 // We no longer report a runtime ambiguous override because the compiler

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -7709,8 +7709,10 @@ class B<T> where T : struct
                 Diagnostic(ErrorCode.ERR_ConWithValCon, "U").WithArguments("U", "T").WithLocation(9, 14));
         }
 
-        [Fact]
-        public void CS0462ERR_AmbigOverride()
+        [Theory]
+        [InlineData(TargetFramework.NetCoreApp)]
+        [InlineData(TargetFramework.Standard)]
+        public void CS0462ERR_AmbigOverride(TargetFramework targetFramework)
         {
             var text = @"class C<T> 
 {
@@ -7723,7 +7725,7 @@ class D : C<int>
    public override void F(int t) {}   // CS0462
 }
 ";
-            var comp = CreateCompilation(text);
+            var comp = CreateCompilation(text, targetFramework: targetFramework);
             if (comp.Assembly.RuntimeSupportsDefaultInterfaceImplementation)
             {
                 comp.VerifyDiagnostics(
@@ -18386,8 +18388,10 @@ class Derived : Base<int, int>, IFace
                 new ErrorDescription { Code = (int)ErrorCode.WRN_MultipleRuntimeImplementationMatches, Line = 20, Column = 33, IsWarning = true });
         }
 
-        [Fact]
-        public void CS1957WRN_MultipleRuntimeOverrideMatches()
+        [Theory]
+        [InlineData(TargetFramework.NetCoreApp)]
+        [InlineData(TargetFramework.Standard)]
+        public void CS1957WRN_MultipleRuntimeOverrideMatches(TargetFramework targetFramework)
         {
             var text =
 @"class Base<TString>
@@ -18406,7 +18410,7 @@ class Derived : Base<string>
 }
 ";
             // We no longer report a runtime ambiguous override (CS1957) because the compiler produces a methodimpl record to disambiguate.
-            CSharpCompilation comp = CreateCompilation(text);
+            CSharpCompilation comp = CreateCompilation(text, targetFramework: targetFramework);
             if (comp.Assembly.RuntimeSupportsDefaultInterfaceImplementation)
             {
                 comp.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -7709,10 +7709,8 @@ class B<T> where T : struct
                 Diagnostic(ErrorCode.ERR_ConWithValCon, "U").WithArguments("U", "T").WithLocation(9, 14));
         }
 
-        [Theory]
-        [InlineData(TargetFramework.NetCoreApp)]
-        [InlineData(TargetFramework.Standard)]
-        public void CS0462ERR_AmbigOverride(TargetFramework targetFramework)
+        [Fact]
+        public void CS0462ERR_AmbigOverride()
         {
             var text = @"class C<T> 
 {
@@ -7725,7 +7723,8 @@ class D : C<int>
    public override void F(int t) {}   // CS0462
 }
 ";
-            var comp = CreateCompilation(text, targetFramework: targetFramework);
+            var comp = CreateCompilation(text, targetFramework: TargetFramework.StandardLatest);
+            Assert.Equal(RuntimeUtilities.IsCoreClrRuntime, comp.Assembly.RuntimeSupportsCovariantReturnsOfClasses);
             if (comp.Assembly.RuntimeSupportsDefaultInterfaceImplementation)
             {
                 comp.VerifyDiagnostics(
@@ -18388,10 +18387,8 @@ class Derived : Base<int, int>, IFace
                 new ErrorDescription { Code = (int)ErrorCode.WRN_MultipleRuntimeImplementationMatches, Line = 20, Column = 33, IsWarning = true });
         }
 
-        [Theory]
-        [InlineData(TargetFramework.NetCoreApp)]
-        [InlineData(TargetFramework.Standard)]
-        public void CS1957WRN_MultipleRuntimeOverrideMatches(TargetFramework targetFramework)
+        [Fact]
+        public void CS1957WRN_MultipleRuntimeOverrideMatches()
         {
             var text =
 @"class Base<TString>
@@ -18410,7 +18407,8 @@ class Derived : Base<string>
 }
 ";
             // We no longer report a runtime ambiguous override (CS1957) because the compiler produces a methodimpl record to disambiguate.
-            CSharpCompilation comp = CreateCompilation(text, targetFramework: targetFramework);
+            CSharpCompilation comp = CreateCompilation(text, targetFramework: TargetFramework.StandardLatest);
+            Assert.Equal(RuntimeUtilities.IsCoreClrRuntime, comp.Assembly.RuntimeSupportsCovariantReturnsOfClasses);
             if (comp.Assembly.RuntimeSupportsDefaultInterfaceImplementation)
             {
                 comp.VerifyDiagnostics(


### PR DESCRIPTION
Fixes #53415

The `Assembly.RuntimeSupports*` was never true in these tests. Ran them against both TFMs so both code paths are actually tested.