### PR TITLE
Only generate build number on first run

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -71,6 +71,7 @@ stages:
           arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven even'
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven odd'
+      condition: eq(variables['System.JobAttempt'], '1')
 
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable


### PR DESCRIPTION
Fixes issue where rerunning a failed build job will result in an incorrect build number. As discoverd in https://github.com/dotnet/sdk/pull/17700