### PR TITLE
Fix optprof config drop path

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -211,7 +211,7 @@ stages:
         ARTIFACTSERVICES_DROP_PAT: $(_DevDivDropAccessToken)
       inputs:
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)'
+        buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)'
         sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
         toLowerCase: false
         usePat: false


### PR DESCRIPTION
Our insertion tool is expecting dnceng build to upload the drop to a different path. e.g.
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/326865?_a=files&path=%2Fsrc%2FTests%2Fconfig%2Frunsettings%2FOfficial%2FOptProf%2FExternal%2Fdotnet.roslyn.props