### PR TITLE
Broaden enforcement on prototype marker

### DIFF
--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -44,7 +44,7 @@ try {
 
   # Verify no PROTOTYPE marker left in main
   if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
-    Write-Host "Checking no PROTOTYPE markers in compiler source"
+    Write-Host "Checking no PROTOTYPE markers in source"
     $prototypes = Get-ChildItem -Path src/*.cs, src/*.vb, src/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
     if ($prototypes) {
       Write-Host "Found PROTOTYPE markers in compiler source:"

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -45,7 +45,7 @@ try {
   # Verify no PROTOTYPE marker left in main
   if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
     Write-Host "Checking no PROTOTYPE markers in compiler source"
-    $prototypes = Get-ChildItem -Path src/Compilers/*.cs, src/Compilers/*.vb,src/Compilers/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
+    $prototypes = Get-ChildItem -Path src/*.cs, src/*.vb, src/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
     if ($prototypes) {
       Write-Host "Found PROTOTYPE markers in compiler source:"
       Write-Host $prototypes

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -47,7 +47,7 @@ try {
     Write-Host "Checking no PROTOTYPE markers in source"
     $prototypes = Get-ChildItem -Path src/*.cs, src/*.vb, src/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
     if ($prototypes) {
-      Write-Host "Found PROTOTYPE markers in compiler source:"
+      Write-Host "Found PROTOTYPE markers in source:"
       Write-Host $prototypes
       throw "PROTOTYPE markers disallowed in compiler source"
     }

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -45,7 +45,7 @@ try {
   # Verify no PROTOTYPE marker left in main
   if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
     Write-Host "Checking no PROTOTYPE markers in source"
-    $prototypes = Get-ChildItem -Path src, eng, scripts -Exclude *.dll,*.exe,*.pdb,*.xlf -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
+    $prototypes = Get-ChildItem -Path src, eng, scripts -Exclude *.dll,*.exe,*.pdb,*.xlf,test-build-correctness.ps1 -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
     if ($prototypes) {
       Write-Host "Found PROTOTYPE markers in source:"
       Write-Host $prototypes

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -45,7 +45,7 @@ try {
   # Verify no PROTOTYPE marker left in main
   if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
     Write-Host "Checking no PROTOTYPE markers in source"
-    $prototypes = Get-ChildItem -Path src/*.cs, src/*.vb, src/*.xml -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
+    $prototypes = Get-ChildItem -Path src, eng, scripts -Exclude *.dll,*.exe,*.pdb,*.xlf -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
     if ($prototypes) {
       Write-Host "Found PROTOTYPE markers in source:"
       Write-Host $prototypes


### PR DESCRIPTION
This first needs discussion with the IDE team.

Relates to https://github.com/dotnet/roslyn/issues/53888