### PR TITLE
Revert "Keep OptProf input indefinitely"

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -215,6 +215,7 @@ stages:
         sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
         toLowerCase: false
         usePat: false
+        retentionDays: 90
       displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
       condition: succeeded()
 


### PR DESCRIPTION
Reverts dotnet/roslyn#53683

Turns out no expiration date means 30 days