### PR TITLE
 Hold onto and reuse GeneratorDrivers

### DIFF
--- a/src/VisualStudio/Core/Test/SolutionExplorer/SourceGeneratorItemTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/SourceGeneratorItemTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Sub SourceGeneratorsListed()
             Dim workspaceXml =
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true">
+                    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
                     </Project>
                 </Workspace>
 
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Async Function PlaceholderItemCreateIfGeneratorProducesNoFiles() As Task
             Dim workspaceXml =
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true">
+                    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
                     </Project>
                 </Workspace>
 
@@ -63,7 +63,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Async Function SingleSourceGeneratedFileProducesItem() As Task
             Dim workspaceXml =
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true">
+                    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
                         <AdditionalDocument FilePath="Test.txt"></AdditionalDocument>
                     </Project>
                 </Workspace>
@@ -92,7 +92,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Async Function MultipleSourceGeneratedFilesProducesSortedItem() As Task
             Dim workspaceXml =
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true">
+                    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
                         <AdditionalDocument FilePath="Test1.txt"></AdditionalDocument>
                         <AdditionalDocument FilePath="Test2.txt"></AdditionalDocument>
                         <AdditionalDocument FilePath="Test3.txt"></AdditionalDocument>
@@ -124,7 +124,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Async Function ChangeToNoGeneratedDocumentsUpdatesListCorrectly() As Task
             Dim workspaceXml =
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true">
+                    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
                         <AdditionalDocument FilePath="Test1.txt"></AdditionalDocument>
                     </Project>
                 </Workspace>
@@ -153,7 +153,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
         Public Async Function AddingAGeneratedDocumentUpdatesListCorrectly() As Task
             Dim workspaceXml =
                 <Workspace>
-                    <Project Language="C#" CommonReferences="true">
+                    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
                     </Project>
                 </Workspace>
 

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpCompilationFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpCompilationFactoryService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         CompilationOptions ICompilationFactoryService.GetDefaultCompilationOptions()
             => s_defaultOptions;
 
-        GeneratorDriver? ICompilationFactoryService.CreateGeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts)
+        GeneratorDriver ICompilationFactoryService.CreateGeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts)
         {
             return CSharpGeneratorDriver.Create(generators, additionalTexts, (CSharpParseOptions)parseOptions, optionsProvider);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Host/CompilationFactory/ICompilationFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/CompilationFactory/ICompilationFactoryService.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.Host
         Compilation CreateCompilation(string assemblyName, CompilationOptions options);
         Compilation CreateSubmissionCompilation(string assemblyName, CompilationOptions options, Type? hostObjectType);
         CompilationOptions GetDefaultCompilationOptions();
-        GeneratorDriver? CreateGeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts);
+        GeneratorDriver CreateGeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalTextWithState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalTextWithState.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;
 
@@ -14,11 +15,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal sealed class AdditionalTextWithState : AdditionalText
     {
         private readonly TextDocumentState _documentState;
+        private static readonly ConditionalWeakTable<TextDocumentState, AdditionalText> _additionalTextsForDocumentStates = new();
+        private static readonly ConditionalWeakTable<TextDocumentState, AdditionalText>.CreateValueCallback s_createAdditionalText = static ts => new AdditionalTextWithState(ts);
+
+        public static AdditionalText FromState(TextDocumentState state)
+        {
+            return _additionalTextsForDocumentStates.GetValue(state, s_createAdditionalText);
+        }
 
         /// <summary>
         /// Create a <see cref="SourceText"/> from a <see cref="TextDocumentState"/>.
         /// </summary>
-        public AdditionalTextWithState(TextDocumentState documentState)
+        private AdditionalTextWithState(TextDocumentState documentState)
             => _documentState = documentState ?? throw new ArgumentNullException(nameof(documentState));
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis
 
         public AnalyzerOptions AnalyzerOptions
             => _lazyAnalyzerOptions ??= new AnalyzerOptions(
-                additionalFiles: AdditionalDocumentStates.SelectAsArray<AdditionalText>(static state => new AdditionalTextWithState(state)),
+                additionalFiles: AdditionalDocumentStates.SelectAsArray(AdditionalTextWithState.FromState),
                 optionsProvider: new WorkspaceAnalyzerConfigOptionsProvider(this));
 
         public async Task<ImmutableDictionary<string, string>> GetAnalyzerOptionsForPathAsync(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction.cs
@@ -9,6 +9,10 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial class SolutionState
     {
+        /// <summary>
+        /// Represents a change that needs to be made to a <see cref="Compilation"/>, <see cref="GeneratorDriver"/>, or both in response to
+        /// some user edit.
+        /// </summary>
         private abstract partial class CompilationAndGeneratorDriverTranslationAction
         {
             public virtual Task<Compilation> TransformCompilationAsync(Compilation oldCompilation, CancellationToken cancellationToken)
@@ -27,6 +31,8 @@ namespace Microsoft.CodeAnalysis
             /// side effects. This opts those out of operating on ones with generated documents where there would be side effects.
             /// </remarks>
             public abstract bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput { get; }
+
+            public virtual GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver) => generatorDriver;
 
             /// <summary>
             /// When changes are made to a solution, we make a list of translation actions. If multiple similar changes happen in rapid

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -82,6 +82,7 @@ namespace Microsoft.CodeAnalysis
                     var newText = AdditionalTextWithState.FromState(_newState);
 
                     // TODO: have the compiler add an API for replacing an additional text
+                    // https://github.com/dotnet/roslyn/issues/54087
                     return generatorDriver.RemoveAdditionalTexts(ImmutableArray.Create(oldText))
                                           .AddAdditionalTexts(ImmutableArray.Create(newText));
                 }
@@ -170,6 +171,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         // TODO: update the existing generator driver; the compiler needs to add an API for that.
                         // In the mean time, drop it and we'll recreate it from scratch.
+                        // https://github.com/dotnet/roslyn/issues/54087
                         return null;
                     }
                     else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -209,6 +209,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         // TODO: update the existing generator driver; the compiler needs to add an API for that.
                         // In the mean time, drop it and we'll recreate it from scratch.
+                        // https://github.com/dotnet/roslyn/issues/54087
                         return null;
                     }
                     else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis
 
                 public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
                 {
-                    return generatorDriver.AddAdditionalTexts(_additionalDocuments.SelectAsArray(AdditionalTextWithState.FromState));
+                    return generatorDriver.RemoveAdditionalTexts(_additionalDocuments.SelectAsArray(AdditionalTextWithState.FromState));
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -50,11 +51,8 @@ namespace Microsoft.CodeAnalysis
 
             internal sealed class TouchAdditionalDocumentAction : CompilationAndGeneratorDriverTranslationAction
             {
-#pragma warning disable IDE0052 // Remove unread private members
-                // https://github.com/dotnet/roslyn/issues/44161: right now there is no way to tell a GeneratorDriver that an additional document changed
                 private readonly TextDocumentState _oldState;
                 private readonly TextDocumentState _newState;
-#pragma warning restore IDE0052 // Remove unread private members
 
                 public TouchAdditionalDocumentAction(TextDocumentState oldState, TextDocumentState newState)
                 {
@@ -76,6 +74,16 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     return null;
+                }
+
+                public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
+                {
+                    var oldText = AdditionalTextWithState.FromState(_oldState);
+                    var newText = AdditionalTextWithState.FromState(_newState);
+
+                    // TODO: have the compiler add an API for replacing an additional text
+                    return generatorDriver.RemoveAdditionalTexts(ImmutableArray.Create(oldText))
+                                          .AddAdditionalTexts(ImmutableArray.Create(newText));
                 }
             }
 
@@ -132,10 +140,12 @@ namespace Microsoft.CodeAnalysis
             internal sealed class ReplaceAllSyntaxTreesAction : CompilationAndGeneratorDriverTranslationAction
             {
                 private readonly ProjectState _state;
+                private readonly bool _isParseOptionChange;
 
-                public ReplaceAllSyntaxTreesAction(ProjectState state)
+                public ReplaceAllSyntaxTreesAction(ProjectState state, bool isParseOptionChange)
                 {
                     _state = state;
+                    _isParseOptionChange = isParseOptionChange;
                 }
 
                 public override async Task<Compilation> TransformCompilationAsync(Compilation oldCompilation, CancellationToken cancellationToken)
@@ -153,15 +163,33 @@ namespace Microsoft.CodeAnalysis
 
                 // Because this removes all trees, it'd also remove the generated trees.
                 public override bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput => false;
+
+                public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
+                {
+                    if (_isParseOptionChange)
+                    {
+                        // TODO: update the existing generator driver; the compiler needs to add an API for that.
+                        // In the mean time, drop it and we'll recreate it from scratch.
+                        return null;
+                    }
+                    else
+                    {
+                        // We are using this as a way to reorder syntax trees -- we don't need to do anything as the driver
+                        // will get the new compilation once we pass it to it.
+                        return generatorDriver;
+                    }
+                }
             }
 
             internal sealed class ProjectCompilationOptionsAction : CompilationAndGeneratorDriverTranslationAction
             {
                 private readonly CompilationOptions _options;
+                private readonly bool _isAnalyzerConfigChange;
 
-                public ProjectCompilationOptionsAction(CompilationOptions options)
+                public ProjectCompilationOptionsAction(CompilationOptions options, bool isAnalyzerConfigChange)
                 {
                     _options = options;
+                    _isAnalyzerConfigChange = isAnalyzerConfigChange;
                 }
 
                 public override Task<Compilation> TransformCompilationAsync(Compilation oldCompilation, CancellationToken cancellationToken)
@@ -172,6 +200,22 @@ namespace Microsoft.CodeAnalysis
                 // Updating the options of a compilation doesn't require us to reparse trees, so we can use this to update
                 // compilations with stale generated trees.
                 public override bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput => true;
+
+                public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
+                {
+                    if (_isAnalyzerConfigChange)
+                    {
+                        // TODO: update the existing generator driver; the compiler needs to add an API for that.
+                        // In the mean time, drop it and we'll recreate it from scratch.
+                        return null;
+                    }
+                    else
+                    {
+                        // Changing any other option is fine and the driver can be reused. The driver
+                        // will get the new compilation once we pass it to it.
+                        return generatorDriver;
+                    }
+                }
             }
 
             internal sealed class ProjectAssemblyNameAction : CompilationAndGeneratorDriverTranslationAction
@@ -195,11 +239,8 @@ namespace Microsoft.CodeAnalysis
 
             internal sealed class AddAnalyzerReferencesAction : CompilationAndGeneratorDriverTranslationAction
             {
-#pragma warning disable IDE0052 // Remove unread private members
-                // https://github.com/dotnet/roslyn/issues/44161: right now there is no way to tell a GeneratorDriver that an analyzer reference has been added
                 private readonly ImmutableArray<AnalyzerReference> _analyzerReferences;
                 private readonly string _language;
-#pragma warning restore IDE0052 // Remove unread private members
 
                 public AddAnalyzerReferencesAction(ImmutableArray<AnalyzerReference> analyzerReferences, string language)
                 {
@@ -211,15 +252,17 @@ namespace Microsoft.CodeAnalysis
                 // translation (which is a no-op). Since we use a 'false' here to mean that it's not worth keeping
                 // the compilation with stale trees around, answering true is still important.
                 public override bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput => true;
+
+                public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
+                {
+                    return generatorDriver.AddGenerators(_analyzerReferences.SelectMany(r => r.GetGenerators(_language)).ToImmutableArray());
+                }
             }
 
             internal sealed class RemoveAnalyzerReferencesAction : CompilationAndGeneratorDriverTranslationAction
             {
-#pragma warning disable IDE0052 // Remove unread private members
-                // https://github.com/dotnet/roslyn/issues/44161: right now there is no way to tell a GeneratorDriver that an analyzer reference has been removed
                 private readonly ImmutableArray<AnalyzerReference> _analyzerReferences;
                 private readonly string _language;
-#pragma warning restore IDE0052 // Remove unread private members
 
                 public RemoveAnalyzerReferencesAction(ImmutableArray<AnalyzerReference> analyzerReferences, string language)
                 {
@@ -231,14 +274,15 @@ namespace Microsoft.CodeAnalysis
                 // translation (which is a no-op). Since we use a 'false' here to mean that it's not worth keeping
                 // the compilation with stale trees around, answering true is still important.
                 public override bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput => true;
+                public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
+                {
+                    return generatorDriver.RemoveGenerators(_analyzerReferences.SelectMany(r => r.GetGenerators(_language)).ToImmutableArray());
+                }
             }
 
             internal sealed class AddAdditionalDocumentsAction : CompilationAndGeneratorDriverTranslationAction
             {
-#pragma warning disable IDE0052 // Remove unread private members
-                // https://github.com/dotnet/roslyn/issues/44161: right now there is no way to tell a GeneratorDriver that an additional file has been added
                 private readonly ImmutableArray<TextDocumentState> _additionalDocuments;
-#pragma warning restore IDE0052 // Remove unread private members
 
                 public AddAdditionalDocumentsAction(ImmutableArray<TextDocumentState> additionalDocuments)
                 {
@@ -249,14 +293,16 @@ namespace Microsoft.CodeAnalysis
                 // translation (which is a no-op). Since we use a 'false' here to mean that it's not worth keeping
                 // the compilation with stale trees around, answering true is still important.
                 public override bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput => true;
+
+                public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
+                {
+                    return generatorDriver.AddAdditionalTexts(_additionalDocuments.SelectAsArray(AdditionalTextWithState.FromState));
+                }
             }
 
             internal sealed class RemoveAdditionalDocumentsAction : CompilationAndGeneratorDriverTranslationAction
             {
-#pragma warning disable IDE0052 // Remove unread private members
-                // https://github.com/dotnet/roslyn/issues/44161: right now there is no way to tell a GeneratorDriver that an additional file has been added
                 private readonly ImmutableArray<TextDocumentState> _additionalDocuments;
-#pragma warning restore IDE0052 // Remove unread private members
 
                 public RemoveAdditionalDocumentsAction(ImmutableArray<TextDocumentState> additionalDocuments)
                 {
@@ -267,6 +313,11 @@ namespace Microsoft.CodeAnalysis
                 // translation (which is a no-op). Since we use a 'false' here to mean that it's not worth keeping
                 // the compilation with stale trees around, answering true is still important.
                 public override bool CanUpdateCompilationWithStaleGeneratedTreesIfGeneratorsGiveSameOutput => true;
+
+                public override GeneratorDriver? TransformGeneratorDriver(GeneratorDriver generatorDriver)
+                {
+                    return generatorDriver.AddAdditionalTexts(_additionalDocuments.SelectAsArray(AdditionalTextWithState.FromState));
+                }
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
@@ -31,7 +31,8 @@ namespace Microsoft.CodeAnalysis
                     compilationWithoutGeneratedDocuments: null,
                     declarationOnlyCompilation: null,
                     generatedDocuments: TextDocumentStates<SourceGeneratedDocumentState>.Empty,
-                    generatedDocumentsAreFinal: false);
+                    generatedDocumentsAreFinal: false,
+                    generatorDriver: null);
 
                 /// <summary>
                 /// A strong reference to the declaration-only compilation. This compilation isn't used to produce symbols,
@@ -52,6 +53,13 @@ namespace Microsoft.CodeAnalysis
                 /// documents are to be considered final and can be reused, or whether they're from a prior snapshot which needs to be recomputed.
                 /// </summary>
                 public TextDocumentStates<SourceGeneratedDocumentState> GeneratedDocuments { get; }
+
+                /// <summary>
+                /// The <see cref="GeneratorDriver"/> that was used for the last run, to allow for incremental reuse. May be null
+                /// if we don't have generators in the first place, haven't ran generators yet for this project, or had to get rid of our
+                /// driver for some reason.
+                /// </summary>
+                public GeneratorDriver? GeneratorDriver { get; }
 
                 /// <summary>
                 /// Whether the generated documents in <see cref="GeneratedDocuments"/> are final and should not be regenerated. It's important
@@ -78,6 +86,7 @@ namespace Microsoft.CodeAnalysis
                     ValueSource<Optional<Compilation>>? compilationWithoutGeneratedDocuments,
                     Compilation? declarationOnlyCompilation,
                     TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
+                    GeneratorDriver? generatorDriver,
                     bool generatedDocumentsAreFinal)
                 {
                     // Declaration-only compilations should never have any references
@@ -86,12 +95,14 @@ namespace Microsoft.CodeAnalysis
                     CompilationWithoutGeneratedDocuments = compilationWithoutGeneratedDocuments;
                     DeclarationOnlyCompilation = declarationOnlyCompilation;
                     GeneratedDocuments = generatedDocuments;
+                    GeneratorDriver = generatorDriver;
                     GeneratedDocumentsAreFinal = generatedDocumentsAreFinal;
                 }
 
                 public static State Create(
                     Compilation compilation,
                     TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
+                    GeneratorDriver? generatorDriver,
                     Compilation? compilationWithGeneratedDocuments,
                     ImmutableArray<ValueTuple<ProjectState, CompilationAndGeneratorDriverTranslationAction>> intermediateProjects)
                 {
@@ -101,8 +112,8 @@ namespace Microsoft.CodeAnalysis
                     // DeclarationState now. We'll pass false for generatedDocumentsAreFinal because this is being called
                     // if our referenced projects are changing, so we'll have to rerun to consume changes.
                     return intermediateProjects.Length == 0
-                        ? new FullDeclarationState(compilation, generatedDocuments, generatedDocumentsAreFinal: false)
-                        : (State)new InProgressState(compilation, generatedDocuments, compilationWithGeneratedDocuments, intermediateProjects);
+                        ? new FullDeclarationState(compilation, generatedDocuments, generatorDriver, generatedDocumentsAreFinal: false)
+                        : new InProgressState(compilation, generatedDocuments, generatorDriver, compilationWithGeneratedDocuments, intermediateProjects);
                 }
 
                 public static ValueSource<Optional<Compilation>> CreateValueSource(
@@ -138,11 +149,13 @@ namespace Microsoft.CodeAnalysis
                 public InProgressState(
                     Compilation inProgressCompilation,
                     TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
+                    GeneratorDriver? generatorDriver,
                     Compilation? compilationWithGeneratedDocuments,
                     ImmutableArray<(ProjectState state, CompilationAndGeneratorDriverTranslationAction action)> intermediateProjects)
                     : base(compilationWithoutGeneratedDocuments: new ConstantValueSource<Optional<Compilation>>(inProgressCompilation),
                            declarationOnlyCompilation: null,
                            generatedDocuments,
+                           generatorDriver,
                            generatedDocumentsAreFinal: false) // since we have a set of transformations to make, we'll always have to run generators again
                 {
                     Contract.ThrowIfTrue(intermediateProjects.IsDefault);
@@ -160,10 +173,12 @@ namespace Microsoft.CodeAnalysis
             {
                 public LightDeclarationState(Compilation declarationOnlyCompilation,
                     TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
+                    GeneratorDriver? generatorDriver,
                     bool generatedDocumentsAreFinal)
                     : base(compilationWithoutGeneratedDocuments: null,
                            declarationOnlyCompilation,
                            generatedDocuments,
+                           generatorDriver,
                            generatedDocumentsAreFinal)
                 {
                 }
@@ -177,10 +192,12 @@ namespace Microsoft.CodeAnalysis
             {
                 public FullDeclarationState(Compilation declarationCompilation,
                     TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
+                    GeneratorDriver? generatorDriver,
                     bool generatedDocumentsAreFinal)
                     : base(new WeakValueSource<Compilation>(declarationCompilation),
                            declarationCompilation.Clone().RemoveAllReferences(),
                            generatedDocuments,
+                           generatorDriver,
                            generatedDocumentsAreFinal)
                 {
                 }
@@ -224,10 +241,12 @@ namespace Microsoft.CodeAnalysis
                     Compilation compilationWithoutGeneratedFiles,
                     bool hasSuccessfullyLoaded,
                     TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
+                    GeneratorDriver? generatorDriver,
                     UnrootedSymbolSet unrootedSymbolSet)
                     : base(compilationWithoutGeneratedFilesSource,
                            compilationWithoutGeneratedFiles.Clone().RemoveAllReferences(),
                            generatedDocuments,
+                           generatorDriver: generatorDriver,
                            generatedDocumentsAreFinal: true) // when we're in a final state, we've ran generators and should not run again
                 {
                     HasSuccessfullyLoaded = hasSuccessfullyLoaded;
@@ -252,6 +271,7 @@ namespace Microsoft.CodeAnalysis
                     Compilation compilationWithoutGeneratedFiles,
                     bool hasSuccessfullyLoaded,
                     TextDocumentStates<SourceGeneratedDocumentState> generatedDocuments,
+                    GeneratorDriver? generatorDriver,
                     Compilation finalCompilation,
                     ProjectId projectId,
                     Dictionary<MetadataReference, ProjectId>? metadataReferenceToProjectId)
@@ -267,7 +287,9 @@ namespace Microsoft.CodeAnalysis
                         compilationWithoutGeneratedFilesSource,
                         compilationWithoutGeneratedFiles,
                         hasSuccessfullyLoaded,
-                        generatedDocuments, unrootedSymbolSet);
+                        generatedDocuments,
+                        generatorDriver,
+                        unrootedSymbolSet);
                 }
 
                 private static void RecordAssemblySymbols(ProjectId projectId, Compilation compilation, Dictionary<MetadataReference, ProjectId>? metadataReferenceToProjectId)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -825,7 +825,7 @@ namespace Microsoft.CodeAnalysis
 
                         if (ProjectState.SourceGenerators.Any())
                         {
-                            var additionalTexts = this.ProjectState.AdditionalDocumentStates.SelectAsArray<AdditionalText>(state => new AdditionalTextWithState(state));
+                            var additionalTexts = this.ProjectState.AdditionalDocumentStates.SelectAsArray(AdditionalTextWithState.FromState);
                             var compilationFactory = this.ProjectState.LanguageServices.GetRequiredService<ICompilationFactoryService>();
 
                             var generatorDriver = compilationFactory.CreateGeneratorDriver(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -726,6 +726,11 @@ namespace Microsoft.CodeAnalysis
             /// <param name="nonAuthoritativeGeneratedDocuments">The generated documents from a previous pass which may
             /// or may not be correct for the current compilation. These states may be used to access cached results, if
             /// and when applicable for the current compilation.</param>
+            /// <param name="compilationWithStaleGeneratedTrees">The compilation from a prior run that contains generated trees, which
+            /// match the states included in <paramref name="nonAuthoritativeGeneratedDocuments"/>. If a generator run here produces
+            /// the same set of generated documents as are in <paramref name="nonAuthoritativeGeneratedDocuments"/>, and we don't need to make any other
+            /// changes to references, we can then use this compilation instead of re-adding source generated files again to the
+            /// <paramref name="compilationWithoutGenerators"/>.</param>
             private async Task<CompilationInfo> FinalizeCompilationAsync(
                 SolutionState solution,
                 Compilation compilationWithoutGenerators,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -758,7 +758,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return ForkProject(newProject, new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(options));
+            return ForkProject(newProject, new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(options, isAnalyzerConfigChange: false));
         }
 
         /// <summary>
@@ -783,7 +783,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return ForkProject(newProject, new CompilationAndGeneratorDriverTranslationAction.ReplaceAllSyntaxTreesAction(newProject));
+                return ForkProject(newProject, new CompilationAndGeneratorDriverTranslationAction.ReplaceAllSyntaxTreesAction(newProject, isParseOptionChange: true));
             }
         }
 
@@ -929,7 +929,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return ForkProject(newProject, new CompilationAndGeneratorDriverTranslationAction.ReplaceAllSyntaxTreesAction(newProject));
+            return ForkProject(newProject, new CompilationAndGeneratorDriverTranslationAction.ReplaceAllSyntaxTreesAction(newProject, isParseOptionChange: false));
         }
 
         /// <summary>
@@ -1116,7 +1116,7 @@ namespace Microsoft.CodeAnalysis
                 (oldProject, documents) =>
                 {
                     var newProject = oldProject.AddAnalyzerConfigDocuments(documents);
-                    return (newProject, new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(newProject.CompilationOptions!));
+                    return (newProject, new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(newProject.CompilationOptions!, isAnalyzerConfigChange: true));
                 });
         }
 
