### PR TITLE
Fix optprof config drop path

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -211,7 +211,7 @@ stages:
         ARTIFACTSERVICES_DROP_PAT: $(_DevDivDropAccessToken)
       inputs:
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)'
+        buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)'
         sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
         toLowerCase: false
         usePat: false


### PR DESCRIPTION
I think we have stopped code flow from 16.11 to 17p1? This is just cherry-pick #53722 