### PR TITLE
Enable nullable reference types integration test harness

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonTraceListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonTraceListener.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 
@@ -11,7 +9,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 {
     internal class WatsonTraceListener : TraceListener
     {
-        public override void Fail(string message, string detailMessage)
+        public override void Fail(string? message, string? detailMessage)
         {
             if (string.IsNullOrEmpty(message))
             {
@@ -27,7 +25,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void Write(object o)
+        public override void Write(object? o)
         {
             if (Debugger.IsLogging())
             {
@@ -35,7 +33,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void Write(object o, string category)
+        public override void Write(object? o, string? category)
         {
             if (Debugger.IsLogging())
             {
@@ -43,7 +41,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void Write(string message)
+        public override void Write(string? message)
         {
             if (Debugger.IsLogging())
             {
@@ -51,7 +49,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void Write(string message, string category)
+        public override void Write(string? message, string? category)
         {
             if (Debugger.IsLogging())
             {
@@ -59,7 +57,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void WriteLine(object o)
+        public override void WriteLine(object? o)
         {
             if (Debugger.IsLogging())
             {
@@ -67,7 +65,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void WriteLine(object o, string category)
+        public override void WriteLine(object? o, string? category)
         {
             if (Debugger.IsLogging())
             {
@@ -75,7 +73,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void WriteLine(string message)
+        public override void WriteLine(string? message)
         {
             if (Debugger.IsLogging())
             {
@@ -83,7 +81,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        public override void WriteLine(string message, string category)
+        public override void WriteLine(string? message, string? category)
         {
             if (Debugger.IsLogging())
             {
@@ -91,7 +89,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        private static void Exit(string message)
+        private static void Exit(string? message)
         {
             FatalError.ReportAndPropagate(new Exception(message));
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationService/IntegrationService.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationService/IntegrationService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -49,7 +47,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             return (IntegrationService)Activator.GetObject(typeof(IntegrationService), uri);
         }
 
-        public string Execute(string assemblyFilePath, string typeFullName, string methodName)
+        public string? Execute(string assemblyFilePath, string typeFullName, string methodName)
         {
             var assembly = Assembly.LoadFrom(assemblyFilePath);
             var type = assembly.GetType(typeFullName);
@@ -76,7 +74,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         }
 
         // Ensure InProcComponents live forever
-        public override object InitializeLifetimeService()
+        public override object? InitializeLifetimeService()
             => null;
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestSetup/AsyncCompletionTracker.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/AsyncCompletionTracker.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;
@@ -56,7 +54,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Setup
 
             // Local function
             void ReleaseToken(object sender, EventArgs e)
-                => Interlocked.Exchange(ref token, null)?.Dispose();
+                => Interlocked.Exchange<IAsyncToken?>(ref token, null)?.Dispose();
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestSetup/EmptyFeatureController.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/EmptyFeatureController.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Setup

--- a/src/VisualStudio/IntegrationTest/TestSetup/IntegrationTestServiceCommands.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/IntegrationTestServiceCommands.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -44,38 +42,39 @@ namespace Microsoft.VisualStudio.IntegrationTest.Setup
         private readonly MenuCommand _startMenuCmd;
         private readonly MenuCommand _stopMenuCmd;
 
-        private IntegrationService _service;
-        private IpcServerChannel _serviceChannel;
+        private IntegrationService? _service;
+        private IpcServerChannel? _serviceChannel;
 
 #pragma warning disable IDE0052 // Remove unread private members - used to hold the marshalled integration test service
-        private ObjRef _marshalledService;
+        private ObjRef? _marshalledService;
 #pragma warning restore IDE0052 // Remove unread private members
 
         private IntegrationTestServiceCommands(Package package)
         {
             _package = package ?? throw new ArgumentNullException(nameof(package));
 
+            var startMenuCmdId = new CommandID(guidTestWindowCmdSet, cmdidStartIntegrationTestService);
+            _startMenuCmd = new MenuCommand(StartServiceCallback, startMenuCmdId)
+            {
+                Enabled = true,
+                Visible = true
+            };
+
+            var stopMenuCmdId = new CommandID(guidTestWindowCmdSet, cmdidStopIntegrationTestService);
+            _stopMenuCmd = new MenuCommand(StopServiceCallback, stopMenuCmdId)
+            {
+                Enabled = false,
+                Visible = false
+            };
+
             if (ServiceProvider.GetService(typeof(IMenuCommandService)) is OleMenuCommandService menuCommandService)
             {
-                var startMenuCmdId = new CommandID(guidTestWindowCmdSet, cmdidStartIntegrationTestService);
-                _startMenuCmd = new MenuCommand(StartServiceCallback, startMenuCmdId)
-                {
-                    Enabled = true,
-                    Visible = true
-                };
                 menuCommandService.AddCommand(_startMenuCmd);
-
-                var stopMenuCmdId = new CommandID(guidTestWindowCmdSet, cmdidStopIntegrationTestService);
-                _stopMenuCmd = new MenuCommand(StopServiceCallback, stopMenuCmdId)
-                {
-                    Enabled = false,
-                    Visible = false
-                };
                 menuCommandService.AddCommand(_stopMenuCmd);
             }
         }
 
-        public static IntegrationTestServiceCommands Instance { get; private set; }
+        public static IntegrationTestServiceCommands? Instance { get; private set; }
 
         private IServiceProvider ServiceProvider => _package;
 

--- a/src/VisualStudio/IntegrationTest/TestSetup/IntegrationTestServicePackage.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/IntegrationTestServicePackage.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionErrorHandler.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionErrorHandler.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading.Tasks;

--- a/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionManager.cs
+++ b/src/VisualStudio/IntegrationTest/TestSetup/TestExtensionManager.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Extensions;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/AutomationElementExtensions.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/AutomationElementExtensions.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading;
 using UIAutomationClient;
@@ -275,10 +274,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             return item;
         }
 
+        [DoesNotReturn]
         private static void ThrowUnableToFindChildException(string path, IUIAutomationElement item)
         {
             // if not found, build a list of available children for debugging purposes
-            var validChildren = new List<string>();
+            var validChildren = new List<string?>();
 
             try
             {
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 string.Join(", ", validChildren)));
         }
 
-        private static string SimpleControlTypeName(IUIAutomationElement element)
+        private static string? SimpleControlTypeName(IUIAutomationElement element)
         {
             var type = ControlType.LookupById((int)element.GetCurrentPropertyValue(AutomationElementIdentifiers.ControlTypeProperty.Id));
             return type?.LocalizedControlType;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/AutomationElementHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/AutomationElementHelper.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 using UIAutomationClient;
 using AutomationElementIdentifiers = System.Windows.Automation.AutomationElementIdentifiers;
 
@@ -23,14 +22,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             if (element != null)
             {
-                var tcs = new TaskCompletionSource<object>();
+                var tcs = new TaskCompletionSource<VoidResult>();
 
                 Helper.Automation.AddAutomationEventHandler(
                     UIA_EventIds.UIA_Invoke_InvokedEventId,
                     element,
                     TreeScope.TreeScope_Element,
                     cacheRequest: null,
-                    new AutomationEventHandler((src, e) => tcs.SetResult(null)));
+                    new AutomationEventHandler((src, e) => tcs.SetResult(default)));
 
                 element.Invoke();
                 await tcs.Task;
@@ -45,7 +44,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
         public static async Task<IUIAutomationElement> FindAutomationElementAsync(string elementName, bool recursive = false)
         {
-            IUIAutomationElement element = null;
+            IUIAutomationElement? element = null;
             var scope = recursive ? TreeScope.TreeScope_Descendants : TreeScope.TreeScope_Children;
             var condition = Helper.Automation.CreatePropertyCondition(AutomationElementIdentifiers.NameProperty.Id, elementName);
 
@@ -55,6 +54,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 () => (element = Helper.Automation.GetRootElement().FindFirst(scope, condition)) != null, expectedResult: true
             ).ConfigureAwait(false);
 
+            Contract.ThrowIfNull(element);
             return element;
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/CaptureTestNameAttribute.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/CaptureTestNameAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Reflection;
 using Xunit.Sdk;
 
@@ -20,7 +18,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// The name of the currently running test, or null if no test is running.
         /// The format is test_class_name.method_name.
         /// </summary>
-        public static string CurrentName { get; set; }
+        public static string? CurrentName { get; set; }
 
         public override void Before(MethodInfo methodUnderTest)
         {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/ClassifiedToken.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/ClassifiedToken.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
-using System.Runtime.Serialization;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
 {
-    [System.Serializable]
+    [Serializable]
     public struct ClassifiedToken
     {
         public ClassifiedToken(string text, string classification)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/Comparison.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/Comparison.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -11,11 +9,17 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
 {
     internal static class Comparison
     {
-        public static bool AreStringValuesEqual(string str1, string str2)
+        public static bool AreStringValuesEqual(string? str1, string? str2)
             => (str1 ?? "") == (str2 ?? "");
 
-        public static bool AreArraysEqual<T>(T[] array1, T[] array2) where T : IEquatable<T>
+        public static bool AreArraysEqual<T>(T[]? array1, T[]? array2) where T : IEquatable<T>
         {
+            if (array1 is null || array2 is null)
+            {
+                // both must be null
+                return array1 == array2;
+            }
+
             if (array1.Length != array2.Length)
             {
                 return false;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/ErrorListItem.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/ErrorListItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Roslyn.Utilities;
 
@@ -29,7 +27,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
             Column = column;
         }
 
-        public bool Equals(ErrorListItem other)
+        public bool Equals(ErrorListItem? other)
             => other != null
             && Comparison.AreStringValuesEqual(Severity, other.Severity)
             && Comparison.AreStringValuesEqual(Description, other.Description)
@@ -38,7 +36,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
             && Line == other.Line
             && Column == other.Column;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => Equals(obj as ErrorListItem);
 
         public override int GetHashCode()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/Expression.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/Expression.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/Parameter.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/Parameter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Roslyn.Utilities;
@@ -13,9 +11,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
     [Serializable]
     public class Parameter : IEquatable<Parameter>
     {
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
-        public string Documentation { get; set; }
+        public string? Documentation { get; set; }
 
         public Parameter() { }
 
@@ -25,7 +23,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
             Documentation = actual.Documentation;
         }
 
-        public bool Equals(Parameter other)
+        public bool Equals(Parameter? other)
         {
             if (other == null)
             {
@@ -36,13 +34,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
                 && Comparison.AreStringValuesEqual(Documentation, other.Documentation);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => Equals(obj as Parameter);
 
         public override int GetHashCode()
             => Hash.Combine(Name, Hash.Combine(Documentation, 0));
 
         public override string ToString()
-            => !string.IsNullOrEmpty(Documentation) ? $"{Name} ({Documentation})" : Name;
+            => !string.IsNullOrEmpty(Documentation) ? $"{Name} ({Documentation})" : $"{Name}";
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
@@ -2,23 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.IO;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils
 {
     public abstract class Identity
     {
-        public string Name { get; protected set; }
+        protected Identity(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
     }
 
     public class Project : Identity
     {
-        public Project(string name, string projectExtension = ".csproj", string relativePath = null)
+        public Project(string name, string projectExtension = ".csproj", string? relativePath = null)
+            : base(name)
         {
-            Name = name;
-
             if (string.IsNullOrWhiteSpace(relativePath))
             {
                 RelativePath = Path.Combine(name, name + projectExtension);
@@ -32,22 +34,22 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils
         /// <summary>
         /// This path is relative to the Solution file. Default value is set to ProjectName\ProjectName.csproj
         /// </summary>
-        public string RelativePath { get; }
+        public string? RelativePath { get; }
     }
 
     public class ProjectReference : Identity
     {
         public ProjectReference(string name)
+            : base(name)
         {
-            Name = name;
         }
     }
 
     public class AssemblyReference : Identity
     {
         public AssemblyReference(string name)
+            : base(name)
         {
-            Name = name;
         }
     }
 
@@ -56,8 +58,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils
         public string Version { get; }
 
         public PackageReference(string name, string version)
+            : base(name)
         {
-            Name = name;
             Version = version;
         }
     }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/Reference.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/Reference.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Roslyn.Utilities;
 
@@ -15,27 +13,27 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
     [Serializable]
     public class Reference : IEquatable<Reference>
     {
-        public string FilePath { get; set; }
+        public string? FilePath { get; set; }
         public int Line { get; set; }
         public int Column { get; set; }
-        public string Code { get; set; }
+        public string? Code { get; set; }
 
         public Reference() { }
 
-        public bool Equals(Reference other)
+        public bool Equals(Reference? other)
         {
             if (other == null)
             {
                 return false;
             }
 
-            return FilePath.Equals(other.FilePath, StringComparison.OrdinalIgnoreCase)
+            return string.Equals(FilePath, other.FilePath, StringComparison.OrdinalIgnoreCase)
                 && Line == other.Line
                 && Column == other.Column
-                && Code.Equals(other.Code);
+                && string.Equals(Code, other.Code, StringComparison.Ordinal);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => Equals(obj as Reference);
 
         public override int GetHashCode()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/Signature.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/Signature.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Text;
@@ -15,15 +13,15 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
     [Serializable]
     public class Signature : IEquatable<Signature>
     {
-        public string Content { get; set; }
+        public string? Content { get; set; }
 
-        public Parameter CurrentParameter { get; set; }
+        public Parameter? CurrentParameter { get; set; }
 
-        public string Documentation { get; set; }
+        public string? Documentation { get; set; }
 
-        public Parameter[] Parameters { get; set; }
+        public Parameter[]? Parameters { get; set; }
 
-        public string PrettyPrintedContent { get; set; }
+        public string? PrettyPrintedContent { get; set; }
 
         public Signature() { }
 
@@ -41,7 +39,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
             PrettyPrintedContent = actual.PrettyPrintedContent;
         }
 
-        public bool Equals(Signature other)
+        public bool Equals(Signature? other)
             => other != null
             && Comparison.AreStringValuesEqual(Content, other.Content)
             && Equals(CurrentParameter, other.CurrentParameter)
@@ -49,7 +47,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common
             && Comparison.AreStringValuesEqual(Documentation, other.Documentation)
             && Comparison.AreArraysEqual(Parameters, other.Parameters);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => Equals(obj as Signature);
 
         public override int GetHashCode()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/DialogHelpers.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/DialogHelpers.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Linq;
@@ -211,8 +210,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                     if (IsLastDayOrLastFiveRecentEntry(eventLogRecord, dotNetEntries.Count))
                     {
                         // Filter the entries by .NetRuntime specific ones
-                        FeedbackItemDotNetEntry entry = null;
-                        if (IsValidDotNetEntry(eventLogRecord, ref entry))
+                        if (IsValidDotNetEntry(eventLogRecord, out var entry))
                         {
                             dotNetEntries.Add(entry);
                         }
@@ -285,7 +283,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// the provider, if it's for certain event log IDs and for VS related EXEs
         /// </summary>
         /// <param name="eventLogRecord">Entry to be checked</param>
-        private static bool IsValidDotNetEntry(EventRecord eventLogRecord, ref FeedbackItemDotNetEntry dotNetEntry)
+        private static bool IsValidDotNetEntry(EventRecord eventLogRecord, [NotNullWhen(true)] out FeedbackItemDotNetEntry? dotNetEntry)
         {
             if (StringComparer.InvariantCultureIgnoreCase.Equals(eventLogRecord.ProviderName, DotNetProviderName)
                  && s_dotNetEventId.Contains(eventLogRecord.Id))
@@ -300,6 +298,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 }
             }
 
+            dotNetEntry = null;
             return false;
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/FeedbackItemDotNetEntry.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/FeedbackItemDotNetEntry.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics.Eventing.Reader;
 using System.Linq;
@@ -45,7 +43,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// </summary>
         public FeedbackItemDotNetEntry(EventRecord eventLogRecord)
         {
-            EventTime = eventLogRecord.TimeCreated.Value.ToUniversalTime();
+            EventTime = eventLogRecord.TimeCreated?.ToUniversalTime() ?? DateTime.MinValue;
             EventId = eventLogRecord.Id;
             Data = string.Join(";", eventLogRecord.Properties.Select(pr => pr.Value ?? string.Empty));
         }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/FeedbackItemWatsonEntry.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/FeedbackItemWatsonEntry.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics.Eventing.Reader;
 using System.Runtime.Serialization;
@@ -126,7 +124,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// </summary>
         public FeedbackItemWatsonEntry(EventRecord eventLogRecord)
         {
-            EventTime = eventLogRecord.TimeCreated.Value.ToUniversalTime();
+            EventTime = eventLogRecord.TimeCreated?.ToUniversalTime() ?? DateTime.MinValue;
             FaultBucket = EventLogCollector.GetEventRecordPropertyToString(eventLogRecord, FaultBucketIndex);
             HashedBucket = EventLogCollector.GetEventRecordPropertyToString(eventLogRecord, HashedBucketIndex);
             WatsonReportId = EventLogCollector.GetEventRecordPropertyToString(eventLogRecord, WatsonReportIdIndex);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Harness/MessageFilter.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Harness/MessageFilter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using IMessageFilter = Microsoft.VisualStudio.OLE.Interop.IMessageFilter;
 using INTERFACEINFO = Microsoft.VisualStudio.OLE.Interop.INTERFACEINFO;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Harness/MessageFilterSafeHandle.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Harness/MessageFilterSafeHandle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/AbstractCodeRefactorDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/AbstractCodeRefactorDialog_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/AddParameterDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/AddParameterDialog_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature;
 using Microsoft.VisualStudio.Threading;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/CSharpInteractiveWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/CSharpInteractiveWindow_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.LanguageServices.CSharp.Interactive;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ChangeSignatureDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ChangeSignatureDialog_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Debugger_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Debugger_InProc.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
-using EnvDTE;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -34,6 +32,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 using UIAutomationClient;
+using Xunit;
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
@@ -77,10 +76,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             var (textViewHost, hr) = TryGetActiveTextViewHost();
             Marshal.ThrowExceptionForHR(hr);
+            Contract.ThrowIfNull(textViewHost);
+
             return textViewHost;
         }
 
-        private static (IWpfTextViewHost textViewHost, int hr) TryGetActiveTextViewHost()
+        private static (IWpfTextViewHost? textViewHost, int hr) TryGetActiveTextViewHost()
         {
             // The active text view might not have finished composing yet, waiting for the application to 'idle'
             // means that it is done pumping messages (including WM_PAINT) and the window should return the correct text view
@@ -258,6 +259,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => ExecuteOnActiveView(view =>
             {
                 var subjectBuffer = view.GetBufferContainingCaret();
+                Contract.ThrowIfNull(subjectBuffer);
+
                 var selectedSpan = view.Selection.SelectedSpans[0];
                 return subjectBuffer.CurrentSnapshot.GetText(selectedSpan);
             });
@@ -266,6 +269,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => ExecuteOnActiveView(view =>
             {
                 var subjectBuffer = view.GetBufferContainingCaret();
+                Contract.ThrowIfNull(subjectBuffer);
+
                 var point = new SnapshotPoint(subjectBuffer.CurrentSnapshot, position);
 
                 view.Caret.MoveTo(point);
@@ -291,7 +296,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         private string PrintSpan(SnapshotSpan span)
                 => $"'{span.GetText().Replace("\\", "\\\\").Replace("\r", "\\r").Replace("\n", "\\n")}'[{span.Start.Position}-{span.Start.Position + span.Length}]";
 
-        private string[] GetTags<TTag>(Predicate<TTag> filter = null)
+        private string[] GetTags<TTag>(Predicate<TTag>? filter = null)
             where TTag : ITag
         {
             bool Filter(TTag tag)
@@ -412,7 +417,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                         string.Format("ISuggestionAction {0} not found.  Buffer content type={1}", menuText, bufferType));
                 }
 
-                IWpfTextView preview = null;
+                IWpfTextView? preview = null;
                 var pane = await set.GetPreviewAsync(CancellationToken.None).ConfigureAwait(true);
                 if (pane is System.Windows.Controls.UserControl)
                 {
@@ -436,7 +441,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return Array.Empty<ClassifiedToken>();
         }
 
-        private static IEnumerable<T> FindDescendants<T>(DependencyObject rootObject) where T : DependencyObject
+        private static IEnumerable<T> FindDescendants<T>(DependencyObject? rootObject) where T : DependencyObject
         {
             if (rootObject != null)
             {
@@ -595,7 +600,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
         }
 
-        public void EditWinFormButtonProperty(string buttonName, string propertyName, string propertyValue, string propertyTypeName = null)
+        public void EditWinFormButtonProperty(string buttonName, string propertyName, string propertyValue, string? propertyTypeName = null)
         {
             using (var waitHandle = new ManualResetEvent(false))
             {
@@ -693,7 +698,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
         }
 
-        public string GetWinFormButtonPropertyValue(string buttonName, string propertyName)
+        public string? GetWinFormButtonPropertyValue(string buttonName, string propertyName)
         {
             var designerHost = (IDesignerHost)GetDTE().ActiveWindow.Object;
             var button = designerHost.Container.Components[buttonName];
@@ -746,7 +751,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 GetActiveVsTextView().GetBuffer(out var textLines);
                 Marshal.ThrowExceptionForHR(textLines.GetLanguageServiceID(out var languageServiceGuid));
                 Marshal.ThrowExceptionForHR(Microsoft.VisualStudio.Shell.ServiceProvider.GlobalProvider.QueryService(languageServiceGuid, out var languageService));
-                var languageContextProvider = languageService as IVsLanguageContextProvider;
+                var languageContextProvider = (IVsLanguageContextProvider)languageService;
 
                 var monitorUserContext = GetGlobalService<SVsMonitorUserContext, IVsMonitorUserContext>();
                 Marshal.ThrowExceptionForHR(monitorUserContext.CreateEmptyContext(out var emptyUserContext));

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc_NavigationBar.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc_NavigationBar.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,6 +16,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 using IObjectWithSite = Microsoft.VisualStudio.OLE.Interop.IObjectWithSite;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 {
     internal partial class Editor_InProc
     {
-        public string GetSelectedNavBarItem(int comboBoxIndex)
+        public string? GetSelectedNavBarItem(int comboBoxIndex)
             => ExecuteOnActiveView(v => GetNavigationBarComboBoxes(v)[comboBoxIndex].SelectedItem?.ToString());
 
         public string[] GetNavBarItems(int comboBoxIndex)
@@ -92,23 +91,28 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return combos;
         }
 
-        private static UIElement GetNavbar(IWpfTextView textView)
+        private static UIElement? GetNavbar(IWpfTextView textView)
         {
             // Visual Studio 2019
             var editorAdaptersFactoryService = GetComponentModelService<IVsEditorAdaptersFactoryService>();
             var viewAdapter = editorAdaptersFactoryService.GetViewAdapter(textView);
+            Contract.ThrowIfNull(viewAdapter);
 
             // Make sure we have the top pane
             //
             // The docs are wrong. When a secondary view exists, it is the secondary view which is on top. The primary
             // view is only on top when there is no secondary view.
             var codeWindow = TryGetCodeWindow(viewAdapter);
+            Contract.ThrowIfNull(codeWindow);
+
             if (ErrorHandler.Succeeded(codeWindow.GetSecondaryView(out var secondaryViewAdapter)))
             {
                 viewAdapter = secondaryViewAdapter;
             }
 
             var textViewHost = editorAdaptersFactoryService.GetWpfTextViewHost(viewAdapter);
+            Contract.ThrowIfNull(textViewHost);
+
             var dropDownMargin = textViewHost.GetTextViewMargin("DropDownMargin");
             if (dropDownMargin != null)
             {
@@ -132,7 +136,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return vsDropDownBarAdapterMargin;
         }
 
-        private static IVsCodeWindow TryGetCodeWindow(IVsTextView textView)
+        private static IVsCodeWindow? TryGetCodeWindow(IVsTextView textView)
         {
             if (textView == null)
             {
@@ -151,7 +155,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 return null;
             }
 
-            IOleServiceProvider oleServiceProvider = null;
+            IOleServiceProvider? oleServiceProvider = null;
             try
             {
                 oleServiceProvider = Marshal.GetObjectForIUnknown(ppvSite) as IOleServiceProvider;
@@ -173,10 +177,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 return null;
             }
 
-            IVsWindowFrame frame = null;
+            IVsWindowFrame? frame = null;
             try
             {
-                frame = Marshal.GetObjectForIUnknown(ppvObject) as IVsWindowFrame;
+                frame = (IVsWindowFrame)Marshal.GetObjectForIUnknown(ppvObject);
             }
             finally
             {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ErrorList_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ErrorList_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -150,7 +148,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public static string GetProject(this IVsTaskItem item)
         {
-            var errorItem = item as IVsErrorItem;
+            var errorItem = (IVsErrorItem)item;
             ErrorHandler.ThrowOnFailure(errorItem.GetHierarchy(out var hierarchy));
             ErrorHandler.ThrowOnFailure(hierarchy.GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID.VSHPROPID_Name, out var name));
             return (string)name;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ExtractInterfaceDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ExtractInterfaceDialog_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/FindReferencesWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/FindReferencesWindow_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using EnvDTE80;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/GenerateTypeDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/GenerateTypeDialog_InProc.cs
@@ -2,15 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls.Primitives;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType;
 using Roslyn.Utilities;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Windows;
@@ -29,7 +27,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
     /// </summary>
     internal abstract class InProcComponent : MarshalByRefObject
     {
-        private static JoinableTaskFactory _joinableTaskFactory;
+        private static JoinableTaskFactory? _joinableTaskFactory;
 
         protected InProcComponent() { }
 
@@ -114,6 +112,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 #pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
 
         // Ensure InProcComponents live forever
-        public override object InitializeLifetimeService() => null;
+        public override object? InitializeLifetimeService() => null;
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/LocalsWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/LocalsWindow_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,7 +34,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
 
             var expressions = dte.Debugger.CurrentStackFrame.Locals;
-            EnvDTE.Expression entry = null;
+            EnvDTE.Expression? entry = null;
 
             var i = 0;
             while (i < entryNames.Length && TryGetEntryInternal(entryNames[i], expressions, out entry))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/MoveToNamespaceDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/MoveToNamespaceDialog_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ObjectBrowserWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ObjectBrowserWindow_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/PickMembersDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/PickMembersDialog_InProc.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls.Primitives;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.PickMembers;
 using Roslyn.Utilities;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/QuickInfoToStringConverter.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/QuickInfoToStringConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,7 +20,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return string.Join(Environment.NewLine, content.Select(GetStringFromItem));
         }
 
-        private static string GetStringFromItem(object item)
+        private static string? GetStringFromItem(object item)
         {
             switch (item)
             {
@@ -91,7 +89,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
         }
 
-        private static string GetStringFromInline(Inline currentInline)
+        private static string? GetStringFromInline(Inline currentInline)
         {
             if (currentInline is LineBreak)
             {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -32,8 +30,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
     internal class SolutionExplorer_InProc : InProcComponent
     {
         private readonly SendKeys_InProc _sendKeys;
-        private Solution2 _solution;
-        private string _fileName;
+        private Solution2? _solution;
+        private string? _fileName;
 
         private static readonly Lazy<IDictionary<string, string>> _csharpProjectTemplates = new Lazy<IDictionary<string, string>>(InitializeCSharpProjectTemplates);
         private static readonly Lazy<IDictionary<string, string>> _visualBasicProjectTemplates = new Lazy<IDictionary<string, string>>(InitializeVisualBasicProjectTemplates);
@@ -116,6 +114,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             get
             {
+                Contract.ThrowIfNull(_solution);
+                Contract.ThrowIfNull(_fileName);
+
                 var solutionFullName = _solution.FullName;
 
                 return string.IsNullOrEmpty(solutionFullName)
@@ -245,6 +246,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var projectPath = Path.Combine(DirectoryName, projectName);
             var projectTemplatePath = GetProjectTemplatePath(projectTemplate, ConvertLanguageName(languageName));
 
+            Contract.ThrowIfNull(_solution);
             _solution.AddFromTemplate(projectTemplatePath, projectPath, projectName, Exclusive: false);
             foreach (var documentElement in projectElement.Elements("Document"))
             {
@@ -350,6 +352,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
             var projectTemplatePath = GetProjectTemplatePath(projectTemplate, ConvertLanguageName(languageName));
 
+            Contract.ThrowIfNull(_solution);
             _solution.AddFromTemplate(projectTemplatePath, projectPath, projectName, Exclusive: false);
         }
 
@@ -361,12 +364,15 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var projectFilePath = Path.Combine(projectPath, projectName + projectFileExtension);
             File.WriteAllText(projectFilePath, projectFileContent);
 
+            Contract.ThrowIfNull(_solution);
             _solution.AddFromFile(projectFilePath);
         }
 
         // TODO: Adjust language name based on whether we are using a web template
         private string GetProjectTemplatePath(string projectTemplate, string languageName)
         {
+            Contract.ThrowIfNull(_solution);
+
             if (languageName.Equals("csharp", StringComparison.OrdinalIgnoreCase) &&
                _csharpProjectTemplates.Value.TryGetValue(projectTemplate, out var csharpProjectTemplate))
             {
@@ -511,7 +517,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 ErrorHandler.ThrowOnFailure(solution.AdviseSolutionEvents(this, out _cookie));
             }
 
-            public event EventHandler AfterCloseSolution;
+            public event EventHandler? AfterCloseSolution;
 
             public void Dispose()
             {
@@ -574,9 +580,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         }
 
         private EnvDTE.Project GetProject(string nameOrFileName)
-            => _solution.Projects.OfType<EnvDTE.Project>().First(p
-                => string.Compare(p.FileName, nameOrFileName, StringComparison.OrdinalIgnoreCase) == 0
-                || string.Compare(p.Name, nameOrFileName, StringComparison.OrdinalIgnoreCase) == 0);
+        {
+            Contract.ThrowIfNull(_solution);
+            return _solution.Projects.OfType<EnvDTE.Project>().First(
+                p => string.Compare(p.FileName, nameOrFileName, StringComparison.OrdinalIgnoreCase) == 0
+                    || string.Compare(p.Name, nameOrFileName, StringComparison.OrdinalIgnoreCase) == 0);
+        }
 
         /// <summary>
         /// Update the given file if it already exists in the project, otherwise add a new file to the project.
@@ -585,7 +594,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         /// <param name="fileName">The name of the file to update or add.</param>
         /// <param name="contents">The contents of the file to overwrite if the file already exists or set if the file it created. Empty string is used if null is passed.</param>
         /// <param name="open">Whether to open the file after it has been updated/created.</param>
-        public void UpdateOrAddFile(string projectName, string fileName, string contents = null, bool open = false)
+        public void UpdateOrAddFile(string projectName, string fileName, string? contents = null, bool open = false)
         {
             var project = GetProject(projectName);
             if (project.ProjectItems.Cast<EnvDTE.ProjectItem>().Any(x => x.Name == fileName))
@@ -605,7 +614,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         /// <param name="fileName">The name of the file to update or add.</param>
         /// <param name="contents">The contents of the file to overwrite. Empty string is used if null is passed.</param>
         /// <param name="open">Whether to open the file after it has been updated.</param>
-        public void UpdateFile(string projectName, string fileName, string contents = null, bool open = false)
+        public void UpdateFile(string projectName, string fileName, string? contents = null, bool open = false)
         {
             void SetText(string text)
             {
@@ -646,7 +655,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         /// <param name="fileName">The name of the file to add.</param>
         /// <param name="contents">The contents of the file to overwrite. An empty file is create if null is passed.</param>
         /// <param name="open">Whether to open the file after it has been updated.</param>
-        public void AddFile(string projectName, string fileName, string contents = null, bool open = false)
+        public void AddFile(string projectName, string fileName, string? contents = null, bool open = false)
         {
             var project = GetProject(projectName);
             var projectDirectory = Path.GetDirectoryName(project.FullName);
@@ -771,13 +780,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             internal delegate void UpdateProjectConfigDoneEvent(IVsHierarchy projectHierarchy, IVsCfg projectConfig, int success);
             internal delegate void UpdateProjectConfigBeginEvent(IVsHierarchy projectHierarchy, IVsCfg projectConfig);
 
-            public event UpdateSolutionDoneEvent OnUpdateSolutionDone;
-            public event UpdateSolutionBeginEvent OnUpdateSolutionBegin;
-            public event UpdateSolutionStartUpdateEvent OnUpdateSolutionStartUpdate;
-            public event Action OnActiveProjectConfigurationChange;
-            public event Action OnUpdateSolutionCancel;
-            public event UpdateProjectConfigDoneEvent OnUpdateProjectConfigDone;
-            public event UpdateProjectConfigBeginEvent OnUpdateProjectConfigBegin;
+            public event UpdateSolutionDoneEvent? OnUpdateSolutionDone;
+            public event UpdateSolutionBeginEvent? OnUpdateSolutionBegin;
+            public event UpdateSolutionStartUpdateEvent? OnUpdateSolutionStartUpdate;
+            public event Action? OnActiveProjectConfigurationChange;
+            public event Action? OnUpdateSolutionCancel;
+            public event UpdateProjectConfigDoneEvent? OnUpdateProjectConfigDone;
+            public event UpdateProjectConfigBeginEvent? OnUpdateProjectConfigBegin;
 
             internal UpdateSolutionEvents(IVsSolutionBuildManager2 solutionBuildManager)
             {
@@ -970,6 +979,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         private EnvDTE.ProjectItem GetProjectItem(string projectName, string relativeFilePath)
         {
+            Contract.ThrowIfNull(_solution);
             var projects = _solution.Projects.Cast<EnvDTE.Project>();
             var project = projects.FirstOrDefault(x => x.Name == projectName);
 
@@ -1011,6 +1021,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         private string GetAbsolutePathForProjectRelativeFilePath(string projectName, string relativeFilePath)
         {
+            Contract.ThrowIfNull(_solution);
             var project = _solution.Projects.Cast<EnvDTE.Project>().First(x => x.Name == projectName);
             var projectPath = Path.GetDirectoryName(project.FullName);
             return Path.Combine(projectPath, relativeFilePath);
@@ -1018,6 +1029,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void ReloadProject(string projectRelativePath)
         {
+            Contract.ThrowIfNull(_solution);
             var solutionPath = Path.GetDirectoryName(_solution.FullName);
             var projectPath = Path.Combine(solutionPath, projectRelativePath);
             _solution.AddFromFile(projectPath);
@@ -1044,8 +1056,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void UnloadProject(string projectName)
         {
+            Contract.ThrowIfNull(_solution);
             var projects = _solution.Projects;
-            EnvDTE.Project project = null;
+            EnvDTE.Project? project = null;
             for (var i = 1; i <= projects.Count; i++)
             {
                 project = projects.Item(i);
@@ -1064,6 +1077,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var solutionExplorer = dte.ToolWindows.SolutionExplorer;
 
             var item = FindFirstItemRecursively(solutionExplorer.UIHierarchyItems, itemName);
+            Contract.ThrowIfNull(item);
+
             item.Select(EnvDTE.vsUISelectionType.vsUISelectionTypeSelect);
             solutionExplorer.Parent.Activate();
         }
@@ -1074,6 +1089,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var solutionExplorer = dte.ToolWindows.SolutionExplorer;
 
             var item = FindItemAtPath(solutionExplorer.UIHierarchyItems, path);
+            Contract.ThrowIfNull(item);
+
             item.Select(EnvDTE.vsUISelectionType.vsUISelectionTypeSelect);
             solutionExplorer.Parent.Activate();
         }
@@ -1084,6 +1101,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var solutionExplorer = dte.ToolWindows.SolutionExplorer;
 
             var item = FindFirstItemRecursively(solutionExplorer.UIHierarchyItems, itemName);
+            Contract.ThrowIfNull(item);
 
             return item.UIHierarchyItems
                 .Cast<EnvDTE.UIHierarchyItem>()
@@ -1097,6 +1115,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var solutionExplorer = dte.ToolWindows.SolutionExplorer;
 
             var item = FindItemAtPath(solutionExplorer.UIHierarchyItems, path);
+            Contract.ThrowIfNull(item);
 
             return item.UIHierarchyItems
                 .Cast<EnvDTE.UIHierarchyItem>()
@@ -1104,11 +1123,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 .ToArray();
         }
 
-        private static EnvDTE.UIHierarchyItem FindItemAtPath(
+        private static EnvDTE.UIHierarchyItem? FindItemAtPath(
             EnvDTE.UIHierarchyItems currentItems,
             string[] path)
         {
-            EnvDTE.UIHierarchyItem item = null;
+            EnvDTE.UIHierarchyItem? item = null;
             foreach (var name in path)
             {
                 item = currentItems.Cast<EnvDTE.UIHierarchyItem>().FirstOrDefault(i => i.Name == name);
@@ -1124,7 +1143,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return item;
         }
 
-        private static EnvDTE.UIHierarchyItem FindFirstItemRecursively(
+        private static EnvDTE.UIHierarchyItem? FindFirstItemRecursively(
             EnvDTE.UIHierarchyItems currentItems,
             string itemName)
         {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/StartPage_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/StartPage_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.Shell.Interop;
 using vsStartUp = EnvDTE.vsStartUp;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -76,7 +74,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
                 const VSConstants.VSStd2KCmdID ECMD_SMARTTASKS = (VSConstants.VSStd2KCmdID)147;
                 var cmdID = ECMD_SMARTTASKS;
-                object obj = null;
+                object? obj = null;
                 shell.PostExecCommand(cmdGroup, (uint)cmdID, (uint)cmdExecOpt, ref obj);
             });
         }
@@ -116,7 +114,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public string[] GetCurrentClassifications()
             => InvokeOnUIThread(cancellationToken =>
             {
-                IClassifier classifier = null;
+                IClassifier? classifier = null;
                 try
                 {
                     var textView = GetActiveTextView();
@@ -424,11 +422,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     }
 
                     var actionSetsForAction = await action.GetActionSetsAsync(CancellationToken.None);
-                    action = await GetFixAllSuggestedActionAsync(actionSetsForAction, fixAllScope.Value);
-                    if (action == null)
+                    var fixAllAction = await GetFixAllSuggestedActionAsync(actionSetsForAction, fixAllScope.Value);
+                    if (fixAllAction == null)
                     {
                         throw new InvalidOperationException($"Unable to find FixAll in {fixAllScope.ToString()} code fix for suggested action '{action.DisplayText}'.");
                     }
+
+                    action = fixAllAction;
 
                     if (willBlockUntilComplete
                         && action is FixAllSuggestedAction fixAllSuggestedAction
@@ -481,7 +481,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return actions;
         }
 
-        private static async Task<FixAllSuggestedAction> GetFixAllSuggestedActionAsync(IEnumerable<SuggestedActionSet> actionSets, FixAllScope fixAllScope)
+        private static async Task<FixAllSuggestedAction?> GetFixAllSuggestedActionAsync(IEnumerable<SuggestedActionSet> actionSets, FixAllScope fixAllScope)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
@@ -501,10 +501,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     if (action.HasActionSets)
                     {
                         var nestedActionSets = await action.GetActionSetsAsync(CancellationToken.None);
-                        fixAllSuggestedAction = await GetFixAllSuggestedActionAsync(nestedActionSets, fixAllScope);
-                        if (fixAllSuggestedAction != null)
+                        var fixAllCodeAction = await GetFixAllSuggestedActionAsync(nestedActionSets, fixAllScope);
+                        if (fixAllCodeAction != null)
                         {
-                            return fixAllSuggestedAction;
+                            return fixAllCodeAction;
                         }
                     }
                 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -101,7 +99,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         private IOption GetOption(string optionName, string feature)
         {
-            var optionService = _visualStudioWorkspace.Services.GetService<IOptionService>();
+            var optionService = _visualStudioWorkspace.Services.GetRequiredService<IOptionService>();
             var option = optionService.GetRegisteredOptions().FirstOrDefault(o => o.Feature == feature && o.Name == optionName);
             if (option == null)
             {
@@ -111,7 +109,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return option;
         }
 
-        private void SetOption(OptionKey optionKey, object result)
+        private void SetOption(OptionKey optionKey, object? result)
             => _visualStudioWorkspace.SetOptions(_visualStudioWorkspace.Options.WithChangedOption(optionKey, result));
 
         private static TestingOnly_WaitingService GetWaitingService()
@@ -215,7 +213,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 GetWaitingService().EnableActiveTokenTracking(true);
             });
 
-        public void SetFeatureOption(string feature, string optionName, string language, string valueString)
+        public void SetFeatureOption(string feature, string optionName, string language, string? valueString)
             => InvokeOnUIThread(cancellationToken =>
             {
                 var option = GetOption(optionName, feature);
@@ -228,7 +226,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 SetOption(optionKey, value);
             });
 
-        public string GetWorkingFolder()
+        public string? GetWorkingFolder()
         {
             var service = _visualStudioWorkspace.Services.GetRequiredService<IPersistentStorageLocationService>();
             return service.TryGetStorageLocation(_visualStudioWorkspace.CurrentSolution);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc_Telemetry.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc_Telemetry.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.Telemetry;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/AbstractSendKeys.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/AbstractSendKeys.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/ButtonBaseExtensions.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/ButtonBaseExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/ComboBoxExtensions.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/ComboBoxExtensions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/KeyPress.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/KeyPress.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input
 {
-    public struct KeyPress
+    public readonly struct KeyPress
     {
         public readonly VirtualKey VirtualKey;
         public readonly ShiftState ShiftState;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys_InProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/ShiftState.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/ShiftState.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/VirtualKey.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/VirtualKey.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input
 {
     public enum VirtualKey : byte

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -346,7 +344,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
         }
 
-        private static string GetPrintableCharText(char ch)
+        private static string? GetPrintableCharText(char ch)
         {
             switch (ch)
             {
@@ -404,10 +402,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         }
 
         /// <summary>Locates the DTE object for the specified process.</summary>
-        public static DTE TryLocateDteForProcess(Process process)
+        public static DTE? TryLocateDteForProcess(Process process)
         {
-            object dte = null;
-            var monikers = new IMoniker[1];
+            object? dte = null;
+            var monikers = new IMoniker?[1];
 
             NativeMethods.GetRunningObjectTable(0, out var runningObjectTable);
             runningObjectTable.EnumRunning(out var enumMoniker);
@@ -429,6 +427,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 }
 
                 var moniker = monikers[0];
+                Contract.ThrowIfNull(moniker);
+
                 moniker.GetDisplayName(bindContext, null, out var fullDisplayName);
 
                 // FullDisplayName will look something like: <ProgID>:<ProcessId>
@@ -450,6 +450,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         }
 
         public static async Task WaitForResultAsync<T>(Func<T> action, T expectedResult)
+            where T : notnull
         {
             while (!action().Equals(expectedResult))
             {
@@ -457,7 +458,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
         }
 
-        public static async Task<T> WaitForNotNullAsync<T>(Func<T> action) where T : class
+        public static async Task<T> WaitForNotNullAsync<T>(Func<T?> action) where T : class
         {
             var result = action();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
-using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Setup.Configuration;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/LightBulbHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/LightBulbHelper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Language.Intellisense;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/AddParameterDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/AddParameterDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/CSharpInteractiveWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/CSharpInteractiveWindow_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ChangeSignatureDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ChangeSignatureDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Debugger_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Debugger_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 using Xunit;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Dialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Dialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.Verifier.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
@@ -177,6 +176,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                 string documentation)
             {
                 var currentParameter = _textViewWindow.GetCurrentSignature().CurrentParameter;
+                Contract.ThrowIfNull(currentParameter);
+
                 Assert.Equal(name, currentParameter.Name);
                 Assert.Equal(documentation, currentParameter.Documentation);
             }
@@ -185,6 +186,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                 params (string name, string documentation)[] parameters)
             {
                 var currentParameters = _textViewWindow.GetCurrentSignature().Parameters;
+                Contract.ThrowIfNull(currentParameters);
+
                 for (var i = 0; i < parameters.Length; i++)
                 {
                     var (expectedName, expectedDocumentation) = parameters[i];

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -165,13 +163,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void DeleteWinFormButton(string buttonName)
             => _editorInProc.DeleteWinFormButton(buttonName);
 
-        public void EditWinFormButtonProperty(string buttonName, string propertyName, string propertyValue, string propertyTypeName = null)
+        public void EditWinFormButtonProperty(string buttonName, string propertyName, string propertyValue, string? propertyTypeName = null)
             => _editorInProc.EditWinFormButtonProperty(buttonName, propertyName, propertyValue, propertyTypeName);
 
         public void EditWinFormButtonEvent(string buttonName, string eventName, string eventHandlerName)
             => _editorInProc.EditWinFormButtonEvent(buttonName, eventName, eventHandlerName);
 
-        public string GetWinFormButtonPropertyValue(string buttonName, string propertyName)
+        public string? GetWinFormButtonPropertyValue(string buttonName, string propertyName)
             => _editorInProc.GetWinFormButtonPropertyValue(buttonName, propertyName);
 
         /// <summary>
@@ -300,19 +298,19 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             return _editorInProc.GetNavBarItems(2);
         }
 
-        public string GetProjectNavBarSelection()
+        public string? GetProjectNavBarSelection()
         {
             _instance.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.NavigationBar);
             return _editorInProc.GetSelectedNavBarItem(0);
         }
 
-        public string GetTypeNavBarSelection()
+        public string? GetTypeNavBarSelection()
         {
             _instance.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.NavigationBar);
             return _editorInProc.GetSelectedNavBarItem(1);
         }
 
-        public string GetMemberNavBarSelection()
+        public string? GetMemberNavBarSelection()
         {
             _instance.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.NavigationBar);
             return _editorInProc.GetSelectedNavBarItem(2);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/EncapsulateField_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/EncapsulateField_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ErrorList_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ErrorList_OutOfProc.Verifier.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
-using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 using Xunit;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ErrorList_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ErrorList_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ExtractInterfaceDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ExtractInterfaceDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/FindReferencesWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/FindReferencesWindow_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/GenerateTypeDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/GenerateTypeDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ImmediateWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ImmediateWindow_OutOfProc.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InlineRenameDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InlineRenameDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Editor.Implementation.InlineRename.HighlightTags;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InteractiveWindow_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InteractiveWindow_OutOfProc.Verifier.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Xunit;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InteractiveWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InteractiveWindow_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/LocalsWindow_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/LocalsWindow_OutOfProc.Verifier.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Xunit;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/LocalsWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/LocalsWindow_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/MoveToNamespaceDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/MoveToNamespaceDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.TestHooks;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ObjectBrowserWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ObjectBrowserWindow_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/OutOfProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/OutOfProcComponent.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/PickMembersDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/PickMembersDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/PreviewChangesDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/PreviewChangesDialog_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Shell_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Shell_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.Verifier.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Xunit;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
+using Roslyn.Utilities;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
@@ -118,7 +117,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void CleanUpOpenSolution()
             => _inProc.CleanUpOpenSolution();
 
-        public void AddFile(ProjectUtils.Project project, string fileName, string contents = null, bool open = false)
+        public void AddFile(ProjectUtils.Project project, string fileName, string? contents = null, bool open = false)
             => _inProc.AddFile(project.Name, fileName, contents, open);
 
         public void SetFileContents(ProjectUtils.Project project, string fileName, string contents)
@@ -167,7 +166,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             => _inProc.SaveFile(project.Name, fileName);
 
         public void ReloadProject(ProjectUtils.Project project)
-            => _inProc.ReloadProject(project.RelativePath);
+        {
+            Contract.ThrowIfNull(project.RelativePath);
+            _inProc.ReloadProject(project.RelativePath);
+        }
 
         public void RestoreNuGetPackages(ProjectUtils.Project project)
             => _inProc.RestoreNuGetPackages(project.Name);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/StartPage_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/StartPage_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.Verifier.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
@@ -58,7 +57,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             /// </returns>
             public bool? CodeActions(
                 IEnumerable<string> expectedItems,
-                string applyFix = null,
+                string? applyFix = null,
                 bool verifyNotShowing = false,
                 bool ensureExpectedItemsAreOrdered = false,
                 FixAllScope? fixAllScope = null,
@@ -91,7 +90,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                     }
                 }
 
-                if (!string.IsNullOrEmpty(applyFix) || fixAllScope.HasValue)
+                if (fixAllScope.HasValue)
+                {
+                    Contract.ThrowIfNull(applyFix);
+                }
+
+                if (!RoslynString.IsNullOrEmpty(applyFix))
                 {
                     var result = _textViewWindow.ApplyLightBulbAction(applyFix, fixAllScope, blockUntilComplete);
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
@@ -127,9 +125,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                 value: value);
         }
 
-        public void SetFeatureOption(string feature, string optionName, string language, string valueString)
+        public void SetFeatureOption(string feature, string optionName, string language, string? valueString)
             => _inProc.SetFeatureOption(feature, optionName, language, valueString);
 
-        public string GetWorkingFolder() => _inProc.GetWorkingFolder();
+        public string? GetWorkingFolder() => _inProc.GetWorkingFolder();
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -56,7 +54,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// A <see cref="Bitmap"/> containing the screen capture of the desktop, or null if a screen
         /// capture can't be created.
         /// </returns>
-        private static BitmapSource TryCaptureFullScreen()
+        private static BitmapSource? TryCaptureFullScreen()
         {
             var width = Screen.PrimaryScreen.Bounds.Width;
             var height = Screen.PrimaryScreen.Bounds.Height;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/TemporaryTextFile.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/TemporaryTextFile.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.IO;
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/TestUtilities.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/TestUtilities.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -105,6 +103,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         }
 
         public static void ThrowIfUnExpectedItemFound<TCollection>(IEnumerable<TCollection> actual, IEnumerable<TCollection> unexpected)
+            where TCollection : notnull
         {
             var shouldThrow = false;
             var sb = new StringBuilder();
@@ -127,7 +126,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
         public static void CompareAsSequenceAndThrowIfNotEqual<TListItem>(IEnumerable<TListItem> expectedList,
             IEnumerable<TListItem> actualList,
-            IEqualityComparer<TListItem> comparer = null)
+            IEqualityComparer<TListItem>? comparer = null)
             where TListItem : IEquatable<TListItem>
         {
             if (!expectedList.SequenceEqual(actualList, comparer))
@@ -137,6 +136,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         }
 
         private static string BuildString<TElement>(IEnumerable<TElement> list)
+            where TElement : notnull
             => string.Join(Environment.NewLine, list.Select(item => item.ToString()).ToArray());
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -265,7 +263,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
         }
 
-        private static DTE GetDebuggerHostDte()
+        private static DTE? GetDebuggerHostDte()
         {
             var currentProcessId = Process.GetCurrentProcess().Id;
             foreach (var process in Process.GetProcessesByName("devenv"))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceContext.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -36,7 +34,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// <summary>
         /// The instance that has already been launched by this factory and can be reused.
         /// </summary>
-        private VisualStudioInstance _currentlyRunningInstance;
+        private VisualStudioInstance? _currentlyRunningInstance;
 
         /// <summary>
         /// Identifies the first time a Visual Studio instance is launched during an integration test run.
@@ -103,7 +101,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         // Depending on the manner in which the assembly was originally loaded, this may end up actually trying to load the assembly a second
         // time and it can fail if the standard assembly resolution logic fails. This ensures that we 'succeed' this secondary load by returning
         // the assembly that is already loaded.
-        private static Assembly AssemblyResolveHandler(object sender, ResolveEventArgs eventArgs)
+        private static Assembly? AssemblyResolveHandler(object sender, ResolveEventArgs eventArgs)
         {
             Debug.WriteLine($"'{eventArgs.RequestingAssembly}' is attempting to resolve '{eventArgs.Name}'");
             var resolvedAssembly = AppDomain.CurrentDomain.GetAssemblies().Where((assembly) => assembly.FullName.Equals(eventArgs.Name)).SingleOrDefault();
@@ -125,6 +123,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             {
                 var shouldStartNewInstance = ShouldStartNewInstance(requiredPackageIds);
                 await UpdateCurrentlyRunningInstanceAsync(requiredPackageIds, shouldStartNewInstance).ConfigureAwait(true);
+                Contract.ThrowIfNull(_currentlyRunningInstance);
 
                 return new VisualStudioInstanceContext(_currentlyRunningInstance, this);
             }
@@ -174,7 +173,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 // We are starting a new instance, so ensure we close the currently running instance, if it exists
                 _currentlyRunningInstance?.Close();
 
-                var instance = LocateVisualStudioInstance(requiredPackageIds) as ISetupInstance2;
+                var instance = (ISetupInstance2)LocateVisualStudioInstance(requiredPackageIds);
                 supportedPackageIds = ImmutableHashSet.CreateRange(instance.GetPackages().Select((supportedPackage) => supportedPackage.GetId()));
                 installationPath = instance.GetInstallationPath();
 
@@ -200,7 +199,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 // We create a new DTE instance in the current context since the COM object could have been separated
                 // from its RCW during the previous test.
 
-                Debug.Assert(_currentlyRunningInstance != null);
+                Contract.ThrowIfNull(_currentlyRunningInstance);
 
                 hostProcess = _currentlyRunningInstance.HostProcess;
                 dte = await IntegrationHelper.WaitForNotNullAsync(() => IntegrationHelper.TryLocateDteForProcess(hostProcess)).ConfigureAwait(true);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 {
     public static class WellKnownCommandNames

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownProjectTemplates.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownProjectTemplates.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 {
     public static class WellKnownProjectTemplates

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownTagNames.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownTagNames.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using Microsoft.CodeAnalysis.Editor.ReferenceHighlighting;
 
@@ -15,7 +13,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public const string MarkerFormatDefinition_HighlightedDefinition = "MarkerFormatDefinition/HighlightedDefinition";
         public const string MarkerFormatDefinition_HighlightedWrittenReference = "MarkerFormatDefinition/HighlightedWrittenReference";
 
-        public static Type GetTagTypeByName(string typeName)
+        public static Type? GetTagTypeByName(string typeName)
         {
             switch (typeName)
             {


### PR DESCRIPTION
This code includes a higher than average use of assertions like `Contract.ThrowIfNull`. This should help narrow down cases where flaky integration tests produce unexpected intermediate results.