### PR TITLE
Don't validate workspace invariants in release builds

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -190,7 +190,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public IReadOnlyList<ProjectId> ProjectIds { get; }
 
-        // [Conditional("DEBUG")]
+        // Only run this in debug builds; even the .Any() call across all projects can be expensive when there's a lot of them.
+        [Conditional("DEBUG")]
         private void CheckInvariants()
         {
             Contract.ThrowIfFalse(_projectIdToProjectStateMap.Count == ProjectIds.Count);


### PR DESCRIPTION
This method appears in some performance traces when you have lots of workspace operations being done. The validations are useful but mostly would catch an error early during development, so there's no reason to run these except in DEBUG.