### PR TITLE
Only call `IServerMutex.Dispose()` from the thread holding the mutex

### DIFF
--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -205,6 +205,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
                             if (!holdsMutex)
                             {
+                                clientMutex = null;
 #pragma warning disable VSTHRD114 // Avoid returning a null Task (False positive: https://github.com/microsoft/vs-threading/issues/637)
                                 return null;
 #pragma warning restore VSTHRD114 // Avoid returning a null Task


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/53420.