@@ -1127,7 +1127,7 @@ namespace Microsoft.CodeAnalysis
                 (oldProject, documentIds, _) =>
                 {
                     var newProject = oldProject.RemoveAnalyzerConfigDocuments(documentIds);
-                    return (newProject, new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(newProject.CompilationOptions!));
+                    return (newProject, new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(newProject.CompilationOptions!, isAnalyzerConfigChange: true));
                 });
         }
 
@@ -1448,7 +1448,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(oldProject != newProject);
 
             return ForkProject(newProject,
-                newProject.CompilationOptions != null ? new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(newProject.CompilationOptions) : null);
+                newProject.CompilationOptions != null ? new CompilationAndGeneratorDriverTranslationAction.ProjectCompilationOptionsAction(newProject.CompilationOptions, isAnalyzerConfigChange: true) : null);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -36,10 +36,7 @@ namespace Microsoft.CodeAnalysis
 
         public static string GetGeneratorTypeName(ISourceGenerator generator)
         {
-            // PROTOTYPE(source-generators): this will return the incorrect type for wrapped generators
-            //                               there is ongoing work to remove the type dependency, so we'll
-            //                               fix it when that merges in
-            return generator.GetType().FullName!;
+            return GeneratorDriver.GetGeneratorType(generator).FullName!;
         }
 
         public static string GetGeneratorAssemblyName(ISourceGenerator generator)

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -92,6 +92,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // We should now have converted three additional files -- the two from the original run and then the one that was changed.
             // The other one should have been kept constant because that didn't change.
             Assert.Equal(3, generator.AdditionalFilesConvertedCount);
