### PR TITLE
Add support for interpolated string handler conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -149,6 +149,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     unconvertedSource.HasErrors);
             }
 
+            if (conversion.Kind == ConversionKind.InterpolatedStringHandler)
+            {
+                var unconvertedSource = (BoundUnconvertedInterpolatedString)source;
+                return new BoundConversion(
+                    syntax,
+                    BindUnconvertedInterpolatedStringToHandlerType(unconvertedSource, (NamedTypeSymbol)destination, diagnostics, isHandlerConversion: true),
+                    conversion,
+                    @checked: false,
+                    explicitCastInCode: false,
+                    conversionGroupOpt,
+                    constantValueOpt: default,
+                    destination);
+            }
+
             if (source.Kind == BoundKind.UnconvertedSwitchExpression)
             {
                 TypeSymbol? type = source.Type;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     @checked: false,
                     explicitCastInCode: false,
                     conversionGroupOpt,
-                    constantValueOpt: default,
+                    constantValueOpt: null,
                     destination);
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -156,8 +156,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     syntax,
                     BindUnconvertedInterpolatedStringToHandlerType(unconvertedSource, (NamedTypeSymbol)destination, diagnostics, isHandlerConversion: true),
                     conversion,
-                    @checked: false,
-                    explicitCastInCode: false,
+                    @checked: CheckOverflowAtRuntime,
+                    explicitCastInCode: isCast && !wasCompilerGenerated,
                     conversionGroupOpt,
                     constantValueOpt: null,
                     destination);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4404,7 +4404,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Helper method to create a synthesized constructor invocation.
         /// </summary>
-        private BoundExpression MakeClassCreationExpression(
+        private BoundExpression MakeConstructorInvocation(
             NamedTypeSymbol type,
             ImmutableArray<BoundExpression> arguments,
             SyntaxNode node,
@@ -4446,7 +4446,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, node.Initializer, node.Type, diagnostics, wasCompilerGenerated);
         }
 
-        /// <param name="typeSyntax">If <paramref name="initializerOpt"/> is not null, this should not be null.</param>
+        /// <param name="typeSyntax">Shouldn't be null if <paramref name="initializerOpt"/> is not null.</param>
         private BoundExpression MakeBadExpressionForObjectCreation(SyntaxNode node, TypeSymbol type, AnalyzedArguments analyzedArguments, InitializerExpressionSyntax? initializerOpt, SyntaxNode? typeSyntax, BindingDiagnosticBag diagnostics, bool wasCompilerGenerated = false)
         {
             var children = ArrayBuilder<BoundExpression>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -199,6 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitDynamic:
                 case ConversionKind.ExplicitDynamic:
                 case ConversionKind.InterpolatedString:
+                case ConversionKind.InterpolatedStringHandler:
                     isTrivial = true;
                     break;
 
@@ -242,6 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion ImplicitDynamic => new Conversion(ConversionKind.ImplicitDynamic);
         internal static Conversion ExplicitDynamic => new Conversion(ConversionKind.ExplicitDynamic);
         internal static Conversion InterpolatedString => new Conversion(ConversionKind.InterpolatedString);
+        internal static Conversion InterpolatedStringHandler => new Conversion(ConversionKind.InterpolatedStringHandler);
         internal static Conversion Deconstruction => new Conversion(ConversionKind.Deconstruction);
         internal static Conversion PinnedObjectToPointer => new Conversion(ConversionKind.PinnedObjectToPointer);
         internal static Conversion ImplicitPointer => new Conversion(ConversionKind.ImplicitPointer);
@@ -576,6 +578,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 return Kind == ConversionKind.InterpolatedString;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the conversion is an interpolated string builder conversion.
+        /// </summary>
+        public bool IsInterpolatedStringHandler
+        {
+            get
+            {
+                return Kind == ConversionKind.InterpolatedStringHandler;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal enum ConversionKind : byte
@@ -63,5 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         DefaultLiteral, // a conversion from a `default` literal to any type
         ObjectCreation, // a conversion from a `new()` expression to any type
+
+        InterpolatedStringHandler, // A conversion from an interpolated string literal to a type attributed with InterpolatedStringBuilderAttribute
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ImplicitPointerToVoid:
                 case ImplicitNullToPointer:
                 case InterpolatedString:
+                case InterpolatedStringHandler:
                 case SwitchExpression:
                 case ConditionalExpression:
                 case Deconstruction:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -84,10 +84,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override Conversion GetInterpolatedStringConversion(BoundUnconvertedInterpolatedString source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
+            if (destination is NamedTypeSymbol { IsInterpolatedStringHandlerType: true })
+            {
+                return Conversion.InterpolatedStringHandler;
+            }
+
             // An interpolated string expression may be converted to the types
             // System.IFormattable and System.FormattableString
-            return (TypeSymbol.Equals(destination, Compilation.GetWellKnownType(WellKnownType.System_IFormattable), TypeCompareKind.ConsiderEverything2) ||
-                    TypeSymbol.Equals(destination, Compilation.GetWellKnownType(WellKnownType.System_FormattableString), TypeCompareKind.ConsiderEverything2))
+            return (TypeSymbol.Equals(destination, Compilation.GetWellKnownType(WellKnownType.System_IFormattable), TypeCompareKind.ConsiderEverything) ||
+                    TypeSymbol.Equals(destination, Compilation.GetWellKnownType(WellKnownType.System_FormattableString), TypeCompareKind.ConsiderEverything))
                 ? Conversion.InterpolatedString : Conversion.NoConversion;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1965,7 +1965,7 @@ outerDefault:
                     }
                 }
 
-                return PreferValOverInParameters(arguments, m1, m1LeastOverriddenParameters, m2, m2LeastOverriddenParameters);
+                return PreferValOverInOrRefInterpolatedHandlerParameters(arguments, m1, m1LeastOverriddenParameters, m2, m2LeastOverriddenParameters);
             }
 
             // If MP is a non-generic method and MQ is a generic method, then MP is better than MQ.
@@ -2105,11 +2105,11 @@ outerDefault:
                 return (m1ModifierCount < m2ModifierCount) ? BetterResult.Left : BetterResult.Right;
             }
 
-            // Otherwise, prefer methods with 'val' parameters over 'in' parameters.
-            return PreferValOverInParameters(arguments, m1, m1LeastOverriddenParameters, m2, m2LeastOverriddenParameters);
+            // Otherwise, prefer methods with 'val' parameters over 'in' parameters and over 'ref' parameters when the argument is an interpolated string handler.
+            return PreferValOverInOrRefInterpolatedHandlerParameters(arguments, m1, m1LeastOverriddenParameters, m2, m2LeastOverriddenParameters);
         }
 
-        private static BetterResult PreferValOverInParameters<TMember>(
+        private static BetterResult PreferValOverInOrRefInterpolatedHandlerParameters<TMember>(
             ArrayBuilder<BoundExpression> arguments,
             MemberResolutionResult<TMember> m1,
             ImmutableArray<ParameterSymbol> parameters1,
@@ -2117,7 +2117,7 @@ outerDefault:
             ImmutableArray<ParameterSymbol> parameters2)
             where TMember : Symbol
         {
-            BetterResult valOverInPreference = BetterResult.Neither;
+            BetterResult valOverInOrRefInterpolatedHandlerPreference = BetterResult.Neither;
 
             for (int i = 0; i < arguments.Count; ++i)
             {
@@ -2126,32 +2126,51 @@ outerDefault:
                     var p1 = GetParameter(i, m1.Result, parameters1);
                     var p2 = GetParameter(i, m2.Result, parameters2);
 
-                    if (p1.RefKind == RefKind.None && p2.RefKind == RefKind.In)
+                    bool isInterpolatedStringHandlerConversion = false;
+
+                    if (m1.IsValid && m2.IsValid)
                     {
-                        if (valOverInPreference == BetterResult.Right)
+                        var c1 = m1.Result.ConversionForArg(i);
+                        var c2 = m2.Result.ConversionForArg(i);
+
+                        isInterpolatedStringHandlerConversion = c1.IsInterpolatedStringHandler && c2.IsInterpolatedStringHandler;
+                        Debug.Assert(!isInterpolatedStringHandlerConversion || arguments[i].Kind == BoundKind.UnconvertedInterpolatedString);
+                    }
+
+                    if (p1.RefKind == RefKind.None && isAcceptableRefMismatch(p2.RefKind, isInterpolatedStringHandlerConversion))
+                    {
+                        if (valOverInOrRefInterpolatedHandlerPreference == BetterResult.Right)
                         {
                             return BetterResult.Neither;
                         }
                         else
                         {
-                            valOverInPreference = BetterResult.Left;
+                            valOverInOrRefInterpolatedHandlerPreference = BetterResult.Left;
                         }
                     }
-                    else if (p2.RefKind == RefKind.None && p1.RefKind == RefKind.In)
+                    else if (p2.RefKind == RefKind.None && isAcceptableRefMismatch(p1.RefKind, isInterpolatedStringHandlerConversion))
                     {
-                        if (valOverInPreference == BetterResult.Left)
+                        if (valOverInOrRefInterpolatedHandlerPreference == BetterResult.Left)
                         {
                             return BetterResult.Neither;
                         }
                         else
                         {
-                            valOverInPreference = BetterResult.Right;
+                            valOverInOrRefInterpolatedHandlerPreference = BetterResult.Right;
                         }
                     }
                 }
             }
 
-            return valOverInPreference;
+            return valOverInOrRefInterpolatedHandlerPreference;
+
+            static bool isAcceptableRefMismatch(RefKind refKind, bool isInterpolatedStringHandlerConversion)
+                => refKind switch
+                {
+                    RefKind.In => true,
+                    RefKind.Ref when isInterpolatedStringHandlerConversion => true,
+                    _ => false
+                };
         }
 
         private static void GetParameterCounts<TMember>(MemberResolutionResult<TMember> m, ArrayBuilder<BoundExpression> arguments, out int declaredParameterCount, out int parametersUsedIncludingExpansionAndOptional) where TMember : Symbol
@@ -2399,6 +2418,26 @@ outerDefault:
                 // Neither conversion from expression is better when the argument is an implicitly-typed out variable declaration.
                 okToDowngradeToNeither = false;
                 return BetterResult.Neither;
+            }
+
+            // C# 10 added interpolated string handler conversions, with the following rule:
+            // Given an implicit conversion C1 that converts from an expression E to a type T1, 
+            // and an implicit conversion C2 that converts from an expression E to a type T2,
+            // C1 is a better conversion than C2 if E is a non-constant interpolated string expression, C1
+            // is an interpolated string handler conversion, and C2 is not an interpolated string
+            // handler conversion
+            // PROTOTYPE(interp-string): Handle binary operators composed only of added interpolated strings
+            if (node is BoundUnconvertedInterpolatedString { ConstantValueOpt: null })
+            {
+                switch ((conv1.Kind, conv2.Kind))
+                {
+                    case (ConversionKind.InterpolatedStringHandler, ConversionKind.InterpolatedStringHandler):
+                        return BetterResult.Neither;
+                    case (ConversionKind.InterpolatedStringHandler, _):
+                        return BetterResult.Left;
+                    case (_, ConversionKind.InterpolatedStringHandler):
+                        return BetterResult.Right;
+                }
             }
 
             // Given an implicit conversion C1 that converts from an expression E to a type T1, 
@@ -3589,6 +3628,18 @@ outerDefault:
                         }
                     }
 
