### PR TITLE
List patterns: parsing changes

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -541,7 +541,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 closeKind: SyntaxKind.CloseBraceToken,
                 out bool isPropertyPatternClause);
             var kind = isPropertyPatternClause ? SyntaxKind.PropertyPatternClause : SyntaxKind.ListPatternClause;
-            return _syntaxFactory.PropertyPatternClause(kind, openBraceToken, subPatterns, closeBraceToken);
+            var result = _syntaxFactory.PropertyPatternClause(kind, openBraceToken, subPatterns, closeBraceToken);
+            if (!isPropertyPatternClause)
+                result = CheckFeatureAvailability(result, MessageID.IDS_FeatureListPattern);
+            return result;
         }
 
         private void ParseSubpatternList(

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case SyntaxKind.DotDotToken:
                     return _syntaxFactory.SlicePattern(
                         CheckFeatureAvailability(EatToken(), MessageID.IDS_FeatureSlicePattern),
-                        IsPossibleSubpatternElement() ? ParseNegatedPattern(precedence, afterIs: false, whenIsKeyword) : null);
+                        IsPossibleSubpatternElement() ? ParsePattern(precedence, afterIs: false, whenIsKeyword) : null);
                 case SyntaxKind.LessThanToken:
                 case SyntaxKind.LessThanEqualsToken:
                 case SyntaxKind.GreaterThanToken:

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -452,6 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             case SyntaxKind.IdentifierToken:
                             case SyntaxKind.OpenBraceToken:
                             case SyntaxKind.OpenParenToken:
+                            case SyntaxKind.OpenBracketToken:
                                 // these all can start a pattern
                                 return false;
                             default:

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
@@ -1060,7 +1060,7 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean, IsInvalid) (
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Patterns)]
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(list-patterns)")]
         public void IsPattern_BadRecursivePattern_02()
         {
             var vbSource = @"

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
@@ -1060,7 +1060,7 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean, IsInvalid) (
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Patterns)]
-        [Fact(Skip = "PROTOTYPE(list-patterns)")]
+        [Fact]
         public void IsPattern_BadRecursivePattern_02()
         {
             var vbSource = @"
@@ -1088,6 +1088,9 @@ class C
 
             var compilation = CreateCompilation(source, new[] { vbCompilation.EmitToImageReference() }, parseOptions: TestOptions.Regular8);
             compilation.VerifyDiagnostics(
+                // (6,31): error CS8652: The feature 'list pattern' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         b = /*<bind>*/o is C1 { Prop[1]: var x }/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{ Prop[1]: var x }").WithArguments("list pattern").WithLocation(6, 31),
                 // (6,31): error CS9200: List patterns may not be used for a value of type 'C1'.
                 //         b = /*<bind>*/o is C1 { Prop[1]: var x }/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_UnsupportedTypeForListPattern, "{ Prop[1]: var x }").WithArguments("C1").WithLocation(6, 31),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_ListPatterns.cs
@@ -351,7 +351,7 @@ class X
 
     public static void Main()
     {
-        foreach (var a in new[] { new[]{1}, new[]{1,2}, new []{1,2,3} })
+        foreach (var a in new[] { new int[1], new int[2], new int[3] })
         {
             Console.WriteLine(Test1(a));
             Console.WriteLine(Test2(a));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_ListPatterns.cs
@@ -238,7 +238,7 @@ public class X
         }
 
         [Fact]
-        public void LengthPattern()
+        public void LengthPattern_01()
         {
             var source = @"
 using System;
@@ -333,6 +333,122 @@ class X
   IL_005a:  ldloc.1
   IL_005b:  ret
 }");
+        }
+
+        [Fact]
+        public void LengthPattern_02()
+        {
+            var source = @"
+using System;
+class X
+{
+    public static bool Test1(int[] a) => a is [1] or [2];
+    public static bool Test2(int[] a) => a is [1 or 2];
+    public static bool Test3(int[] a) => a is [>=1] and [<3];
+    public static bool Test4(int[] a) => a is [>=1 and <3];
+    public static bool Test5(int[] a) => a is [not 3];
+    public static bool Test6(int[] a) => a is {} and not [3];
+
+    public static void Main()
+    {
+        foreach (var a in new[] { new[]{1}, new[]{1,2}, new []{1,2,3} })
+        {
+            Console.WriteLine(Test1(a));
+            Console.WriteLine(Test2(a));
+            Console.WriteLine(Test3(a));
+            Console.WriteLine(Test4(a));
+            Console.WriteLine(Test5(a));
+            Console.WriteLine(Test6(a));
+        }
+    } 
+}
+";
+            var compilation = CreateCompilation(source, parseOptions: TestOptions.RegularWithListPatterns, options: TestOptions.ReleaseExe);
+            compilation.VerifyEmitDiagnostics();
+            string expectedOutput = @"
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+False
+False
+False
+False
+False
+False
+";
+            var verifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            string expectedIL12 = @"{
+  // Code size       24 (0x18)
+  .maxstack  2
+  .locals init (int V_0,
+                bool V_1)
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0014
+  IL_0003:  ldarg.0
+  IL_0004:  callvirt   ""int System.Array.Length.get""
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  ldc.i4.1
+  IL_000c:  sub
+  IL_000d:  ldc.i4.1
+  IL_000e:  bgt.un.s   IL_0014
+  IL_0010:  ldc.i4.1
+  IL_0011:  stloc.1
+  IL_0012:  br.s       IL_0016
+  IL_0014:  ldc.i4.0
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
+  IL_0017:  ret
+}";
+            string expectedIL34 = @"{
+  // Code size       21 (0x15)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0013
+  IL_0003:  ldarg.0
+  IL_0004:  callvirt   ""int System.Array.Length.get""
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  ldc.i4.1
+  IL_000c:  blt.s      IL_0013
+  IL_000e:  ldloc.0
+  IL_000f:  ldc.i4.3
+  IL_0010:  clt
+  IL_0012:  ret
+  IL_0013:  ldc.i4.0
+  IL_0014:  ret
+}";
+            string expectedIL56 = @"{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0010
+  IL_0003:  ldarg.0
+  IL_0004:  callvirt   ""int System.Array.Length.get""
+  IL_0009:  ldc.i4.3
+  IL_000a:  ceq
+  IL_000c:  ldc.i4.0
+  IL_000d:  ceq
+  IL_000f:  ret
+  IL_0010:  ldc.i4.0
+  IL_0011:  ret
+}";
+            verifier.VerifyIL("X.Test1", expectedIL12);
+            verifier.VerifyIL("X.Test2", expectedIL12);
+            verifier.VerifyIL("X.Test3", expectedIL34);
+            verifier.VerifyIL("X.Test4", expectedIL34);
+            verifier.VerifyIL("X.Test5", expectedIL56);
+            verifier.VerifyIL("X.Test6", expectedIL56);
         }
 
         [Fact]
@@ -1584,7 +1700,8 @@ class X
         _ = a is {1,2,3} and {1,2,3};
         _ = a is ([>0]) and ([<0]);   // 5
         _ = a is ([>0]) and ([>=0]);
-        // PROTOTYPE(list-patterns) Parsing length patterns inside combinators
+        _ = a is [>0] and [<0];       // 6
+        _ = a is [>0] and [>=0];
     } 
 }
 ";
@@ -1604,7 +1721,10 @@ class X
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is {1,2,3} and {1,2,4}").WithArguments("int[]").WithLocation(13, 13),
                 // (15,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
                 //         _ = a is ([>0]) and ([<0]);   // 5
