### PR TITLE
Optimize detection of generated code analysis flags

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2237,11 +2237,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         // Location is in generated code if either the containing tree is a generated code file OR if it is a hidden source location.
         protected bool IsGeneratedOrHiddenCodeLocation(SyntaxTree syntaxTree, TextSpan span)
-            => IsGeneratedCode(syntaxTree) || IsHiddenSourceLocation(syntaxTree, span);
+        {
+            return IsGeneratedCode(syntaxTree) || isHiddenSourceLocation(syntaxTree, span);
 
-        protected bool IsHiddenSourceLocation(SyntaxTree syntaxTree, TextSpan span)
-            => HasHiddenRegions(syntaxTree) &&
-               syntaxTree.IsHiddenPosition(span.Start);
+            // Local function
+            bool isHiddenSourceLocation(SyntaxTree syntaxTree, TextSpan span)
+                => HasHiddenRegions(syntaxTree) && syntaxTree.IsHiddenPosition(span.Start);
+        }
+
+        private bool IsGeneratedOrHiddenCodeLocation(SyntaxTree syntaxTree, SyntaxNode node)
+        {
+            // Avoid accessing node.Span unless the node is in a non-generated tree with hidden locations
+            return IsGeneratedCode(syntaxTree) || isHiddenSourceLocation(syntaxTree, node);
+
+            // Local function
+            bool isHiddenSourceLocation(SyntaxTree syntaxTree, SyntaxNode node)
+                => HasHiddenRegions(syntaxTree) && syntaxTree.IsHiddenPosition(node.SpanStart);
+        }
 
         [PerformanceSensitive(
             "https://github.com/dotnet/roslyn/pull/23637",

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Func<SyntaxTree, SemanticModel>? _getSemanticModel;
         private readonly Func<DiagnosticAnalyzer, bool> _shouldSkipAnalysisOnGeneratedCode;
         private readonly Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> _shouldSuppressGeneratedCodeDiagnostic;
-        private readonly Func<SyntaxTree, TextSpan, bool> _isGeneratedCodeLocation;
+        private readonly Func<SyntaxTree, SyntaxNode, bool> _isGeneratedCodeLocation;
         private readonly Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, bool>? _isAnalyzerSuppressedForTree;
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             Func<DiagnosticAnalyzer, bool> shouldSkipAnalysisOnGeneratedCode,
             Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> shouldSuppressGeneratedCodeDiagnostic,
-            Func<SyntaxTree, TextSpan, bool> isGeneratedCodeLocation,
+            Func<SyntaxTree, SyntaxNode, bool> isGeneratedCodeLocation,
             Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, bool> isAnalyzerSuppressedForTree,
             Func<DiagnosticAnalyzer, object?> getAnalyzerGate,
             Func<SyntaxTree, SemanticModel> getSemanticModel,
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             Func<DiagnosticAnalyzer, bool> shouldSkipAnalysisOnGeneratedCode,
             Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> shouldSuppressGeneratedCodeDiagnostic,
-            Func<SyntaxTree, TextSpan, bool> isGeneratedCodeLocation,
+            Func<SyntaxTree, SyntaxNode, bool> isGeneratedCodeLocation,
             Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, bool>? isAnalyzerSuppressedForTree,
             Func<DiagnosticAnalyzer, object?>? getAnalyzerGate,
             Func<SyntaxTree, SemanticModel>? getSemanticModel,
@@ -1870,7 +1870,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             // Check if the node is generated code that must be skipped.
             if (_shouldSkipAnalysisOnGeneratedCode(analyzer) &&
-                _isGeneratedCodeLocation(node.SyntaxTree, node.Span))
+                _isGeneratedCodeLocation(node.SyntaxTree, node))
             {
                 return false;
             }
@@ -1888,7 +1888,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             // Check if the operation syntax is generated code that must be skipped.
             if (operation.Syntax != null && _shouldSkipAnalysisOnGeneratedCode(analyzer) &&
-                _isGeneratedCodeLocation(operation.Syntax.SyntaxTree, operation.Syntax.Span))
+                _isGeneratedCodeLocation(operation.Syntax.SyntaxTree, operation.Syntax))
             {
                 return false;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -217,13 +217,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         /// <summary>
-        /// Returns <see cref="GeneratedCodeAnalysisFlags"/> for the given analyzer.
-        /// If an analyzer hasn't configured generated code analysis, returns <see cref="AnalyzerDriver.DefaultGeneratedCodeAnalysisFlags"/>.
+        /// Determines the <see cref="GeneratedCodeAnalysisFlags"/> for the given analyzer.
+        /// If an analyzer hasn't configured generated code analysis, the default value
+        /// <see cref="AnalyzerDriver.DefaultGeneratedCodeAnalysisFlags"/> will be used.
         /// </summary>
-        public async Task<GeneratedCodeAnalysisFlags> GetGeneratedCodeAnalysisFlagsAsync(DiagnosticAnalyzer analyzer, AnalyzerExecutor analyzerExecutor)
+        public async Task TrackGeneratedCodeAnalysisFlagsAsync(DiagnosticAnalyzer analyzer, AnalyzerExecutor analyzerExecutor)
         {
             var sessionScope = await GetSessionAnalysisScopeAsync(analyzer, analyzerExecutor).ConfigureAwait(false);
-            return sessionScope.GetGeneratedCodeAnalysisFlags(analyzer);
+            sessionScope.TrackGeneratedCodeAnalysisFlags(analyzerExecutor.Compilation, analyzer);
         }
 
         private static void ForceLocalizableStringExceptions(LocalizableString localizableString, EventHandler<Exception> handler)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalyzer.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -13,6 +16,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     public abstract class DiagnosticAnalyzer
     {
         /// <summary>
+        /// This field caches the result of <see cref="AnalysisContext.ConfigureGeneratedCodeAnalysis"/> for the first
+        /// initialization containing at least one registered callback.
+        /// </summary>
+        /// <value>
+        /// The value is a <see cref="GeneratedCodeAnalysisFlags"/> stored as an integer, or -1 if the value has not
+        /// been assigned.
+        /// </value>
+        private int _generatedCodeAnalysisFlags = -1;
+
+        /// <summary>
+        /// This collection is typically <see langword="null"/>. For cases where code analysis flags for a compilation
+        /// differ from <see cref="_generatedCodeAnalysisFlags"/> (only occurs if an analyzer does not consistently
+        /// report this flag), this collection is created to hold the differing values.
+        /// </summary>
+        private ConditionalWeakTable<Compilation, StrongBox<GeneratedCodeAnalysisFlags>>? _generatedCodeAnalysisFlagsOverride;
+
+        /// <summary>
         /// Returns a set of descriptors for the diagnostics that this analyzer is capable of producing.
         /// </summary>
         public abstract ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
@@ -22,6 +42,43 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="context"></param>
         public abstract void Initialize(AnalysisContext context);
+
+        internal void SetGeneratedCodeAnalysisFlags(Compilation compilation, GeneratedCodeAnalysisFlags generatedCodeAnalysisFlags)
+        {
+            // Set _generatedCodeAnalysisFlags to the new value if it does not already have a value. The resulting
+            // value can be:
+            //
+            //  -1: The value was not initialized prior to this call, but is now initialized and matches the current flags.
+            //  generatedCodeAnalysisFlags: The value was already initialized prior to this call, and matches the current flags.
+            //  other: The value was initialized prior to this call, and does not match the current flags. An override is required.
+            var commonFlags = Interlocked.CompareExchange(ref _generatedCodeAnalysisFlags, (int)generatedCodeAnalysisFlags, -1);
+            if (commonFlags == -1 || commonFlags == (int)generatedCodeAnalysisFlags)
+            {
+                return;
+            }
+
+            RoslynLazyInitializer.EnsureInitialized(ref _generatedCodeAnalysisFlagsOverride, static () => new ConditionalWeakTable<Compilation, StrongBox<GeneratedCodeAnalysisFlags>>());
+
+            // SetGeneratedCodeAnalysisFlags is only allowed to be called once for a given compilation.
+            _generatedCodeAnalysisFlagsOverride.Add(compilation, new StrongBox<GeneratedCodeAnalysisFlags>(generatedCodeAnalysisFlags));
+        }
+
+        internal GeneratedCodeAnalysisFlags GetGeneratedCodeAnalysisFlags(Compilation compilation)
+        {
+            if (_generatedCodeAnalysisFlagsOverride is not null
+                && _generatedCodeAnalysisFlagsOverride.TryGetValue(compilation, out var flags))
+            {
+                return flags.Value;
+            }
+
+            if (_generatedCodeAnalysisFlags == -1)
+            {
+                Debug.Fail("Expected the flags to be set for a compilation before checking them.");
+                return AnalyzerDriver.DefaultGeneratedCodeAnalysisFlags;
+            }
+
+            return (GeneratedCodeAnalysisFlags)_generatedCodeAnalysisFlags;
+        }
 
         public sealed override bool Equals(object? obj)
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -363,10 +363,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _concurrentAnalyzers.Contains(analyzer);
         }
 
-        public GeneratedCodeAnalysisFlags GetGeneratedCodeAnalysisFlags(DiagnosticAnalyzer analyzer)
+        public void TrackGeneratedCodeAnalysisFlags(Compilation compilation, DiagnosticAnalyzer analyzer)
         {
-            GeneratedCodeAnalysisFlags mode;
-            return _generatedCodeConfigurationMap.TryGetValue(analyzer, out mode) ? mode : AnalyzerDriver.DefaultGeneratedCodeAnalysisFlags;
+            var flags = _generatedCodeConfigurationMap.TryGetValue(analyzer, out var value) ? value : AnalyzerDriver.DefaultGeneratedCodeAnalysisFlags;
+            analyzer.SetGeneratedCodeAnalysisFlags(compilation, flags);
         }
 
         public void RegisterCompilationStartAction(DiagnosticAnalyzer analyzer, Action<CompilationStartAnalysisContext> action)


### PR DESCRIPTION
* Store `GeneratedCodeAnalysisFlags` on `DiagnosticAnalyzer` for direct access
* Avoid calling `SyntaxNode.Span` on hot path when the value is not used

Addresses 25% of the total CPU time observed in AB#1335637.