### PR TITLE
Handle CallerArgumentExpression in attributes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -766,19 +766,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // Boxing or identity conversion:
-                    parameterType = Compilation.GetSpecialType(SpecialType.System_Int32);
+                    parameterType = GetSpecialType(SpecialType.System_Int32, diagnostics, syntax);
                     defaultValue = line;
                 }
             }
             else if (!IsEarlyAttributeBinder && parameter.IsCallerFilePath)
             {
-                parameterType = Compilation.GetSpecialType(SpecialType.System_String);
+                parameterType = GetSpecialType(SpecialType.System_String, diagnostics, syntax);
                 kind = TypedConstantKind.Primitive;
                 defaultValue = syntax.SyntaxTree.GetDisplayPath(syntax.Name.Span, Compilation.Options.SourceReferenceResolver);
             }
             else if (!IsEarlyAttributeBinder && parameter.IsCallerMemberName && (object)((ContextualAttributeBinder)this).AttributedMember != null)
             {
-                parameterType = Compilation.GetSpecialType(SpecialType.System_String);
+                parameterType = GetSpecialType(SpecialType.System_String, diagnostics, syntax);
                 kind = TypedConstantKind.Primitive;
                 defaultValue = ((ContextualAttributeBinder)this).AttributedMember.GetMemberCallerName();
             }
@@ -787,7 +787,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(argumentsCount <= syntax.ArgumentList.Arguments.Count);
                 CheckFeatureAvailability(syntax.ArgumentList, MessageID.IDS_FeatureCallerArgumentExpression, diagnostics);
-                parameterType = Compilation.GetSpecialType(SpecialType.System_String);
+                parameterType = GetSpecialType(SpecialType.System_String, diagnostics, syntax);
                 kind = TypedConstantKind.Primitive;
                 defaultValue = syntax.ArgumentList.Arguments[argumentIndex].Expression.ToString();
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    reorderedArgument = GetDefaultValueArgument(parameter, syntax, argumentsToParams, diagnostics);
+                    reorderedArgument = GetDefaultValueArgument(parameter, syntax, argumentsToParams, argumentsCount, diagnostics);
                     sourceIndices = sourceIndices ?? CreateSourceIndicesArray(i, parameterCount);
                 }
 
@@ -714,7 +714,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    return GetDefaultValueArgument(parameter, syntax, argumentsToParams, diagnostics);
+                    return GetDefaultValueArgument(parameter, syntax, argumentsToParams, argumentsCount, diagnostics);
                 }
             }
         }
@@ -738,7 +738,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return sourceIndices;
         }
 
