### PR TITLE
Add OmniSharpInlineHintsService to ExternalAccess

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation;
+using Microsoft.CodeAnalysis.GoToDefinition;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.GoToDefinition
+{
+    internal static class OmniSharpFindDefinitionService
+    {
+        internal static async Task<ImmutableArray<OmniSharpNavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var service = document.GetRequiredLanguageService<IFindDefinitionService>();
+            var result = await service.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
+            return result.NullToEmpty().SelectAsArray(original => new OmniSharpNavigableItem(original.DisplayTaggedParts, original.Document, original.SourceSpan));
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.InlineHints
+{
+    internal struct OmniSharpInlineHintsService
+    {
+        public async Task<ImmutableArray<OmniSharpInlineHint>> GetInlineHintsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+        {
+            var service = document.GetRequiredLanguageService<IInlineHintsService>();
+            var hints = await service.GetInlineHintsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+            return hints.SelectAsArray(static h => new OmniSharpInlineHint(
+                h.Span,
+                h.DisplayParts,
+                (document, cancellationToken) => h.GetDescriptionAsync(document, cancellationToken)));
+        }
+    }
+
+    internal readonly struct OmniSharpInlineHint
+    {
+        private readonly Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>> _getDescriptionAsync;
+
+        public OmniSharpInlineHint(
+            TextSpan span,
+            ImmutableArray<TaggedText> displayParts,
+            Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>> getDescriptionAsync)
+        {
+            Span = span;
+            DisplayParts = displayParts;
+            _getDescriptionAsync = getDescriptionAsync;
+        }
+
+        public readonly TextSpan Span { get; }
+        public readonly ImmutableArray<TaggedText> DisplayParts { get; }
+
+        public Task<ImmutableArray<TaggedText>> GetDescrptionAsync(Document document, CancellationToken cancellationToken)
+            => _getDescriptionAsync.Invoke(document, cancellationToken);
+    }
+}

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.InlineHints
 {
     internal static class OmniSharpInlineHintsService
     {
-        public async Task<ImmutableArray<OmniSharpInlineHint>> GetInlineHintsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+        public static async Task<ImmutableArray<OmniSharpInlineHint>> GetInlineHintsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {
             var service = document.GetRequiredLanguageService<IInlineHintsService>();
             var hints = await service.GetInlineHintsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.InlineHints
 {
-    internal struct OmniSharpInlineHintsService
+    internal static class OmniSharpInlineHintsService
     {
         public async Task<ImmutableArray<OmniSharpInlineHint>> GetInlineHintsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {

--- a/src/Tools/ExternalAccess/OmniSharp/Navigation/OmniSharpNavigableItem.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Navigation/OmniSharpNavigableItem.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation
+{
+    internal struct OmniSharpNavigableItem
+    {
+        public OmniSharpNavigableItem(ImmutableArray<TaggedText> displayTaggedParts, Document document, TextSpan sourceSpan)
+        {
+            DisplayTaggedParts = displayTaggedParts;
+            Document = document;
+            SourceSpan = sourceSpan;
+        }
+
+        public ImmutableArray<TaggedText> DisplayTaggedParts { get; }
+
+        public Document Document { get; }
+
+        public TextSpan SourceSpan { get; }
+    }
+}

--- a/src/Tools/ExternalAccess/OmniSharp/Navigation/OmniSharpNavigableItem.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Navigation/OmniSharpNavigableItem.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation
 {
-    internal struct OmniSharpNavigableItem
+    internal readonly struct OmniSharpNavigableItem
     {
         public OmniSharpNavigableItem(ImmutableArray<TaggedText> displayTaggedParts, Document document, TextSpan sourceSpan)
         {


### PR DESCRIPTION
After consuling with @CyrusNajmabadi and @akhera99, I believe we should be OK to add IInlineHintsService to the OmniSharp ExternalAccess layer, so that they can take advantage of the proposed vscode APIs and leverage our existing implementation without having to rewrite.