+                    bool hasInterpolatedStringRefMismatch = false;
+                    if (argument.Kind == BoundKind.UnconvertedInterpolatedString
+                        && parameterRefKind == RefKind.Ref
+                        && parameters.ParameterTypes[argumentPosition].Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true, IsValueType: true })
+                    {
+                        // For interpolated strings handlers, we allow an interpolated string expression to be passed as if `ref` was specified
+                        // in the source when the handler type is a value type.
+                        // PROTOTYPE(interp-string): allow binary additions of interpolated strings to match as well.
+                        hasInterpolatedStringRefMismatch = true;
+                        argumentRefKind = parameterRefKind;
+                    }
+
                     conversion = CheckArgumentForApplicability(
                         candidate,
                         argument,
@@ -3597,7 +3648,8 @@ outerDefault:
                         parameterRefKind,
                         ignoreOpenTypes,
                         ref useSiteInfo,
-                        forExtensionMethodThisArg);
+                        forExtensionMethodThisArg,
+                        hasInterpolatedStringRefMismatch);
 
                     if (forExtensionMethodThisArg && !Conversions.IsValidExtensionMethodThisArgConversion(conversion))
                     {
@@ -3614,7 +3666,7 @@ outerDefault:
 
                     if (!conversion.Exists)
                     {
-                        badArguments = badArguments ?? ArrayBuilder<int>.GetInstance();
+                        badArguments ??= ArrayBuilder<int>.GetInstance();
                         badArguments.Add(argumentPosition);
                     }
                 }
@@ -3658,7 +3710,8 @@ outerDefault:
             RefKind parRefKind,
             bool ignoreOpenTypes,
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
-            bool forExtensionMethodThisArg)
+            bool forExtensionMethodThisArg,
+            bool hasInterpolatedStringRefMismatch)
         {
             // Spec 7.5.3.1
             // For each argument in A, the parameter passing mode of the argument (i.e., value, ref, or out) is identical
@@ -3699,12 +3752,20 @@ outerDefault:
                 return Conversion.Identity;
             }
 
-            if (argRefKind == RefKind.None)
+            if (argRefKind == RefKind.None || hasInterpolatedStringRefMismatch)
             {
                 var conversion = forExtensionMethodThisArg ?
                     Conversions.ClassifyImplicitExtensionMethodThisArgConversion(argument, argument.Type, parameterType, ref useSiteInfo) :
                     Conversions.ClassifyImplicitConversionFromExpression(argument, parameterType, ref useSiteInfo);
                 Debug.Assert((!conversion.Exists) || conversion.IsImplicit, "ClassifyImplicitConversion should only return implicit conversions");
+
+                if (hasInterpolatedStringRefMismatch && !conversion.IsInterpolatedStringHandler)
+                {
+                    // We allowed a ref mismatch under the assumption the conversion would be an interpolated string handler conversion. If it's not, then there was
+                    // actually no conversion because of the refkind mismatch.
+                    return Conversion.NoConversion;
+                }
+
                 return conversion;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2106,6 +2106,7 @@ outerDefault:
             }
 
             // Otherwise, prefer methods with 'val' parameters over 'in' parameters and over 'ref' parameters when the argument is an interpolated string handler.
+            // PROTOTYPE(interp-string): Document in the spec
             return PreferValOverInOrRefInterpolatedHandlerParameters(arguments, m1, m1LeastOverriddenParameters, m2, m2LeastOverriddenParameters);
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -510,6 +510,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_QueryRangeVariableSameAsTypeParam:
                 case ErrorCode.ERR_DeprecatedCollectionInitAddStr:
                 case ErrorCode.ERR_DeprecatedSymbolStr:
+                case ErrorCode.ERR_FeatureInPreview: // LangVersion should never change how we bind things
                     return false;
                 default:
                     return true;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -510,7 +510,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_QueryRangeVariableSameAsTypeParam:
                 case ErrorCode.ERR_DeprecatedCollectionInitAddStr:
                 case ErrorCode.ERR_DeprecatedSymbolStr:
-                case ErrorCode.ERR_FeatureInPreview: // LangVersion should never change how we bind things
                     return false;
                 default:
                     return true;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6721,6 +6721,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultState = NullableFlowState.NotNull;
                     break;
 
+                case ConversionKind.InterpolatedStringHandler:
+                    // PROTOTYPE(interp-string): Handle
+                    resultState = NullableFlowState.NotNull;
+                    break;
+
                 case ConversionKind.ObjectCreation:
                 case ConversionKind.SwitchExpression:
                 case ConversionKind.ConditionalExpression:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -503,10 +503,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Patch refKinds for arguments that match 'In' parameters to have effective RefKind.
+        /// Patch refKinds for arguments that match 'In' or 'Ref' parameters to have effective RefKind.
         /// For the purpose of further analysis we will mark the arguments as -
         /// - In        if was originally passed as None
         /// - StrictIn  if was originally passed as In
+        /// - Ref       if the argument is an interpolated string literal subject to an interpolated string handler conversion. No other types
+        ///             are patched here.
         /// Here and in the layers after the lowering we only care about None/notNone differences for the arguments
         /// Except for async stack spilling which needs to know whether arguments were originally passed as "In" and must obey "no copying" rule.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -5,13 +5,11 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Operations;
 using Roslyn.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -521,22 +519,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (paramRefKind == RefKind.In)
                 {
                     var argRefKind = argumentRefKindsOpt.IsDefault ? RefKind.None : argumentRefKindsOpt[i];
-
-                    if (refKindsBuilder == null)
-                    {
-                        if (!argumentRefKindsOpt.IsDefault)
-                        {
-                            Debug.Assert(!argumentRefKindsOpt.IsEmpty);
-                            refKindsBuilder = ArrayBuilder<RefKind>.GetInstance(parameters.Length);
-                            refKindsBuilder.AddRange(argumentRefKindsOpt);
-                        }
-                        else
-                        {
-                            refKindsBuilder = ArrayBuilder<RefKind>.GetInstance(parameters.Length, fillWithValue: RefKind.None);
-                        }
-                    }
-
+                    fillRefKindsBuilder(argumentRefKindsOpt, parameters, ref refKindsBuilder);
                     refKindsBuilder[i] = argRefKind == RefKind.None ? paramRefKind : RefKindExtensions.StrictIn;
+                }
+                else if (paramRefKind == RefKind.Ref)
+                {
+                    var argRefKind = argumentRefKindsOpt.IsDefault ? RefKind.None : argumentRefKindsOpt[i];
+                    if (argRefKind == RefKind.None)
+                    {
+                        // Interpolated strings used as interpolated string handlers are allowed to match ref parameters without `ref`
+                        Debug.Assert(parameters[i].Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true, IsValueType: true });
+
+                        fillRefKindsBuilder(argumentRefKindsOpt, parameters, ref refKindsBuilder);
+                        refKindsBuilder[i] = RefKind.Ref;
+                    }
                 }
             }
 
@@ -548,6 +544,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             // NOTE: we may have more arguments than parameters in a case of arglist. That is ok.
             Debug.Assert(argumentRefKindsOpt.IsDefault || argumentRefKindsOpt.Length >= parameters.Length);
             return argumentRefKindsOpt;