-        private TypedConstant GetDefaultValueArgument(ParameterSymbol parameter, AttributeSyntax syntax, ImmutableArray<int> argumentsToParams, BindingDiagnosticBag diagnostics)
+        private TypedConstant GetDefaultValueArgument(ParameterSymbol parameter, AttributeSyntax syntax, ImmutableArray<int> argumentsToParams, int argumentsCount, BindingDiagnosticBag diagnostics)
         {
             var parameterType = parameter.Type;
             ConstantValue? defaultConstantValue = parameter.IsOptional ? parameter.ExplicitDefaultConstantValue : ConstantValue.NotAvailable;
@@ -783,8 +783,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 defaultValue = ((ContextualAttributeBinder)this).AttributedMember.GetMemberCallerName();
             }
             else if (!IsEarlyAttributeBinder && syntax.ArgumentList is not null &&
-                getCallerArgumentArgumentIndex(parameter, argumentsToParams) is int argumentIndex && argumentIndex > -1 && argumentIndex < syntax.ArgumentList.Arguments.Count)
+                getCallerArgumentArgumentIndex(parameter, argumentsToParams) is int argumentIndex && argumentIndex > -1 && argumentIndex < argumentsCount)
             {
+                Debug.Assert(argumentsCount <= syntax.ArgumentList.Arguments.Count);
                 CheckFeatureAvailability(syntax.ArgumentList, MessageID.IDS_FeatureCallerArgumentExpression, diagnostics);
                 parameterType = Compilation.GetSpecialType(SpecialType.System_String);
                 kind = TypedConstantKind.Primitive;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -849,7 +849,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             static int getCallerArgumentArgumentIndex(ParameterSymbol parameter, ImmutableArray<int> argumentsToParams)
             {
-                return argumentsToParams.IsDefault
+                return argumentsToParams.IsDefault || parameter.CallerArgumentExpressionParameterIndex == -1
                         ? parameter.CallerArgumentExpressionParameterIndex
                         : argumentsToParams.IndexOf(parameter.CallerArgumentExpressionParameterIndex);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -822,6 +822,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else if (!IsEarlyAttributeBinder && syntax.ArgumentList is not null &&
                 getCallerArgumentArgumentIndex(parameter, constructorArgumentNamesOpt) is int argumentIndex && argumentIndex > -1 && argumentIndex < argumentsCount)
             {
+                CheckFeatureAvailability(syntax.ArgumentList, MessageID.IDS_FeatureCallerArgumentExpression, diagnostics);
                 parameterType = Compilation.GetSpecialType(SpecialType.System_String);
                 kind = TypedConstantKind.Primitive;
                 defaultValue = syntax.ArgumentList.Arguments[argumentIndex].Expression.ToString();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -782,7 +782,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 kind = TypedConstantKind.Primitive;
                 defaultValue = ((ContextualAttributeBinder)this).AttributedMember.GetMemberCallerName();
             }
-            else if (!IsEarlyAttributeBinder && syntax.ArgumentList is not null &&
+            // We check IsCallerMemberName here since the above if can be reached with AttributedMember == null, in which case,
+            // We shouldn't be checking CallerArgumentExpression
+            else if (!IsEarlyAttributeBinder && syntax.ArgumentList is not null && !parameter.IsCallerMemberName &&
                 getCallerArgumentArgumentIndex(parameter, argumentsToParams) is int argumentIndex && argumentIndex > -1 && argumentIndex < argumentsCount)
             {
                 Debug.Assert(argumentsCount <= syntax.ArgumentList.Arguments.Count);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -820,7 +820,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 defaultValue = ((ContextualAttributeBinder)this).AttributedMember.GetMemberCallerName();
             }
             else if (!IsEarlyAttributeBinder && syntax.ArgumentList is not null &&
-                getArgumentIndex(parameter, constructorArgumentNamesOpt) is int argumentIndex && argumentIndex > -1 && argumentIndex < argumentsCount)
+                getCallerArgumentArgumentIndex(parameter, constructorArgumentNamesOpt) is int argumentIndex && argumentIndex > -1 && argumentIndex < argumentsCount)
             {
                 parameterType = Compilation.GetSpecialType(SpecialType.System_String);
                 kind = TypedConstantKind.Primitive;
@@ -882,12 +882,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new TypedConstant(parameterType, kind, defaultValue);
             }
 
-            static int getArgumentIndex(ParameterSymbol parameter, ImmutableArray<string> constructorArgumentNamesOpt)
+            static int getCallerArgumentArgumentIndex(ParameterSymbol parameter, ImmutableArray<string> constructorArgumentNamesOpt)
             {
                 if (constructorArgumentNamesOpt.IsDefault || parameter.CallerArgumentExpressionParameterIndex == -1)
                 {
                     return parameter.CallerArgumentExpressionParameterIndex;
                 }
+
 
                 Debug.Assert(parameter.ContainingSymbol is MethodSymbol);
                 var methodSymbol = (MethodSymbol)parameter.ContainingSymbol;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -893,7 +893,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(parameter.ContainingSymbol is MethodSymbol);
                 var methodSymbol = (MethodSymbol)parameter.ContainingSymbol;
                 var callerArgumentParameter = methodSymbol.Parameters[parameter.CallerArgumentExpressionParameterIndex];
-                return constructorArgumentNamesOpt.IndexOf(callerArgumentParameter.Name);
+                return GetMatchingNamedConstructorArgumentIndex(callerArgumentParameter.Name, constructorArgumentNamesOpt, startIndex: 0, constructorArgumentNamesOpt.Length);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -628,6 +628,38 @@ class Program
 '0', '2', '2', '0+0', '', '1+1'");
         }
 
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void TestArgumentExpressionInAttributeConstructor_OptionalAndFieldInitializer()
+        {
+            string source = @"
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+class MyAttribute : Attribute
+{
+    public MyAttribute([CallerArgumentExpression(""a"")] string expr_a = ""<default0>"", string a = ""<default1>"")
+    {
+        Console.WriteLine($""'{a}', '{expr_a}'"");
+    }
+
+    public int A;
+    public int B;
+}
+
+[My(A=1, B=2)]
+class Program
+{
+    static void Main()
+    {
+        typeof(Program).GetCustomAttribute(typeof(MyAttribute));
+    }
+}";
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview);
+            compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "'<default1>', '<default0>'");
+        }
+
         [Fact]
         public void TestCallerInfoAttributesWithSaneDefaultValues()
         {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -627,12 +627,9 @@ public class Program
             compilation.VerifyDiagnostics(
                 // (9,32): warning CS8917: The CallerArgumentExpressionAttribute applied to parameter 'arg' will have no effect. It is overriden by the CallerMemberNameAttribute.
                 //     public MyAttribute(int p, [CallerArgumentExpression(p)] [CallerMemberName] string arg = "<default>")
-                Diagnostic(ErrorCode.WRN_CallerMemberNamePreferredOverCallerArgumentExpression, "CallerArgumentExpression").WithArguments("arg").WithLocation(9, 32),
-                // (15,4): error CS8652: The feature 'caller argument expression' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                // [My(default(int))]
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "(default(int))").WithArguments("caller argument expression").WithLocation(15, 4)
+                Diagnostic(ErrorCode.WRN_CallerMemberNamePreferredOverCallerArgumentExpression, "CallerArgumentExpression").WithArguments("arg").WithLocation(9, 32)
                 );
