### PR TITLE
Ensure we only add to string table while holding write lock.

### DIFF
--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -86,11 +86,9 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             public Task<bool> ChecksumMatchesAsync(TKey key, Checksum checksum, CancellationToken cancellationToken)
-            {
-                return Storage.PerformReadAsync(
+                => Storage.PerformReadAsync(
                     static t => t.self.ChecksumMatches(t.key, t.checksum, t.cancellationToken),
                     (self: this, key, checksum, cancellationToken), cancellationToken);
-            }
 
             private bool ChecksumMatches(TKey key, Checksum checksum, CancellationToken cancellationToken)
             {
@@ -104,11 +102,9 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             public Task<Stream?> ReadStreamAsync(TKey key, Checksum? checksum, CancellationToken cancellationToken)
-            {
-                return Storage.PerformReadAsync(
+                => Storage.PerformReadAsync(
                     static t => t.self.ReadStream(t.key, t.checksum, t.cancellationToken),
                     (self: this, key, checksum, cancellationToken), cancellationToken);
-            }
 
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", AllowCaptures = false)]
             private Stream? ReadStream(TKey key, Checksum? checksum, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -136,11 +136,11 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                 {
                     using var _ = Storage._connectionPool.Target.GetPooledConnection(out var connection);
 
-                    // We're in the reading path, so we can't allow TryGetDatabaseId to write.  Note that this is ok,
-                    // and actually provides the semantics we want.  Specifically, we can be trying to read data that
-                    // either exists in the DB or not.  If it doesn't exist in the DB, then it's fine to fail to map
-                    // from the key to a DB id (since there's nothing to lookup anyways).  And if it does exist in
-                    // the db then finding the ID would succeed (without writing) and we could continue.
+                    // We're in the reading-only scheduler path, so we can't allow TryGetDatabaseId to write.  Note that
+                    // this is ok, and actually provides the semantics we want.  Specifically, we can be trying to read
+                    // data that either exists in the DB or not.  If it doesn't exist in the DB, then it's fine to fail
+                    // to map from the key to a DB id (since there's nothing to lookup anyways).  And if it does exist
+                    // in the db then finding the ID would succeed (without writing) and we could continue.
                     if (TryGetDatabaseId(connection, key, allowWrite: false, out var dataId))
                     {
                         try

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -140,6 +140,11 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                 {
                     using var _ = Storage._connectionPool.Target.GetPooledConnection(out var connection);
 
+                    // We're in the reading path, so we can't allow TryGetDatabaseId to write.  Note that this is ok,
+                    // and actually provides the semantics we want.  Specifically, we can be trying to read data that
+                    // either exists in the DB or not.  If it doesn't exist in the DB, then it's fine to fail to map
+                    // from the key to a DB id (since there's nothing to lookup anyways).  And if it does exist in
+                    // the db then finding the ID would succeed (without writing) and we could continue.
                     if (TryGetDatabaseId(connection, key, allowWrite: false, out var dataId))
                     {
                         try

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -93,10 +93,10 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             private bool ChecksumMatches(TKey key, Checksum checksum, CancellationToken cancellationToken)
             {
                 var optional = ReadColumn(
-                        key,
-                        static (self, connection, database, rowId) => self.ReadChecksum(connection, database, rowId),
-                        this,
-                        cancellationToken);
+                    key,
+                    static (self, connection, database, rowId) => self.ReadChecksum(connection, database, rowId),
+                    this,
+                    cancellationToken);
                 return optional.HasValue && checksum == optional.Value;
             }
 

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.Accessor.cs
@@ -68,6 +68,17 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
             protected abstract Table Table { get; }
 
+            /// <summary>
+            /// Gets the internal sqlite db-id (effectively the row-id for the doc or proj table, or just the string-id
+            /// for the solution table) for the provided caller key.  This db-id will be looked up and returned if a
+            /// mapping already exists for it in the db.  Otherwise, a guaranteed unique id will be created for it and
+            /// stored in the db for the future.  This allows all associated data to be cheaply associated with the 
+            /// simple ID, avoiding lots of db bloat if we used the full <paramref name="key"/> in numerous places.
+            /// </summary>
+            /// <param name="allowWrite">Whether or not the caller owns the write lock and thus is ok with the DB id
+            /// being generated and stored for this component key when it currently does not exist.  If <see
+            /// langword="false"/> then failing to find the key will result in <see langword="false"/> being returned.
+            /// </param>
             protected abstract bool TryGetDatabaseId(SqlConnection connection, TKey key, bool allowWrite, out TDatabaseId dataId);
             protected abstract void BindFirstParameter(SqlStatement statement, TDatabaseId dataId);
             protected abstract TWriteQueueKey GetWriteQueueKey(TKey key);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentIds.cs
@@ -21,32 +21,29 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
         /// Given a document, and the name of a stream to read/write, gets the integral DB ID to 
         /// use to find the data inside the DocumentData table.
         /// </summary>
-        private bool TryGetDocumentDataId(SqlConnection connection, DocumentKey documentKey, string name, out long dataId)
+        private bool TryGetDocumentDataId(
+            SqlConnection connection, DocumentKey documentKey, string name, bool allowWrite, out long dataId)
         {
             dataId = 0;
 
-            var documentId = TryGetDocumentId(connection, documentKey);
-            var nameId = TryGetStringId(connection, name);
+            var documentId = TryGetDocumentId(connection, documentKey, allowWrite);
+            var nameId = TryGetStringId(connection, name, allowWrite);
             if (documentId == null || nameId == null)
-            {
                 return false;
-            }
 
             // Our data ID is just a 64bit int combining the two 32bit values of our documentId and nameId.
             dataId = CombineInt32ValuesToInt64(documentId.Value, nameId.Value);
             return true;
         }
 
-        private int? TryGetDocumentId(SqlConnection connection, DocumentKey document)
+        private int? TryGetDocumentId(SqlConnection connection, DocumentKey document, bool allowWrite)
         {
             // First see if we've cached the ID for this value locally.  If so, just return
             // what we already have.
             if (_documentIdToIdMap.TryGetValue(document.Id, out var existingId))
-            {
                 return existingId;
-            }
 
-            var id = TryGetDocumentIdFromDatabase(connection, document);
+            var id = TryGetDocumentIdFromDatabase(connection, document, allowWrite);
             if (id != null)
             {
                 // Cache the value locally so we don't need to go back to the DB in the future.
@@ -56,28 +53,23 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             return id;
         }
 
-        private int? TryGetDocumentIdFromDatabase(SqlConnection connection, DocumentKey document)
+        private int? TryGetDocumentIdFromDatabase(SqlConnection connection, DocumentKey document, bool allowWrite)
         {
-            var projectId = TryGetProjectId(connection, document.Project);
+            var projectId = TryGetProjectId(connection, document.Project, allowWrite);
             if (projectId == null)
-            {
                 return null;
-            }
 
             // Key the document off its project id, and its path and name.  That way we work properly
             // in host and test scenarios.
-            var documentPathId = TryGetStringId(connection, document.FilePath);
-            var documentNameId = TryGetStringId(connection, document.Name);
+            var documentPathId = TryGetStringId(connection, document.FilePath, allowWrite);
+            var documentNameId = TryGetStringId(connection, document.Name, allowWrite);
 
             if (documentPathId == null || documentNameId == null)
-            {
                 return null;
-            }
 
             // Unique identify the document through the key:  projectId-documentPathId-documentNameId
             return TryGetStringId(
-                connection,
-                GetDocumentIdString(projectId.Value, documentPathId.Value, documentNameId.Value));
+                connection, GetDocumentIdString(projectId.Value, documentPathId.Value, documentNameId.Value), allowWrite);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentSerialization.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_DocumentSerialization.cs
@@ -41,8 +41,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             protected override (DocumentId, string) GetWriteQueueKey((DocumentKey documentKey, string name) key)
                 => (key.documentKey.Id, key.name);
 
-            protected override bool TryGetDatabaseId(SqlConnection connection, (DocumentKey documentKey, string name) key, out long dataId)
-                => Storage.TryGetDocumentDataId(connection, key.documentKey, key.name, out dataId);
+            protected override bool TryGetDatabaseId(SqlConnection connection, (DocumentKey documentKey, string name) key, bool allowWrite, out long dataId)
+                => Storage.TryGetDocumentDataId(connection, key.documentKey, key.name, allowWrite, out dataId);
 
             protected override void BindFirstParameter(SqlStatement statement, long dataId)
                 => statement.BindInt64Parameter(parameterIndex: 1, value: dataId);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectIds.cs
@@ -21,12 +21,13 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
         /// Given a project, and the name of a stream to read/write, gets the integral DB ID to 
         /// use to find the data inside the ProjectData table.
         /// </summary>
-        private bool TryGetProjectDataId(SqlConnection connection, ProjectKey project, string name, out long dataId)
+        private bool TryGetProjectDataId(
+            SqlConnection connection, ProjectKey project, string name, bool allowWrite, out long dataId)
         {
             dataId = 0;
 
-            var projectId = TryGetProjectId(connection, project);
-            var nameId = TryGetStringId(connection, name);
+            var projectId = TryGetProjectId(connection, project, allowWrite);
+            var nameId = TryGetStringId(connection, name, allowWrite);
             if (projectId == null || nameId == null)
             {
                 return false;
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             return true;
         }
 
-        private int? TryGetProjectId(SqlConnection connection, ProjectKey project)
+        private int? TryGetProjectId(SqlConnection connection, ProjectKey project, bool allowWrite)
         {
             // First see if we've cached the ID for this value locally.  If so, just return
             // what we already have.
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                 return existingId;
             }
 
-            var id = TryGetProjectIdFromDatabase(connection, project);
+            var id = TryGetProjectIdFromDatabase(connection, project, allowWrite);
             if (id != null)
             {
                 // Cache the value locally so we don't need to go back to the DB in the future.
@@ -56,21 +57,18 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             return id;
         }
 
-        private int? TryGetProjectIdFromDatabase(SqlConnection connection, ProjectKey project)
+        private int? TryGetProjectIdFromDatabase(SqlConnection connection, ProjectKey project, bool allowWrite)
         {
             // Key the project off both its path and name.  That way we work properly
             // in host and test scenarios.
-            var projectPathId = TryGetStringId(connection, project.FilePath);
-            var projectNameId = TryGetStringId(connection, project.Name);
+            var projectPathId = TryGetStringId(connection, project.FilePath, allowWrite);
+            var projectNameId = TryGetStringId(connection, project.Name, allowWrite);
 
             if (projectPathId == null || projectNameId == null)
-            {
                 return null;
-            }
 
             return TryGetStringId(
-                connection,
-                GetProjectIdString(projectPathId.Value, projectNameId.Value));
+                connection, GetProjectIdString(projectPathId.Value, projectNameId.Value), allowWrite);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectSerialization.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_ProjectSerialization.cs
@@ -41,8 +41,8 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             protected override (ProjectId projectId, string name) GetWriteQueueKey((ProjectKey projectKey, string name) key)
                 => (key.projectKey.Id, key.name);
 
-            protected override bool TryGetDatabaseId(SqlConnection connection, (ProjectKey projectKey, string name) key, out long dataId)
-                => Storage.TryGetProjectDataId(connection, key.projectKey, key.name, out dataId);
+            protected override bool TryGetDatabaseId(SqlConnection connection, (ProjectKey projectKey, string name) key, bool allowWrite, out long dataId)
+                => Storage.TryGetProjectDataId(connection, key.projectKey, key.name, allowWrite, out dataId);
 
             protected override void BindFirstParameter(SqlStatement statement, long dataId)
                 => statement.BindInt64Parameter(parameterIndex: 1, value: dataId);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_SolutionSerialization.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_SolutionSerialization.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             protected override string GetWriteQueueKey(string key)
                 => key;
 
-            protected override bool TryGetDatabaseId(SqlConnection connection, string key, out string dataId)
+            protected override bool TryGetDatabaseId(SqlConnection connection, string key, bool allowWrite, out string dataId)
             {
                 // For the SolutionDataTable the key itself acts as the data-id.
                 dataId = key;

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
     {
         private readonly ConcurrentDictionary<string, int> _stringToIdMap = new();
 
-        private int? TryGetStringId(SqlConnection connection, string? value)
+        private int? TryGetStringId(SqlConnection connection, string? value, bool allowWrite)
         {
             // Null strings are not supported at all.  Just ignore these. Any read/writes 
             // to null values will fail and will return 'false/null' to indicate failure
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             }
 
             // Otherwise, try to get or add the string to the string table in the database.
-            var id = TryGetStringIdFromDatabase(connection, value);
+            var id = TryGetStringIdFromDatabase(connection, value, allowWrite);
             if (id != null)
             {
                 _stringToIdMap[value] = id.Value;
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             return id;
         }
 
-        private int? TryGetStringIdFromDatabase(SqlConnection connection, string value)
+        private int? TryGetStringIdFromDatabase(SqlConnection connection, string value, bool allowWrite)
         {
             // First, check if we can find that string in the string table.
             var stringId = TryGetStringIdFromDatabaseWorker(connection, value, canReturnNull: true);
@@ -52,6 +52,11 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
                 // We're done at this point.
                 return stringId;
             }
+
+            // If we're in a context where our caller doesn't have hte write lock, give up now.  They will
+            // call back in with the write lock to allow safe adding of this db ID after this.
+            if (!allowWrite)
+                return null;
 
             // The string wasn't in the db string table.  Add it.  Note: this may fail if some
             // other thread/process beats us there as this table has a 'unique' constraint on the

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_Threading.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_Threading.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
         // Write tasks go to the exclusive-scheduler so they run exclusively of all other threading
         // tasks we need to do.
-        public Task<bool> PerformWriteAsync<TArg>(Func<TArg, bool> func, TArg arg, CancellationToken cancellationToken) where TArg : struct
+        public Task<TResult> PerformWriteAsync<TArg, TResult>(Func<TArg, TResult> func, TArg arg, CancellationToken cancellationToken) where TArg : struct
         {
             // Suppress ExecutionContext flow for asynchronous operations that write to the database. In addition to
             // avoiding ExecutionContext allocations, this clears the LogicalCallContext and avoids the need to clone


### PR DESCRIPTION
Shoudl be reviewed with whitespace changes off. 

Should fix issue where two components accessing the storage service at the same time could lead to tons of locking exceptions while both populate the DB with all their strings:

![image](https://user-images.githubusercontent.com/4564579/120696936-f8349700-c461-11eb-9858-1412b5d20926.png)

RPS tracking here: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4832458&view=results