+
+            static void fillRefKindsBuilder(ImmutableArray<RefKind> argumentRefKindsOpt, ImmutableArray<ParameterSymbol> parameters, [NotNull] ref ArrayBuilder<RefKind>? refKindsBuilder)
+            {
+                if (refKindsBuilder == null)
+                {
+                    if (!argumentRefKindsOpt.IsDefault)
+                    {
+                        Debug.Assert(!argumentRefKindsOpt.IsEmpty);
+                        refKindsBuilder = ArrayBuilder<RefKind>.GetInstance(parameters.Length);
+                        refKindsBuilder.AddRange(argumentRefKindsOpt);
+                    }
+                    else
+                    {
+                        refKindsBuilder = ArrayBuilder<RefKind>.GetInstance(parameters.Length, fillWithValue: RefKind.None);
+                    }
+                }
+            }
         }
 
         internal static ImmutableArray<IArgumentOperation> MakeArgumentsInEvaluationOrder(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -16,16 +15,19 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitConversion(BoundConversion node)
         {
-            if (node.ConversionKind == ConversionKind.InterpolatedString)
+            switch (node.ConversionKind)
             {
-                return RewriteInterpolatedStringConversion(node);
-            }
+                case ConversionKind.InterpolatedString:
+                    return RewriteInterpolatedStringConversion(node);
+                case ConversionKind.InterpolatedStringHandler:
+                    Debug.Assert(node.Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true });
 
-            if (node.ConversionKind is ConversionKind.SwitchExpression or ConversionKind.ConditionalExpression)
-            {
-                // Skip through target-typed conditionals and switches
-                Debug.Assert(node.Operand is BoundConditionalOperator { WasTargetTyped: true } or BoundConvertedSwitchExpression { WasTargetTyped: true });
-                return Visit(node.Operand)!;
+                    (ArrayBuilder<BoundExpression> builderPatternExpressions, BoundLocal handlerLocal) = RewriteToInterpolatedStringHandlerPattern((BoundInterpolatedString)node.Operand);
+                    return _factory.Sequence(ImmutableArray.Create(handlerLocal.LocalSymbol), builderPatternExpressions.ToImmutableAndFree(), handlerLocal);
+                case ConversionKind.SwitchExpression or ConversionKind.ConditionalExpression:
+                    // Skip through target-typed conditionals and switches
+                    Debug.Assert(node.Operand is BoundConditionalOperator { WasTargetTyped: true } or BoundConvertedSwitchExpression { WasTargetTyped: true });
+                    return Visit(node.Operand)!;
             }
 
             var rewrittenType = VisitType(node.Type);

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.CodeAnalysis.CSharp.Conversion.IsInterpolatedStringHandler.get -> bool
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.RecordStructDeclaration = 9068 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 override Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetUsedAssemblyReferences(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.MetadataReference>
 Microsoft.CodeAnalysis.CSharp.Syntax.LambdaExpressionSyntax.AddAttributeLists(params Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.LambdaExpressionSyntax

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -92,6 +92,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
+            internal override bool IsInterpolatedStringHandlerType => false;
+
             public override ImmutableArray<Symbol> GetMembers(string name)
             {
                 var symbols = _nameToSymbols[name];

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -209,6 +209,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
+            internal override bool IsInterpolatedStringHandlerType => false;
+
             internal override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotationsNoUseSiteDiagnostics
             {
                 get { return GetTypeParametersAsTypeArguments(); }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownEarlyAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownEarlyAttributeData.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownEarlyAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownEarlyAttributeData.cs
@@ -1,0 +1,27 @@
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Information decoded early from well-known custom attributes applied on a type.
+    /// </summary>
+    internal sealed class TypeEarlyWellKnownAttributeData : CommonTypeEarlyWellKnownAttributeData
+    {
+        #region InterpolatedStringHandlerAttribute
+        private bool _hasInterpolatedStringHandlerAttribute;
+        public bool HasInterpolatedStringHandlerAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasInterpolatedStringHandlerAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasInterpolatedStringHandlerAttribute = value;
+                SetDataStored();
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -431,6 +431,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
+        internal override bool IsInterpolatedStringHandlerType => false;
+
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol>? basesBeingResolved)
         {
             return ImmutableArray<NamedTypeSymbol>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             internal string lazyDefaultMemberName;
             internal NamedTypeSymbol lazyComImportCoClassType = ErrorTypeSymbol.UnknownResultType;
             internal ThreeState lazyHasEmbeddedAttribute = ThreeState.Unknown;
+            internal ThreeState lazyHasInterpolatedStringBuilderAttribute = ThreeState.Unknown;
 
 #if DEBUG
             internal bool IsDefaultValue()
@@ -154,7 +155,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     !lazyContainsExtensionMethods.HasValue() &&
                     lazyDefaultMemberName == null &&
                     (object)lazyComImportCoClassType == (object)ErrorTypeSymbol.UnknownResultType &&
-                    !lazyHasEmbeddedAttribute.HasValue();
+                    !lazyHasEmbeddedAttribute.HasValue() &&
+                    !lazyHasInterpolatedStringBuilderAttribute.HasValue();
             }
 #endif
         }
@@ -384,6 +386,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        internal sealed override bool IsInterpolatedStringHandlerType
+        {
+            get
+            {
+                var uncommon = GetUncommonProperties();
+                if (uncommon == s_noUncommonProperties)
+                {
+                    return false;
+                }
+
+                if (!uncommon.lazyHasInterpolatedStringBuilderAttribute.HasValue())
+                {
+                    uncommon.lazyHasInterpolatedStringBuilderAttribute = ContainingPEModule.Module.HasInterpolatedStringBuilderAttribute(_handle).ToThreeState();
+                }
+
+                return uncommon.lazyHasInterpolatedStringBuilderAttribute.Value();
+            }
+        }
 
         internal override bool HasCodeAnalysisEmbeddedAttribute
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             internal string lazyDefaultMemberName;
             internal NamedTypeSymbol lazyComImportCoClassType = ErrorTypeSymbol.UnknownResultType;
             internal ThreeState lazyHasEmbeddedAttribute = ThreeState.Unknown;
-            internal ThreeState lazyHasInterpolatedStringBuilderAttribute = ThreeState.Unknown;
+            internal ThreeState lazyHasInterpolatedStringHandlerAttribute = ThreeState.Unknown;
 
 #if DEBUG
             internal bool IsDefaultValue()
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     lazyDefaultMemberName == null &&
                     (object)lazyComImportCoClassType == (object)ErrorTypeSymbol.UnknownResultType &&
                     !lazyHasEmbeddedAttribute.HasValue() &&
-                    !lazyHasInterpolatedStringBuilderAttribute.HasValue();
+                    !lazyHasInterpolatedStringHandlerAttribute.HasValue();
             }
 #endif
         }
@@ -396,12 +396,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     return false;
                 }
 
-                if (!uncommon.lazyHasInterpolatedStringBuilderAttribute.HasValue())
+                if (!uncommon.lazyHasInterpolatedStringHandlerAttribute.HasValue())
                 {
-                    uncommon.lazyHasInterpolatedStringBuilderAttribute = ContainingPEModule.Module.HasInterpolatedStringBuilderAttribute(_handle).ToThreeState();
+                    uncommon.lazyHasInterpolatedStringHandlerAttribute = ContainingPEModule.Module.HasInterpolatedStringHandlerAttribute(_handle).ToThreeState();
                 }
 
-                return uncommon.lazyHasInterpolatedStringBuilderAttribute.Value();
+                return uncommon.lazyHasInterpolatedStringHandlerAttribute.Value();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1009,6 +1009,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasCodeAnalysisEmbeddedAttribute { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this type has System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute or not.
+        /// </summary>
+        internal abstract bool IsInterpolatedStringHandlerType { get; }
+
         internal static readonly Func<TypeWithAnnotations, bool> TypeWithAnnotationsIsNullFunction = type => !type.HasType;
 
         internal static readonly Func<TypeWithAnnotations, bool> TypeWithAnnotationsIsErrorType = type => type.HasType && type.Type.IsErrorType();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -165,6 +165,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
+        internal override bool IsInterpolatedStringHandlerType => false;
+
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable;
 
         internal sealed override NamedTypeSymbol NativeIntegerUnderlyingType => null;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SimpleProgramNamedTypeSymbol.cs
@@ -193,6 +193,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
+        internal override bool IsInterpolatedStringHandlerType => false;
+
         protected override MembersAndInitializers BuildMembersAndInitializers(BindingDiagnosticBag diagnostics)
         {
             bool reportAnError = false;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -854,7 +854,7 @@ next:;
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonTypeEarlyWellKnownAttributeData? GetEarlyDecodedWellKnownAttributeData()
+        internal TypeEarlyWellKnownAttributeData? GetEarlyDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
@@ -862,7 +862,7 @@ next:;
                 attributesBag = this.GetAttributesBag();
             }
 
-            return (CommonTypeEarlyWellKnownAttributeData)attributesBag.EarlyDecodedWellKnownAttributeData;
+            return (TypeEarlyWellKnownAttributeData)attributesBag.EarlyDecodedWellKnownAttributeData;
         }
 
         internal override CSharpAttributeData? EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments)
