### PR TITLE
Fix regression with var pattern nullability

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (Type?.IsTypeParameterDisallowingAnnotationInCSharp8() == true)
             {
                 var type = TypeWithAnnotations.Create(Type, NullableAnnotation.NotAnnotated);
-                return State == NullableFlowState.MaybeDefault ? type.SetIsAnnotated(compilation) : type;
+                return (State == NullableFlowState.MaybeDefault || asAnnotatedType) ? type.SetIsAnnotated(compilation) : type;
             }
             NullableAnnotation annotation = asAnnotatedType ?
                 (Type?.IsValueType == true ? NullableAnnotation.NotAnnotated : NullableAnnotation.Annotated) :

--- a/src/Dependencies/Collections/SegmentedDictionary`2.cs
+++ b/src/Dependencies/Collections/SegmentedDictionary`2.cs
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Collections
 ConcurrentOperation:
             ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
 ReturnFound:
-            ref var value = ref entry._value;
+            ref TValue value = ref entry._value;
 Return:
             return ref value;
 ReturnNotFound:


### PR DESCRIPTION
There was a regression in `LearnFromDecisionDag` in 16.10 for top-level `var` patterns in https://github.com/dotnet/roslyn/pull/51001

Also fix https://github.com/dotnet/roslyn/issues/52925 (type of `var` should have an annotation) and https://github.com/dotnet/roslyn/issues/46236 (`GetDeclaredSymbol` on such `var` declarations)
Note that any change to the inferred type of `var` is breaking in `ref var` scenario. We've hit this in bootstrap build and I've added a test to illustrate.