+
+            // Change one of the source documents, and rerun; we should again only reprocess that one change.
+            project = project.AddDocument("Source.cs", SourceText.From("")).Project;
+
+            compilation = await project.GetRequiredCompilationAsync(CancellationToken.None);
+
+            // We have one extra syntax tree now, but it did not require any invocations of the incremental generator.
+            Assert.Equal(3, compilation.SyntaxTrees.Count());
+            Assert.Equal(3, generator.AdditionalFilesConvertedCount);
         }
 
         [Fact]

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -20,15 +21,25 @@ namespace Microsoft.CodeAnalysis.UnitTests
     [UseExportProvider]
     public class SolutionWithSourceGeneratorTests : TestBase
     {
+        // This is used to add on the preview language version which controls incremental generators being allowed.
+        // TODO: remove this method entirely and the calls once incremental generators are no longer preview
+        private static Project WithPreviewLanguageVersion(Project project)
+        {
+            return project.WithParseOptions(((CSharpParseOptions)project.ParseOptions!).WithLanguageVersion(LanguageVersion.Preview));
+        }
+
         [Theory]
         [CombinatorialData]
-        public async Task SourceGeneratorBasedOnAdditionalFileGeneratesSyntaxTreesOnce(
+        public async Task SourceGeneratorBasedOnAdditionalFileGeneratesSyntaxTrees(
             bool fetchCompilationBeforeAddingGenerator,
             bool useRecoverableTrees)
         {
+            // This test is just the sanity test to make sure generators work at all. There's not a special scenario being
+            // tested.
+
             using var workspace = useRecoverableTrees ? CreateWorkspaceWithRecoverableSyntaxTreesAndWeakCompilations() : CreateWorkspace();
-            var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented() { });
-            var project = AddEmptyProject(workspace.CurrentSolution)
+            var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
+            var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference);
 
             // Optionally fetch the compilation first, which validates that we handle both running the generator
@@ -58,8 +69,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public async Task SourceGeneratorContentStillIncludedAfterSourceFileChange()
         {
             using var workspace = CreateWorkspace();
-            var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented() { });
-            var project = AddEmptyProject(workspace.CurrentSolution)
+            var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
+            var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddDocument("Hello.cs", "// Source File").Project
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project;
@@ -90,8 +101,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public async Task SourceGeneratorContentChangesAfterAdditionalFileChanges()
         {
             using var workspace = CreateWorkspace();
-            var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented() { });
-            var project = AddEmptyProject(workspace.CurrentSolution)
+            var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
+            var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project;
 
@@ -119,7 +130,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspace();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
-            var project = AddEmptyProject(workspace.CurrentSolution)
+            var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddDocument("Hello.cs", "// Source File").Project
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project;
@@ -139,7 +150,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspace();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
-            var projectBeforeChange = AddEmptyProject(workspace.CurrentSolution)
+            var projectBeforeChange = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project;
 
@@ -178,7 +189,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             static Solution AddProjectWithReference(Solution solution, TestGeneratorReference analyzerReference)
             {
-                var project = AddEmptyProject(solution);
+                var project = WithPreviewLanguageVersion(AddEmptyProject(solution));
                 project = project.AddAnalyzerReference(analyzerReference);
                 project = project.AddAdditionalDocument("Test.txt", "Hello, world!").Project;
 
@@ -191,7 +202,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspace();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
-            var solution = AddEmptyProject(workspace.CurrentSolution)
+            var solution = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project.Solution;
 
@@ -207,6 +218,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var compilationWithGenerator = await solution.GetRequiredProject(projectIdWithGenerator).GetRequiredCompilationAsync(CancellationToken.None);
 
+            Assert.NotEmpty(compilationWithGenerator.SyntaxTrees);
             Assert.Same(compilationWithGenerator, compilationReference.Compilation);
         }
 
@@ -215,7 +227,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspaceWithRecoverableSyntaxTreesAndWeakCompilations();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
-            var project = AddEmptyProject(workspace.CurrentSolution)
+            var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project;
 
@@ -239,7 +251,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspace();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
-            var project = AddEmptyProject(workspace.CurrentSolution)
+            var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project;
 
@@ -253,7 +265,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspace();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
-            var project = AddEmptyProject(workspace.CurrentSolution)
+            var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddDocument("RegularDocument.cs", "// Source File", filePath: "RegularDocument.cs").Project
                 .AddAdditionalDocument("Test.txt", "Hello, world!").Project;
@@ -427,7 +439,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = CreateWorkspace();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
-            var originalAdditionalFile = AddEmptyProject(workspace.CurrentSolution)
+            var originalAdditionalFile = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
                 .AddAdditionalDocument("Test.txt", SourceText.From(""));
 

--- a/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
+++ b/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
@@ -13,6 +13,16 @@ namespace Roslyn.Test.Utilities
 {
     internal sealed class GenerateFileForEachAdditionalFileWithContentsCommented : IIncrementalGenerator
     {
+        /// <remarks>
+        /// This should only be updated with Interlocked APIs.
+        /// </remarks>
+        private int _additionalFilesConvertedCount;
+
+        /// <summary>
+        /// The number of additional files we converted to a source file. This can be used to assert incrementality.
+        /// </summary>
+        public int AdditionalFilesConvertedCount => _additionalFilesConvertedCount;
+
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
             context.RegisterExecutionPipeline(pipelineContext =>
@@ -24,8 +34,10 @@ namespace Roslyn.Test.Utilities
             });
         }
 
-        private static SourceText GenerateSourceForAdditionalFile(AdditionalText file, CancellationToken cancellationToken)
+        private SourceText GenerateSourceForAdditionalFile(AdditionalText file, CancellationToken cancellationToken)
         {
+            Interlocked.Increment(ref _additionalFilesConvertedCount);
+
             // We're going to "comment" out the contents of the file when generating this
             var sourceText = file.GetText(cancellationToken);
             Contract.ThrowIfNull(sourceText, "Failed to fetch the text of an additional file.");
@@ -37,6 +49,5 @@ namespace Roslyn.Test.Utilities
         }
 
         private static string GetGeneratedFileName(string path) => $"{Path.GetFileNameWithoutExtension(path)}.generated";
-
     }
 }

