### PR TITLE
Move telemetry initialization outside of package load to ensure it is…

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -33,7 +33,6 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Interactive;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.RuleSets;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectTelemetry;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TodoComments;
 using Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReferences;
@@ -121,16 +120,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
 
             _workspace = _componentModel.GetService<VisualStudioWorkspace>();
             _workspace.Services.GetService<IExperimentationService>();
-
-            // Fetch the session synchronously on the UI thread; if this doesn't happen before we try using this on
-            // the background thread then we will experience hangs like we see in this bug:
-            // https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=190808 or
-            // https://devdiv.visualstudio.com/DevDiv/_workitems?id=296981&_a=edit
-            var telemetryService = (VisualStudioWorkspaceTelemetryService)_workspace.Services.GetRequiredService<IWorkspaceTelemetryService>();
-            telemetryService.InitializeTelemetrySession(TelemetryService.DefaultSession);
-
-            Logger.Log(FunctionId.Run_Environment,
-                KeyValueLogMessage.Create(m => m["Version"] = FileVersionInfo.GetVersionInfo(typeof(VisualStudioWorkspace).Assembly.Location).FileVersion));
 
             InitializeColors();
 

--- a/src/VisualStudio/Core/Def/Telemetry/AbstractWorkspaceTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/AbstractWorkspaceTelemetryService.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -21,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 
         protected abstract ILogger CreateLogger(TelemetrySession telemetrySession);
 
-        public void InitializeTelemetrySession(TelemetrySession telemetrySession)
+        public Task InitializeTelemetrySessionAsync(TelemetrySession telemetrySession, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(CurrentSession is null);
 
@@ -30,11 +32,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 
             CurrentSession = telemetrySession;
 
-            TelemetrySessionInitialized();
+            return TelemetrySessionInitializedAsync(cancellationToken);
         }
 
-        protected virtual void TelemetrySessionInitialized()
+        protected virtual Task TelemetrySessionInitializedAsync(CancellationToken cancellationToken)
         {
+            return Task.CompletedTask;
         }
 
         public bool HasActiveSession

--- a/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryInitializer.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryInitializer.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Telemetry;
+using Microsoft.VisualStudio.Telemetry;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServices.Telemetry
+{
+    [ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.Host), Shared]
+    internal class VisualStudioTelemetryInitializer : IEventListener<object>
+    {
+        private readonly VisualStudioWorkspace _visualStudioWorkspace;
+        private readonly IThreadingContext _threadingContext;
+        private readonly IAsynchronousOperationListener _asynchronousOperationListener;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public VisualStudioTelemetryInitializer(
+            VisualStudioWorkspace visualStudioWorkspace,
+            IThreadingContext threadingContext,
+            IAsynchronousOperationListenerProvider listenerProvider)
+        {
+            _visualStudioWorkspace = visualStudioWorkspace;
+            _threadingContext = threadingContext;
+            _asynchronousOperationListener = listenerProvider.GetListener(FeatureAttribute.Telemetry);
+        }
+
+        public void StartListening(Workspace workspace, object serviceOpt)
+        {
+            if (workspace is VisualStudioWorkspace)
+            {
+                var _ = StartListeningAsync();
+            }
+        }
+
+        private async Task StartListeningAsync()
+        {
+            // Have to catch all exceptions coming through here as this is called from a
+            // fire-and-forget method and we want to make sure nothing leaks out.
+            try
+            {
+                using var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(InitializeTelemetryAsync));
+                await InitializeTelemetryAsync(_threadingContext.DisposalToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is normal (during VS closing).  Just ignore.
+            }
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
+            {
+                // Otherwise report a watson for any other exception.  Don't bring down VS.  This is
+                // a BG service we don't want impacting the user experience.
+            }
+        }
+
+        private async Task InitializeTelemetryAsync(CancellationToken cancellationToken)
+        {
+            // Fetch the session synchronously on the UI thread; if this doesn't happen before we try using this on
+            // the background thread then we will experience hangs like we see in this bug:
+            // https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=190808 or
+            // https://devdiv.visualstudio.com/DevDiv/_workitems?id=296981&_a=edit
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            var session = TelemetryService.DefaultSession;
+
+            // Now that the telemetry session has been initialized, the rest of the work can happen off of the UI thread.
+            await TaskScheduler.Default;
+
+            var telemetryService = (VisualStudioWorkspaceTelemetryService)_visualStudioWorkspace.Services.GetRequiredService<IWorkspaceTelemetryService>();
+            await telemetryService.InitializeTelemetrySessionAsync(session, cancellationToken).ConfigureAwait(false);
+
+            Logger.Log(FunctionId.Run_Environment,
+                KeyValueLogMessage.Create(m => m["Version"] = FileVersionInfo.GetVersionInfo(typeof(VisualStudioWorkspace).Assembly.Location).FileVersion));
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
@@ -45,5 +45,6 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public const string TodoCommentList = nameof(TodoCommentList);
         public const string LanguageServer = nameof(LanguageServer);
         public const string Workspace = nameof(Workspace);
+        public const string Telemetry = nameof(Telemetry);
     }
 }

--- a/src/Workspaces/Remote/Core/IRemoteHostService.cs
+++ b/src/Workspaces/Remote/Core/IRemoteHostService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         void InitializeGlobalState(int uiCultureLCID, int cultureLCID, CancellationToken cancellationToken);
 
-        void InitializeTelemetrySession(int hostProcessId, string serializedSession, CancellationToken cancellationToken);
+        Task InitializeTelemetrySessionAsync(int hostProcessId, string serializedSession, CancellationToken cancellationToken);
 
         /// <summary>
         /// This is only for debugging

--- a/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Host/RemoteHostService.cs
@@ -102,9 +102,9 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <summary>
         /// Remote API. Initializes ServiceHub process global state.
         /// </summary>
-        public void InitializeTelemetrySession(int hostProcessId, string serializedSession, CancellationToken cancellationToken)
+        public Task InitializeTelemetrySessionAsync(int hostProcessId, string serializedSession, CancellationToken cancellationToken)
         {
-            RunService(() =>
+            return RunServiceAsync(async () =>
             {
                 var services = GetWorkspace().Services;
 
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var telemetrySession = new TelemetrySession(serializedSession);
                 telemetrySession.Start();
 
-                telemetryService.InitializeTelemetrySession(telemetrySession);
+                await telemetryService.InitializeTelemetrySessionAsync(telemetrySession, cancellationToken).ConfigureAwait(false);
                 telemetryService.RegisterUnexpectedExceptionLogger(Logger);
 
                 // log telemetry that service hub started


### PR DESCRIPTION
… initialized whenever the VS workspace is created

While attempting to add telemetry for local search investigations, I noticed that no telemetry was being captured when I opened Roslyn.sln without any files opened.  It looks like this is because the RoslynPackage was not loaded until I opened a file, and telemetry is only initialized once the package loads.

To ensure we're accurately capturing the events we want to be capturing, I've moved telemetry initialization to on workspace start.  In the process I refactored a little bit to make more things async and combine initializations.
