### PR TITLE
Fix out of memory exception in SyntaxEditor

### DIFF
--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
@@ -316,7 +316,10 @@ namespace Microsoft.CodeAnalysis.Editing
             public override SyntaxNode Apply(SyntaxNode root, SyntaxGenerator generator)
             {
                 var current = root.GetCurrentNode(this.Node);
-                Contract.ThrowIfNull(current, $"GetCurrentNode returned null with the following node: {this.Node}");
+                if (current is null)
+                {
+                    Contract.Fail($"GetCurrentNode returned null with the following node: {this.Node}");
+                }
 
                 var newNode = _modifier(current, generator);
                 newNode = _editor.ApplyTrackingToNewNode(newNode);
@@ -342,7 +345,10 @@ namespace Microsoft.CodeAnalysis.Editing
             public override SyntaxNode Apply(SyntaxNode root, SyntaxGenerator generator)
             {
                 var current = root.GetCurrentNode(this.Node);
-                Contract.ThrowIfNull(current, $"GetCurrentNode returned null with the following node: {this.Node}");
+                if (current is null)
+                {
+                    Contract.Fail($"GetCurrentNode returned null with the following node: {this.Node}");
+                }
 
                 var newNodes = _modifier(current, generator).ToList();
                 for (var i = 0; i < newNodes.Count; i++)
@@ -375,7 +381,10 @@ namespace Microsoft.CodeAnalysis.Editing
             public override SyntaxNode Apply(SyntaxNode root, SyntaxGenerator generator)
             {
                 var current = root.GetCurrentNode(this.Node);
-                Contract.ThrowIfNull(current, $"GetCurrentNode returned null with the following node: {this.Node}");
+                if (current is null)
+                {
+                    Contract.Fail($"GetCurrentNode returned null with the following node: {this.Node}");
+                }
 
                 var newNode = _modifier(current, generator, _argument);
                 newNode = _editor.ApplyTrackingToNewNode(newNode);


### PR DESCRIPTION
Fixes [AB#1327217](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1327217)
A change I made last year that added a debug assert has resulted in some OOM exceptions. This modifies the code so we only evaluate the node when the associated `current` variable is null.