### PR TITLE
Item with prefix causes out of range exception

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionResolveHandler.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             // The prefix matches, consume the matching prefix from the lsp completion item label.
-            var displayTextWithSuffix = lspCompletionItem.Label.Substring(completionItem.DisplayTextPrefix.Length, lspCompletionItem.Label.Length);
+            var displayTextWithSuffix = lspCompletionItem.Label.Substring(completionItem.DisplayTextPrefix.Length, lspCompletionItem.Label.Length - completionItem.DisplayTextPrefix.Length);
             if (!displayTextWithSuffix.EndsWith(completionItem.DisplayTextSuffix, StringComparison.Ordinal))
             {
                 return false;


### PR DESCRIPTION
A bug was introduced here https://github.com/dotnet/roslyn/pull/53279/files#diff-f3fdd4b27af7f22c725fec19321e1c0e1b66e4ea9e66b9ce1218b8574605b78cR109 which causes out of range exception on any item with a prefix because the length of the prefix is not subtracted from the overall length. 

![image](https://user-images.githubusercontent.com/5735905/118289972-316a8e80-b4d6-11eb-8fd4-c5b0dd141084.png)

`(byte)` has prefix `(` and only the length of `byte)` should be taken, not the length of `(byte)`