### PR TITLE
Add a property to pass through the initial assembly name

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -86,6 +86,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 projectGuid,
                 hierarchy,
                 binOutputPath,
+                assemblyName: null,
                 CancellationToken.None);
 
             cpsProject.SetOptions(ImmutableArray.Create(commandLineArguments));
@@ -105,6 +106,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 Guid.NewGuid(),
                 hierarchy,
                 binOutputPath: null,
+                assemblyName: null,
                 CancellationToken.None);
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         /// <param name="projectUniqueName">Unique name for the project.</param>
         /// <param name="projectFilePath">Full path to the project file for the project.</param>
         /// <param name="projectGuid">Project guid.</param>
-        /// <param name="hierarchy">Obsolete. The argument is ignored.</param>
+        /// <param name="hierarchy">The IVsHierarchy for the project; this is used to track linked files across multiple projects when determining contexts.</param>
         /// <param name="binOutputPath">Initial project binary output path.</param>
         Task<IWorkspaceProjectContext> CreateProjectContextAsync(
             string languageName,

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
@@ -17,6 +17,10 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         [Obsolete("Use CreateProjectContextAsync instead")]
         IWorkspaceProjectContext CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath);
 
+        /// <inheritdoc cref="CreateProjectContextAsync"/>
+        [Obsolete("Use CreateProjectContextAsync instead")]
+        IWorkspaceProjectContext CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath, string? assemblyName);
+
         /// <summary>
         /// Creates and initializes a new Workspace project and returns a <see
         /// cref="IWorkspaceProjectContext"/> to lazily initialize the properties and items for the
@@ -29,6 +33,14 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         /// <param name="projectGuid">Project guid.</param>
         /// <param name="hierarchy">Obsolete. The argument is ignored.</param>
         /// <param name="binOutputPath">Initial project binary output path.</param>
-        Task<IWorkspaceProjectContext> CreateProjectContextAsync(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath, CancellationToken cancellationToken);
+        Task<IWorkspaceProjectContext> CreateProjectContextAsync(
+            string languageName,
+            string projectUniqueName,
+            string projectFilePath,
+            Guid projectGuid,
+            object? hierarchy,
+            string? binOutputPath,
+            string? assemblyName,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
     {
         /// <inheritdoc cref="CreateProjectContextAsync"/>
         [Obsolete("Use CreateProjectContextAsync instead")]
-        IWorkspaceProjectContext CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object hierarchy, string binOutputPath);
+        IWorkspaceProjectContext CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath);
 
         /// <summary>
         /// Creates and initializes a new Workspace project and returns a <see
@@ -31,6 +29,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         /// <param name="projectGuid">Project guid.</param>
         /// <param name="hierarchy">Obsolete. The argument is ignored.</param>
         /// <param name="binOutputPath">Initial project binary output path.</param>
-        Task<IWorkspaceProjectContext> CreateProjectContextAsync(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object hierarchy, string binOutputPath, CancellationToken cancellationToken);
+        Task<IWorkspaceProjectContext> CreateProjectContextAsync(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -44,7 +44,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         IWorkspaceProjectContext IWorkspaceProjectContextFactory.CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath)
         {
             return _threadingContext.JoinableTaskFactory.Run(() =>
-                this.CreateProjectContextAsync(languageName, projectUniqueName, projectFilePath, projectGuid, hierarchy, binOutputPath, CancellationToken.None));
+                this.CreateProjectContextAsync(languageName, projectUniqueName, projectFilePath, projectGuid, hierarchy, binOutputPath, assemblyName: null, CancellationToken.None));
+        }
+
+        IWorkspaceProjectContext IWorkspaceProjectContextFactory.CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath, string? assemblyName)
+        {
+            return _threadingContext.JoinableTaskFactory.Run(() =>
+                this.CreateProjectContextAsync(languageName, projectUniqueName, projectFilePath, projectGuid, hierarchy, binOutputPath, assemblyName, CancellationToken.None));
         }
 
         public async Task<IWorkspaceProjectContext> CreateProjectContextAsync(
@@ -54,12 +60,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             Guid projectGuid,
             object? hierarchy,
             string? binOutputPath,
+            string? assemblyName,
             CancellationToken cancellationToken)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             var creationInfo = new VisualStudioProjectCreationInfo
             {
+                AssemblyName = assemblyName,
                 FilePath = projectFilePath,
                 Hierarchy = hierarchy as IVsHierarchy,
                 ProjectGuid = projectGuid,

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.ComponentModel.Composition;
 using System.Threading;
@@ -43,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             _serviceProvider = (Shell.IAsyncServiceProvider)serviceProvider;
         }
 
-        IWorkspaceProjectContext IWorkspaceProjectContextFactory.CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object hierarchy, string binOutputPath)
+        IWorkspaceProjectContext IWorkspaceProjectContextFactory.CreateProjectContext(string languageName, string projectUniqueName, string projectFilePath, Guid projectGuid, object? hierarchy, string? binOutputPath)
         {
             return _threadingContext.JoinableTaskFactory.Run(() =>
                 this.CreateProjectContextAsync(languageName, projectUniqueName, projectFilePath, projectGuid, hierarchy, binOutputPath, CancellationToken.None));
@@ -52,10 +50,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public async Task<IWorkspaceProjectContext> CreateProjectContextAsync(
             string languageName,
             string projectUniqueName,
-            string projectFilePath,
+            string? projectFilePath,
             Guid projectGuid,
-            object hierarchy,
-            string binOutputPath,
+            object? hierarchy,
+            string? binOutputPath,
             CancellationToken cancellationToken)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             set => _visualStudioProject.HasAllInformation = value;
         }
 
-        public CPSProject(VisualStudioProject visualStudioProject, VisualStudioWorkspaceImpl visualStudioWorkspace, IProjectCodeModelFactory projectCodeModelFactory, Guid projectGuid, string binOutputPath)
+        public CPSProject(VisualStudioProject visualStudioProject, VisualStudioWorkspaceImpl visualStudioWorkspace, IProjectCodeModelFactory projectCodeModelFactory, Guid projectGuid, string? binOutputPath)
         {
             _visualStudioProject = visualStudioProject;
             _visualStudioWorkspace = visualStudioWorkspace;


### PR DESCRIPTION
This is port of https://github.com/dotnet/roslyn/pull/53599 back for 16.11.

Right now we don't get the command line string for options until the full design time build has completed; however the project system can still give us the evaluated string which is likely to be close enough. This allows features that want to get symbol names for source to have a better chance of having something that they can use and look up in caches or in the cloud.