### PR TITLE
Don't special case anonymous types when generating type syntax

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
@@ -40,14 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         private static TypeSyntax GenerateTypeSyntax(
             INamespaceOrTypeSymbol symbol, bool nameSyntax, bool allowVar = true)
         {
-            var type = symbol as ITypeSymbol;
-            if (type != null && type.ContainsAnonymousType())
-            {
-                // something with an anonymous type can only be represented with 'var', regardless
-                // of what the user's preferences might be.
-                return SyntaxFactory.IdentifierName("var");
-            }
-
             var syntax = symbol.Accept(TypeSyntaxGeneratorVisitor.Create(nameSyntax))!
                                .WithAdditionalAnnotations(Simplifier.Annotation);
 
@@ -56,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 syntax = syntax.WithAdditionalAnnotations(DoNotAllowVarAnnotation.Annotation);
             }
 
-            if (type != null && type.IsReferenceType)
+            if (symbol is ITypeSymbol { IsReferenceType: true })
             {
                 var additionalAnnotation = type.NullableAnnotation switch
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 syntax = syntax.WithAdditionalAnnotations(DoNotAllowVarAnnotation.Annotation);
             }
 
-            if (symbol is ITypeSymbol { IsReferenceType: true })
+            if (symbol is ITypeSymbol { IsReferenceType: true } type)
             {
                 var additionalAnnotation = type.NullableAnnotation switch
                 {


### PR DESCRIPTION
Related to: #53574
Draft to see what this will fail to get a sense of why this was needed ~~as I don't see an obvious reason.~~