### PR TITLE
Add FadingOptionsProvider

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.ExtractMethod;
+using Microsoft.CodeAnalysis.Fading;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -767,6 +768,18 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get { return GetBooleanOption(CSharpFormattingOptions2.WrappingPreserveSingleLine); }
             set { SetBooleanOption(CSharpFormattingOptions2.WrappingPreserveSingleLine, value); }
+        }
+
+        public int Fading_FadeOutUnreachableCode
+        {
+            get { return GetBooleanOption(FadingOptions.FadeOutUnreachableCode); }
+            set { SetBooleanOption(FadingOptions.FadeOutUnreachableCode, value); }
+        }
+
+        public int Fading_FadeOutUnusedImports
+        {
+            get { return GetBooleanOption(FadingOptions.FadeOutUnusedImports); }
+            set { SetBooleanOption(FadingOptions.FadeOutUnusedImports, value); }
         }
 
         private int GetBooleanOption(Option2<bool> key)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Editor.Shared.Options
 Imports Microsoft.CodeAnalysis.ExtractMethod
+Imports Microsoft.CodeAnalysis.Fading
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Shared.Options
 Imports Microsoft.CodeAnalysis.Simplification
@@ -292,6 +293,24 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             End Get
             Set(value As Integer)
                 SetBooleanOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, value)
+            End Set
+        End Property
+
+        Public Property Fading_FadeOutUnreachableCode As Boolean
+            Get
+                Return GetBooleanOption(FadingOptions.FadeOutUnreachableCode)
+            End Get
+            Set(value As Boolean)
+                SetBooleanOption(FadingOptions.FadeOutUnreachableCode, value)
+            End Set
+        End Property
+
+        Public Property Fading_FadeOutUnusedImports As Boolean
+            Get
+                Return GetBooleanOption(FadingOptions.FadeOutUnusedImports)
+            End Get
+            Set(value As Boolean)
+                SetBooleanOption(FadingOptions.FadeOutUnusedImports, value)
             End Set
         End Property
 

--- a/src/Workspaces/Core/Portable/Fading/FadingOptionsProvider.cs
+++ b/src/Workspaces/Core/Portable/Fading/FadingOptionsProvider.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Options.Providers;
+
+namespace Microsoft.CodeAnalysis.Fading
+{
+    [ExportOptionProvider, Shared]
+    internal class FadingOptionsProvider : IOptionProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FadingOptionsProvider()
+        {
+        }
+
+        public ImmutableArray<IOption> Options { get; } = FadingOptions.AllOptions.As<IOption>();
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Fading/FadingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Fading/FadingOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Fading
@@ -15,5 +16,9 @@ namespace Microsoft.CodeAnalysis.Fading
         public static readonly PerLanguageOption2<bool> FadeOutUnreachableCode = new(
             nameof(FadingOptions), nameof(FadeOutUnreachableCode), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(FadeOutUnreachableCode)}"));
+
+        public static readonly ImmutableArray<IOption2> AllOptions = ImmutableArray.Create<IOption2>(
+            FadeOutUnusedImports,
+            FadeOutUnreachableCode);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/53872

Without the OptionsProvider the fading options are not available from OOP and the default value of `true` is used instead.