### PR TITLE
Add line numbers to contract failures

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
@@ -22,11 +22,11 @@ namespace Roslyn.Utilities
         /// all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull<T>([NotNull] T value)
+        public static void ThrowIfNull<T>([NotNull] T value, [CallerLineNumber] int lineNumber = 0)
         {
             if (value is null)
             {
-                Fail("Unexpected null");
+                Fail("Unexpected null", lineNumber);
             }
         }
 
@@ -35,11 +35,11 @@ namespace Roslyn.Utilities
         /// all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull<T>([NotNull] T value, string message)
+        public static void ThrowIfNull<T>([NotNull] T value, string message, [CallerLineNumber] int lineNumber = 0)
         {
             if (value is null)
             {
-                Fail(message);
+                Fail(message, lineNumber);
             }
         }
 
@@ -48,11 +48,11 @@ namespace Roslyn.Utilities
         /// in all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition)
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, [CallerLineNumber] int lineNumber = 0)
         {
             if (!condition)
             {
-                Fail("Unexpected false");
+                Fail("Unexpected false", lineNumber);
             }
         }
 
@@ -61,11 +61,11 @@ namespace Roslyn.Utilities
         /// in all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, string message)
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, string message, [CallerLineNumber] int lineNumber = 0)
         {
             if (!condition)
             {
-                Fail(message);
+                Fail(message, lineNumber);
             }
         }
 
@@ -74,11 +74,11 @@ namespace Roslyn.Utilities
         /// all builds.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition)
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, [CallerLineNumber] int lineNumber = 0)
         {
             if (condition)
             {
-                Fail("Unexpected true");
+                Fail("Unexpected true", lineNumber);
             }
         }
 
@@ -87,18 +87,18 @@ namespace Roslyn.Utilities
         /// all builds.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, string message)
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, string message, [CallerLineNumber] int lineNumber = 0)
         {
             if (condition)
             {
-                Fail(message);
+                Fail(message, lineNumber);
             }
         }
 
         [DebuggerHidden]
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void Fail(string message = "Unexpected")
-            => throw new InvalidOperationException(message);
+        public static void Fail(string message = "Unexpected", [CallerLineNumber] int lineNumber = 0)
+            => throw new InvalidOperationException($"{message} - line {lineNumber}");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/53706

The goal here is to make it easier to investigate reports where we get a failure report where we get nothing more than: `Unexpected` in a particular method.  When there is just a single `Contract.ThrowIfNull` in that method, then the issue is obvious.  However, when tehre are several contract calls, it can be extremely difficult to tell which one actually failed.  By adding the line number we can vastly improve understanding what has failed, without needing a dump.