### PR TITLE
Record structs: Support parameter wrapping and doc comments (IDE)

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -55,6 +55,22 @@ record R;";
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void TypingCharacter_RecordStruct()
+        {
+            var code =
+@"//$$
+record struct R;";
+
+            var expected =
+@"/// <summary>
+/// $$
+/// </summary>
+record struct R;";
+
+            VerifyTypingCharacter(code, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void TypingCharacter_RecordWithPositionalParameters()
         {
             var code =
@@ -68,6 +84,24 @@ record R(string S, int I);";
 /// <param name=""S""></param>
 /// <param name=""I""></param>
 record R(string S, int I);";
+
+            VerifyTypingCharacter(code, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void TypingCharacter_RecordStructWithPositionalParameters()
+        {
+            var code =
+@"//$$
+record struct R(string S, int I);";
+
+            var expected =
+@"/// <summary>
+/// $$
+/// </summary>
+/// <param name=""S""></param>
+/// <param name=""I""></param>
+record struct R(string S, int I);";
 
             VerifyTypingCharacter(code, expected);
         }
@@ -1516,6 +1550,20 @@ record R;";
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void Command_RecordStruct()
+        {
+            var code = "record struct R$$;";
+
+            var expected =
+@"/// <summary>
+/// $$
+/// </summary>
+record struct R;";
+
+            VerifyInsertCommentCommand(code, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void Command_RecordWithPositionalParameters()
         {
             var code = "record R$$(string S, int I);";
@@ -1527,6 +1575,22 @@ record R;";
 /// <param name=""S""></param>
 /// <param name=""I""></param>
 record R(string S, int I);";
+
+            VerifyInsertCommentCommand(code, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void Command_RecordStructWithPositionalParameters()
+        {
+            var code = "record struct R$$(string S, int I);";
+
+            var expected =
+@"/// <summary>
+/// $$
+/// </summary>
+/// <param name=""S""></param>
+/// <param name=""I""></param>
+record struct R(string S, int I);";
 
             VerifyInsertCommentCommand(code, expected);
         }

--- a/src/EditorFeatures/CSharpTest/Wrapping/ParameterWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/ParameterWrappingTests.cs
@@ -6,6 +6,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Wrapping;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
@@ -922,6 +923,42 @@ GetIndentionColumn(30),
         }
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestRecord_Semicolon()
+        {
+            await TestInRegularAndScript1Async(
+"record R([||]int I, string S);",
+@"record R(int I,
+         string S);");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestRecord_Braces()
+        {
+            await TestInRegularAndScript1Async(
+"record R([||]int I, string S) { }",
+@"record R(int I,
+         string S) { }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestRecordStruct_Semicolon()
+        {
+            await TestInRegularAndScript1Async(
+"record struct R([||]int I, string S);",
+@"record struct R(int I,
+                string S);", new TestParameters(TestOptions.RegularPreview));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestRecordStruct_Braces()
+        {
+            await TestInRegularAndScript1Async(
+"record struct R([||]int I, string S) { }",
+@"record struct R(int I,
+                string S) { }", new TestParameters(TestOptions.RegularPreview));
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 SyntaxKind.ParenthesizedLambdaExpression => ((ParenthesizedLambdaExpressionSyntax)declaration).ParameterList,
                 SyntaxKind.LocalFunctionStatement => ((LocalFunctionStatementSyntax)declaration).ParameterList,
                 SyntaxKind.AnonymousMethodExpression => ((AnonymousMethodExpressionSyntax)declaration).ParameterList,
-                SyntaxKind.RecordDeclaration => ((RecordDeclarationSyntax)declaration).ParameterList,
+                SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration => ((RecordDeclarationSyntax)declaration).ParameterList,
                 _ => null,
             };
 


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn/issues/53631