### PR TITLE
Fix OptProf test name

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -8,75 +8,75 @@
           "filteredTestCases": [
             {
               "filename": "/Microsoft.CodeAnalysis.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.CSharp.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.Text.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.Xaml.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.Features.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.Remote.Workspaces.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.CSharp.Features.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.Features.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.CSharp.Workspaces.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.Implementation.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.CSharp.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.Workspaces.dll",
-              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated" ]
+              "testCases":[ "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated" ]
             }
           ]
         },
@@ -452,7 +452,7 @@
           "container": "XamlOptProf",
           "testCases": [
             "Microsoft.Test.Performance.XamlOptProfCreateTests.UwpCreateProject_SurfaceIsolated",
-            "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated"
+            "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated"
           ]
         }
       ]
@@ -496,7 +496,7 @@
           "container": "XamlOptProf",
           "testCases": [
             "Microsoft.Test.Performance.XamlOptProfCreateTests.UwpCreateProject_SurfaceIsolated",
-            "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_DesignerIsolated"
+            "Microsoft.Test.Performance.XamlOptProfCreateTests.WpfCreateProject_SurfaceIsolated"
           ]
         }
       ]


### PR DESCRIPTION
The test name was changed recently
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS?path=%2Fsrc%2FTests%2FXamlOptProf%2FXamlOptProfTests.cs&version=GBmain&line=71&lineEnd=72&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents