### PR TITLE
Suppress ExecutionContext flow on SQLite hot path

### DIFF
--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_Threading.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_Threading.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SQLite.v2
 {
@@ -28,12 +29,30 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
         // Read tasks go to the concurrent-scheduler where they can run concurrently with other read
         // tasks.
         private Task<TResult> PerformReadAsync<TArg, TResult>(Func<TArg, TResult> func, TArg arg, CancellationToken cancellationToken) where TArg : struct
-            => PerformTaskAsync(func, arg, _connectionPoolService.Scheduler.ConcurrentScheduler, cancellationToken);
+        {
+            // Suppress ExecutionContext flow for asynchronous operations that write to the database. In addition to
+            // avoiding ExecutionContext allocations, this clears the LogicalCallContext and avoids the need to clone
+            // data set by CallContext.LogicalSetData at each yielding await in the task tree.
+            //
+            // ⚠ DO NOT AWAIT INSIDE THE USING. The Dispose method that restores ExecutionContext flow must run on the
+            // same thread where SuppressFlow was originally run.
+            using var _ = FlowControlHelper.TrySuppressFlow();
+            return PerformTaskAsync(func, arg, _connectionPoolService.Scheduler.ConcurrentScheduler, cancellationToken);
+        }
 
         // Write tasks go to the exclusive-scheduler so they run exclusively of all other threading
         // tasks we need to do.
         public Task<bool> PerformWriteAsync<TArg>(Func<TArg, bool> func, TArg arg, CancellationToken cancellationToken) where TArg : struct
-            => PerformTaskAsync(func, arg, _connectionPoolService.Scheduler.ExclusiveScheduler, cancellationToken);
+        {
+            // Suppress ExecutionContext flow for asynchronous operations that write to the database. In addition to
+            // avoiding ExecutionContext allocations, this clears the LogicalCallContext and avoids the need to clone
+            // data set by CallContext.LogicalSetData at each yielding await in the task tree.
+            //
+            // ⚠ DO NOT AWAIT INSIDE THE USING. The Dispose method that restores ExecutionContext flow must run on the
+            // same thread where SuppressFlow was originally run.
+            using var _ = FlowControlHelper.TrySuppressFlow();
+            return PerformTaskAsync(func, arg, _connectionPoolService.Scheduler.ExclusiveScheduler, cancellationToken);
+        }
 
         public Task PerformWriteAsync(Action action, CancellationToken cancellationToken)
             => PerformWriteAsync(vt =>

--- a/src/Workspaces/Core/Portable/Utilities/FlowControlHelper.cs
+++ b/src/Workspaces/Core/Portable/Utilities/FlowControlHelper.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+
+namespace Roslyn.Utilities
+{
+    internal static class FlowControlHelper
+    {
+        public static AsyncFlowControlHelper TrySuppressFlow()
+            => new(ExecutionContext.IsFlowSuppressed() ? default : ExecutionContext.SuppressFlow());
+
+        public struct AsyncFlowControlHelper : IDisposable
+        {
+            private readonly AsyncFlowControl _asyncFlowControl;
+
+            public AsyncFlowControlHelper(AsyncFlowControl asyncFlowControl)
+            {
+                _asyncFlowControl = asyncFlowControl;
+            }
+
+            public void Dispose()
+            {
+                if (_asyncFlowControl != default)
+                {
+                    _asyncFlowControl.Dispose();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Avoids approximately 1 million calls to `LogicalCallContext.Clone()`, which reduces GC and CPU overhead for this heavily asynchronous path.

Fixes [AB#1326123](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1326123)