### PR TITLE
Revert changes to TypeScriptWaitContext wrappers

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptWaitContextWrapper.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptWaitContextWrapper.cs
@@ -4,18 +4,18 @@
 
 using System;
 using System.Threading;
-using Microsoft.VisualStudio.Utilities;
+using Microsoft.CodeAnalysis.Editor.Host;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
     [Obsolete("This is just a wrapper around the public Visual Studio API IUIThreadOperationContext, please use it directly.")]
     internal readonly struct VSTypeScriptWaitContextWrapper
     {
-        private readonly IUIThreadOperationContext _context;
+        private readonly IWaitContext _underlyingObject;
 
-        public VSTypeScriptWaitContextWrapper(IUIThreadOperationContext context)
-            => _context = context;
+        public VSTypeScriptWaitContextWrapper(IWaitContext underlyingObject)
+            => _underlyingObject = underlyingObject;
 
-        public CancellationToken CancellationToken => _context.UserCancellationToken;
+        public CancellationToken CancellationToken => _underlyingObject.CancellationToken;
     }
 }

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptWaitIndicatorWrapper.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptWaitIndicatorWrapper.cs
@@ -3,20 +3,20 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.VisualStudio.Utilities;
+using Microsoft.CodeAnalysis.Editor.Host;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
     [Obsolete("This is just a wrapper around the public Visual Studio API IUIThreadOperationContext, please use it directly.")]
     internal readonly struct VSTypeScriptWaitIndicatorWrapper
     {
-        private readonly IUIThreadOperationExecutor _underlyingObject;
+        private readonly IWaitIndicator _underlyingObject;
 
-        public VSTypeScriptWaitIndicatorWrapper(IUIThreadOperationExecutor underlyingObject)
+        public VSTypeScriptWaitIndicatorWrapper(IWaitIndicator underlyingObject)
             => _underlyingObject = underlyingObject;
 
         public VSTypeScriptWaitIndicatorResult Wait(string title, string message, bool allowCancel, Action<VSTypeScriptWaitContextWrapper> action)
-            => (VSTypeScriptWaitIndicatorResult)_underlyingObject.Execute(title, message, allowCancel, showProgress: false, context => action(new VSTypeScriptWaitContextWrapper(context)));
+            => (VSTypeScriptWaitIndicatorResult)_underlyingObject.Wait(title, message, allowCancel, context => action(new VSTypeScriptWaitContextWrapper(context)));
 
     }
 }


### PR DESCRIPTION
These should have been left as is as a part of 299d55d2b5d7602cae875816e9d13b3483d3fcdb, as this otherwise created breaking API changes.