-            // CompileAndVerify(compilation, expectedOutput: "Main"); PROTOTYPE(caller-expr): Uncomment after fixing the above stated issue.
+            CompileAndVerify(compilation, expectedOutput: "<default>");
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -589,7 +589,7 @@ param1: param1_value, param2: param2_value
 param1: param1_value, param2: param2_value");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void TestArgumentExpressionInAttributeConstructor_NamedAndOptionalParameters()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -1215,12 +1215,19 @@ class Program
 ";
 
             string source = @"
+using System.Reflection;
+
 [My(1+2)]
 class Program
 {
+    static void Main()
+    {
+        typeof(Program).GetCustomAttribute(typeof(MyAttribute));
+    }
 }";
-            var compilation = CreateCompilationWithILAndMscorlib40(source, il, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll, parseOptions: TestOptions.RegularPreview);
+            var compilation = CreateCompilationWithILAndMscorlib40(source, il, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview);
             compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "'3', '0'");
             var arguments = compilation.GetTypeByMetadataName("Program").GetAttributes().Single().CommonConstructorArguments;
             Assert.Equal(2, arguments.Length);
             Assert.Equal(3, arguments[0].Value);

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -118,7 +118,7 @@ public static class FromFirstAssembly
     }
 }
 ";
-            var comp1 = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp);
+            var comp1 = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, parseOptions: TestOptions.Regular9);
             comp1.VerifyDiagnostics();
             var ref1 = comp1.EmitToImageReference();
 
@@ -209,7 +209,7 @@ class Program
 }
 ";
 
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
             compilation.VerifyDiagnostics(
                 // (12,22): warning CS8918: The CallerArgumentExpressionAttribute applied to parameter 'arg' will have no effect. It is applied with an invalid parameter name.
                 //     static void Log([CallerArgumentExpression(pp)] string arg = "<default>")
@@ -239,7 +239,7 @@ class Program
 }
 ";
 
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
             compilation.VerifyDiagnostics(
                 // (12,29): warning CS8917: The CallerArgumentExpressionAttribute applied to parameter 'arg' will have no effect. It is overriden by the MemberNameAttribute.
                 //     static void Log(int p, [CallerArgumentExpression(p)] [CallerMemberName] string arg = "<default>")
@@ -382,7 +382,7 @@ public static class C
 }
 ";
 
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
             compilation.VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: @"<Main>$
 <default-arg-expression>");
@@ -585,7 +585,7 @@ public class Program
 }
 ";
 
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
             compilation.VerifyDiagnostics(
                 // (12,22): warning CS8918: The CallerArgumentExpressionAttribute applied to parameter 'arg' will have no effect. It is applied with an invalid parameter name.
                 //     static void Log([CallerArgumentExpression(pp)] string arg = "<default>")
@@ -621,7 +621,7 @@ public class Program
 }
 ";
 
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
             // PROTOTYPE(caller-expr): This is inconsistent with the behavior of invocations, which doesn't show a lang version error.
             // The error shouldn't be there since caller member names wins over caller argument expression.
             compilation.VerifyDiagnostics(
@@ -798,7 +798,7 @@ public class Program
 }
 ";
 
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
             compilation.VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: @"<default-caller-name>
 <default-arg-expression>");
@@ -834,7 +834,7 @@ public class Program
 }
 ";
 
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
             compilation.VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: @"<default>
 value");

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -414,6 +414,34 @@ public static class C
 value");
         }
 
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void TestArgumentExpressionInAttributeConstructor()
+        {
+            string source = @"
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+public class MyAttribute : Attribute
+{
+    public MyAttribute(string s, [CallerArgumentExpression(""s"")] string x = """") => Console.WriteLine($""'{s}', '{x}'"");
+}
+
+[My(""Hello"")]
+public class Program
+{
+    static void Main()
+    {
+        typeof(Program).GetCustomAttribute(typeof(MyAttribute));
+    }
+}
+";
+
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "'Hello', '\"Hello\"'");
+        }
+
         [Fact]
         public void TestCallerInfoAttributesWithSaneDefaultValues()
         {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -464,6 +464,7 @@ public class MyAttribute : Attribute
     const string p = nameof(p);
     public MyAttribute(int p, [CallerArgumentExpression(p)] string arg = ""<default-arg>"")
     {
+        Console.WriteLine(arg);
     }
 }
 


### PR DESCRIPTION
Draft for now as it's currently not working 😕 

![image](https://user-images.githubusercontent.com/31348972/118945199-88001e80-b955-11eb-9a1c-2a723e6b0b6c.png)

The code I wrote seems to be getting the default value for correctly as shown in the below screenshot. So no idea what's going on.

![image](https://user-images.githubusercontent.com/31348972/118945448-c0076180-b955-11eb-8624-7840c14a2f80.png)

@333fred @AlekseyTs Would you be able to help here?

---

Test plan: https://github.com/dotnet/roslyn/issues/52745.