--- a/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
+++ b/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
@@ -30,7 +30,7 @@ namespace Roslyn.Test.Utilities
                 pipelineContext.Sources.AdditionalTexts.GenerateSource((generatorContext, additionalText) =>
                     generatorContext.AddSource(
                         GetGeneratedFileName(additionalText.Path),
-                        GenerateSourceForAdditionalFile(additionalText, CancellationToken.None)));
+                        GenerateSourceForAdditionalFile(additionalText, generatorContext.CancellationToken)));
             });
         }
 

--- a/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
+++ b/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
@@ -25,12 +25,12 @@ namespace Roslyn.Test.Utilities
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            context.RegisterExecutionPipeline(pipelineContext =>
+            context.RegisterExecutionPipeline(context =>
             {
-                pipelineContext.Sources.AdditionalTexts.GenerateSource((generatorContext, additionalText) =>
-                    generatorContext.AddSource(
+                context.Sources.AdditionalTexts.GenerateSource((context, additionalText) =>
+                    context.AddSource(
                         GetGeneratedFileName(additionalText.Path),
-                        GenerateSourceForAdditionalFile(additionalText, generatorContext.CancellationToken)));
+                        GenerateSourceForAdditionalFile(additionalText, context.CancellationToken)));
             });
         }
 

--- a/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
+++ b/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
@@ -4,40 +4,39 @@
 
 using System.IO;
 using System.Text;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Roslyn.Test.Utilities
 {
-    internal sealed class GenerateFileForEachAdditionalFileWithContentsCommented : ISourceGenerator
+    internal sealed class GenerateFileForEachAdditionalFileWithContentsCommented : IIncrementalGenerator
     {
-        public void Execute(GeneratorExecutionContext context)
+        public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            foreach (var file in context.AdditionalFiles)
+            context.RegisterExecutionPipeline(pipelineContext =>
             {
-                AddSourceForAdditionalFile(context, file);
-            }
+                pipelineContext.Sources.AdditionalTexts.GenerateSource((generatorContext, additionalText) =>
+                    generatorContext.AddSource(
+                        GetGeneratedFileName(additionalText.Path),
+                        GenerateSourceForAdditionalFile(additionalText, CancellationToken.None)));
+            });
         }
 
