### PR TITLE
Don't do partial ngen for codelens

### DIFF
--- a/src/VisualStudio/CodeLens/Microsoft.VisualStudio.LanguageServices.CodeLens.csproj
+++ b/src/VisualStudio/CodeLens/Microsoft.VisualStudio.LanguageServices.CodeLens.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>Microsoft.VisualStudio.LanguageServices.CodeLens</RootNamespace>
     <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ApplyNgenOptimization>partial</ApplyNgenOptimization>
     <!-- NuGet -->
     <IsPackable>false</IsPackable>
     <PackageDescription>


### PR DESCRIPTION
Since optprof tests no longer generate IBC data for this assembly. 
(and missing data fails the build https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=4768775&view=logs&j=20fcf628-b65c-5865-625a-1cef81cda63b&t=4468d756-8020-55ac-ccb3-96d58c9610f2)