### PR TITLE
API-Extension: IArgumentOperations for pattern based calls

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/ForEachStatementInfo.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/ForEachStatementInfo.cs
@@ -4,6 +4,8 @@
 
 using System;
 using Roslyn.Utilities;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -23,9 +25,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         public IMethodSymbol? GetEnumeratorMethod { get; }
 
         /// <summary>
+        /// Gets the &quot;GetEnumerator&quot; method arguments.
+        /// </summary>
+        public ImmutableArray<IArgumentOperation> GetEnumeratorMethodArguments { get; }
+
+        /// <summary>
         /// Gets the &quot;MoveNext&quot; method (or &quot;MoveNextAsync&quot; in an asynchronous foreach).
         /// </summary>
         public IMethodSymbol? MoveNextMethod { get; }
+
+        /// <summary>
+        /// Gets the &quot;MoveNext&quot; method arguments (or &quot;MoveNextAsync&quot; arguments in an asynchronous foreach).
+        /// </summary>
+        public ImmutableArray<IArgumentOperation> MoveNextMethodArguments { get; }
+
 
         /// <summary>
         /// Gets the &quot;Current&quot; property.
@@ -36,6 +49,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Gets the &quot;Dispose&quot; method (or &quot;DisposeAsync&quot; in an asynchronous foreach).
         /// </summary>
         public IMethodSymbol? DisposeMethod { get; }
+
+        /// <summary>
+        /// Gets the &quot;Dispose&quot; method arguments (or &quot;DisposeAsync&quot; method arguments in an asynchronous foreach).
+        /// </summary>
+        public ImmutableArray<IArgumentOperation> DisposeMethodArguments { get; }
 
         /// <summary>
         /// The intermediate type to which the output of the <see cref="CurrentProperty"/> is converted
@@ -64,18 +82,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal ForEachStatementInfo(bool isAsync,
                                       IMethodSymbol getEnumeratorMethod,
+                                      ImmutableArray<IArgumentOperation> getEnumeratorMethodArguments,
                                       IMethodSymbol moveNextMethod,
+                                      ImmutableArray<IArgumentOperation> moveNextMethodArguments,
                                       IPropertySymbol currentProperty,
                                       IMethodSymbol disposeMethod,
+                                      ImmutableArray<IArgumentOperation> disposeMethodArguments,
                                       ITypeSymbol elementType,
                                       Conversion elementConversion,
                                       Conversion currentConversion)
         {
             this.IsAsynchronous = isAsync;
             this.GetEnumeratorMethod = getEnumeratorMethod;
+            this.GetEnumeratorMethodArguments = getEnumeratorMethodArguments;
             this.MoveNextMethod = moveNextMethod;
+            this.MoveNextMethodArguments = moveNextMethodArguments;
             this.CurrentProperty = currentProperty;
             this.DisposeMethod = disposeMethod;
+            this.DisposeMethodArguments = disposeMethodArguments;
             this.ElementType = elementType;
             this.ElementConversion = elementConversion;
             this.CurrentConversion = currentConversion;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.DisposeMethodArguments.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Operations.IArgumentOperation>
+Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.GetEnumeratorMethodArguments.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Operations.IArgumentOperation>
+Microsoft.CodeAnalysis.CSharp.ForEachStatementInfo.MoveNextMethodArguments.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Operations.IArgumentOperation>
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.RecordStructDeclaration = 9068 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 override Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetUsedAssemblyReferences(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.MetadataReference>
 Microsoft.CodeAnalysis.CSharp.Syntax.LambdaExpressionSyntax.AddAttributeLists(params Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.LambdaExpressionSyntax

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ForEachStatementInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ForEachStatementInfoTests.cs
@@ -4,9 +4,11 @@
 
 #nullable disable
 
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
@@ -39,6 +41,9 @@ class E2
             var mn1 = (IMethodSymbol)e1.GetMembers("MoveNext").Single();
             var cur1 = (IPropertySymbol)e1.GetMembers("Current").Single();
             var disp1 = (IMethodSymbol)e1.GetMembers("Dispose").Single();
+            var dispArgs1 = ImmutableArray<IArgumentOperation>.Empty;
+            var mnArgs1 = ImmutableArray<IArgumentOperation>.Empty;
+            var geArgs1 = ImmutableArray<IArgumentOperation>.Empty;
             var conv1 = Conversion.Identity;
 
             var e2 = (ITypeSymbol)c.GlobalNamespace.GetMembers("E2").Single();
@@ -49,14 +54,14 @@ class E2
             var conv2 = Conversion.NoConversion;
 
             EqualityTesting.AssertEqual(default(ForEachStatementInfo), default(ForEachStatementInfo));
-            EqualityTesting.AssertEqual(new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1));
-            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge2, mn1, cur1, disp1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1));
-            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, mn2, cur1, disp1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1));
-            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, mn1, cur2, disp1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1));
-            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp2, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1));
-            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv2, conv1), new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1));
-            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv2), new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1));
-            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, mn1, cur1, disp1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: false, ge1, mn1, cur1, disp1, e1, conv1, conv1));
+            EqualityTesting.AssertEqual(new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
+            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge2, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
+            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn2, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
+            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur2, disp1, dispArgs1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
+            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp2, dispArgs1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
+            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv2, conv1), new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
+            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv2), new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
+            EqualityTesting.AssertNotEqual(new ForEachStatementInfo(isAsync: true, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1), new ForEachStatementInfo(isAsync: false, ge1, geArgs1, mn1, mnArgs1, cur1, disp1, dispArgs1, e1, conv1, conv1));
         }
     }
 }

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -494,6 +494,14 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Always false for VB.
         /// </summary>
         bool IsAsynchronous { get; }
