### PR TITLE
Only store tracking spans in the editor side of nav bar items

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarItemService.cs
@@ -2,22 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
     internal interface INavigationBarItemService : ILanguageService
     {
-        Task<IList<NavigationBarItem>?> GetItemsAsync(Document document, CancellationToken cancellationToken);
+        Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, ITextSnapshot textSnapshot, CancellationToken cancellationToken);
         bool ShowItemGrayedIfNear(NavigationBarItem item);
 
         /// <summary>
         /// Returns <see langword="true"/> if navigation (or generation) happened.  <see langword="false"/> otherwise.
         /// </summary>
-        Task<bool> TryNavigateToItemAsync(Document document, NavigationBarItem item, ITextView view, CancellationToken cancellationToken);
+        Task<bool> TryNavigateToItemAsync(Document document, NavigationBarItem item, ITextView view, ITextSnapshot textSnapshot, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -21,20 +19,13 @@ namespace Microsoft.CodeAnalysis.Editor
         public int Indent { get; }
         public ImmutableArray<NavigationBarItem> ChildItems { get; }
 
-        public ImmutableArray<TextSpan> Spans { get; internal set; }
-        internal ImmutableArray<ITrackingSpan> TrackingSpans { get; set; } = ImmutableArray<ITrackingSpan>.Empty;
-
-        // Legacy constructor for TypeScript.
-        [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
-        public NavigationBarItem(string text, Glyph glyph, IList<TextSpan> spans, IList<NavigationBarItem>? childItems = null, int indent = 0, bool bolded = false, bool grayed = false)
-            : this(text, glyph, spans.ToImmutableArrayOrEmpty(), childItems.ToImmutableArrayOrEmpty(), indent, bolded, grayed)
-        {
-        }
+        public TextSpan? Span { get; internal set; }
+        internal ITrackingSpan? TrackingSpan { get; set; }
 
         public NavigationBarItem(
             string text,
             Glyph glyph,
-            ImmutableArray<TextSpan> spans,
+            TextSpan? span,
             ImmutableArray<NavigationBarItem> childItems = default,
             int indent = 0,
             bool bolded = false,
@@ -42,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor
         {
             this.Text = text;
             this.Glyph = glyph;
-            this.Spans = spans.NullToEmpty();
+            this.Span = span;
             this.ChildItems = childItems.NullToEmpty();
             this.Indent = indent;
             this.Bolded = bolded;
@@ -51,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor
 
         internal void InitializeTrackingSpans(ITextSnapshot textSnapshot)
         {
-            this.TrackingSpans = this.Spans.SelectAsArray(s => textSnapshot.CreateTrackingSpan(s.ToSpan(), SpanTrackingMode.EdgeExclusive));
+            this.TrackingSpan = this.Span == null ? null : textSnapshot.CreateTrackingSpan(this.Span.Value.ToSpan(), SpanTrackingMode.EdgeExclusive);
             this.ChildItems.Do(i => i.InitializeTrackingSpans(textSnapshot));
         }
     }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarItem.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
@@ -19,13 +18,12 @@ namespace Microsoft.CodeAnalysis.Editor
         public int Indent { get; }
         public ImmutableArray<NavigationBarItem> ChildItems { get; }
 
-        public TextSpan? Span { get; internal set; }
-        internal ITrackingSpan? TrackingSpan { get; set; }
+        public ImmutableArray<ITrackingSpan> TrackingSpans { get; }
 
         public NavigationBarItem(
             string text,
             Glyph glyph,
-            TextSpan? span,
+            ImmutableArray<ITrackingSpan> trackingSpans,
             ImmutableArray<NavigationBarItem> childItems = default,
             int indent = 0,
             bool bolded = false,
@@ -33,17 +31,14 @@ namespace Microsoft.CodeAnalysis.Editor
         {
             this.Text = text;
             this.Glyph = glyph;
-            this.Span = span;
+            this.TrackingSpans = trackingSpans;
             this.ChildItems = childItems.NullToEmpty();
             this.Indent = indent;
             this.Bolded = bolded;
             this.Grayed = grayed;
         }
 
-        internal void InitializeTrackingSpans(ITextSnapshot textSnapshot)
-        {
-            this.TrackingSpan = this.Span == null ? null : textSnapshot.CreateTrackingSpan(this.Span.Value.ToSpan(), SpanTrackingMode.EdgeExclusive);
-            this.ChildItems.Do(i => i.InitializeTrackingSpans(textSnapshot));
-        }
+        internal static ImmutableArray<ITrackingSpan> GetTrackingSpans(ITextSnapshot textSnapshot, ImmutableArray<TextSpan> spans)
+            => spans.NullToEmpty().SelectAsArray(static (s, ts) => ts.CreateTrackingSpan(s.ToSpan(), SpanTrackingMode.EdgeExclusive), textSnapshot);
     }
 }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarPresentedItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarPresentedItem.cs
@@ -16,14 +16,14 @@ namespace Microsoft.CodeAnalysis.Editor
         public NavigationBarPresentedItem(
             string text,
             Glyph glyph,
-            ImmutableArray<TextSpan> spans,
+            TextSpan? span,
             ImmutableArray<NavigationBarItem> childItems = default,
             bool bolded = false,
             bool grayed = false)
             : base(
                   text,
                   glyph,
-                  spans,
+                  span,
                   childItems,
                   indent: 0,
                   bolded: bolded,

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarPresentedItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarPresentedItem.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
@@ -16,14 +16,14 @@ namespace Microsoft.CodeAnalysis.Editor
         public NavigationBarPresentedItem(
             string text,
             Glyph glyph,
-            TextSpan? span,
+            ImmutableArray<ITrackingSpan> trackingSpans,
             ImmutableArray<NavigationBarItem> childItems = default,
             bool bolded = false,
             bool grayed = false)
             : base(
                   text,
                   glyph,
-                  span,
+                  trackingSpans,
                   childItems,
                   indent: 0,
                   bolded: bolded,

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarProjectItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarProjectItem.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor
@@ -21,7 +21,8 @@ namespace Microsoft.CodeAnalysis.Editor
             Workspace workspace,
             DocumentId documentId,
             string language)
-                : base(text, glyph, span: null,
+                : base(text, glyph,
+                       trackingSpans: ImmutableArray<ITrackingSpan>.Empty,
                        childItems: ImmutableArray<NavigationBarItem>.Empty,
                        indent: 0, bolded: false, grayed: false)
         {

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarProjectItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarProjectItem.cs
@@ -21,8 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor
             Workspace workspace,
             DocumentId documentId,
             string language)
-                : base(text, glyph,
-                       spans: ImmutableArray<TextSpan>.Empty,
+                : base(text, glyph, span: null,
                        childItems: ImmutableArray<NavigationBarItem>.Empty,
                        indent: 0, bolded: false, grayed: false)
         {

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/WrappedNavigationBarItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/WrappedNavigationBarItem.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.NavigationBar;
-using Roslyn.Utilities;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
@@ -14,17 +15,25 @@ namespace Microsoft.CodeAnalysis.Editor
     {
         public readonly RoslynNavigationBarItem UnderlyingItem;
 
-        internal WrappedNavigationBarItem(RoslynNavigationBarItem underlyingItem)
+        internal WrappedNavigationBarItem(
+            RoslynNavigationBarItem underlyingItem, ITextSnapshot textSnapshot)
             : base(
                   underlyingItem.Text,
                   underlyingItem.Glyph,
-                  (underlyingItem as RoslynNavigationBarItem.SymbolItem)?.Spans.FirstOrNull(),
-                  underlyingItem.ChildItems.SelectAsArray(v => (NavigationBarItem)new WrappedNavigationBarItem(v)),
+                  GetTrackingSpans(underlyingItem, textSnapshot),
+                  underlyingItem.ChildItems.SelectAsArray(v => (NavigationBarItem)new WrappedNavigationBarItem(v, textSnapshot)),
                   underlyingItem.Indent,
                   underlyingItem.Bolded,
                   underlyingItem.Grayed)
         {
             UnderlyingItem = underlyingItem;
+        }
+
+        private static ImmutableArray<ITrackingSpan> GetTrackingSpans(RoslynNavigationBarItem underlyingItem, ITextSnapshot textSnapshot)
+        {
+            return underlyingItem is not RoslynNavigationBarItem.SymbolItem symbolItem
+                ? ImmutableArray<ITrackingSpan>.Empty
+                : GetTrackingSpans(textSnapshot, symbolItem.Spans);
         }
     }
 }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/WrappedNavigationBarItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/WrappedNavigationBarItem.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.NavigationBar;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor
             : base(
                   underlyingItem.Text,
                   underlyingItem.Glyph,
-                  (underlyingItem as RoslynNavigationBarItem.SymbolItem)?.Spans ?? default,
+                  (underlyingItem as RoslynNavigationBarItem.SymbolItem)?.Spans.FirstOrNull(),
                   underlyingItem.ChildItems.SelectAsArray(v => (NavigationBarItem)new WrappedNavigationBarItem(v)),
                   underlyingItem.Indent,
                   underlyingItem.Bolded,

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptNavigationBarItemService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -13,7 +12,7 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
@@ -34,21 +33,24 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
             _service = service;
         }
 
-        public async Task<IList<NavigationBarItem>?> GetItemsAsync(Document document, CancellationToken cancellationToken)
+        public async Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(
+            Document document, ITextSnapshot textSnapshot, CancellationToken cancellationToken)
         {
             var items = await _service.GetItemsAsync(document, cancellationToken).ConfigureAwait(false);
-            return items.Select(x => ConvertToNavigationBarItem(x)).ToList();
+            return items.SelectAsArray(x => ConvertToNavigationBarItem(x, textSnapshot));
         }
 
-        public async Task<bool> TryNavigateToItemAsync(Document document, NavigationBarItem item, ITextView view, CancellationToken cancellationToken)
+        public async Task<bool> TryNavigateToItemAsync(
+            Document document, NavigationBarItem item, ITextView view, ITextSnapshot textSnapshot, CancellationToken cancellationToken)
         {
-            if (item.Span != null)
+            if (item.TrackingSpans.Any())
             {
+                var span = item.TrackingSpans[0].GetSpan(textSnapshot);
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
                 var workspace = document.Project.Solution.Workspace;
                 var navigationService = VSTypeScriptDocumentNavigationServiceWrapper.Create(workspace);
-                navigationService.TryNavigateToPosition(workspace, document.Id, item.Span.Value.Start, virtualSpace: 0, options: null, cancellationToken: cancellationToken);
+                navigationService.TryNavigateToPosition(workspace, document.Id, span.Start, virtualSpace: 0, options: null, cancellationToken: cancellationToken);
             }
 
             return true;
@@ -59,14 +61,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
             return true;
         }
 
-        private static NavigationBarItem ConvertToNavigationBarItem(VSTypescriptNavigationBarItem item)
+        private static NavigationBarItem ConvertToNavigationBarItem(VSTypescriptNavigationBarItem item, ITextSnapshot textSnapshot)
         {
-            var spans = item.Spans.NullToEmpty();
             return new InternalNavigationBarItem(
                 item.Text,
                 VSTypeScriptGlyphHelpers.ConvertTo(item.Glyph),
-                spans.Length == 0 ? null : spans[0],
-                item.ChildItems.SelectAsArray(x => ConvertToNavigationBarItem(x)),
+                NavigationBarItem.GetTrackingSpans(textSnapshot, item.Spans),
+                item.ChildItems.SelectAsArray(x => ConvertToNavigationBarItem(x, textSnapshot)),
                 item.Indent,
                 item.Bolded,
                 item.Grayed);
@@ -74,8 +75,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 
         private class InternalNavigationBarItem : NavigationBarItem
         {
-            public InternalNavigationBarItem(string text, Glyph glyph, TextSpan? span, ImmutableArray<NavigationBarItem> childItems, int indent, bool bolded, bool grayed)
-                : base(text, glyph, span, childItems, indent, bolded, grayed)
+            public InternalNavigationBarItem(string text, Glyph glyph, ImmutableArray<ITrackingSpan> trackingSpans, ImmutableArray<NavigationBarItem> childItems, int indent, bool bolded, bool grayed)
+                : base(text, glyph, trackingSpans, childItems, indent, bolded, grayed)
             {
             }
         }

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -299,18 +299,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
             if (oldRight != null)
             {
-                newRight = new NavigationBarPresentedItem(oldRight.Text, oldRight.Glyph, oldRight.Spans, oldRight.ChildItems, oldRight.Bolded, oldRight.Grayed || selectedItems.ShowMemberItemGrayed)
+                newRight = new NavigationBarPresentedItem(oldRight.Text, oldRight.Glyph, oldRight.Span, oldRight.ChildItems, oldRight.Bolded, oldRight.Grayed || selectedItems.ShowMemberItemGrayed)
                 {
-                    TrackingSpans = oldRight.TrackingSpans
+                    TrackingSpan = oldRight.TrackingSpan
                 };
                 listOfRight.Add(newRight);
             }
 
             if (oldLeft != null)
             {
-                newLeft = new NavigationBarPresentedItem(oldLeft.Text, oldLeft.Glyph, oldLeft.Spans, listOfRight.ToImmutable(), oldLeft.Bolded, oldLeft.Grayed || selectedItems.ShowTypeItemGrayed)
+                newLeft = new NavigationBarPresentedItem(oldLeft.Text, oldLeft.Glyph, oldLeft.Span, listOfRight.ToImmutable(), oldLeft.Bolded, oldLeft.Grayed || selectedItems.ShowTypeItemGrayed)
                 {
-                    TrackingSpans = oldLeft.TrackingSpans
+                    TrackingSpan = oldLeft.TrackingSpan
                 };
                 listOfLeft.Add(newLeft);
             }
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                 {
                     var navBarService = document.GetRequiredLanguageService<INavigationBarItemService>();
                     var snapshot = _subjectBuffer.CurrentSnapshot;
-                    item.Spans = item.TrackingSpans.SelectAsArray(ts => ts.GetSpan(snapshot).Span.ToTextSpan());
+                    item.Span = item.TrackingSpan == null ? null : item.TrackingSpan.GetSpan(snapshot).Span.ToTextSpan();
                     var view = _presenter.TryGetCurrentView();
 
                     // ConfigureAwait(true) as we have to come back to UI thread in order to kick of the refresh task

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -299,19 +299,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
             if (oldRight != null)
             {
-                newRight = new NavigationBarPresentedItem(oldRight.Text, oldRight.Glyph, oldRight.Span, oldRight.ChildItems, oldRight.Bolded, oldRight.Grayed || selectedItems.ShowMemberItemGrayed)
-                {
-                    TrackingSpan = oldRight.TrackingSpan
-                };
+                newRight = new NavigationBarPresentedItem(oldRight.Text, oldRight.Glyph, oldRight.TrackingSpans, oldRight.ChildItems, oldRight.Bolded, oldRight.Grayed || selectedItems.ShowMemberItemGrayed);
                 listOfRight.Add(newRight);
             }
 
             if (oldLeft != null)
             {
-                newLeft = new NavigationBarPresentedItem(oldLeft.Text, oldLeft.Glyph, oldLeft.Span, listOfRight.ToImmutable(), oldLeft.Bolded, oldLeft.Grayed || selectedItems.ShowTypeItemGrayed)
-                {
-                    TrackingSpan = oldLeft.TrackingSpan
-                };
+                newLeft = new NavigationBarPresentedItem(oldLeft.Text, oldLeft.Glyph, oldLeft.TrackingSpans, listOfRight.ToImmutable(), oldLeft.Bolded, oldLeft.Grayed || selectedItems.ShowTypeItemGrayed);
                 listOfLeft.Add(newLeft);
             }
 
@@ -383,7 +377,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                 {
                     var navBarService = document.GetRequiredLanguageService<INavigationBarItemService>();
                     var snapshot = _subjectBuffer.CurrentSnapshot;
-                    item.Span = item.TrackingSpan == null ? null : item.TrackingSpan.GetSpan(snapshot).Span.ToTextSpan();
                     var view = _presenter.TryGetCurrentView();
 
                     // ConfigureAwait(true) as we have to come back to UI thread in order to kick of the refresh task
@@ -392,7 +385,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                     // exist in the type list that are only there to show a set a particular set of items in the member
                     // list.  So selecting such an item should only update the member list, and we do not want a refresh
                     // to wipe that out.
-                    if (!await navBarService.TryNavigateToItemAsync(document, item, view, cancellationToken).ConfigureAwait(true))
+                    if (!await navBarService.TryNavigateToItemAsync(document, item, view, snapshot, cancellationToken).ConfigureAwait(true))
                         return;
                 }
             }

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -118,11 +118,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                 using (Logger.LogBlock(FunctionId.NavigationBar_ComputeModelAsync, cancellationToken))
                 {
                     var items = await languageService.GetItemsAsync(document, snapshot, cancellationToken).ConfigureAwait(false);
-                    if (items != null)
-                    {
-                        var version = await document.Project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
-                        return new NavigationBarModel(items.ToImmutableArray(), version, languageService);
-                    }
+                    var version = await document.Project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
+                    return new NavigationBarModel(items, version, languageService);
                 }
             }
 

--- a/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
@@ -38,8 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim snapshot = (Await document.GetTextAsync()).FindCorrespondingEditorTextSnapshot()
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
-                Dim actualItems = Await service.GetItemsAsync(document, Nothing)
-                actualItems.Do(Sub(i) i.InitializeTrackingSpans(snapshot))
+                Dim actualItems = Await service.GetItemsAsync(document, snapshot, Nothing)
 
                 AssertEqual(expectedItems, actualItems, document.GetLanguageService(Of ISyntaxFactsService)().IsCaseSensitive)
             End Using
@@ -57,8 +56,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim snapshot = (Await document.GetTextAsync()).FindCorrespondingEditorTextSnapshot()
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
-                Dim items = Await service.GetItemsAsync(document, Nothing)
-                items.Do(Sub(i) i.InitializeTrackingSpans(snapshot))
+                Dim items = Await service.GetItemsAsync(document, snapshot, Nothing)
 
                 Dim hostDocument = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
                 Dim model As New NavigationBarModel(items.ToImmutableArray(), VersionStamp.Create(), service)
@@ -91,8 +89,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
 
-                Dim items = Await service.GetItemsAsync(document, Nothing)
-                items.Do(Sub(i) i.InitializeTrackingSpans(snapshot))
+                Dim items = Await service.GetItemsAsync(document, snapshot, Nothing)
 
                 Dim leftItem = items.Single(Function(i) i.Text = leftItemToSelectText)
                 Dim rightItem = selectRightItem(leftItem.ChildItems)
@@ -120,8 +117,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim snapshot = (Await sourceDocument.GetTextAsync()).FindCorrespondingEditorTextSnapshot()
 
                 Dim service = DirectCast(sourceDocument.GetLanguageService(Of INavigationBarItemService)(), AbstractEditorNavigationBarItemService)
-                Dim items = Await service.GetItemsAsync(sourceDocument, Nothing)
-                items.Do(Sub(i) i.InitializeTrackingSpans(snapshot))
+                Dim items = Await service.GetItemsAsync(sourceDocument, snapshot, Nothing)
 
                 Dim leftItem = items.Single(Function(i) i.Text = leftItemToSelectText)
                 Dim rightItem = leftItem.ChildItems.Single(Function(i) i.Text = rightItemToSelectText)

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -47,9 +47,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public async Task<bool> TryNavigateToItemAsync(Document document, NavigationBarItem item, ITextView view, CancellationToken cancellationToken)
         {
             // The logic here was ported from FSharp's implementation. The main reason was to avoid shimming INotificationService.
-            if (!item.Spans.IsEmpty)
+            if (item.Span != null)
             {
-                var span = item.Spans.First();
+                var span = item.Span.Value;
                 var workspace = document.Project.Solution.Workspace;
                 var navigationService = workspace.Services.GetRequiredService<IFSharpDocumentNavigationService>();
 
@@ -77,11 +77,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         private static NavigationBarItem ConvertToNavigationBarItem(FSharpNavigationBarItem item)
         {
             var childItems = item.ChildItems ?? SpecializedCollections.EmptyList<FSharpNavigationBarItem>();
+            var spans = item.Spans.ToImmutableArrayOrEmpty();
 
             return new InternalNavigationBarItem(
                 item.Text,
                 FSharpGlyphHelpers.ConvertTo(item.Glyph),
-                item.Spans.ToImmutableArrayOrEmpty(),
+                spans.Length == 0 ? null : spans[0],
                 childItems.SelectAsArray(x => ConvertToNavigationBarItem(x)),
                 item.Indent,
                 item.Bolded,
@@ -90,8 +91,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 
         private class InternalNavigationBarItem : NavigationBarItem
         {
-            public InternalNavigationBarItem(string text, Glyph glyph, ImmutableArray<TextSpan> spans, ImmutableArray<NavigationBarItem> childItems, int indent, bool bolded, bool grayed)
-                : base(text, glyph, spans, childItems, indent, bolded, grayed)
+            public InternalNavigationBarItem(string text, Glyph glyph, TextSpan? span, ImmutableArray<NavigationBarItem> childItems, int indent, bool bolded, bool grayed)
+                : base(text, glyph, span, childItems, indent, bolded, grayed)
             {
             }
         }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -93,14 +93,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 
         private class InternalNavigationBarItem : NavigationBarItem
         {
-            public InternalNavigationBarItem(
-                string text,
-                Glyph glyph,
-                ImmutableArray<ITrackingSpan> trackingSpans,
-                ImmutableArray<NavigationBarItem> childItems,
-                int indent,
-                bool bolded,
-                bool grayed)
+            public InternalNavigationBarItem(string text, Glyph glyph, ImmutableArray<ITrackingSpan> trackingSpans, ImmutableArray<NavigationBarItem> childItems, int indent, bool bolded, bool grayed)
                 : base(text, glyph, trackingSpans, childItems, indent, bolded, grayed)
             {
             }


### PR DESCRIPTION
This is part of a larger refactoring for navbars.  The final form will be that a navbar item can store:

1. teh full (tracking) span(s) in this document that will be used to determine if the item should be selected based on user position.
2. the (tracking) span in the document to navigate to if the item is selected.
3. the doc-id + span if the item should cause navigation to another file (for example, in partial cases).

this PR does '1'.
