### PR TITLE
Don't offer refactorings with invalid framework versions

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -1764,5 +1764,30 @@ unsafe class Z
     }
 }", compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
         }
+
+        [WorkItem(53467, "https://github.com/dotnet/roslyn/issues/53467")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        public async Task TestMissingWhenTypeNotInCompilation()
+        {
+            await TestMissingAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"">
+        <Document>
+using System;
+using System.Collections.Generic;
+#nullable enable
+
+<![CDATA[ class Z<T> where T : class ]]>
+{
+    int a;
+    string b;
+    T? c;
+    [||]
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
@@ -1884,5 +1884,33 @@ class C
     public int J { get; }
 }", index: 3);
         }
+
+        [WorkItem(53467, "https://github.com/dotnet/roslyn/issues/53467")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestMissingWhenTypeNotInCompilation()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"">
+        <Document>
+public class Foo
+{
+    public Foo(int prop1)
+    {
+        Prop1 = prop1;
+    }
+
+    public int Prop1 { get; }
+}
+
+public class Bar : Foo
+{
+    public Bar(int prop1, int [||]prop2) : base(prop1) { }
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
     }
 }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -202,6 +202,12 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 return null;
             }
 
+            // We shouldn't offer a refactoring if the compilation is invalid.
+            if (semanticModel.Compilation.GetTypeByMetadataName("System.ArgumentNullException") is null)
+            {
+                return null;
+            }
+
             using var _ = ArrayBuilder<PickMembersOption>.GetInstance(out var pickMemberOptions);
             var canAddNullCheck = viableMembers.Any(
                 m => m.GetSymbolType().CanAddNullCheck());

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -201,9 +201,10 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 return null;
             }
 
-            // We shouldn't offer a refactoring if the compilation doesn't contain this type, as we use
-            // it later in our computations.
-            if (semanticModel.Compilation.GetTypeByMetadataName(typeof(ArgumentNullException).FullName) is null)
+            // We shouldn't offer a refactoring if the compilation doesn't contain the ArgumentNullException type,
+            // as we use it later in our computations.
+            var argumentNullExceptionType = typeof(ArgumentNullException).FullName;
+            if (argumentNullExceptionType is null || semanticModel.Compilation.GetTypeByMetadataName(argumentNullExceptionType) is null)
             {
                 return null;
             }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -18,7 +18,6 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PickMembers;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -202,8 +201,9 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 return null;
             }
 
-            // We shouldn't offer a refactoring if the compilation is invalid.
-            if (semanticModel.Compilation.GetTypeByMetadataName("System.ArgumentNullException") is null)
+            // We shouldn't offer a refactoring if the compilation doesn't contain this type, as we use
+            // it later in our computations.
+            if (semanticModel.Compilation.GetTypeByMetadataName(typeof(ArgumentNullException).FullName) is null)
             {
                 return null;
             }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             }
 
             // We shouldn't offer a refactoring if the compilation doesn't contain the ArgumentNullException type,
-            // as we use it later in our computations.
+            // as we use it later on in our computations.
             var argumentNullExceptionType = typeof(ArgumentNullException).FullName;
             if (argumentNullExceptionType is null || semanticModel.Compilation.GetTypeByMetadataName(argumentNullExceptionType) is null)
             {

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
@@ -102,8 +102,8 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                 return;
             }
 
-            // We shouldn't offer a refactoring if the compilation doesn't contain this type, as we use
-            // it later in our computations.
+            // We shouldn't offer a refactoring if the compilation doesn't contain the ArgumentNullException type,
+            // as we use it later on in our computations.
             var argumentNullExceptionType = typeof(ArgumentNullException).FullName;
             if (argumentNullExceptionType is null || semanticModel.Compilation.GetTypeByMetadataName(argumentNullExceptionType) is null)
             {

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
@@ -104,7 +104,8 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
 
             // We shouldn't offer a refactoring if the compilation doesn't contain this type, as we use
             // it later in our computations.
-            if (semanticModel.Compilation.GetTypeByMetadataName(typeof(ArgumentNullException).FullName) is null)
+            var argumentNullExceptionType = typeof(ArgumentNullException).FullName;
+            if (argumentNullExceptionType is null || semanticModel.Compilation.GetTypeByMetadataName(argumentNullExceptionType) is null)
             {
                 return;
             }

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
@@ -102,6 +102,12 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                 return;
             }
 
+            // We shouldn't offer a refactoring if the compilation is invalid.
+            if (semanticModel.Compilation.GetTypeByMetadataName("System.ArgumentNullException") is null)
+            {
+                return;
+            }
+
             if (CanOfferRefactoring(functionDeclaration, semanticModel, syntaxFacts, cancellationToken, out var blockStatementOpt))
             {
                 // Ok.  Looks like the selected parameter could be refactored. Defer to subclass to 

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
@@ -102,8 +102,9 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                 return;
             }
 
-            // We shouldn't offer a refactoring if the compilation is invalid.
-            if (semanticModel.Compilation.GetTypeByMetadataName("System.ArgumentNullException") is null)
+            // We shouldn't offer a refactoring if the compilation doesn't contain this type, as we use
+            // it later in our computations.
+            if (semanticModel.Compilation.GetTypeByMetadataName(typeof(ArgumentNullException).FullName) is null)
             {
                 return;
             }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -174,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         private static SyntaxNode CreateNewArgumentNullException(SyntaxGenerator factory, Compilation compilation, IParameterSymbol parameter)
             => factory.ObjectCreationExpression(
-                compilation.GetTypeByMetadataName("System.ArgumentNullException"),
+                compilation.GetTypeByMetadataName(typeof(ArgumentNullException).FullName),
                 factory.NameOfExpression(
                     factory.IdentifierName(parameter.Name))).WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/53467

Specifying an invalid framework version would cause both `GenerateConstructor` and `AddParameterCheck` to crash due to the check here, which can return null: https://sourceroslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/SyntaxGeneratorExtensions.cs,177
In these cases, we shouldn't offer the refactorings at all.

I poked around and couldn't figure out a good way to add tests for this, since the current testing infrastructure seems to only expect valid framework versions. If there's a way to do this that I'm missing, please let me know!