### PR TITLE
Auto-attach to service hub process on debug

### DIFF
--- a/src/Deployment/Properties/launchSettings.json
+++ b/src/Deployment/Properties/launchSettings.json
@@ -3,12 +3,18 @@
     "Visual Studio Extension": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
-      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log"
+      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
+      "environmentVariables": {
+        "SERVICEHUBDEBUGHOSTONSTARTUP": "All"
+      }
     },
     "Visual Studio Extension (with Native Debugging)": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
       "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
+      "environmentVariables": {
+        "SERVICEHUBDEBUGHOSTONSTARTUP": "All"
+      },
       "nativeDebugging": true
     }
   }

--- a/src/Deployment/Properties/launchSettings.json
+++ b/src/Deployment/Properties/launchSettings.json
@@ -3,6 +3,11 @@
     "Visual Studio Extension": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log"
+    },
+    "Visual Studio Extension (with ServiceHub Debugging)": {
+      "commandName": "Executable",
+      "executablePath": "$(DevEnvDir)devenv.exe",
       "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
       "environmentVariables": {
         "SERVICEHUBDEBUGHOSTONSTARTUP": "All"
@@ -12,9 +17,6 @@
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
       "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
-      "environmentVariables": {
-        "SERVICEHUBDEBUGHOSTONSTARTUP": "All"
-      },
       "nativeDebugging": true
     }
   }


### PR DESCRIPTION
> Set the environment variable SERVICEHUBDEBUGHOSTONSTARTUP to All. This will pop up a debug dialog whenever a ServiceHub Host process starts running. You will then be able to attach a debugger to that process. In more complex scenarios, this same environment variable can be set with the name of the specific ServiceHub Host process you would like debug dialogs to be shown for. ex. ServiceHub.Host.CLR.exe.

I think we just want to set this value in environment we launch VS in. 