-        public void Initialize(GeneratorInitializationContext context)
-        {
-            // TODO: context.RegisterForAdditionalFileChanges(UpdateContext);
-        }
-
-        private static void AddSourceForAdditionalFile(GeneratorExecutionContext context, AdditionalText file)
+        private static SourceText GenerateSourceForAdditionalFile(AdditionalText file, CancellationToken cancellationToken)
         {
             // We're going to "comment" out the contents of the file when generating this
-            var sourceText = file.GetText(context.CancellationToken);
+            var sourceText = file.GetText(cancellationToken);
             Contract.ThrowIfNull(sourceText, "Failed to fetch the text of an additional file.");
 
             var changes = sourceText.Lines.SelectAsArray(l => new TextChange(new TextSpan(l.Start, length: 0), "// "));
             var generatedText = sourceText.WithChanges(changes);
 
-            // TODO: remove the generatedText.ToString() when I don't have to specify the encoding
-            context.AddSource(GetGeneratedFileName(file.Path), SourceText.From(generatedText.ToString(), encoding: Encoding.UTF8));
+            return SourceText.From(generatedText.ToString(), encoding: Encoding.UTF8);
         }
 
         private static string GetGeneratedFileName(string path) => $"{Path.GetFileNameWithoutExtension(path)}.generated";
+
     }
 }

--- a/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
+++ b/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
@@ -27,7 +27,7 @@ namespace Roslyn.Test.Utilities
         {
             context.RegisterExecutionPipeline(context =>
             {
-                context.Sources.AdditionalTexts.GenerateSource((context, additionalText) =>
+                context.RegisterSourceOutput(context.AdditionalTextsProvider, (context, additionalText) =>
                     context.AddSource(
                         GetGeneratedFileName(additionalText.Path),
                         GenerateSourceForAdditionalFile(additionalText, context.CancellationToken)));

--- a/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
+++ b/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
@@ -33,6 +33,11 @@ namespace Roslyn.Test.Utilities
             _checksum = Checksum.From(checksumArray);
         }
 
+        public TestGeneratorReference(IIncrementalGenerator generator)
+            : this(GeneratorDriver.WrapGenerator(generator))
+        {
+        }
+
         public override string? FullPath => null;
         public override object Id => this;
         public Guid Guid { get; }


### PR DESCRIPTION
Right now we were simply creating a new GeneratorDriver every time we needed to run generators; this will allow us to more efficiently reuse prior runs with our new incremental API.