### PR TITLE
Avoid generating Document instances in cases where we only need a documentId in the work coordinator.

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -84,24 +84,24 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     using (data.AsyncToken)
                     {
                         // we have a hint. check whether we can take advantage of it
-                        if (await TryEnqueueFromHintAsync(data.Document, data.ChangedMember).ConfigureAwait(continueOnCapturedContext: false))
-                        {
+                        if (await TryEnqueueFromHintAsync(data).ConfigureAwait(continueOnCapturedContext: false))
                             return;
-                        }
 
-                        EnqueueFullProjectDependency(data.Document);
+                        EnqueueFullProjectDependency(data.Project);
                     }
                 }
 
                 private Data Dequeue()
                     => DequeueWorker(_workGate, _pendingWork, CancellationToken);
 
-                private async Task<bool> TryEnqueueFromHintAsync(Document document, SyntaxPath? changedMember)
+                private async Task<bool> TryEnqueueFromHintAsync(Data data)
                 {
+                    var changedMember = data.ChangedMember;
                     if (changedMember == null)
-                    {
                         return false;
-                    }
+
+                    var document = data.GetRequiredDocument();
+
                     // see whether we already have semantic model. otherwise, use the expansive full project dependency one
                     // TODO: if there is a reliable way to track changed member, we could use GetSemanticModel here which could
                     //       rebuild compilation from scratch
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     if (IsInternal(symbol))
                     {
                         var assembly = symbol.ContainingAssembly;
-                        EnqueueFullProjectDependency(document, assembly);
+                        EnqueueFullProjectDependency(document.Project, assembly);
                         return true;
                     }
 
@@ -209,9 +209,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                            SymbolKind.Property;
                 }
 
-                private void EnqueueFullProjectDependency(Document document, IAssemblySymbol? internalVisibleToAssembly = null)
+                private void EnqueueFullProjectDependency(Project project, IAssemblySymbol? internalVisibleToAssembly = null)
                 {
-                    var self = document.Project.Id;
+                    var self = project.Id;
 
                     // if there is no hint (this can happen for cases such as solution/project load and etc), 
                     // we can postpone it even further
@@ -223,22 +223,18 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     // most likely we got here since we are called due to typing.
                     // calculate dependency here and register each affected project to the next pipe line
-                    var solution = document.Project.Solution;
+                    var solution = project.Solution;
                     foreach (var projectId in GetProjectsToAnalyze(solution, self))
                     {
-                        var project = solution.GetProject(projectId);
-                        if (project == null)
-                        {
+                        var otherProject = solution.GetProject(projectId);
+                        if (otherProject == null)
                             continue;
-                        }
 
-                        if (project.TryGetCompilation(out var compilation))
+                        if (otherProject.TryGetCompilation(out var compilation))
                         {
                             var assembly = compilation.Assembly;
                             if (assembly != null && !assembly.IsSameAssemblyOrHasFriendAccessTo(internalVisibleToAssembly))
-                            {
                                 continue;
-                            }
                         }
 
                         _processor.Enqueue(projectId);
@@ -247,23 +243,23 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     Logger.Log(FunctionId.WorkCoordinator_SemanticChange_FullProjects, internalVisibleToAssembly == null ? "full" : "internals");
                 }
 
-                public void Enqueue(Document document, SyntaxPath? changedMember)
+                public void Enqueue(Project project, DocumentId documentId, Document? document, SyntaxPath? changedMember)
                 {
                     UpdateLastAccessTime();
 
                     using (_workGate.DisposableWait(CancellationToken))
                     {
-                        if (_pendingWork.TryGetValue(document.Id, out var data))
+                        if (_pendingWork.TryGetValue(documentId, out var data))
                         {
                             // create new async token and dispose old one.
                             var newAsyncToken = Listener.BeginAsyncOperation(nameof(Enqueue), tag: _registration.Workspace);
                             data.AsyncToken.Dispose();
 
-                            _pendingWork[document.Id] = new Data(document, data.ChangedMember == changedMember ? changedMember : null, newAsyncToken);
+                            _pendingWork[documentId] = new Data(project, documentId, document, data.ChangedMember == changedMember ? changedMember : null, newAsyncToken);
                             return;
                         }
 
-                        _pendingWork.Add(document.Id, new Data(document, changedMember, Listener.BeginAsyncOperation(nameof(Enqueue), tag: _registration.Workspace)));
+                        _pendingWork.Add(documentId, new Data(project, documentId, document, changedMember, Listener.BeginAsyncOperation(nameof(Enqueue), tag: _registration.Workspace)));
                         _gate.Release();
                     }
 
@@ -320,16 +316,24 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 private readonly struct Data
                 {
-                    public readonly Document Document;
+                    private readonly Document? _document;
+
+                    public readonly Project Project;
+                    public readonly DocumentId DocumentId;
                     public readonly SyntaxPath? ChangedMember;
                     public readonly IAsyncToken AsyncToken;
 
-                    public Data(Document document, SyntaxPath? changedMember, IAsyncToken asyncToken)
+                    public Data(Project project, DocumentId documentId, Document? document, SyntaxPath? changedMember, IAsyncToken asyncToken)
                     {
-                        AsyncToken = asyncToken;
-                        Document = document;
+                        _document = document;
+                        Project = project;
+                        DocumentId = documentId;
                         ChangedMember = changedMember;
+                        AsyncToken = asyncToken;
                     }
+
+                    public Document GetRequiredDocument()
+                        => WorkCoordinator.GetRequiredDocument(Project, DocumentId, _document);
                 }
 
                 private class ProjectProcessor : IdleProcessor

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -183,11 +183,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         Debug.Assert(location.IsInSource);
 
-                        var document = solution.GetDocument(location.SourceTree, projectId);
-                        if (document == null || thisDocument == document)
+                        var documentId = solution.GetDocumentId(location.SourceTree, projectId);
+                        if (documentId == null || thisDocument.Id == documentId)
                             continue;
 
-                        await _processor.EnqueueWorkItemAsync(document.Project, document.Id, document).ConfigureAwait(false);
+                        await _processor.EnqueueWorkItemAsync(solution.GetRequiredProject(documentId.ProjectId), documentId, document: null).ConfigureAwait(false);
                     }
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         _gate.Release();
                     }
 