+        /// <summary>
+        /// Invoked method for disposing.
+        /// </summary>
+        IMethodSymbol DisposeMethod { get; }
+        /// <summary>
+        /// Arguments of the dispose invocation.
+        /// </summary>
+        ImmutableArray<IArgumentOperation> DisposeMethodArguments { get; }
     }
     /// <summary>
     /// Represents an operation that drops the resulting value and the type of the underlying wrapped <see cref="Operation" />.
@@ -3189,6 +3197,14 @@ namespace Microsoft.CodeAnalysis.Operations
         /// True if this is an asynchronous using declaration.
         /// </summary>
         bool IsAsynchronous { get; }
+        /// <summary>
+        /// Invoked method for disposing.
+        /// </summary>
+        IMethodSymbol DisposeMethod { get; }
+        /// <summary>
+        /// Arguments of the dispose invocation.
+        /// </summary>
+        ImmutableArray<IArgumentOperation> DisposeMethodArguments { get; }
     }
     /// <summary>
     /// Represents a negated pattern.

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -485,6 +485,20 @@
         </summary>
       </Comments>
     </Property>
+    <Property Name="DisposeMethod" Type="IMethodSymbol" SkipGeneration="true">
+        <Comments>
+            <summary>
+                Invoked method for disposing.
+            </summary>
+        </Comments>
+    </Property>
+    <Property Name="DisposeMethodArguments" Type="ImmutableArray&lt;IArgumentOperation&gt;" SkipGeneration="true">
+        <Comments>
+            <summary>
+                Arguments of the dispose invocation.
+            </summary>
+        </Comments>
+    </Property>
     <Property Name="DisposeInfo" Type="DisposeOperationInfo" Internal="true">
       <Comments>
         <summary>Information about the method that will be invoked to dispose the <see cref="Resources" /> when pattern based disposal is used.</summary>
@@ -2943,6 +2957,20 @@
       <Comments>
         <summary>True if this is an asynchronous using declaration.</summary>
       </Comments>
+    </Property>
+    <Property Name="DisposeMethod" Type="IMethodSymbol" SkipGeneration="true">
+        <Comments>
+            <summary>
+                Invoked method for disposing.
+            </summary>
+        </Comments>
+    </Property>
+    <Property Name="DisposeMethodArguments" Type="ImmutableArray&lt;IArgumentOperation&gt;" SkipGeneration="true">
+        <Comments>
+            <summary>
+                Arguments of the dispose invocation.
+            </summary>
+        </Comments>
     </Property>
     <Property Name="DisposeInfo" Type="DisposeOperationInfo" Internal="true">
       <Comments>


### PR DESCRIPTION
fixes: https://github.com/dotnet/roslyn/issues/53781

Open questions:
- How to handle equality / hash-code for arguments
- Should DisposeInfo only filled with pattern-based dispose infos? (If this remains the case, how can we return the special / wellknown members without a semantic model)?
- Is it okay to use GetForEachLoopOperatorInfo to avoid a "double implementation"?

We need to create tests for the API extension - should we extend existing tests or do we need to create new ones?