@@ -875,7 +875,7 @@ next:;
                 boundAttribute = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, out hasAnyDiagnostics);
                 if (!boundAttribute.HasErrors)
                 {
-                    arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>().HasComImportAttribute = true;
+                    arguments.GetOrCreateData<TypeEarlyWellKnownAttributeData>().HasComImportAttribute = true;
                     if (!hasAnyDiagnostics)
                     {
                         return boundAttribute;
@@ -890,7 +890,7 @@ next:;
                 boundAttribute = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, out hasAnyDiagnostics);
                 if (!boundAttribute.HasErrors)
                 {
-                    arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>().HasCodeAnalysisEmbeddedAttribute = true;
+                    arguments.GetOrCreateData<TypeEarlyWellKnownAttributeData>().HasCodeAnalysisEmbeddedAttribute = true;
                     if (!hasAnyDiagnostics)
                     {
                         return boundAttribute;
@@ -906,7 +906,7 @@ next:;
                 if (!boundAttribute.HasErrors)
                 {
                     string? name = boundAttribute.GetConstructorArgument<string>(0, SpecialType.System_String);
-                    arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>().AddConditionalSymbol(name);
+                    arguments.GetOrCreateData<TypeEarlyWellKnownAttributeData>().AddConditionalSymbol(name);
                     if (!hasAnyDiagnostics)
                     {
                         return boundAttribute;
@@ -921,7 +921,7 @@ next:;
             {
                 if (obsoleteData != null)
                 {
-                    arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>().ObsoleteAttributeData = obsoleteData;
+                    arguments.GetOrCreateData<TypeEarlyWellKnownAttributeData>().ObsoleteAttributeData = obsoleteData;
                 }
 
                 return boundAttribute;
@@ -935,7 +935,7 @@ next:;
                     AttributeUsageInfo info = this.DecodeAttributeUsageAttribute(boundAttribute, arguments.AttributeSyntax, diagnose: false);
                     if (!info.IsNull)
                     {
-                        var typeData = arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>();
+                        var typeData = arguments.GetOrCreateData<TypeEarlyWellKnownAttributeData>();
                         if (typeData.AttributeUsageInfo.IsNull)
                         {
                             typeData.AttributeUsageInfo = info;
@@ -964,7 +964,7 @@ next:;
                 boundAttribute = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, out hasAnyDiagnostics);
                 if (!boundAttribute.HasErrors)
                 {
-                    arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>().HasInterpolatedStringHandlerAttribute = true;
+                    arguments.GetOrCreateData<TypeEarlyWellKnownAttributeData>().HasInterpolatedStringHandlerAttribute = true;
                     if (!hasAnyDiagnostics)
                     {
                         return boundAttribute;
@@ -982,7 +982,7 @@ next:;
         {
             Debug.Assert(this.SpecialType == SpecialType.System_Object || this.DeclaringCompilation.IsAttributeType(this));
 
-            CommonTypeEarlyWellKnownAttributeData data = this.GetEarlyDecodedWellKnownAttributeData();
+            TypeEarlyWellKnownAttributeData data = this.GetEarlyDecodedWellKnownAttributeData();
             if (data != null && !data.AttributeUsageInfo.IsNull)
             {
                 return data.AttributeUsageInfo;
@@ -1002,7 +1002,7 @@ next:;
                 var lazyCustomAttributesBag = _lazyCustomAttributesBag;
                 if (lazyCustomAttributesBag != null && lazyCustomAttributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
                 {
-                    var data = (CommonTypeEarlyWellKnownAttributeData)lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData;
+                    var data = (TypeEarlyWellKnownAttributeData)lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData;
                     return data != null ? data.ObsoleteAttributeData : null;
                 }
 
@@ -1227,7 +1227,7 @@ next:;
         {
             get
             {
-                CommonTypeEarlyWellKnownAttributeData data = this.GetEarlyDecodedWellKnownAttributeData();
+                TypeEarlyWellKnownAttributeData data = this.GetEarlyDecodedWellKnownAttributeData();
                 return data != null && data.HasComImportAttribute;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -130,6 +130,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => false;
 
+        internal sealed override bool IsInterpolatedStringHandlerType => false;
+
         public override ImmutableArray<Symbol> GetMembers()
         {
             Symbol constructor = this.Constructor;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -99,6 +99,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => true;
 
+        internal override bool IsInterpolatedStringHandlerType => false;
+
         internal override bool HasSpecialName => false;
 
         internal override bool IsComImport => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -192,6 +192,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => _underlyingType.HasCodeAnalysisEmbeddedAttribute;
 
+        internal override bool IsInterpolatedStringHandlerType => _underlyingType.IsInterpolatedStringHandlerType;
+
         internal override ObsoleteAttributeData ObsoleteAttributeData
         {
             get { return _underlyingType.ObsoleteAttributeData; }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -4127,9 +4127,27 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"");
+            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
 
-            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0(bool)", @"1.000Literal");
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0(bool)", @"
+{
+  // Code size       35 (0x23)
+  .maxstack  2
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  brfalse.s  IL_0012
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  initobj    ""CustomHandler""
+  IL_000b:  ldloc.0
+  IL_000c:  call       ""string CustomHandler.op_Implicit(CustomHandler)""
+  IL_0011:  ret
+  IL_0012:  ldstr      ""{0,2:f}Literal""
+  IL_0017:  ldc.i4.1
+  IL_0018:  box        ""int""
+  IL_001d:  call       ""string string.Format(string, object)""
+  IL_0022:  ret
+}
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -4367,7 +4367,7 @@ public partial struct CustomHandler
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaInference_AmbiguousInOlderLangVersions()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -3277,6 +3277,12 @@ public " + type + " " + name + @"
             Assert.Null(semanticInfo.ImplicitConversion.Method);
         }
 
+        private CompilationVerifier CompileAndVerifyOnCorrectPlatforms(CSharpCompilation compilation, string expectedOutput)
+         => CompileAndVerify(
+             compilation,
+             expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? expectedOutput : null,
+             verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped);
+
         [ConditionalTheory(typeof(NoIOperationValidation))]
         [CombinatorialData]
         public void CustomHandlerLocal([CombinatorialValues("class", "struct")] string type, bool useBoolReturns)
@@ -3959,7 +3965,7 @@ public ref struct S
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial class", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"value:Field", verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped);
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"value:Field");
 
             verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0()", @"
 {
@@ -4028,7 +4034,7 @@ namespace System.Runtime.CompilerServices
             );
 
             comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"value:Field", verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped);
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"value:Field");
 
             verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0()", @"
 {
@@ -4075,7 +4081,7 @@ static class C
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4139,7 +4145,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal", verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped);
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"1.000Literal");
 
             verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0(bool)", @"
 {
@@ -4186,7 +4192,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4266,7 +4272,7 @@ Console.WriteLine(x);
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4324,7 +4330,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"1.000Literal");
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"1.000Literal");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
@@ -4392,7 +4398,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4476,7 +4482,7 @@ public partial struct CustomHandler
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4555,7 +4561,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"1.000Literal");
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"1.000Literal");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
@@ -4604,7 +4610,7 @@ public partial struct CustomHandler
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4666,7 +4672,7 @@ public partial struct CustomHandler
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4754,7 +4760,7 @@ public partial struct CustomHandler
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4808,7 +4814,7 @@ void M(ref CustomHandler c) => System.Console.WriteLine(c);";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4869,7 +4875,7 @@ void M(in CustomHandler c) => System.Console.WriteLine(c);";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4910,7 +4916,7 @@ void M(in CustomHandler c) => System.Console.WriteLine(c);";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -4956,7 +4962,7 @@ class C
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -5002,7 +5008,7 @@ class C
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             VerifyInterpolatedStringExpression(comp);
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f
@@ -5052,7 +5058,7 @@ class C
                 GetCustomHandlerType("CustomHandler2", "struct", useBoolReturns: false, includeOneTimeHelpers: false)
             }, parseOptions: TestOptions.RegularPreview);
             VerifyInterpolatedStringExpression(comp, "CustomHandler1");
-            var verifier = CompileAndVerify(comp, verify: ExecutionConditionUtil.IsMonoOrCoreClr ? Verification.Passes : Verification.Skipped, expectedOutput: @"
+            var verifier = CompileAndVerifyOnCorrectPlatforms(comp, expectedOutput: @"
 value:1
 alignment:2
 format:f

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -4,6 +4,8 @@
 
 #nullable disable
 
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -1208,7 +1210,7 @@ static class C
 namespace System.Runtime.CompilerServices
 {
     using System.Text;
-    public ref struct DefaultInterpolatedStringHandler
+    public ref partial struct DefaultInterpolatedStringHandler
     {
         private readonly StringBuilder _builder;
         public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
@@ -3171,9 +3173,1880 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            // PROTOTYPE(interp-string): Have a symmetric test for just using AppendLiteral when we have general builder
-            // type support (that the compiler won't optimize away to just the literal value)
             CompileAndVerify(source, expectedOutput: "value:1");
+        }
+
+        [ConditionalFact(typeof(NoIOperationValidation))]
+        public void MixedBuilderReturnTypes_04()
+        {
+            var source = @"
+using System;
+using System.Text;
+using System.Runtime.CompilerServices;
+
+Console.WriteLine((CustomHandler)$""l"");
+
+[InterpolatedStringHandler]
+public class CustomHandler
+{
+    private readonly StringBuilder _builder;
+    public CustomHandler(int literalLength, int formattedCount)
+    {
+        _builder = new StringBuilder();
+    }
+    public override string ToString() => _builder.ToString();
+    public bool AppendFormatted(object o) => true;
+    public void AppendLiteral(string s)
+    {
+        _builder.AppendLine(""literal:"" + s.ToString());
+    }
+}
+";
+
+            CompileAndVerify(new[] { source, InterpolatedStringHandlerAttribute }, parseOptions: TestOptions.RegularPreview, expectedOutput: "literal:l");
+        }
+
+        private const string InterpolatedStringHandlerAttribute = @"
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+    public sealed class InterpolatedStringHandlerAttribute : Attribute
+    {
+        public InterpolatedStringHandlerAttribute()
+        {
+        }
+    }
+}
+";
+
+        private string GetCustomHandlerType(string name, string type, bool useBoolReturns, bool includeAttributeDefinition = true)
+        {
+            var returnType = useBoolReturns ? "bool" : "void";
+            var returnStatement = useBoolReturns ? "return true;" : "return;";
+
+            return @"
+using System.Text;
+[System.Runtime.CompilerServices.InterpolatedStringHandler]
+public " + type + " " + name + @"
+{
+    private readonly StringBuilder _builder;
+    public " + name + @"(int literalLength, int formattedCount)
+    {
+        _builder = new();
+    }
+    public " + returnType + @" AppendLiteral(string literal)
+    {
+        _builder.AppendLine(""literal:"" + literal);
+        " + returnStatement + @"
+    }
+    public " + returnType + @" AppendFormatted(object o, int alignment = 0, string format = null)
+    {
+        _builder.AppendLine(""value:"" + o?.ToString());
+        _builder.AppendLine(""alignment:"" + alignment.ToString());
+        _builder.AppendLine(""format:"" + format);
+        " + returnStatement + @"
+    }
+    public override string ToString() => _builder.ToString();
+}
+" + (includeAttributeDefinition ? InterpolatedStringHandlerAttribute : "");
+        }
+
+        private void VerifyInterpolatedStringExpression(CSharpCompilation comp, string handlerType = "CustomHandler")
+        {
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var interpolatedString = tree.GetRoot().DescendantNodes().OfType<InterpolatedStringExpressionSyntax>().Single();
+            var semanticInfo = model.GetSemanticInfoSummary(interpolatedString);
+
+            Assert.Equal(SpecialType.System_String, semanticInfo.Type.SpecialType);
+            Assert.Equal(handlerType, semanticInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal(ConversionKind.InterpolatedStringHandler, semanticInfo.ImplicitConversion.Kind);
+            Assert.True(semanticInfo.ImplicitConversion.Exists);
+            Assert.True(semanticInfo.ImplicitConversion.IsValid);
+            Assert.True(semanticInfo.ImplicitConversion.IsInterpolatedStringHandler);
+            Assert.Null(semanticInfo.ImplicitConversion.Method);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void CustomHandlerLocal([CombinatorialValues("class", "struct")] string type, bool useBoolReturns)
+        {
+            var code = @"
+CustomHandler builder = $""Literal{1,2:f}"";
+System.Console.WriteLine(builder.ToString());";
+
+            var builder = GetCustomHandlerType("CustomHandler", "struct", useBoolReturns);
+            var comp = CreateCompilation(new[] { code, builder }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+literal:Literal
+value:1
+alignment:2
+format:f");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", getIl());
+
+            string getIl() => useBoolReturns switch
+            {
+                true => @"
+{
+  // Code size       67 (0x43)
+  .maxstack  4
+  .locals init (CustomHandler V_0, //builder
+                CustomHandler V_1)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  ldc.i4.7
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""CustomHandler..ctor(int, int)""
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  ldstr      ""Literal""
+  IL_0010:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0015:  brfalse.s  IL_002c
+  IL_0017:  ldloca.s   V_1
+  IL_0019:  ldc.i4.1
+  IL_001a:  box        ""int""
+  IL_001f:  ldc.i4.2
+  IL_0020:  ldstr      ""f""
+  IL_0025:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_002a:  br.s       IL_002d
+  IL_002c:  ldc.i4.0
+  IL_002d:  pop
+  IL_002e:  ldloc.1
+  IL_002f:  stloc.0
+  IL_0030:  ldloca.s   V_0
+  IL_0032:  constrained. ""CustomHandler""
+  IL_0038:  callvirt   ""string object.ToString()""
+  IL_003d:  call       ""void System.Console.WriteLine(string)""
+  IL_0042:  ret
+}
+",
+                false => @"
+{
+  // Code size       61 (0x3d)
+  .maxstack  4
+  .locals init (CustomHandler V_0, //builder
+                CustomHandler V_1)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  ldc.i4.7
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""CustomHandler..ctor(int, int)""
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  ldstr      ""Literal""
+  IL_0010:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0015:  ldloca.s   V_1
+  IL_0017:  ldc.i4.1
+  IL_0018:  box        ""int""
+  IL_001d:  ldc.i4.2
+  IL_001e:  ldstr      ""f""
+  IL_0023:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0028:  ldloc.1
+  IL_0029:  stloc.0
+  IL_002a:  ldloca.s   V_0
+  IL_002c:  constrained. ""CustomHandler""
+  IL_0032:  callvirt   ""string object.ToString()""
+  IL_0037:  call       ""void System.Console.WriteLine(string)""
+  IL_003c:  ret
+}
+"
+            };
+        }
+
+        [Fact]
+        public void CustomHandlerMethodArgument()
+        {
+            var code = @"
+M($""{1,2:f}Literal"");
+void M(CustomHandler b)
+{
+    System.Console.WriteLine(b.ToString());
+}";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL(@"<top-level-statements-entry-point>", @"
+{
+  // Code size       50 (0x32)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldc.i4.1
+  IL_000a:  box        ""int""
+  IL_000f:  ldc.i4.2
+  IL_0010:  ldstr      ""f""
+  IL_0015:  callvirt   ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_001a:  brfalse.s  IL_0029
+  IL_001c:  ldloc.0
+  IL_001d:  ldstr      ""Literal""
+  IL_0022:  callvirt   ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
+  IL_002b:  ldloc.0
+  IL_002c:  call       ""void <Program>$.<<Main>$>g__M|0_0(CustomHandler)""
+  IL_0031:  ret
+}
+");
+        }
+
+        [Fact]
+        public void HandlerConversionPreferredOverStringForNonConstant()
+        {
+            var code = @"
+C.M($""{1,2:f}Literal"");
+class C
+{
+    public static void M(CustomHandler b)
+    {
+        System.Console.WriteLine(b.ToString());
+    }
+    public static void M(string s)
+    {
+        throw null;
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL(@"<top-level-statements-entry-point>", @"
+{
+  // Code size       50 (0x32)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldc.i4.1
+  IL_000a:  box        ""int""
+  IL_000f:  ldc.i4.2
+  IL_0010:  ldstr      ""f""
+  IL_0015:  callvirt   ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_001a:  brfalse.s  IL_0029
+  IL_001c:  ldloc.0
+  IL_001d:  ldstr      ""Literal""
+  IL_0022:  callvirt   ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
+  IL_002b:  ldloc.0
+  IL_002c:  call       ""void C.M(CustomHandler)""
+  IL_0031:  ret
+}
+");
+        }
+
+        [Fact]
+        public void StringPreferredOverHandlerConversionForConstant()
+        {
+            var code = @"
+C.M($""{""Literal""}"");
+class C
+{
+    public static void M(CustomHandler b)
+    {
+        throw null;
+    }
+    public static void M(string s)
+    {
+        System.Console.WriteLine(s);
+    }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"Literal");
+
+            verifier.VerifyIL(@"<top-level-statements-entry-point>", @"
+{
+  // Code size       11 (0xb)
+  .maxstack  1
+  IL_0000:  ldstr      ""Literal""
+  IL_0005:  call       ""void C.M(string)""
+  IL_000a:  ret
+}
+");
+        }
+
+        [Fact]
+        public void HandlerConversionPreferredOverStringForNonConstant_AttributeConstructor()
+        {
+            var code = @"
+using System;
+
+[Attr($""{1}"")]
+class Attr : Attribute
+{
+    public Attr(string s) {}
+    public Attr(CustomHandler c) {}
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(
+                // (4,2): error CS0181: Attribute constructor parameter 'c' has type 'CustomHandler', which is not a valid attribute parameter type
+                // [Attr($"{1}")]
+                Diagnostic(ErrorCode.ERR_BadAttributeParamType, "Attr").WithArguments("c", "CustomHandler").WithLocation(4, 2)
+            );
+            VerifyInterpolatedStringExpression(comp);
+
+            var attr = comp.SourceAssembly.SourceModule.GlobalNamespace.GetTypeMember("Attr");
+            Assert.Equal("Attr..ctor(CustomHandler c)", attr.GetAttributes().Single().AttributeConstructor.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void StringPreferredOverHandlerConversionForConstant_AttributeConstructor()
+        {
+            var code = @"
+using System;
+
+[Attr($""{""Literal""}"")]
+class Attr : Attribute
+{
+    public Attr(string s) {}
+    public Attr(CustomHandler c) {}
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp, symbolValidator: validate, sourceSymbolValidator: validate);
+
+            void validate(ModuleSymbol m)
+            {
+                var attr = m.GlobalNamespace.GetTypeMember("Attr");
+                Assert.Equal("Attr..ctor(System.String s)", attr.GetAttributes().Single().AttributeConstructor.ToTestDisplayString());
+            }
+        }
+
+        [Fact]
+        public void MultipleBuilderTypes()
+        {
+            var code = @"
+C.M($"""");
+
+class C
+{
+    public static void M(CustomHandler1 c) => throw null;
+    public static void M(CustomHandler2 c) => throw null;
+}";
+
+            var comp = CreateCompilation(new[]
+            {
+                code,
+                GetCustomHandlerType("CustomHandler1", "struct", useBoolReturns: false),
+                GetCustomHandlerType("CustomHandler2", "struct", useBoolReturns: false, includeAttributeDefinition: false)
+            }, parseOptions: TestOptions.RegularPreview);
+
+            comp.VerifyDiagnostics(
+                // (2,3): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(CustomHandler1)' and 'C.M(CustomHandler2)'
+                // C.M($"");
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(CustomHandler1)", "C.M(CustomHandler2)").WithLocation(2, 3)
+            );
+        }
+
+        [Fact]
+        public void GenericOverloadResolution_01()
+        {
+            var code = @"
+using System;
+
+C.M($""{1,2:f}Literal"");
+
+class C
+{
+    public static void M<T>(T t) => throw null;
+    public static void M(CustomHandler c) => Console.WriteLine(c);
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       50 (0x32)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldc.i4.1
+  IL_000a:  box        ""int""
+  IL_000f:  ldc.i4.2
+  IL_0010:  ldstr      ""f""
+  IL_0015:  callvirt   ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_001a:  brfalse.s  IL_0029
+  IL_001c:  ldloc.0
+  IL_001d:  ldstr      ""Literal""
+  IL_0022:  callvirt   ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
+  IL_002b:  ldloc.0
+  IL_002c:  call       ""void C.M(CustomHandler)""
+  IL_0031:  ret
+}
+");
+        }
+
+        [Fact]
+        public void GenericOverloadResolution_02()
+        {
+            var code = @"
+using System;
+
+C.M($""{1,2:f}Literal"");
+
+class C
+{
+    public static void M<T>(T t) where T : CustomHandler => throw null;
+    public static void M(CustomHandler c) => Console.WriteLine(c);
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       50 (0x32)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldc.i4.1
+  IL_000a:  box        ""int""
+  IL_000f:  ldc.i4.2
+  IL_0010:  ldstr      ""f""
+  IL_0015:  callvirt   ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_001a:  brfalse.s  IL_0029
+  IL_001c:  ldloc.0
+  IL_001d:  ldstr      ""Literal""
+  IL_0022:  callvirt   ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
+  IL_002b:  ldloc.0
+  IL_002c:  call       ""void C.M(CustomHandler)""
+  IL_0031:  ret
+}
+");
+        }
+
+        [Fact]
+        public void GenericOverloadResolution_03()
+        {
+            var code = @"
+C.M($""{1,2:f}Literal"");
+
+class C
+{
+    public static void M<T>(T t) where T : CustomHandler => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(
+                // (2,3): error CS0311: The type 'string' cannot be used as type parameter 'T' in the generic type or method 'C.M<T>(T)'. There is no implicit reference conversion from 'string' to 'CustomHandler'.
+                // C.M($"{1,2:f}Literal");
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M").WithArguments("C.M<T>(T)", "CustomHandler", "T", "string").WithLocation(2, 3)
+            );
+        }
+
+        [Fact]
+        public void GenericInference_01()
+        {
+            var code = @"
+C.M($""{1,2:f}Literal"", default(CustomHandler));
+C.M(default(CustomHandler), $""{1,2:f}Literal"");
+
+class C
+{
+    public static void M<T>(T t1, T t2) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(
+                // (2,3): error CS0411: The type arguments for method 'C.M<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // C.M($"{1,2:f}Literal", default(CustomHandler));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M").WithArguments("C.M<T>(T, T)").WithLocation(2, 3),
+                // (3,3): error CS0411: The type arguments for method 'C.M<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // C.M(default(CustomHandler), $"{1,2:f}Literal");
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M").WithArguments("C.M<T>(T, T)").WithLocation(3, 3)
+            );
+        }
+
+        [Fact]
+        public void GenericInference_02()
+        {
+            var code = @"
+using System;
+C.M(default(CustomHandler), () => $""{1,2:f}Literal"");
+
+class C
+{
+    public static void M<T>(T t1, Func<T> t2) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(
+                // (3,3): error CS0411: The type arguments for method 'C.M<T>(T, Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // C.M(default(CustomHandler), () => $"{1,2:f}Literal");
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M").WithArguments("C.M<T>(T, System.Func<T>)").WithLocation(3, 3)
+            );
+        }
+
+        [Fact]
+        public void GenericInference_03()
+        {
+            var code = @"
+using System;
+C.M($""{1,2:f}Literal"", default(CustomHandler));
+
+class C
+{
+    public static void M<T>(T t1, T t2) => Console.WriteLine(t1);
+}
+
+partial class CustomHandler
+{
+    public static implicit operator CustomHandler(string s) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       51 (0x33)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldc.i4.1
+  IL_000a:  box        ""int""
+  IL_000f:  ldc.i4.2
+  IL_0010:  ldstr      ""f""
+  IL_0015:  callvirt   ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_001a:  brfalse.s  IL_0029
+  IL_001c:  ldloc.0
+  IL_001d:  ldstr      ""Literal""
+  IL_0022:  callvirt   ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
+  IL_002b:  ldloc.0
+  IL_002c:  ldnull
+  IL_002d:  call       ""void C.M<CustomHandler>(CustomHandler, CustomHandler)""
+  IL_0032:  ret
+}
+");
+        }
+
+        [Fact]
+        public void GenericInference_04()
+        {
+            var code = @"
+using System;
+C.M(default(CustomHandler), () => $""{1,2:f}Literal"");
+
+class C
+{
+    public static void M<T>(T t1, Func<T> t2) => Console.WriteLine(t2());
+}
+
+partial class CustomHandler
+{
+    public static implicit operator CustomHandler(string s) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<Program>$.<>c.<<Main>$>b__0_0()", @"
+{
+  // Code size       45 (0x2d)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldc.i4.1
+  IL_000a:  box        ""int""
+  IL_000f:  ldc.i4.2
+  IL_0010:  ldstr      ""f""
+  IL_0015:  callvirt   ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_001a:  brfalse.s  IL_0029
+  IL_001c:  ldloc.0
+  IL_001d:  ldstr      ""Literal""
+  IL_0022:  callvirt   ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
+  IL_002b:  ldloc.0
+  IL_002c:  ret
+}
+");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_01()
+        {
+            var code = @"
+using System;
+Func<CustomHandler> f = () => $""{1,2:f}Literal"";
+Console.WriteLine(f());
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0()", @"
+{
+  // Code size       45 (0x2d)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldc.i4.1
+  IL_000a:  box        ""int""
+  IL_000f:  ldc.i4.2
+  IL_0010:  ldstr      ""f""
+  IL_0015:  callvirt   ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_001a:  brfalse.s  IL_0029
+  IL_001c:  ldloc.0
+  IL_001d:  ldstr      ""Literal""
+  IL_0022:  callvirt   ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
+  IL_002b:  ldloc.0
+  IL_002c:  ret
+}
+");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_02()
+        {
+            var code = @"
+using System;
+C.M(() => $""{1,2:f}Literal"");
+
+class C
+{
+    public static void M(Func<string> f) => Console.WriteLine(f());
+    public static void M(Func<CustomHandler> f) => throw null;
+}
+";
+
+            // Interpolated string handler conversions are not considered when determining the natural type of an expression: the natural return type of this lambda is string,
+            // so we don't even consider that there is a conversion from interpolated string expression to CustomHandler here (Sections 12.6.3.13 and 12.6.3.15 of the spec).
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
+
+            // No DefaultInterpolatedStringHandler was included in the compilation, so it falls back to string.Format
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0()", @"
+{
+  // Code size       17 (0x11)
+  .maxstack  2
+  IL_0000:  ldstr      ""{0,2:f}Literal""
+  IL_0005:  ldc.i4.1
+  IL_0006:  box        ""int""
+  IL_000b:  call       ""string string.Format(string, object)""
+  IL_0010:  ret
+}
+");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_03()
+        {
+            // Same as 2, but using a type that isn't allowed in an interpolated string. There is an implicit conversion error on the ref struct
+            // when converting to a string, because S cannot be a component of an interpolated string. This conversion error causes the lambda to
+            // fail to bind as Func<string>, even though the natural return type is string, and the only successful bind is Func<CustomHandler>.
+
+            var code = @"
+using System;
+C.M(() => $""{new S { Field = ""Field"" }}"");
+
+static class C
+{
+    public static void M(Func<string> f) => throw null;
+    public static void M(Func<CustomHandler> f) => Console.WriteLine(f());
+}
+
+public partial class CustomHandler
+{
+    public void AppendFormatted(S value) => _builder.AppendLine(""value:"" + value.Field);
+}
+public ref struct S
+{
+    public string Field { get; set; }
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial class", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"value:Field");
+
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0()", @"
+{
+  // Code size       35 (0x23)
+  .maxstack  4
+  .locals init (S V_0)
+  IL_0000:  ldc.i4.0
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  dup
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  initobj    ""S""
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  ldstr      ""Field""
+  IL_0017:  call       ""void S.Field.set""
+  IL_001c:  ldloc.0
+  IL_001d:  callvirt   ""void CustomHandler.AppendFormatted(S)""
+  IL_0022:  ret
+}
+");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_04()
+        {
+            // Same as 3, but with S added to DefaultInterpolatedStringHandler (which then allows the lambda to be bound as Func<string>, matching the natural return type)
+
+            var code = @"
+using System;
+C.M(() => $""{new S { Field = ""Field"" }}"");
+
+static class C
+{
+    public static void M(Func<string> f) => Console.WriteLine(f());
+    public static void M(Func<CustomHandler> f) => throw null;
+}
+
+public partial class CustomHandler
+{
+    public void AppendFormatted(S value) => throw null;
+}
+public ref struct S
+{
+    public string Field { get; set; }
+}
+namespace System.Runtime.CompilerServices
+{
+    public ref partial struct DefaultInterpolatedStringHandler
+    {
+        public void AppendFormatted(S value) => _builder.AppendLine(""value:"" + value.Field);
+    }
+}
+";
+
+            string[] source = new[] {
+                code,
+                GetCustomHandlerType("CustomHandler", "partial class", useBoolReturns: false),
+                GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: true, useBoolReturns: false)
+            };
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (3,14): error CS8652: The feature 'interpolated string handlers' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // C.M(() => $"{new S { Field = "Field" }}");
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, @"new S { Field = ""Field"" }").WithArguments("interpolated string handlers").WithLocation(3, 14)
+            );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"value:Field");
+
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0()", @"
+{
+  // Code size       45 (0x2d)
+  .maxstack  3
+  .locals init (System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_0,
+                S V_1)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.0
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  initobj    ""S""
+  IL_0013:  ldloca.s   V_1
+  IL_0015:  ldstr      ""Field""
+  IL_001a:  call       ""void S.Field.set""
+  IL_001f:  ldloc.1
+  IL_0020:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(S)""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
+  IL_002c:  ret
+}
+");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_05()
+        {
+            var code = @"
+using System;
+C.M(b => 
+    {
+        if (b) return default(CustomHandler);
+        else return $""{1,2:f}Literal"";
+    });
+
+static class C
+{
+    public static void M(Func<bool, string> f) => throw null;
+    public static void M(Func<bool, CustomHandler> f) => Console.WriteLine(f(false));
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0(bool)", @"
+{
+  // Code size       55 (0x37)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  brfalse.s  IL_000d
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  initobj    ""CustomHandler""
+  IL_000b:  ldloc.0
+  IL_000c:  ret
+  IL_000d:  ldloca.s   V_0
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.1
+  IL_0011:  call       ""CustomHandler..ctor(int, int)""
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  ldc.i4.1
+  IL_0019:  box        ""int""
+  IL_001e:  ldc.i4.2
+  IL_001f:  ldstr      ""f""
+  IL_0024:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  ldstr      ""Literal""
+  IL_0030:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0035:  ldloc.0
+  IL_0036:  ret
+}
+");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_06()
+        {
+            // Same as 5, but with an implicit conversion from the builder type to string. This implicit conversion
+            // means that a best common type can be inferred for all branches of the lambda expression (Section 12.6.3.15 of the spec)
+            // and because there is a best common type, the inferred return type of the lambda is string. Since the inferred return type
+            // has an identity conversion to the return type of Func<bool, string>, that is preferred.
+            var code = @"
+using System;
+C.M(b => 
+    {
+        if (b) return default(CustomHandler);
+        else return $""{1,2:f}Literal"";
+    });
+
+static class C
+{
+    public static void M(Func<bool, string> f) => Console.WriteLine(f(false));
+    public static void M(Func<bool, CustomHandler> f) => throw null;
+}
+public partial struct CustomHandler
+{
+    public static implicit operator string(CustomHandler c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"");
+
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0(bool)", @"1.000Literal");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_07()
+        {
+            // Same as 5, but with an implicit conversion from string to the builder type.
+            var code = @"
+using System;
+C.M(b => 
+    {
+        if (b) return default(CustomHandler);
+        else return $""{1,2:f}Literal"";
+    });
+
+static class C
+{
+    public static void M(Func<bool, string> f) => Console.WriteLine(f(false));
+    public static void M(Func<bool, CustomHandler> f) => Console.WriteLine(f(false));
+}
+public partial struct CustomHandler
+{
+    public static implicit operator CustomHandler(string s) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0(bool)", @"
+{
+  // Code size       55 (0x37)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  brfalse.s  IL_000d
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  initobj    ""CustomHandler""
+  IL_000b:  ldloc.0
+  IL_000c:  ret
+  IL_000d:  ldloca.s   V_0
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.1
+  IL_0011:  call       ""CustomHandler..ctor(int, int)""
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  ldc.i4.1
+  IL_0019:  box        ""int""
+  IL_001e:  ldc.i4.2
+  IL_001f:  ldstr      ""f""
+  IL_0024:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  ldstr      ""Literal""
+  IL_0030:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0035:  ldloc.0
+  IL_0036:  ret
+}
+");
+        }
+
+        [Fact]
+        public void LambdaReturnInference_08()
+        {
+            // Same as 5, but with an implicit conversion from the builder type to string and from string to the builder type.
+            var code = @"
+using System;
+C.M(b => 
+    {
+        if (b) return default(CustomHandler);
+        else return $""{1,2:f}Literal"";
+    });
+
+static class C
+{
+    public static void M(Func<bool, string> f) => Console.WriteLine(f(false));
+    public static void M(Func<bool, CustomHandler> f) => throw null;
+}
+public partial struct CustomHandler
+{
+    public static implicit operator string(CustomHandler c) => throw null;
+    public static implicit operator CustomHandler(string c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (3,3): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(Func<bool, string>)' and 'C.M(Func<bool, CustomHandler>)'
+                // C.M(b => 
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(System.Func<bool, string>)", "C.M(System.Func<bool, CustomHandler>)").WithLocation(3, 3)
+            );
+        }
+
+        [Fact]
+        public void TernaryTypes_01()
+        {
+            var code = @"
+using System;
+
+var x = (bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal"";
+Console.WriteLine(x);
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       76 (0x4c)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brtrue.s   IL_0038
+  IL_000d:  ldloca.s   V_0
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.1
+  IL_0011:  call       ""CustomHandler..ctor(int, int)""
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  ldc.i4.1
+  IL_0019:  box        ""int""
+  IL_001e:  ldc.i4.2
+  IL_001f:  ldstr      ""f""
+  IL_0024:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  ldstr      ""Literal""
+  IL_0030:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0035:  ldloc.0
+  IL_0036:  br.s       IL_0041
+  IL_0038:  ldloca.s   V_0
+  IL_003a:  initobj    ""CustomHandler""
+  IL_0040:  ldloc.0
+  IL_0041:  box        ""CustomHandler""
+  IL_0046:  call       ""void System.Console.WriteLine(object)""
+  IL_004b:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TernaryTypes_02()
+        {
+            // Same as 01, but with a conversion from CustomHandler to string. The rules here are similar to LambdaReturnInference_06
+            var code = @"
+using System;
+
+var x = (bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal"";
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator string(CustomHandler c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       51 (0x33)
+  .maxstack  2
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brtrue.s   IL_001f
+  IL_000d:  ldstr      ""{0,2:f}Literal""
+  IL_0012:  ldc.i4.1
+  IL_0013:  box        ""int""
+  IL_0018:  call       ""string string.Format(string, object)""
+  IL_001d:  br.s       IL_002d
+  IL_001f:  ldloca.s   V_0
+  IL_0021:  initobj    ""CustomHandler""
+  IL_0027:  ldloc.0
+  IL_0028:  call       ""string CustomHandler.op_Implicit(CustomHandler)""
+  IL_002d:  call       ""void System.Console.WriteLine(string)""
+  IL_0032:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TernaryTypes_03()
+        {
+            // Same as 02, but with a target-type
+            var code = @"
+using System;
+
+CustomHandler x = (bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal"";
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator string(CustomHandler c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (4,19): error CS0029: Cannot implicitly convert type 'string' to 'CustomHandler'
+                // CustomHandler x = (bool)(object)false ? default(CustomHandler) : $"{1,2:f}Literal";
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"(bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal""").WithArguments("string", "CustomHandler").WithLocation(4, 19)
+            );
+        }
+
+        [Fact]
+        public void TernaryTypes_04()
+        {
+            // Same 01, but with a conversion from string to CustomHandler. The rules here are similar to LambdaReturnInference_07
+            var code = @"
+using System;
+
+var x = (bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal"";
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator CustomHandler(string c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       76 (0x4c)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brtrue.s   IL_0038
+  IL_000d:  ldloca.s   V_0
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.1
+  IL_0011:  call       ""CustomHandler..ctor(int, int)""
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  ldc.i4.1
+  IL_0019:  box        ""int""
+  IL_001e:  ldc.i4.2
+  IL_001f:  ldstr      ""f""
+  IL_0024:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  ldstr      ""Literal""
+  IL_0030:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0035:  ldloc.0
+  IL_0036:  br.s       IL_0041
+  IL_0038:  ldloca.s   V_0
+  IL_003a:  initobj    ""CustomHandler""
+  IL_0040:  ldloc.0
+  IL_0041:  box        ""CustomHandler""
+  IL_0046:  call       ""void System.Console.WriteLine(object)""
+  IL_004b:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TernaryTypes_05()
+        {
+            // Same 01, but with a conversion from string to CustomHandler and CustomHandler to string.
+            var code = @"
+using System;
+
+var x = (bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal"";
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator CustomHandler(string c) => throw null;
+    public static implicit operator string(CustomHandler c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (4,9): error CS0172: Type of conditional expression cannot be determined because 'CustomHandler' and 'string' implicitly convert to one another
+                // var x = (bool)(object)false ? default(CustomHandler) : $"{1,2:f}Literal";
+                Diagnostic(ErrorCode.ERR_AmbigQM, @"(bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal""").WithArguments("CustomHandler", "string").WithLocation(4, 9)
+            );
+        }
+
+        [Fact]
+        public void TernaryTypes_06()
+        {
+            // Same 05, but with a target type
+            var code = @"
+using System;
+
+CustomHandler x = (bool)(object)false ? default(CustomHandler) : $""{1,2:f}Literal"";
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator CustomHandler(string c) => throw null;
+    public static implicit operator string(CustomHandler c) => c.ToString();
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       76 (0x4c)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brtrue.s   IL_0038
+  IL_000d:  ldloca.s   V_0
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.1
+  IL_0011:  call       ""CustomHandler..ctor(int, int)""
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  ldc.i4.1
+  IL_0019:  box        ""int""
+  IL_001e:  ldc.i4.2
+  IL_001f:  ldstr      ""f""
+  IL_0024:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  ldstr      ""Literal""
+  IL_0030:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0035:  ldloc.0
+  IL_0036:  br.s       IL_0041
+  IL_0038:  ldloca.s   V_0
+  IL_003a:  initobj    ""CustomHandler""
+  IL_0040:  ldloc.0
+  IL_0041:  call       ""string CustomHandler.op_Implicit(CustomHandler)""
+  IL_0046:  call       ""void System.Console.WriteLine(string)""
+  IL_004b:  ret
+}
+");
+        }
+
+        [Fact]
+        public void SwitchTypes_01()
+        {
+            // Switch expressions infer a best type based on _types_, not based on expressions (section 12.6.3.15 of the spec). Because this is based on types
+            // and not on expression conversions, no best type can be found for this switch expression.
+
+            var code = @"
+using System;
+
+var x = (bool)(object)false switch { true => default(CustomHandler), false => $""{1,2:f}Literal"" };
+Console.WriteLine(x);
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (4,29): error CS8506: No best type was found for the switch expression.
+                // var x = (bool)(object)false switch { true => default(CustomHandler), false => $"{1,2:f}Literal" };
+                Diagnostic(ErrorCode.ERR_SwitchExpressionNoBestType, "switch").WithLocation(4, 29)
+            );
+        }
+
+        [Fact]
+        public void SwitchTypes_02()
+        {
+            // Same as 01, but with a conversion from CustomHandler. This allows the switch expression to infer a best-common type, which is string.
+            var code = @"
+using System;
+
+var x = (bool)(object)false switch { true => default(CustomHandler), false => $""{1,2:f}Literal"" };
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator string(CustomHandler c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       54 (0x36)
+  .maxstack  2
+  .locals init (string V_0,
+                CustomHandler V_1)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brfalse.s  IL_001e
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  initobj    ""CustomHandler""
+  IL_0015:  ldloc.1
+  IL_0016:  call       ""string CustomHandler.op_Implicit(CustomHandler)""
+  IL_001b:  stloc.0
+  IL_001c:  br.s       IL_002f
+  IL_001e:  ldstr      ""{0,2:f}Literal""
+  IL_0023:  ldc.i4.1
+  IL_0024:  box        ""int""
+  IL_0029:  call       ""string string.Format(string, object)""
+  IL_002e:  stloc.0
+  IL_002f:  ldloc.0
+  IL_0030:  call       ""void System.Console.WriteLine(string)""
+  IL_0035:  ret
+}
+");
+        }
+
+        [Fact]
+        public void SwitchTypes_03()
+        {
+            // Same 02, but with a target-type. The natural type will fail to compile, so the switch will use a target type (unlike TernaryTypes_03, which fails to compile).
+            var code = @"
+using System;
+
+CustomHandler x = (bool)(object)false switch { true => default(CustomHandler), false => $""{1,2:f}Literal"" };
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator string(CustomHandler c) => c.ToString();
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       79 (0x4f)
+  .maxstack  4
+  .locals init (CustomHandler V_0,
+                CustomHandler V_1)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brfalse.s  IL_0019
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  initobj    ""CustomHandler""
+  IL_0015:  ldloc.1
+  IL_0016:  stloc.0
+  IL_0017:  br.s       IL_0043
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldc.i4.7
+  IL_001c:  ldc.i4.1
+  IL_001d:  call       ""CustomHandler..ctor(int, int)""
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  ldc.i4.1
+  IL_0025:  box        ""int""
+  IL_002a:  ldc.i4.2
+  IL_002b:  ldstr      ""f""
+  IL_0030:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0035:  ldloca.s   V_1
+  IL_0037:  ldstr      ""Literal""
+  IL_003c:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0041:  ldloc.1
+  IL_0042:  stloc.0
+  IL_0043:  ldloc.0
+  IL_0044:  call       ""string CustomHandler.op_Implicit(CustomHandler)""
+  IL_0049:  call       ""void System.Console.WriteLine(string)""
+  IL_004e:  ret
+}
+");
+        }
+
+        [Fact]
+        public void SwitchTypes_04()
+        {
+            // Same as 01, but with a conversion to CustomHandler. This allows the switch expression to infer a best-common type, which is CustomHandler.
+            var code = @"
+using System;
+
+var x = (bool)(object)false switch { true => default(CustomHandler), false => $""{1,2:f}Literal"" };
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator CustomHandler(string c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       79 (0x4f)
+  .maxstack  4
+  .locals init (CustomHandler V_0,
+                CustomHandler V_1)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brfalse.s  IL_0019
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  initobj    ""CustomHandler""
+  IL_0015:  ldloc.1
+  IL_0016:  stloc.0
+  IL_0017:  br.s       IL_0043
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldc.i4.7
+  IL_001c:  ldc.i4.1
+  IL_001d:  call       ""CustomHandler..ctor(int, int)""
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  ldc.i4.1
+  IL_0025:  box        ""int""
+  IL_002a:  ldc.i4.2
+  IL_002b:  ldstr      ""f""
+  IL_0030:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0035:  ldloca.s   V_1
+  IL_0037:  ldstr      ""Literal""
+  IL_003c:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0041:  ldloc.1
+  IL_0042:  stloc.0
+  IL_0043:  ldloc.0
+  IL_0044:  box        ""CustomHandler""
+  IL_0049:  call       ""void System.Console.WriteLine(object)""
+  IL_004e:  ret
+}
+");
+        }
+
+        [Fact]
+        public void SwitchTypes_05()
+        {
+            // Same as 01, but with conversions in both directions. No best common type can be found.
+            var code = @"
+using System;
+
+var x = (bool)(object)false switch { true => default(CustomHandler), false => $""{1,2:f}Literal"" };
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator CustomHandler(string c) => throw null;
+    public static implicit operator string(CustomHandler c) => throw null;
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (4,29): error CS8506: No best type was found for the switch expression.
+                // var x = (bool)(object)false switch { true => default(CustomHandler), false => $"{1,2:f}Literal" };
+                Diagnostic(ErrorCode.ERR_SwitchExpressionNoBestType, "switch").WithLocation(4, 29)
+            );
+        }
+
+        [Fact]
+        public void SwitchTypes_06()
+        {
+            // Same as 05, but with a target type.
+            var code = @"
+using System;
+
+CustomHandler x = (bool)(object)false switch { true => default(CustomHandler), false => $""{1,2:f}Literal"" };
+Console.WriteLine(x);
+
+public partial struct CustomHandler
+{
+    public static implicit operator CustomHandler(string c) => throw null;
+    public static implicit operator string(CustomHandler c) => c.ToString();
+}
+";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       79 (0x4f)
+  .maxstack  4
+  .locals init (CustomHandler V_0,
+                CustomHandler V_1)
+  IL_0000:  ldc.i4.0
+  IL_0001:  box        ""bool""
+  IL_0006:  unbox.any  ""bool""
+  IL_000b:  brfalse.s  IL_0019
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  initobj    ""CustomHandler""
+  IL_0015:  ldloc.1
+  IL_0016:  stloc.0
+  IL_0017:  br.s       IL_0043
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldc.i4.7
+  IL_001c:  ldc.i4.1
+  IL_001d:  call       ""CustomHandler..ctor(int, int)""
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  ldc.i4.1
+  IL_0025:  box        ""int""
+  IL_002a:  ldc.i4.2
+  IL_002b:  ldstr      ""f""
+  IL_0030:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0035:  ldloca.s   V_1
+  IL_0037:  ldstr      ""Literal""
+  IL_003c:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0041:  ldloc.1
+  IL_0042:  stloc.0
+  IL_0043:  ldloc.0
+  IL_0044:  call       ""string CustomHandler.op_Implicit(CustomHandler)""
+  IL_0049:  call       ""void System.Console.WriteLine(string)""
+  IL_004e:  ret
+}
+");
+        }
+
+        [Fact]
+        public void PassAsRefWithoutKeyword_01()
+        {
+            var code = @"
+M($""{1,2:f}Literal"");
+
+void M(ref CustomHandler c) => System.Console.WriteLine(c);";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       48 (0x30)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.7
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""CustomHandler..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldc.i4.1
+  IL_000c:  box        ""int""
+  IL_0011:  ldc.i4.2
+  IL_0012:  ldstr      ""f""
+  IL_0017:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  ldstr      ""Literal""
+  IL_0023:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0028:  ldloca.s   V_0
+  IL_002a:  call       ""void <Program>$.<<Main>$>g__M|0_0(ref CustomHandler)""
+  IL_002f:  ret
+}
+");
+        }
+
+        [Fact]
+        public void PassAsRefWithoutKeyword_02()
+        {
+            var code = @"
+M($""{1,2:f}Literal"");
+M(ref $""{1,2:f}Literal"");
+
+void M(ref CustomHandler c) => System.Console.WriteLine(c);";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (2,3): error CS1620: Argument 1 must be passed with the 'ref' keyword
+                // M($"{1,2:f}Literal");
+                Diagnostic(ErrorCode.ERR_BadArgRef, @"$""{1,2:f}Literal""").WithArguments("1", "ref").WithLocation(2, 3),
+                // (3,7): error CS1510: A ref or out value must be an assignable variable
+                // M(ref $"{1,2:f}Literal");
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, @"$""{1,2:f}Literal""").WithLocation(3, 7)
+            );
+        }
+
+        [Fact]
+        public void PassAsRefWithoutKeyword_03()
+        {
+            var code = @"
+M($""{1,2:f}Literal"");
+
+void M(in CustomHandler c) => System.Console.WriteLine(c);";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       45 (0x2d)
+  .maxstack  5
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldc.i4.7
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     ""CustomHandler..ctor(int, int)""
+  IL_0007:  dup
+  IL_0008:  ldc.i4.1
+  IL_0009:  box        ""int""
+  IL_000e:  ldc.i4.2
+  IL_000f:  ldstr      ""f""
+  IL_0014:  callvirt   ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0019:  dup
+  IL_001a:  ldstr      ""Literal""
+  IL_001f:  callvirt   ""void CustomHandler.AppendLiteral(string)""
+  IL_0024:  stloc.0
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""void <Program>$.<<Main>$>g__M|0_0(in CustomHandler)""
+  IL_002c:  ret
+}
+");
+        }
+
+        [Fact]
+        public void PassAsRefWithoutKeyword_04()
+        {
+            var code = @"
+M($""{1,2:f}Literal"");
+
+void M(in CustomHandler c) => System.Console.WriteLine(c);";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       48 (0x30)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.7
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""CustomHandler..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldc.i4.1
+  IL_000c:  box        ""int""
+  IL_0011:  ldc.i4.2
+  IL_0012:  ldstr      ""f""
+  IL_0017:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  ldstr      ""Literal""
+  IL_0023:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0028:  ldloca.s   V_0
+  IL_002a:  call       ""void <Program>$.<<Main>$>g__M|0_0(in CustomHandler)""
+  IL_002f:  ret
+}
+");
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RefOverloadResolution_Struct([CombinatorialValues("in", "ref")] string refKind)
+        {
+            var code = @"
+C.M($""{1,2:f}Literal"");
+
+class C
+{
+    public static void M(CustomHandler c) => System.Console.WriteLine(c);
+    public static void M(" + refKind + @" CustomHandler c) => System.Console.WriteLine(c);
+}";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       47 (0x2f)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.7
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""CustomHandler..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldc.i4.1
+  IL_000c:  box        ""int""
+  IL_0011:  ldc.i4.2
+  IL_0012:  ldstr      ""f""
+  IL_0017:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  ldstr      ""Literal""
+  IL_0023:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0028:  ldloc.0
+  IL_0029:  call       ""void C.M(CustomHandler)""
+  IL_002e:  ret
+}
+");
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void RefOverloadResolution_Class([CombinatorialValues("in", "ref")] string refKind)
+        {
+            var code = @"
+C.M($""{1,2:f}Literal"");
+
+class C
+{
+    public static void M(CustomHandler c) => System.Console.WriteLine(c);
+    public static void M(" + refKind + @" CustomHandler c) => System.Console.WriteLine(c);
+}";
+
+            var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+            VerifyInterpolatedStringExpression(comp);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       47 (0x2f)
+  .maxstack  4
+  .locals init (CustomHandler V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.7
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""CustomHandler..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldc.i4.1
+  IL_000c:  box        ""int""
+  IL_0011:  ldc.i4.2
+  IL_0012:  ldstr      ""f""
+  IL_0017:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  ldstr      ""Literal""
+  IL_0023:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0028:  ldloc.0
+  IL_0029:  call       ""void C.M(CustomHandler)""
+  IL_002e:  ret
+}
+");
+        }
+
+        [Fact]
+        public void RefOverloadResolution_MultipleBuilderTypes()
+        {
+            var code = @"
+C.M($""{1,2:f}Literal"");
+
+class C
+{
+    public static void M(CustomHandler1 c) => System.Console.WriteLine(c);
+    public static void M(ref CustomHandler2 c) => throw null;
+}";
+
+            var comp = CreateCompilation(new[]
+            {
+                code,
+                GetCustomHandlerType("CustomHandler1", "struct", useBoolReturns: false),
+                GetCustomHandlerType("CustomHandler2", "struct", useBoolReturns: false, includeAttributeDefinition: false)
+            }, parseOptions: TestOptions.RegularPreview);
+            VerifyInterpolatedStringExpression(comp, "CustomHandler1");
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+value:1
+alignment:2
+format:f
+literal:Literal");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       47 (0x2f)
+  .maxstack  4
+  .locals init (CustomHandler1 V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.7
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       ""CustomHandler1..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldc.i4.1
+  IL_000c:  box        ""int""
+  IL_0011:  ldc.i4.2
+  IL_0012:  ldstr      ""f""
+  IL_0017:  call       ""void CustomHandler1.AppendFormatted(object, int, string)""
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  ldstr      ""Literal""
+  IL_0023:  call       ""void CustomHandler1.AppendLiteral(string)""
+  IL_0028:  ldloc.0
+  IL_0029:  call       ""void C.M(CustomHandler1)""
+  IL_002e:  ret
+}
+");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -3267,7 +3267,7 @@ public " + type + " " + name + @"
             Assert.Null(semanticInfo.ImplicitConversion.Method);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(NoIOperationValidation))]
         [CombinatorialData]
         public void CustomHandlerLocal([CombinatorialValues("class", "struct")] string type, bool useBoolReturns)
         {
@@ -3352,7 +3352,7 @@ format:f");
             };
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void CustomHandlerMethodArgument()
         {
             var code = @"
@@ -3399,7 +3399,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void HandlerConversionPreferredOverStringForNonConstant()
         {
             var code = @"
@@ -3454,7 +3454,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void StringPreferredOverHandlerConversionForConstant()
         {
             var code = @"
@@ -3486,7 +3486,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void HandlerConversionPreferredOverStringForNonConstant_AttributeConstructor()
         {
             var code = @"
@@ -3512,7 +3512,7 @@ class Attr : Attribute
             Assert.Equal("Attr..ctor(CustomHandler c)", attr.GetAttributes().Single().AttributeConstructor.ToTestDisplayString());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void StringPreferredOverHandlerConversionForConstant_AttributeConstructor()
         {
             var code = @"
@@ -3536,7 +3536,7 @@ class Attr : Attribute
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void MultipleBuilderTypes()
         {
             var code = @"
@@ -3562,7 +3562,7 @@ class C
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void GenericOverloadResolution_01()
         {
             var code = @"
@@ -3614,7 +3614,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void GenericOverloadResolution_02()
         {
             var code = @"
@@ -3666,7 +3666,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void GenericOverloadResolution_03()
         {
             var code = @"
@@ -3686,7 +3686,7 @@ class C
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void GenericInference_01()
         {
             var code = @"
@@ -3710,7 +3710,7 @@ class C
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void GenericInference_02()
         {
             var code = @"
@@ -3731,7 +3731,7 @@ class C
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void GenericInference_03()
         {
             var code = @"
@@ -3787,7 +3787,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void GenericInference_04()
         {
             var code = @"
@@ -3841,7 +3841,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_01()
         {
             var code = @"
@@ -3886,7 +3886,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_02()
         {
             var code = @"
@@ -3903,7 +3903,7 @@ class C
             // Interpolated string handler conversions are not considered when determining the natural type of an expression: the natural return type of this lambda is string,
             // so we don't even consider that there is a conversion from interpolated string expression to CustomHandler here (Sections 12.6.3.13 and 12.6.3.15 of the spec).
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "class", useBoolReturns: true) }, parseOptions: TestOptions.RegularPreview);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
+            var verifier = CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsWindows ? @"1.00Literal" : @"1.000Literal");
 
             // No DefaultInterpolatedStringHandler was included in the compilation, so it falls back to string.Format
             verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0()", @"
@@ -3919,7 +3919,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_03()
         {
             // Same as 2, but using a type that isn't allowed in an interpolated string. There is an implicit conversion error on the ref struct
@@ -3971,7 +3971,7 @@ public ref struct S
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_04()
         {
             // Same as 3, but with S added to DefaultInterpolatedStringHandler (which then allows the lambda to be bound as Func<string>, matching the natural return type)
@@ -4044,7 +4044,7 @@ namespace System.Runtime.CompilerServices
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_05()
         {
             var code = @"
@@ -4100,7 +4100,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_06()
         {
             // Same as 5, but with an implicit conversion from the builder type to string. This implicit conversion
@@ -4127,7 +4127,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
+            var verifier = CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsWindows ? @"1.00Literal" : @"1.000Literal");
 
             verifier.VerifyIL(@"<Program>$.<>c.<<Main>$>b__0_0(bool)", @"
 {
@@ -4150,7 +4150,7 @@ public partial struct CustomHandler
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_07()
         {
             // Same as 5, but with an implicit conversion from string to the builder type.
@@ -4210,7 +4210,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaReturnInference_08()
         {
             // Same as 5, but with an implicit conversion from the builder type to string and from string to the builder type.
@@ -4242,7 +4242,7 @@ public partial struct CustomHandler
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void TernaryTypes_01()
         {
             var code = @"
@@ -4294,7 +4294,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void TernaryTypes_02()
         {
             // Same as 01, but with a conversion from CustomHandler to string. The rules here are similar to LambdaReturnInference_06
@@ -4311,7 +4311,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
+            var verifier = CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsWindows ? @"1.00Literal" : @"1.000Literal");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
@@ -4337,7 +4337,7 @@ public partial struct CustomHandler
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void TernaryTypes_03()
         {
             // Same as 02, but with a target-type
@@ -4361,7 +4361,7 @@ public partial struct CustomHandler
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void TernaryTypes_04()
         {
             // Same 01, but with a conversion from string to CustomHandler. The rules here are similar to LambdaReturnInference_07
@@ -4418,7 +4418,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void TernaryTypes_05()
         {
             // Same 01, but with a conversion from string to CustomHandler and CustomHandler to string.
@@ -4443,7 +4443,7 @@ public partial struct CustomHandler
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void TernaryTypes_06()
         {
             // Same 05, but with a target type
@@ -4502,7 +4502,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void SwitchTypes_01()
         {
             // Switch expressions infer a best type based on _types_, not based on expressions (section 12.6.3.15 of the spec). Because this is based on types
@@ -4523,7 +4523,7 @@ Console.WriteLine(x);
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void SwitchTypes_02()
         {
             // Same as 01, but with a conversion from CustomHandler. This allows the switch expression to infer a best-common type, which is string.
@@ -4540,7 +4540,7 @@ public partial struct CustomHandler
 ";
 
             var comp = CreateCompilation(new[] { code, GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"1.000Literal");
+            var verifier = CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsWindows ? @"1.00Literal" : @"1.000Literal");
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
@@ -4570,7 +4570,7 @@ public partial struct CustomHandler
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void SwitchTypes_03()
         {
             // Same 02, but with a target-type. The natural type will fail to compile, so the switch will use a target type (unlike TernaryTypes_03, which fails to compile).
@@ -4632,7 +4632,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void SwitchTypes_04()
         {
             // Same as 01, but with a conversion to CustomHandler. This allows the switch expression to infer a best-common type, which is CustomHandler.
@@ -4694,7 +4694,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void SwitchTypes_05()
         {
             // Same as 01, but with conversions in both directions. No best common type can be found.
@@ -4719,7 +4719,7 @@ public partial struct CustomHandler
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void SwitchTypes_06()
         {
             // Same as 05, but with a target type.
@@ -4782,7 +4782,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void PassAsRefWithoutKeyword_01()
         {
             var code = @"
@@ -4823,7 +4823,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void PassAsRefWithoutKeyword_02()
         {
             var code = @"
@@ -4843,7 +4843,7 @@ void M(ref CustomHandler c) => System.Console.WriteLine(c);";
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void PassAsRefWithoutKeyword_03()
         {
             var code = @"
@@ -4884,7 +4884,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void PassAsRefWithoutKeyword_04()
         {
             var code = @"
@@ -4925,7 +4925,7 @@ literal:Literal");
 ");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(NoIOperationValidation))]
         [CombinatorialData]
         public void RefOverloadResolution_Struct([CombinatorialValues("in", "ref")] string refKind)
         {
@@ -4971,7 +4971,7 @@ literal:Literal");
 ");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(NoIOperationValidation))]
         [CombinatorialData]
         public void RefOverloadResolution_Class([CombinatorialValues("in", "ref")] string refKind)
         {
@@ -5017,7 +5017,7 @@ literal:Literal");
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void RefOverloadResolution_MultipleBuilderTypes()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -327,5 +327,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal override bool IsRecord => false;
         internal override bool IsRecordStruct => false;
         internal override bool HasPossibleWellKnownCloneMethod() => false;
+        internal override bool IsInterpolatedStringHandlerType => false;
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.CodeAnalysis
             return FindTargetAttribute(token, AttributeDescription.CodeAnalysisEmbeddedAttribute).HasValue;
         }
 
-        internal bool HasInterpolatedStringBuilderAttribute(EntityHandle token)
+        internal bool HasInterpolatedStringHandlerAttribute(EntityHandle token)
         {
             return FindTargetAttribute(token, AttributeDescription.InterpolatedStringHandlerAttribute).HasValue;
         }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1002,6 +1002,11 @@ namespace Microsoft.CodeAnalysis
             return FindTargetAttribute(token, AttributeDescription.CodeAnalysisEmbeddedAttribute).HasValue;
         }
 
+        internal bool HasInterpolatedStringBuilderAttribute(EntityHandle token)
+        {
+            return FindTargetAttribute(token, AttributeDescription.InterpolatedStringHandlerAttribute).HasValue;
+        }
+
         internal bool HasDefaultMemberAttribute(EntityHandle token, out string memberName)
         {
             return HasStringValuedAttribute(token, AttributeDescription.DefaultMemberAttribute, out memberName);

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -474,5 +474,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription NativeIntegerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NativeIntegerAttribute", s_signaturesOfNativeIntegerAttribute);
         internal static readonly AttributeDescription ModuleInitializerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ModuleInitializerAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription UnmanagedCallersOnlyAttribute = new AttributeDescription("System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute", s_signatures_HasThis_Void_Only);
+        internal static readonly AttributeDescription InterpolatedStringHandlerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "InterpolatedStringHandlerAttribute", s_signatures_HasThis_Void_Only);
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeEarlyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeEarlyWellKnownAttributeData.cs
@@ -113,5 +113,23 @@ namespace Microsoft.CodeAnalysis
             }
         }
         #endregion
+
+        #region InterpolatedStringHandlerAttribute
+        private bool _hasInterpolatedStringHandlerAttribute;
+        public bool HasInterpolatedStringHandlerAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasInterpolatedStringHandlerAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasInterpolatedStringHandlerAttribute = value;
+                SetDataStored();
+            }
+        }
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeEarlyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeEarlyWellKnownAttributeData.cs
@@ -4,19 +4,15 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
     /// Information decoded from early well-known custom attributes applied on a type.
     /// </summary>
-    internal class CommonTypeEarlyWellKnownAttributeData : EarlyWellKnownAttributeData
+    internal abstract class CommonTypeEarlyWellKnownAttributeData : EarlyWellKnownAttributeData
     {
         #region AttributeUsageAttribute
         private AttributeUsageInfo _attributeUsageInfo = AttributeUsageInfo.Null;
@@ -109,24 +105,6 @@ namespace Microsoft.CodeAnalysis
             {
                 VerifySealed(expected: false);
                 _hasCodeAnalysisEmbeddedAttribute = value;
-                SetDataStored();
-            }
-        }
-        #endregion
-
-        #region InterpolatedStringHandlerAttribute
-        private bool _hasInterpolatedStringHandlerAttribute;
-        public bool HasInterpolatedStringHandlerAttribute
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _hasInterpolatedStringHandlerAttribute;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _hasInterpolatedStringHandlerAttribute = value;
                 SetDataStored();
             }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -351,6 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override bool IsRecord => false;
         internal override bool IsRecordStruct => false;
         internal override bool HasPossibleWellKnownCloneMethod() => false;
+        internal override bool IsInterpolatedStringHandlerType => false;
 
         [Conditional("DEBUG")]
         internal static void VerifyTypeParameters(Symbol container, ImmutableArray<TypeParameterSymbol> typeParameters)


### PR DESCRIPTION
This PR allows interpolated strings to convert to types marked with InterpolatedStringBuilderAttribute, allows the RefKind to mismatch, and implements support for the better conversion rules.