### PR TITLE
Don't throw in BoundDecisionDagNode.GetDebuggerDisplay()

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDagNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDagNode.cs
@@ -114,7 +114,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         : $"leaf `{node.Label.Name}`");
                     break;
                 default:
-                    throw ExceptionUtilities.UnexpectedValue(this);
+                    builder.Append(base.GetDebuggerDisplay());
+                    break;
             }
 
             return pooledBuilder.ToStringAndFree();


### PR DESCRIPTION
It occurred to me that we may want to avoid throwing in DebuggerDisplay even when we failed to handle a new kind of node.