-                    Logger.Log(FunctionId.WorkCoordinator_SemanticChange_Enqueue, s_enqueueLogger, Environment.TickCount, document.Id, changedMember != null);
+                    Logger.Log(FunctionId.WorkCoordinator_SemanticChange_Enqueue, s_enqueueLogger, Environment.TickCount, documentId, changedMember != null);
                 }
 
                 private static TValue DequeueWorker<TKey, TValue>(NonReentrantLock gate, Dictionary<TKey, TValue> map, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -316,24 +316,24 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 private readonly struct Data
                 {
+                    private readonly DocumentId _documentId;
                     private readonly Document? _document;
 
                     public readonly Project Project;
-                    public readonly DocumentId DocumentId;
                     public readonly SyntaxPath? ChangedMember;
                     public readonly IAsyncToken AsyncToken;
 
                     public Data(Project project, DocumentId documentId, Document? document, SyntaxPath? changedMember, IAsyncToken asyncToken)
                     {
+                        _documentId = documentId;
                         _document = document;
                         Project = project;
-                        DocumentId = documentId;
                         ChangedMember = changedMember;
                         AsyncToken = asyncToken;
                     }
 
                     public Document GetRequiredDocument()
-                        => WorkCoordinator.GetRequiredDocument(Project, DocumentId, _document);
+                        => WorkCoordinator.GetRequiredDocument(Project, _documentId, _document);
                 }
 
                 private class ProjectProcessor : IdleProcessor

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -455,7 +455,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     // must use "Document" here so that the snapshot doesn't go away. we need the snapshot to calculate p2p dependency graph later.
                     // due to this, we might hold onto solution (and things kept alive by it) little bit longer than usual.
-                    _semanticChangeProcessor.Enqueue(GetRequiredDocument(project, documentId, document), currentMember);
+                    _semanticChangeProcessor.Enqueue(project, documentId, document, currentMember);
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/53816