### PR TITLE
Remove Compiler's dependency on net472 package

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -140,9 +140,6 @@ package name=$(VisualStudioInsertionComponent)
         version=$(VsixVersion)
         vs.package.productArch=neutral
 
-vs.dependencies
-  vs.dependency id=Microsoft.Net.PackageGroup.4.7.2.Redist
-
 vs.nonCriticalProcesses
   vs.nonCriticalProcess name="VBCSCompiler"
 


### PR DESCRIPTION
This is blocking the removal of Microsoft.Net.PackageGroup.4.7.2.Redist from VS. Microsoft.Net.PackageGroup.4.8.Redist is being pulled in by VS core workload, so this dependency is no longer required.

Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1333293