### PR TITLE
Introduce resx for BuildValidator and MS.CA.Rebuild to allow localization

### DIFF
--- a/src/Compilers/Core/Rebuild/CompilationFactory.cs
+++ b/src/Compilers/Core/Rebuild/CompilationFactory.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
             {
                 if (rebuildPdbStream is object)
                 {
-                    throw new ArgumentException("PDB stream must be null because the compilation has an embedded PDB", nameof(rebuildPdbStream));
+                    throw new ArgumentException(RebuildResources.PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB, nameof(rebuildPdbStream));
                 }
 
                 debugInformationFormat = DebugInformationFormat.Embedded;
@@ -127,13 +127,13 @@ namespace Microsoft.CodeAnalysis.Rebuild
             {
                 if (rebuildPdbStream is null)
                 {
-                    throw new ArgumentException("A non-null PDB stream must be provided because the compilation does not have an embedded PDB", nameof(rebuildPdbStream));
+                    throw new ArgumentException(RebuildResources.A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB, nameof(rebuildPdbStream));
                 }
 
                 debugInformationFormat = DebugInformationFormat.PortablePdb;
                 var codeViewEntry = OptionsReader.PeReader.ReadDebugDirectory().Single(entry => entry.Type == DebugDirectoryEntryType.CodeView);
                 var codeView = OptionsReader.PeReader.ReadCodeViewDebugDirectoryData(codeViewEntry);
-                pdbFilePath = codeView.Path ?? throw new InvalidOperationException("Could not get PDB file path");
+                pdbFilePath = codeView.Path ?? throw new InvalidOperationException(RebuildResources.Could_not_get_PDB_file_path);
             }
 
             var rebuildData = new RebuildData(

--- a/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
+++ b/src/Compilers/Core/Rebuild/CompilationOptionsReader.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
         {
             if (!TryGetMetadataCompilationOptionsBlobReader(out var reader))
             {
-                throw new InvalidOperationException("Does not contain metadata compilation options");
+                throw new InvalidOperationException(RebuildResources.Does_not_contain_metadata_compilation_options);
             }
             return reader;
         }
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
             var pdbCompilationOptions = GetMetadataCompilationOptions();
             if (!pdbCompilationOptions.TryGetUniqueOption(CompilationOptionNames.Language, out var language))
             {
-                throw new Exception("Invalid language name");
+                throw new Exception(RebuildResources.Invalid_language_name);
             }
 
             return language;
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
                 // byte has data. 
                 if ((embedInteropTypesAndKind & 0b11111100) != 0)
                 {
-                    throw new InvalidDataException($"Unexpected value for EmbedInteropTypes/MetadataImageKind {embedInteropTypesAndKind}");
+                    throw new InvalidDataException(string.Format(RebuildResources.Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0, embedInteropTypesAndKind));
                 }
 
                 var embedInteropTypes = (embedInteropTypesAndKind & 0b10) == 0b10;
@@ -465,7 +465,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
                 {
                     if (value is null or { Length: 0 })
                     {
-                        throw new InvalidDataException("Encountered null or empty key for compilation options pairs");
+                        throw new InvalidDataException(RebuildResources.Encountered_null_or_empty_key_for_compilation_options_pairs);
                     }
 
                     key = value;

--- a/src/Compilers/Core/Rebuild/Extensions.cs
+++ b/src/Compilers/Core/Rebuild/Extensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
             var b = blobReader.ReadByte();
             if (b != '\0')
             {
-                throw new InvalidDataException($"Encountered unexpected byte \"{b}\" when expecting a null terminator");
+                throw new InvalidDataException(string.Format(RebuildResources.Encountered_unexpected_byte_0_when_expecting_a_null_terminator, b));
             }
         }
 

--- a/src/Compilers/Core/Rebuild/MetadataCompilationOptions.cs
+++ b/src/Compilers/Core/Rebuild/MetadataCompilationOptions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
             var optionValues = _options.Where(pair => pair.optionName == optionName).ToArray();
             if (optionValues.Length != 1)
             {
-                throw new InvalidOperationException($"{optionName} exists {optionValues.Length} times in compilation options");
+                throw new InvalidOperationException(string.Format(RebuildResources._0_exists_1_times_in_compilation_options, optionName, optionValues.Length));
             }
 
             return optionValues[0].value;

--- a/src/Compilers/Core/Rebuild/Microsoft.CodeAnalysis.Rebuild.csproj
+++ b/src/Compilers/Core/Rebuild/Microsoft.CodeAnalysis.Rebuild.csproj
@@ -25,4 +25,8 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Rebuild.UnitTests" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="RebuildResources.resx" GenerateSource="true" />
+  </ItemGroup>
 </Project>

--- a/src/Compilers/Core/Rebuild/RebuildResources.resx
+++ b/src/Compilers/Core/Rebuild/RebuildResources.resx
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="0_exists_1_times_in_compilation_options" xml:space="preserve">
+    <value>'{0}' exists '{1}' times in compilation options.</value>
+  </data>
+  <data name="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB" xml:space="preserve">
+    <value>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</value>
+  </data>
+  <data name="Cannot_create_compilation_options_0" xml:space="preserve">
+    <value>Cannot create compilation options: {0}</value>
+  </data>
+  <data name="Could_not_get_PDB_file_path" xml:space="preserve">
+    <value>Could not get PDB file path.</value>
+  </data>
+  <data name="Does_not_contain_metadata_compilation_options" xml:space="preserve">
+    <value>Does not contain metadata compilation options.</value>
+  </data>
+  <data name="Encountered_null_or_empty_key_for_compilation_options_pairs" xml:space="preserve">
+    <value>Encountered null or empty key for compilation options pairs.</value>
+  </data>
+  <data name="Encountered_unexpected_byte_0_when_expecting_a_null_terminator" xml:space="preserve">
+    <value>Encountered unexpected byte '{0}' when expecting a null terminator.</value>
+  </data>
+  <data name="Invalid_language_name" xml:space="preserve">
+    <value>Invalid language name.</value>
+  </data>
+  <data name="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB" xml:space="preserve">
+    <value>PDB stream must be null because the compilation has an embedded PDB.</value>
+  </data>
+  <data name="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0" xml:space="preserve">
+    <value>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</value>
+  </data>
+</root>

--- a/src/Compilers/Core/Rebuild/VisualBasicCompilationFactory.cs
+++ b/src/Compilers/Core/Rebuild/VisualBasicCompilationFactory.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Rebuild
                 var diagnostic = diagnostics?.FirstOrDefault(x => x.IsUnsuppressedError);
                 if (diagnostic is object)
                 {
-                    throw new Exception($"Cannot create compilation options: {diagnostic}");
+                    throw new Exception(string.Format(RebuildResources.Cannot_create_compilation_options_0, diagnostic));
                 }
             }
 

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.cs.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.cs.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.de.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.de.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.es.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.es.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.fr.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.fr.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.it.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.it.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.ja.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.ja.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.ko.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.ko.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.pl.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.pl.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.pt-BR.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.pt-BR.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.ru.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.ru.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.tr.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.tr.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.zh-Hans.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Compilers/Core/Rebuild/xlf/RebuildResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Rebuild/xlf/RebuildResources.zh-Hant.xlf
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../RebuildResources.resx">
+    <body>
+      <trans-unit id="0_exists_1_times_in_compilation_options">
+        <source>'{0}' exists '{1}' times in compilation options.</source>
+        <target state="new">'{0}' exists '{1}' times in compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="A_non_null_PDB_stream_must_be_provided_because_the_compilation_does_not_have_an_embedded_PDB">
+        <source>A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</source>
+        <target state="new">A non-null PDB stream must be provided because the compilation does not have an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Cannot_create_compilation_options_0">
+        <source>Cannot create compilation options: {0}</source>
+        <target state="new">Cannot create compilation options: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_get_PDB_file_path">
+        <source>Could not get PDB file path.</source>
+        <target state="new">Could not get PDB file path.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Does_not_contain_metadata_compilation_options">
+        <source>Does not contain metadata compilation options.</source>
+        <target state="new">Does not contain metadata compilation options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_null_or_empty_key_for_compilation_options_pairs">
+        <source>Encountered null or empty key for compilation options pairs.</source>
+        <target state="new">Encountered null or empty key for compilation options pairs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encountered_unexpected_byte_0_when_expecting_a_null_terminator">
+        <source>Encountered unexpected byte '{0}' when expecting a null terminator.</source>
+        <target state="new">Encountered unexpected byte '{0}' when expecting a null terminator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Invalid_language_name">
+        <source>Invalid language name.</source>
+        <target state="new">Invalid language name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PDB_stream_must_be_null_because_the_compilation_has_an_embedded_PDB">
+        <source>PDB stream must be null because the compilation has an embedded PDB.</source>
+        <target state="new">PDB stream must be null because the compilation has an embedded PDB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unexpected_value_for_EmbedInteropTypes_MetadataImageKind_0">
+        <source>Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</source>
+        <target state="new">Unexpected value for EmbedInteropTypes/MetadataImageKind '{0}'.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/BuildValidator.csproj
+++ b/src/Tools/BuildValidator/BuildValidator.csproj
@@ -27,5 +27,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="BuildValidatorResources.resx" GenerateSource="true" />
+  </ItemGroup>
   <Import Project="$(RepositoryEngineeringDir)targets\ILDAsm.targets" />
 </Project>

--- a/src/Tools/BuildValidator/BuildValidatorResources.resx
+++ b/src/Tools/BuildValidator/BuildValidatorResources.resx
@@ -117,7 +117,28 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Runtime_platform_not_supported_for_testing" xml:space="preserve">
-    <value>Runtime platform not supported for testing.</value>
+  <data name="Assemblies_to_be_excluded_substring_match" xml:space="preserve">
+    <value>Assemblies to be excluded (substring match)</value>
+  </data>
+  <data name="Do_not_output_log_information_to_console" xml:space="preserve">
+    <value>Do not output log information to console</value>
+  </data>
+  <data name="Output_debug_info_when_rebuild_is_not_equal_to_the_original" xml:space="preserve">
+    <value>Output debug info when rebuild is not equal to the original</value>
+  </data>
+  <data name="Output_verbose_log_information" xml:space="preserve">
+    <value>Output verbose log information</value>
+  </data>
+  <data name="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times" xml:space="preserve">
+    <value>Path to assemblies to rebuild (can be specified one or more times)</value>
+  </data>
+  <data name="Path_to_output_debug_info" xml:space="preserve">
+    <value>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</value>
+  </data>
+  <data name="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times" xml:space="preserve">
+    <value>Path to referenced assemblies (can be specified zero or more times)</value>
+  </data>
+  <data name="Path_to_sources_to_use_in_rebuild" xml:space="preserve">
+    <value>Path to sources to use in rebuild</value>
   </data>
 </root>

--- a/src/Tools/BuildValidator/BuildValidatorResources.resx
+++ b/src/Tools/BuildValidator/BuildValidatorResources.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Runtime_platform_not_supported_for_testing" xml:space="preserve">
+    <value>Runtime platform not supported for testing.</value>
+  </data>
+</root>

--- a/src/Tools/BuildValidator/IldasmUtilities.cs
+++ b/src/Tools/BuildValidator/IldasmUtilities.cs
@@ -31,7 +31,7 @@ namespace BuildValidator
             }
             else
             {
-                throw new PlatformNotSupportedException(BuildValidatorResources.Runtime_platform_not_supported_for_testing);
+                throw new PlatformNotSupportedException();
             }
 
             return Path.Combine(directory, "runtimes", ridName, "native", ildasmExeName);

