### PR TITLE
Move focus back to text editor when Inheritance Margin is closed

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceGlyphFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceGlyphFactory.cs
@@ -44,9 +44,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 var membersOnLine = inheritanceMarginTag.MembersOnLine;
                 Contract.ThrowIfTrue(membersOnLine.IsEmpty);
 
-                // ZoomLevel of textView is percentage based. (e.g. 20 -> 400 means 20% -> 400%)
-                // and the scaleFactor of CrispImage is 1 based. (e.g 1 means 100%)
-                var scaleFactor = _textView.ZoomLevel / 100;
                 return new MarginGlyph.InheritanceMargin(
                     _threadingContext,
                     _streamingFindUsagesPresenter,
@@ -54,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                     _classificationFormatMap,
                     _waitIndicator,
                     inheritanceMarginTag,
-                    scaleFactor);
+                    _textView);
             }
 
             return null;

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
 {
@@ -25,6 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         private readonly IStreamingFindUsagesPresenter _streamingFindUsagesPresenter;
         private readonly IWaitIndicator _waitIndicator;
         private readonly Workspace _workspace;
+        private readonly IWpfTextView _textView;
 
         public InheritanceMargin(
             IThreadingContext threadingContext,
@@ -33,14 +35,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             IClassificationFormatMap classificationFormatMap,
             IWaitIndicator waitIndicator,
             InheritanceMarginTag tag,
-            double scaleFactor)
+            IWpfTextView textView)
         {
             _threadingContext = threadingContext;
             _streamingFindUsagesPresenter = streamingFindUsagesPresenter;
             _workspace = tag.Workspace;
             _waitIndicator = waitIndicator;
+            _textView = textView;
             InitializeComponent();
 
+            // ZoomLevel of textView is percentage based. (e.g. 20 -> 400 means 20% -> 400%)
+            // and the scaleFactor of CrispImage is 1 based. (e.g 1 means 100%)
+            var scaleFactor = textView.ZoomLevel;
             var viewModel = InheritanceMarginViewModel.Create(classificationTypeMap, classificationFormatMap, tag, scaleFactor);
             DataContext = viewModel;
             ContextMenu.DataContext = viewModel;
@@ -99,6 +105,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         private void ContextMenu_OnClose(object sender, RoutedEventArgs e)
         {
             ResetBorderToInitialColor();
+            // Move the focus back to textView when the context menu is closed.
+            // It ensures the focus won't be left at the margin
+            ResetFocus();
         }
 
         private void ContextMenu_OnOpen(object sender, RoutedEventArgs e)
@@ -130,6 +139,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         {
             this.Background = Brushes.Transparent;
             this.BorderBrush = Brushes.Transparent;
+        }
+
+        private void ResetFocus()
+        {
+            if (!_textView.HasAggregateFocus)
+            {
+                var visualElement = _textView.VisualElement;
+                if (visualElement.Focusable)
+                {
+                    Keyboard.Focus(visualElement);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/53374

Before:
![before](https://user-images.githubusercontent.com/24360909/120047494-95f31680-bfc9-11eb-9ff5-2268b8c4e7d1.gif)

After:
![after](https://user-images.githubusercontent.com/24360909/120047514-9ee3e800-bfc9-11eb-865e-62a869489418.gif)
