### PR TITLE
Enable consumption of user-defined conversion operators declared in interfaces

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -493,6 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // We're wrapping the collection expression in a (non-synthesized) conversion so that its converted
             // type (i.e. builder.CollectionType) will be available in the binding API.
+            Debug.Assert(!builder.CollectionConversion.IsUserDefined);
             BoundConversion convertedCollectionExpression = new BoundConversion(
                 collectionExpr.Syntax,
                 collectionExpr,
@@ -1259,6 +1260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(_syntax, useSiteInfo);
 
                 // Unconditionally convert here, to match what we set the ConvertedExpression to in the main BoundForEachStatement node.
+                Debug.Assert(!collectionConversion.IsUserDefined);
                 collectionExpr = new BoundConversion(
                     collectionExpr.Syntax,
                     collectionExpr,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -382,6 +382,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal TypeParameterSymbol? ConstrainedToTypeOpt
+        {
+            get
+            {
+                var uncommonData = _uncommonData;
+                if (uncommonData != null && uncommonData._conversionMethod is null)
+                {
+                    var conversionResult = uncommonData._conversionResult;
+                    if (conversionResult.Kind == UserDefinedConversionResultKind.Valid)
+                    {
+                        UserDefinedConversionAnalysis analysis = conversionResult.Results[conversionResult.Best];
+                        return analysis.ConstrainedToTypeOpt;
+                    }
+                }
+
+                return null;
+            }
+        }
+
         internal DeconstructMethodInfo DeconstructionInfo
         {
             get

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedConversionAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedConversionAnalysis.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public readonly TypeSymbol FromType;
         public readonly TypeSymbol ToType;
+        public readonly TypeParameterSymbol ConstrainedToTypeOpt;
         public readonly MethodSymbol Operator;
 
         public readonly Conversion SourceConversion;
@@ -27,6 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly UserDefinedConversionAnalysisKind Kind;
 
         public static UserDefinedConversionAnalysis Normal(
+            TypeParameterSymbol constrainedToTypeOpt,
             MethodSymbol op,
             Conversion sourceConversion,
             Conversion targetConversion,
@@ -35,6 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new UserDefinedConversionAnalysis(
                 UserDefinedConversionAnalysisKind.ApplicableInNormalForm,
+                constrainedToTypeOpt,
                 op,
                 sourceConversion,
                 targetConversion,
@@ -43,6 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public static UserDefinedConversionAnalysis Lifted(
+            TypeParameterSymbol constrainedToTypeOpt,
             MethodSymbol op,
             Conversion sourceConversion,
             Conversion targetConversion,
@@ -51,6 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new UserDefinedConversionAnalysis(
                 UserDefinedConversionAnalysisKind.ApplicableInLiftedForm,
+                constrainedToTypeOpt,
                 op,
                 sourceConversion,
                 targetConversion,
@@ -60,6 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private UserDefinedConversionAnalysis(
             UserDefinedConversionAnalysisKind kind,
+            TypeParameterSymbol constrainedToTypeOpt,
             MethodSymbol op,
             Conversion sourceConversion,
             Conversion targetConversion,
@@ -67,6 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol toType)
         {
             this.Kind = kind;
+            this.ConstrainedToTypeOpt = constrainedToTypeOpt;
             this.Operator = op;
             this.SourceConversion = sourceConversion;
             this.TargetConversion = targetConversion;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedConversions.cs
@@ -15,8 +15,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class ConversionsBase
     {
-        private static TypeSymbol GetUnderlyingEffectiveType(TypeSymbol type, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        public static void AddTypesParticipatingInUserDefinedConversion(ArrayBuilder<TypeSymbol> result, TypeSymbol type, bool includeBaseTypes, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
+            // CONSIDER: These sets are usually small; if they are large then this is an O(n^2)
+            // CONSIDER: algorithm. We could use a hash table instead to build up the set.
+
             // Spec 6.4.4: User-defined implicit conversions 
             // Spec 6.4.5: User-defined explicit conversions 
             // 
@@ -24,57 +27,80 @@ namespace Microsoft.CodeAnalysis.CSharp
             //   * If S or T are nullable types, let Su and Tu be their underlying types, otherwise let Su and Tu be S and T, respectively. 
             //   * If Su or Tu are type parameters, S0 and T0 are their effective base types, otherwise S0 and T0 are equal to Su and Tu, respectively.
 
-            if ((object)type != null)
-            {
-                type = type.StrippedType();
+            // Spec 6.4.4: User-defined implicit conversions
+            //   Find the set of types D from which user-defined conversion operators
+            //   will be considered. This set consists of S0 (if S0 is a class or struct),
+            //   the base classes of S0 (if S0 is a class), and T0 (if T0 is a class or struct).
+            //
+            // Spec 6.4.5: User-defined explicit conversions
+            //   Find the set of types, D, from which user-defined conversion operators will be considered. 
+            //   This set consists of S0 (if S0 is a class or struct), the base classes of S0 (if S0 is a class),
+            //   T0 (if T0 is a class or struct), and the base classes of T0 (if T0 is a class).
 
-                if (type.IsTypeParameter())
-                {
-                    type = ((TypeParameterSymbol)type).EffectiveBaseClass(ref useSiteInfo);
-                }
-            }
+            // PROTOTYPE(StaticAbstractMembersInInterfaces): Adjust the above specification quote appropriately.
 
-            return type;
-        }
-
-        public static void AddTypesParticipatingInUserDefinedConversion(ArrayBuilder<NamedTypeSymbol> result, TypeSymbol type, bool includeBaseTypes, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
-        {
             if ((object)type == null)
             {
                 return;
             }
 
-            // CONSIDER: These sets are usually small; if they are large then this is an O(n^2)
-            // CONSIDER: algorithm. We could use a hash table instead to build up the set.
-
-            Debug.Assert(!type.IsTypeParameter());
+            type = type.StrippedType();
 
             // optimization:
             bool excludeExisting = result.Count > 0;
 
-            if (type.IsClassType() || type.IsStructType())
+            if (type is TypeParameterSymbol typeParameter)
             {
-                var namedType = (NamedTypeSymbol)type;
-                if (!excludeExisting || !HasIdentityConversionToAny(namedType, result))
+                NamedTypeSymbol effectiveBaseClass = typeParameter.EffectiveBaseClass(ref useSiteInfo);
+
+                addFromClassOrStruct(result, excludeExisting, effectiveBaseClass, includeBaseTypes, ref useSiteInfo);
+
+                switch (effectiveBaseClass.SpecialType)
                 {
-                    result.Add(namedType);
+                    case SpecialType.System_ValueType:
+                    case SpecialType.System_Enum:
+                    case SpecialType.System_Array:
+                    case SpecialType.System_Object:
+                        if (!excludeExisting || !HasIdentityConversionToAny(typeParameter, result))
+                        {
+                            // Add the type parameter to the set as well. This will be treated equivalent to adding its 
+                            // effective interfaces to the set. We are not doing that here because we still need to know 
+                            // the originating type parameter as "constrained to" type.
+                            result.Add(typeParameter);
+                        }
+                        break;
                 }
             }
-
-            if (!includeBaseTypes)
+            else
             {
-                return;
+                addFromClassOrStruct(result, excludeExisting, type, includeBaseTypes, ref useSiteInfo);
             }
 
-            NamedTypeSymbol t = type.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteInfo);
-            while ((object)t != null)
+            static void addFromClassOrStruct(ArrayBuilder<TypeSymbol> result, bool excludeExisting, TypeSymbol type, bool includeBaseTypes, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
-                if (!excludeExisting || !HasIdentityConversionToAny(t, result))
+                if (type.IsClassType() || type.IsStructType())
                 {
-                    result.Add(t);
+                    if (!excludeExisting || !HasIdentityConversionToAny(type, result))
+                    {
+                        result.Add(type);
+                    }
                 }
 
-                t = t.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteInfo);
+                if (!includeBaseTypes)
+                {
+                    return;
+                }
+
+                NamedTypeSymbol t = type.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteInfo);
+                while ((object)t != null)
+                {
+                    if (!excludeExisting || !HasIdentityConversionToAny(t, result))
+                    {
+                        result.Add(t);
+                    }
+
+                    t = t.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteInfo);
+                }
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //   A user-defined implicit conversion from an expression E to type T is processed as follows:
 
             // SPEC: Find the set of types D from which user-defined conversion operators...
-            var d = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+            var d = ArrayBuilder<TypeSymbol>.GetInstance();
             ComputeUserDefinedImplicitConversionTypeSet(source, target, d, ref useSiteInfo);
 
             // SPEC: Find the set of applicable user-defined and lifted conversion operators, U...
@@ -114,18 +114,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return UserDefinedConversionResult.Valid(u, best.Value);
         }
 
-        private static void ComputeUserDefinedImplicitConversionTypeSet(TypeSymbol s, TypeSymbol t, ArrayBuilder<NamedTypeSymbol> d, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private static void ComputeUserDefinedImplicitConversionTypeSet(TypeSymbol s, TypeSymbol t, ArrayBuilder<TypeSymbol> d, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             // Spec 6.4.4: User-defined implicit conversions
             //   Find the set of types D from which user-defined conversion operators
             //   will be considered. This set consists of S0 (if S0 is a class or struct),
             //   the base classes of S0 (if S0 is a class), and T0 (if T0 is a class or struct).
 
-            TypeSymbol s0 = GetUnderlyingEffectiveType(s, ref useSiteInfo);
-            TypeSymbol t0 = GetUnderlyingEffectiveType(t, ref useSiteInfo);
-
-            AddTypesParticipatingInUserDefinedConversion(d, s0, includeBaseTypes: true, useSiteInfo: ref useSiteInfo);
-            AddTypesParticipatingInUserDefinedConversion(d, t0, includeBaseTypes: false, useSiteInfo: ref useSiteInfo);
+            AddTypesParticipatingInUserDefinedConversion(d, s, includeBaseTypes: true, useSiteInfo: ref useSiteInfo);
+            AddTypesParticipatingInUserDefinedConversion(d, t, includeBaseTypes: false, useSiteInfo: ref useSiteInfo);
         }
 
         /// <summary>
@@ -145,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression sourceExpression,
             TypeSymbol source,
             TypeSymbol target,
-            ArrayBuilder<NamedTypeSymbol> d,
+            ArrayBuilder<TypeSymbol> d,
             ArrayBuilder<UserDefinedConversionAnalysis> u,
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
             bool allowAnyTarget = false)
@@ -246,7 +243,42 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            foreach (NamedTypeSymbol declaringType in d)
+            HashSet<NamedTypeSymbol> lookedInInterfaces = null;
+
+            foreach (TypeSymbol declaringType in d)
+            {
+                if (declaringType is TypeParameterSymbol typeParameter)
+                {
+                    ImmutableArray<NamedTypeSymbol> interfaceTypes = typeParameter.AllEffectiveInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteInfo);
+
+                    if (!interfaceTypes.IsEmpty)
+                    {
+                        lookedInInterfaces ??= new HashSet<NamedTypeSymbol>(Symbols.SymbolEqualityComparer.AllIgnoreOptions); // Equivalent to has identity conversion check
+
+                        foreach (var interfaceType in interfaceTypes)
+                        {
+                            if (lookedInInterfaces.Add(interfaceType))
+                            {
+                                addCandidatesFromType(constrainedToTypeOpt: typeParameter, interfaceType, sourceExpression, source, target, u, ref useSiteInfo, allowAnyTarget);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    addCandidatesFromType(constrainedToTypeOpt: null, (NamedTypeSymbol)declaringType, sourceExpression, source, target, u, ref useSiteInfo, allowAnyTarget);
+                }
+            }
+
+            void addCandidatesFromType(
+                TypeParameterSymbol constrainedToTypeOpt,
+                NamedTypeSymbol declaringType,
+                BoundExpression sourceExpression,
+                TypeSymbol source,
+                TypeSymbol target,
+                ArrayBuilder<UserDefinedConversionAnalysis> u,
+                ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
+                bool allowAnyTarget)
             {
                 foreach (MethodSymbol op in declaringType.GetOperators(WellKnownMemberNames.ImplicitConversionName))
                 {
@@ -281,7 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 EncompassingImplicitConversion(null, convertsTo, target, ref useSiteInfo);
                         }
 
-                        u.Add(UserDefinedConversionAnalysis.Normal(op, fromConversion, toConversion, convertsFrom, convertsTo));
+                        u.Add(UserDefinedConversionAnalysis.Normal(constrainedToTypeOpt, op, fromConversion, toConversion, convertsFrom, convertsTo));
                     }
                     else if ((object)source != null && source.IsNullableType() && convertsFrom.IsNonNullableValueType() &&
                         (allowAnyTarget || target.CanBeAssignedNull()))
@@ -309,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             Conversion.Identity;
                         if (liftedFromConversion.Exists && liftedToConversion.Exists)
                         {
-                            u.Add(UserDefinedConversionAnalysis.Lifted(op, liftedFromConversion, liftedToConversion, nullableFrom, nullableTo));
+                            u.Add(UserDefinedConversionAnalysis.Lifted(constrainedToTypeOpt, op, liftedFromConversion, liftedToConversion, nullableFrom, nullableTo));
                         }
                     }
                 }
@@ -889,7 +921,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC VIOLATION: We do the same to maintain compatibility with the native compiler.
 
             // (a) Compute the set of types D from which user-defined conversion operators should be considered by considering only the source type.
-            var d = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+            var d = ArrayBuilder<TypeSymbol>.GetInstance();
             ComputeUserDefinedImplicitConversionTypeSet(source, t: null, d: d, useSiteInfo: ref useSiteInfo);
 
             // (b) Instead of computing applicable user defined implicit conversions U from the source type to a specific target type,

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -739,6 +739,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 default:
+
+                    if (_inExpressionLambda && node.Conversion.Method is MethodSymbol method && method.IsAbstract && method.IsStatic)
+                    {
+                        Error(ErrorCode.ERR_ExpressionTreeContainsAbstractStaticMemberAccess, node);
+                    }
                     break;
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -936,7 +936,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (nonNullValue != null)
             {
                 Debug.Assert(conversion.Method is { });
-                return MakeLiftedUserDefinedConversionConsequence(BoundCall.Synthesized(syntax, receiverOpt: null, conversion.Method, nonNullValue), type);
+                var constrainedToTypeOpt = conversion.ConstrainedToTypeOpt;
+                return MakeLiftedUserDefinedConversionConsequence(BoundCall.Synthesized(syntax, receiverOpt: constrainedToTypeOpt is null ? null : new BoundTypeExpression(syntax, aliasOpt: null, constrainedToTypeOpt), conversion.Method, nonNullValue), type);
             }
 
             return DistributeLiftedConversionIntoLiftedOperand(syntax, operand, conversion, false, type);
@@ -1073,7 +1074,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundReadOnlySpanFromArray(syntax, rewrittenOperand, conversion.Method, rewrittenType) { WasCompilerGenerated = true };
             }
 
-            BoundExpression result = BoundCall.Synthesized(syntax, receiverOpt: null, conversion.Method, rewrittenOperand);
+            var constrainedToTypeOpt = conversion.ConstrainedToTypeOpt;
+            BoundExpression result = BoundCall.Synthesized(syntax, receiverOpt: constrainedToTypeOpt is null ? null : new BoundTypeExpression(syntax, aliasOpt: null, constrainedToTypeOpt), conversion.Method, rewrittenOperand);
             Debug.Assert(TypeSymbol.Equals(result.Type, rewrittenType, TypeCompareKind.ConsiderEverything2));
             return result;
         }
@@ -1143,7 +1145,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // op_Whatever(temp.GetValueOrDefault())
             Debug.Assert(conversion.Method is { });
-            BoundCall userDefinedCall = BoundCall.Synthesized(syntax, receiverOpt: null, conversion.Method, callGetValueOrDefault);
+            var constrainedToTypeOpt = conversion.ConstrainedToTypeOpt;
+            BoundCall userDefinedCall = BoundCall.Synthesized(syntax, receiverOpt: constrainedToTypeOpt is null ? null : new BoundTypeExpression(syntax, aliasOpt: null, constrainedToTypeOpt), conversion.Method, callGetValueOrDefault);
 
             // new R?(op_Whatever(temp.GetValueOrDefault())
             BoundExpression consequence = MakeLiftedUserDefinedConversionConsequence(userDefinedCall, rewrittenType);
@@ -1474,7 +1477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         else
                         {
                             // TODO: how do we distinguish from normal and lifted conversions here?
-                            var analysis = UserDefinedConversionAnalysis.Normal(meth, fromConversion, toConversion, fromType, toType);
+                            var analysis = UserDefinedConversionAnalysis.Normal(conversion.ConstrainedToTypeOpt, meth, fromConversion, toConversion, fromType, toType);
                             var result = UserDefinedConversionResult.Valid(ImmutableArray.Create<UserDefinedConversionAnalysis>(analysis), 0);
                             return new Conversion(result, conversion.IsImplicit);
                         }
@@ -1556,6 +1559,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private Conversion TryMakeUserDefinedConversion(SyntaxNode syntax, MethodSymbol meth, TypeSymbol fromType, TypeSymbol toType, bool isImplicit = true)
         {
+            Debug.Assert(!meth.ContainingType.IsInterface);
+
             Conversion fromConversion = TryMakeConversion(syntax, fromType, meth.Parameters[0].Type);
             if (!fromConversion.Exists)
             {
@@ -1569,7 +1574,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // TODO: distinguish between normal and lifted conversions here
-            var analysis = UserDefinedConversionAnalysis.Normal(meth, fromConversion, toConversion, fromType, toType);
+            var analysis = UserDefinedConversionAnalysis.Normal(constrainedToTypeOpt: null, meth, fromConversion, toConversion, fromType, toType);
             var result = UserDefinedConversionResult.Valid(ImmutableArray.Create<UserDefinedConversionAnalysis>(analysis), 0);
             return new Conversion(result, isImplicit);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -203,6 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case ConversionKind.ExplicitUserDefined:
                 case ConversionKind.ImplicitUserDefined:
+                    Debug.Assert(conversion.ConstrainedToTypeOpt is null);
                     return new Conversion(conversion.Kind, VisitMethodSymbol(conversion.Method), conversion.IsExtensionMethod);
                 case ConversionKind.MethodGroup:
                     throw ExceptionUtilities.UnexpectedValue(conversion.Kind);


### PR DESCRIPTION
Related to https://github.com/dotnet/csharplang/pull/4773.