--- a/src/Tools/BuildValidator/IldasmUtilities.cs
+++ b/src/Tools/BuildValidator/IldasmUtilities.cs
@@ -31,7 +31,7 @@ namespace BuildValidator
             }
             else
             {
-                throw new PlatformNotSupportedException("Runtime platform not supported for testing");
+                throw new PlatformNotSupportedException(BuildValidatorResources.Runtime_platform_not_supported_for_testing);
             }
 
             return Path.Combine(directory, "runtimes", ridName, "native", ildasmExeName);

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -9,17 +9,11 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
-using System.Net.Http.Headers;
-using System.Reflection;
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Rebuild;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Console;
 using Newtonsoft.Json;
 
 namespace BuildValidator
@@ -40,28 +34,28 @@ namespace BuildValidator
             var rootCommand = new RootCommand
             {
                 new Option<string>(
-                    "--assembliesPath", "Path to assemblies to rebuild (can be specified one or more times)"
+                    "--assembliesPath", BuildValidatorResources.Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times
                 ) { IsRequired = true, Argument = { Arity = ArgumentArity.OneOrMore } },
                 new Option<string>(
-                    "--exclude", "Assemblies to be excluded (substring match)"
+                    "--exclude", BuildValidatorResources.Assemblies_to_be_excluded_substring_match
                 ) { Argument = { Arity = ArgumentArity.ZeroOrMore } },
                 new Option<string>(
-                    "--sourcePath", "Path to sources to use in rebuild"
+                    "--sourcePath", BuildValidatorResources.Path_to_sources_to_use_in_rebuild
                 ) { IsRequired = true },
                 new Option<string>(
-                    "--referencesPath", "Path to referenced assemblies (can be specified zero or more times)"
+                    "--referencesPath", BuildValidatorResources.Path_to_referenced_assemblies_can_be_specified_zero_or_more_times
                 ) { Argument = { Arity = ArgumentArity.ZeroOrMore } },
                 new Option<bool>(
-                    "--verbose", "Output verbose log information"
+                    "--verbose", BuildValidatorResources.Output_verbose_log_information
                 ),
                 new Option<bool>(
-                    "--quiet", "Do not output log information to console"
+                    "--quiet", BuildValidatorResources.Do_not_output_log_information_to_console
                 ),
                 new Option<bool>(
-                    "--debug", "Output debug info when rebuild is not equal to the original"
+                    "--debug", BuildValidatorResources.Output_debug_info_when_rebuild_is_not_equal_to_the_original
                 ),
                 new Option<string?>(
-                    "--debugPath", "Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled."
+                    "--debugPath", BuildValidatorResources.Path_to_output_debug_info
                 )
             };
             rootCommand.Handler = CommandHandler.Create(new Func<string[], string[]?, string, string[]?, bool, bool, bool, string, int>(HandleCommand));

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.cs.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.cs.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.cs.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.cs.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.de.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.de.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.de.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.de.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.es.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.es.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.es.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.es.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.fr.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.fr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.fr.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.fr.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.it.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.it.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.it.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.it.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.ja.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.ja.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.ja.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.ja.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.ko.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.ko.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.ko.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.ko.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.pl.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.pl.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.pl.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.pl.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.pt-BR.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.pt-BR.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.pt-BR.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.pt-BR.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.ru.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.ru.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.ru.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.ru.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.tr.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.tr.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.tr.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.tr.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hans.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hans.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hans.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hans.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hant.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hant.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../BuildValidatorResources.resx">
     <body>
