### PR TITLE
Always make sure we have the right comparer for DocumentIds

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -12,7 +11,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -24,7 +22,8 @@ namespace Microsoft.CodeAnalysis
     internal readonly struct TextDocumentStates<TState>
         where TState : TextDocumentState
     {
-        public static readonly TextDocumentStates<TState> Empty = new(ImmutableList<DocumentId>.Empty, ImmutableSortedDictionary<DocumentId, TState>.Empty);
+        public static readonly TextDocumentStates<TState> Empty =
+            new(ImmutableList<DocumentId>.Empty, ImmutableSortedDictionary.Create<DocumentId, TState>(DocumentIdComparer.Instance));
 
         private readonly ImmutableList<DocumentId> _ids;
 
@@ -37,6 +36,8 @@ namespace Microsoft.CodeAnalysis
 
         private TextDocumentStates(ImmutableList<DocumentId> ids, ImmutableSortedDictionary<DocumentId, TState> map)
         {
+            Debug.Assert(map.KeyComparer == DocumentIdComparer.Instance);
+
             _ids = ids;
             _map = map;
         }


### PR DESCRIPTION
I believe this fixes https://github.com/dotnet/roslyn/issues/52698, although I don't have a dump for that issue so I'm having to deduce what I think happened based on the stack alone. Unfortunately the stack also has some frames inlined so there's a bit more guessing than usual:

The stack shows that we ended up in Comparer.Compare and it threw; the only exception that it throws directly if the thing being compared isn't IComparable. There aren't many uses of ImmutableSortedDictionary in Roslyn, but the one specific one that makes sense to be under GetDocumentState is the one we have inside our TextDocumentStates type. And that one is one where we normally pass in a custom comparer to pass in DocumentIds, so it seems logical that we somehow ended up with a map that didn't have our comparer.

It turns out the Empty member we had didn't specify one, so if we started with the Empty member and then added stuff from there, we'd end up with such a map without a comparer. Why didn't we see this right away? Because it turns out we only have a few uses of .Empty, most of which are with source generated files. And even then we often are creating the source generated collections with something else.