-                Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is ([>0]) and ([<0])").WithArguments("int[]").WithLocation(15, 13)
+                Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is ([>0]) and ([<0])").WithArguments("int[]").WithLocation(15, 13),
+                // (17,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
+                //         _ = a is [>0] and [<0];       // 6
+                Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [>0] and [<0]").WithArguments("int[]").WithLocation(17, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -6697,12 +6697,9 @@ switch (e)
         public void TrailingCommaInPositionalPattern_01()
         {
             UsingExpression("e is ( X: 3, )",
-                // (1,6): error CS8652: The feature 'list pattern' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                // e is { , }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{ , }").WithArguments("list pattern").WithLocation(1, 6),
-                // (1,8): error CS8504: Pattern missing
-                // e is { , }
-                Diagnostic(ErrorCode.ERR_MissingPattern, ",").WithLocation(1, 8)
+                // (1,14): error CS8504: Pattern missing
+                // e is ( X: 3, )
+                Diagnostic(ErrorCode.ERR_MissingPattern, ")").WithLocation(1, 14)
                 );
             N(SyntaxKind.IsPatternExpression);
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -6652,10 +6652,13 @@ switch (e)
             EOF();
         }
 
-        [Fact(Skip = "PROTOTYPE(list-patterns)")]
+        [Fact]
         public void TrailingCommaInPropertyPattern_02()
         {
             UsingExpression("e is { , }",
+                // (1,6): error CS8652: The feature 'list pattern' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // e is { , }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{ , }").WithArguments("list pattern").WithLocation(1, 6),
                 // (1,8): error CS8504: Pattern missing
                 // e is { , }
                 Diagnostic(ErrorCode.ERR_MissingPattern, ",").WithLocation(1, 8)
@@ -6694,9 +6697,12 @@ switch (e)
         public void TrailingCommaInPositionalPattern_01()
         {
             UsingExpression("e is ( X: 3, )",
-                // (1,14): error CS8504: Pattern missing
-                // e is ( X: 3, )
-                Diagnostic(ErrorCode.ERR_MissingPattern, ")").WithLocation(1, 14)
+                // (1,6): error CS8652: The feature 'list pattern' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // e is { , }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{ , }").WithArguments("list pattern").WithLocation(1, 6),
+                // (1,8): error CS8504: Pattern missing
+                // e is { , }
+                Diagnostic(ErrorCode.ERR_MissingPattern, ",").WithLocation(1, 8)
                 );
             N(SyntaxKind.IsPatternExpression);
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -6652,7 +6652,7 @@ switch (e)
             EOF();
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(list-patterns)")]
         public void TrailingCommaInPropertyPattern_02()
         {
             UsingExpression("e is { , }",

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests_ListPatterns.cs
@@ -674,6 +674,146 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void LengthPattern_17()
+        {
+            UsingExpression(@"c is not [<0]");
+
+            N(SyntaxKind.IsPatternExpression);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "c");
+                }
+                N(SyntaxKind.IsKeyword);
+                N(SyntaxKind.NotPattern);
+                {
+                    N(SyntaxKind.NotKeyword);
+                    N(SyntaxKind.RecursivePattern);
+                    {
+                        N(SyntaxKind.LengthPatternClause);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.RelationalPattern);
+                            {
+                                N(SyntaxKind.LessThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LengthPattern_18()
+        {
+            UsingExpression(@"c is [0] and [1]");
+
+            N(SyntaxKind.IsPatternExpression);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "c");
+                }
+                N(SyntaxKind.IsKeyword);
+                N(SyntaxKind.AndPattern);
+                {
+                    N(SyntaxKind.RecursivePattern);
+                    {
+                        N(SyntaxKind.LengthPatternClause);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ConstantPattern);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                    N(SyntaxKind.AndKeyword);
+                    N(SyntaxKind.RecursivePattern);
+                    {
+                        N(SyntaxKind.LengthPatternClause);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ConstantPattern);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LengthPattern_19()
+        {
+            UsingExpression(@"c is int [0] or [1]");
+
+            N(SyntaxKind.IsPatternExpression);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "c");
+                }
+                N(SyntaxKind.IsKeyword);
+                N(SyntaxKind.OrPattern);
+                {
+                    N(SyntaxKind.RecursivePattern);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.LengthPatternClause);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ConstantPattern);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                    N(SyntaxKind.OrKeyword);
+                    N(SyntaxKind.RecursivePattern);
+                    {
+                        N(SyntaxKind.LengthPatternClause);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ConstantPattern);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
         public void NoRegressionOnEmptyPropertyPattern()
         {
             UsingExpression(@"c is {}");

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests_ListPatterns.cs
@@ -1058,11 +1058,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         N(SyntaxKind.OpenBraceToken);
                         N(SyntaxKind.Subpattern);
                         {
-                            N(SyntaxKind.OrPattern);
+                            N(SyntaxKind.SlicePattern);
                             {
-                                N(SyntaxKind.SlicePattern);
+                                N(SyntaxKind.DotDotToken);
+                                N(SyntaxKind.OrPattern);
                                 {
-                                    N(SyntaxKind.DotDotToken);
                                     N(SyntaxKind.ConstantPattern);
                                     {
                                         N(SyntaxKind.IdentifierName);
@@ -1070,13 +1070,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                                             N(SyntaxKind.IdentifierToken, "p");
                                         }
                                     }
-                                }
-                                N(SyntaxKind.OrKeyword);
-                                N(SyntaxKind.ConstantPattern);
-                                {
-                                    N(SyntaxKind.IdentifierName);
+                                    N(SyntaxKind.OrKeyword);
+                                    N(SyntaxKind.ConstantPattern);
                                     {
-                                        N(SyntaxKind.IdentifierToken, "q");
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "q");
+                                        }
                                     }
                                 }
                             }
@@ -1107,11 +1107,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         N(SyntaxKind.OpenBraceToken);
                         N(SyntaxKind.Subpattern);
                         {
-                            N(SyntaxKind.OrPattern);
+                            N(SyntaxKind.SlicePattern);
                             {
-                                N(SyntaxKind.SlicePattern);
+                                N(SyntaxKind.DotDotToken);
+                                N(SyntaxKind.OrPattern);
                                 {
-                                    N(SyntaxKind.DotDotToken);
                                     N(SyntaxKind.ConstantPattern);
                                     {
                                         N(SyntaxKind.IdentifierName);
@@ -1119,16 +1119,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                                             N(SyntaxKind.IdentifierToken, "p");
                                         }
                                     }
-                                }
-                                N(SyntaxKind.OrKeyword);
-                                N(SyntaxKind.SlicePattern);
-                                {
-                                    N(SyntaxKind.DotDotToken);
-                                    N(SyntaxKind.ConstantPattern);
+                                    N(SyntaxKind.OrKeyword);
+                                    N(SyntaxKind.SlicePattern);
                                     {
-                                        N(SyntaxKind.IdentifierName);
+                                        N(SyntaxKind.DotDotToken);
+                                        N(SyntaxKind.ConstantPattern);
                                         {
-                                            N(SyntaxKind.IdentifierToken, "q");
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "q");
+                                            }
                                         }
                                     }
                                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests_ListPatterns.cs
@@ -735,7 +735,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             UsingExpression(@"c is {{}}");
             verify();
 
-            UsingExpression(@"c is {{}}", TestOptions.Regular9);
+            UsingExpression(@"c is {{}}", TestOptions.Regular9,
+                // (1,6): error CS8652: The feature 'list pattern' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // c is {{}}
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{{}}").WithArguments("list pattern").WithLocation(1, 6));
             verify();
 
             void verify()
@@ -831,6 +834,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             verify();
 
             UsingExpression(@"c is {..}", TestOptions.Regular9,
+                // (1,6): error CS8652: The feature 'list pattern' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // c is {..}
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{..}").WithArguments("list pattern").WithLocation(1, 6),
                 // (1,7): error CS8652: The feature 'slice pattern' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // c is {..}
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "..").WithArguments("slice pattern").WithLocation(1, 7));


### PR DESCRIPTION
In this PR:

- Add langversion check in the parser
- Relax slice subpattern to accept any pattern
- Support length patterns in combinators

Test plan: https://github.com/dotnet/roslyn/issues/51289