-      <trans-unit id="Runtime_platform_not_supported_for_testing">
-        <source>Runtime platform not supported for testing.</source>
-        <target state="new">Runtime platform not supported for testing.</target>
+      <trans-unit id="Assemblies_to_be_excluded_substring_match">
+        <source>Assemblies to be excluded (substring match)</source>
+        <target state="new">Assemblies to be excluded (substring match)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Do_not_output_log_information_to_console">
+        <source>Do not output log information to console</source>
+        <target state="new">Do not output log information to console</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_debug_info_when_rebuild_is_not_equal_to_the_original">
+        <source>Output debug info when rebuild is not equal to the original</source>
+        <target state="new">Output debug info when rebuild is not equal to the original</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Output_verbose_log_information">
+        <source>Output verbose log information</source>
+        <target state="new">Output verbose log information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times">
+        <source>Path to assemblies to rebuild (can be specified one or more times)</source>
+        <target state="new">Path to assemblies to rebuild (can be specified one or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_output_debug_info">
+        <source>Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</source>
+        <target state="new">Path to output debug info. Defaults to the user temp directory. Note that a unique debug path should be specified for every instance of the tool running with `--debug` enabled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_referenced_assemblies_can_be_specified_zero_or_more_times">
+        <source>Path to referenced assemblies (can be specified zero or more times)</source>
+        <target state="new">Path to referenced assemblies (can be specified zero or more times)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Path_to_sources_to_use_in_rebuild">
+        <source>Path to sources to use in rebuild</source>
+        <target state="new">Path to sources to use in rebuild</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hant.xlf
+++ b/src/Tools/BuildValidator/xlf/BuildValidatorResources.zh-Hant.xlf
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../BuildValidatorResources.resx">
+    <body>
+      <trans-unit id="Runtime_platform_not_supported_for_testing">
+        <source>Runtime platform not supported for testing.</source>
+        <target state="new">Runtime platform not supported for testing.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Fixes #52349

- I added periods to the end of exception messages when moving to resx.
- Enclosed variable inputs to the messages with single quotes.
- Replaced an existing double quotes with single quotes to be consistent since this is what used across the whole codebase.




- [ ] TODO: Haven't yet completed moving everything.
- [ ] Are there any projects other than BuildValidator and Rebuild?

cc @RikkiGibson 