### PR TITLE
Pass the updated type tokens to the debugger

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -898,7 +898,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     {
                         Contract.ThrowIfNull(emitResult.Baseline);
 
-                        // TODO: Pass these to ManagedModuleUpdate in the new debugger contracts API
                         var updatedMethodTokens = emitResult.UpdatedMethods.SelectAsArray(h => MetadataTokens.GetToken(h));
                         var updatedTypeTokens = emitResult.UpdatedTypes.SelectAsArray(h => MetadataTokens.GetToken(h));
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -921,7 +921,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             pdbStream.ToImmutableArray(),
                             lineEdits,
                             updatedMethodTokens,
-                            updatedTypes: ImmutableArray<int>.Empty,
+                            updatedTypeTokens,
                             activeStatementsInUpdatedMethods,
                             exceptionRegionUpdates));
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/52585

Follow up for main-vs-deps to pass the right things to the debugger.

@tmat PTAL