### PR TITLE
Always compute frozen partial documents in the BG to ensure any incurred IO is never on the UI thread.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -604,7 +604,7 @@ class D { }
                 if (hasX)
                 {
                     var doc2Z = cs.GetDocument(document2.Id);
-                    var partialDoc2Z = doc2Z.WithFrozenPartialSemantics(CancellationToken.None);
+                    var partialDoc2Z = await doc2Z.WithFrozenPartialSemanticsAsync(CancellationToken.None);
                     var compilation2Z = await partialDoc2Z.Project.GetCompilationAsync();
                     var classDz = compilation2Z.SourceModule.GlobalNamespace.GetTypeMembers("D").Single();
                     var classCz = classDz.BaseType;

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_ComputeModel.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                         AssertIsBackground();
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        var document = Controller.DocumentProvider.GetDocument(caretPosition.Snapshot, cancellationToken);
+                        var document = await Controller.DocumentProvider.GetDocumentAsync(caretPosition.Snapshot, cancellationToken).ConfigureAwait(false);
                         if (document == null)
                         {
                             return currentModel;

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             // parsing/loading.  For cross language projects, this also produces semantic classifications more quickly
             // as we do not have to wait on skeletons to be built.
 
-            document = document.WithFrozenPartialSemantics(context.CancellationToken);
+            document = await document.WithFrozenPartialSemanticsAsync(context.CancellationToken).ConfigureAwait(false);
             spanToTag = new DocumentSnapshotSpan(document, spanToTag.SnapshotSpan);
 
             var classified = await TryClassifyContainingMemberSpanAsync(

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 {
     internal interface IDocumentProvider
     {
-        Document GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken);
+        ValueTask<Document> GetDocumentAsync(ITextSnapshot snapshot, CancellationToken cancellationToken);
     }
 
     internal class DocumentProvider : ForegroundThreadAffinitizedObject, IDocumentProvider
@@ -24,10 +24,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
         {
         }
 
-        public Document GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken)
+        public ValueTask<Document> GetDocumentAsync(ITextSnapshot snapshot, CancellationToken cancellationToken)
         {
             AssertIsBackground();
-            return snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
+            return snapshot.AsText().GetDocumentWithFrozenPartialSemanticsAsync(cancellationToken);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             {
                 // When navigating, just use the partial semantics workspace.  Navigation doesn't need the fully bound
                 // compilations to be created, and it can save us a lot of costly time building skeleton assemblies.
-                var document = _subjectBuffer.CurrentSnapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
+                var document = await _subjectBuffer.CurrentSnapshot.AsText().GetDocumentWithFrozenPartialSemanticsAsync(cancellationToken).ConfigureAwait(false);
                 if (document != null)
                 {
                     var navBarService = document.GetRequiredLanguageService<INavigationBarItemService>();

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             // as this is just something that happens during solution load and will pass once that is over.  By using
             // partial semantics, we can ensure we don't spend an inordinate amount of time computing and using full
             // compilation data (like skeleton assemblies).
-            var document = snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
+            var document = await snapshot.AsText().GetDocumentWithFrozenPartialSemanticsAsync(cancellationToken).ConfigureAwait(false);
             if (document == null)
                 return null;
 

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <WpfFact>
         Public Sub InvokeSignatureHelpWithoutDocumentShouldNotStartNewSession()
             Dim emptyProvider = New Mock(Of IDocumentProvider)(MockBehavior.Strict)
-            emptyProvider.Setup(Function(p) p.GetDocument(It.IsAny(Of ITextSnapshot), It.IsAny(Of CancellationToken))).Returns(DirectCast(Nothing, Document))
+            emptyProvider.Setup(Function(p) p.GetDocumentAsync(It.IsAny(Of ITextSnapshot), It.IsAny(Of CancellationToken))).Returns(New ValueTask(Of Document)(DirectCast(Nothing, Document)))
             Dim controller As Controller = CreateController(documentProvider:=emptyProvider)
 
             GetMocks(controller).PresenterSession.Setup(Sub(p) p.Dismiss())
@@ -254,7 +254,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 New TypeCharCommandArgs(CreateMock(Of ITextView), CreateMock(Of ITextBuffer), "a"c),
                 Sub() GetMocks(controller).Buffer.Insert(0, "a"), TestCommandExecutionContext.Create())
 
-            GetMocks(controller).DocumentProvider.Verify(Function(p) p.GetDocument(It.IsAny(Of ITextSnapshot), It.IsAny(Of CancellationToken)), Times.Never)
+            GetMocks(controller).DocumentProvider.Verify(Function(p) p.GetDocumentAsync(It.IsAny(Of ITextSnapshot), It.IsAny(Of CancellationToken)), Times.Never)
         End Sub
 
         Private Shared ReadOnly s_controllerMocksMap As New ConditionalWeakTable(Of Controller, ControllerMocks)
@@ -288,7 +288,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim asyncListener = AsynchronousOperationListenerProvider.NullListener
             If documentProvider Is Nothing Then
                 documentProvider = New Mock(Of IDocumentProvider)(MockBehavior.Strict)
-                documentProvider.Setup(Function(p) p.GetDocument(It.IsAny(Of ITextSnapshot), It.IsAny(Of CancellationToken))).Returns(document)
+                documentProvider.Setup(Function(p) p.GetDocumentAsync(It.IsAny(Of ITextSnapshot), It.IsAny(Of CancellationToken))).Returns(New ValueTask(Of Document)(document))
             End If
 
             If provider Is Nothing Then

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 ' Use frozen partial semantics here.  We're operating on the UI thread, and we don't want to block the
                 ' user indefinitely while getting full semantics for this projects (which can require building all
                 ' projects we depend on).
-                Dim document = currentSnapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken)
+                Dim document = currentSnapshot.AsText().GetDocumentWithFrozenPartialSemanticsAsync(cancellationToken).AsTask().WaitAndGetResult(cancellationToken)
                 If document Is Nothing Then
                     Return
                 End If

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -274,7 +274,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                         return VSConstants.E_FAIL;
                     }
 
-                    var document = snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
+                    var document = snapshot.AsText().GetDocumentWithFrozenPartialSemanticsAsync(cancellationToken).AsTask().WaitAndGetResult(cancellationToken);
                     if (document != null)
                     {
                         var point = nullablePoint.Value;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
             else
             {
-                var frozenDocument = document.WithFrozenPartialSemantics(cancellationToken);
+                var frozenDocument = await document.WithFrozenPartialSemanticsAsync(cancellationToken).ConfigureAwait(false);
                 return await frozenDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis
         ///
         /// Use this method to gain access to potentially incomplete semantics quickly.
         /// </summary>
-        internal virtual Document WithFrozenPartialSemantics(CancellationToken cancellationToken)
+        internal virtual async ValueTask<Document> WithFrozenPartialSemanticsAsync(CancellationToken cancellationToken)
         {
             var solution = this.Project.Solution;
             var workspace = solution.Workspace;
@@ -456,7 +456,8 @@ namespace Microsoft.CodeAnalysis
                 workspace.PartialSemanticsEnabled &&
                 this.Project.SupportsCompilation)
             {
-                var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id, cancellationToken);
+                var newSolution = await this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocumentAsync(
+                    this.Id, cancellationToken).ConfigureAwait(false);
                 return newSolution.GetDocument(this.Id)!;
             }
             else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1631,9 +1631,9 @@ namespace Microsoft.CodeAnalysis
         /// 
         /// This not intended to be the public API, use Document.WithFrozenPartialSemantics() instead.
         /// </summary>
-        internal Solution WithFrozenPartialCompilationIncludingSpecificDocument(DocumentId documentId, CancellationToken cancellationToken)
+        internal async ValueTask<Solution> WithFrozenPartialCompilationIncludingSpecificDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
-            var newState = _state.WithFrozenPartialCompilationIncludingSpecificDocument(documentId, cancellationToken);
+            var newState = await _state.WithFrozenPartialCompilationIncludingSpecificDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
             return new Solution(newState);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -31,7 +32,7 @@ namespace Microsoft.CodeAnalysis
             // we'd need to potentially deal with the combination where that happens on a snapshot that was already
             // forked; rather than trying to deal with that combo we'll just fall back to not doing anything special
             // which is allowed.
-            return new(this);
+            return ValueTaskFactory.FromResult(this);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocument.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -24,13 +25,13 @@ namespace Microsoft.CodeAnalysis
         public string HintName => State.HintName;
         internal SourceGeneratedDocumentIdentity Identity => State.Identity;
 
-        internal override Document WithFrozenPartialSemantics(CancellationToken cancellationToken)
+        internal override ValueTask<Document> WithFrozenPartialSemanticsAsync(CancellationToken cancellationToken)
         {
             // For us to implement frozen partial semantics here with a source generated document,
             // we'd need to potentially deal with the combination where that happens on a snapshot that was already
             // forked; rather than trying to deal with that combo we'll just fall back to not doing anything special
             // which is allowed.
-            return this;
+            return new(this);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -114,10 +115,10 @@ namespace Microsoft.CodeAnalysis.Text
         /// with the specified text's container, or the text's container isn't associated with a workspace,
         /// then the method returns false.
         /// </summary>
-        internal static Document? GetDocumentWithFrozenPartialSemantics(this SourceText text, CancellationToken cancellationToken)
+        internal static async ValueTask<Document?> GetDocumentWithFrozenPartialSemanticsAsync(this SourceText text, CancellationToken cancellationToken)
         {
             var document = text.GetOpenDocumentInCurrentContextWithChanges();
-            return document?.WithFrozenPartialSemantics(cancellationToken);
+            return document == null ? null : await document.WithFrozenPartialSemanticsAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2567,7 +2567,7 @@ public class C : A {
         }
 
         [Fact]
-        public void TestFrozenPartialProjectAlwaysIsIncomplete()
+        public async Task TestFrozenPartialProjectAlwaysIsIncomplete()
         {
             var workspace = new AdhocWorkspace();
             var project1 = workspace.AddProject("CSharpProject", LanguageNames.CSharp);
@@ -2584,7 +2584,7 @@ public class C : A {
             var document = workspace.AddDocument(project2.Id, "Test.cs", SourceText.From(""));
 
             // Nothing should have incomplete references, and everything should build
-            var frozenSolution = document.WithFrozenPartialSemantics(CancellationToken.None).Project.Solution;
+            var frozenSolution = (await document.WithFrozenPartialSemanticsAsync(CancellationToken.None)).Project.Solution;
 
             Assert.True(frozenSolution.GetProject(project1.Id).HasSuccessfullyLoadedAsync().Result);
             Assert.True(frozenSolution.GetProject(project2.Id).HasSuccessfullyLoadedAsync().Result);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Equal(2, fullCompilation.SyntaxTrees.Count());
 
-            var partialProject = project.Documents.Single().WithFrozenPartialSemantics(CancellationToken.None).Project;
+            var partialProject = (await project.Documents.Single().WithFrozenPartialSemanticsAsync(CancellationToken.None)).Project;
             var partialCompilation = await partialProject.GetRequiredCompilationAsync(CancellationToken.None);
 
             Assert.Same(fullCompilation, partialCompilation);
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             await project.GetCompilationAsync();
 
             // Produce an in-progress snapshot
-            project = project.Documents.Single(d => d.Name == "RegularDocument.cs").WithFrozenPartialSemantics(CancellationToken.None).Project;
+            project = (await project.Documents.Single(d => d.Name == "RegularDocument.cs").WithFrozenPartialSemanticsAsync(CancellationToken.None)).Project;
 
             // The generated tree should still be there; even if the regular compilation fell away we've now cached the 
             // generated trees.

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -411,7 +411,7 @@ language: LanguageNames.CSharp);
             pws.SetParseOptions(projid, parseOptions.WithLanguageVersion(CS.LanguageVersion.CSharp3));
 
             // get partial semantics doc
-            var frozen = pws.CurrentSolution.GetDocument(docid1).WithFrozenPartialSemantics(CancellationToken.None);
+            var frozen = await pws.CurrentSolution.GetDocument(docid1).WithFrozenPartialSemanticsAsync(CancellationToken.None);
         }
 
         public class WorkspaceWithPartialSemantics : Workspace


### PR DESCRIPTION
Curious how we feel about this approach @jasonmalinowski 