### PR TITLE
Avoid accessing a disposed CancellationSeries

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// Series of tokens used to cancel previous outstanding work when new work comes in. Also used as the lock
             /// to ensure threadsafe writing of _eventWorkQueue.
             /// </summary>
-            private readonly CancellationSeries _cancellationSeries;
+            private readonly ReferenceCountedDisposable<CancellationSeries> _cancellationSeries;
 
             /// <summary>
             /// Work queue that collects high priority requests to call TagsChanged with.
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _dataSource = dataSource;
                 _asyncListener = asyncListener;
 
-                _cancellationSeries = new CancellationSeries(_disposalTokenSource.Token);
+                _cancellationSeries = new ReferenceCountedDisposable<CancellationSeries>(new CancellationSeries(_disposalTokenSource.Token));
 
                 _highPriTagsChangedQueue = new AsyncBatchingWorkQueue<NormalizedSnapshotSpanCollection>(
                     TaggerDelay.NearImmediate.ComputeTimeDelay(),

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -58,7 +58,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// </summary>
             private readonly IAsynchronousOperationListener _asyncListener;
 
-            private readonly CancellationTokenSource _disposalTokenSource = new();
+            private readonly CancellationTokenSource _disposalTokenSource;
+            private readonly CancellationToken _disposalToken;
 
             /// <summary>
             /// Work queue that collects event notifications and kicks off the work to process them.
@@ -121,19 +122,22 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 if (dataSource.SpanTrackingMode == SpanTrackingMode.Custom)
                     throw new ArgumentException("SpanTrackingMode.Custom not allowed.", "spanTrackingMode");
 
+                _disposalTokenSource = new CancellationTokenSource();
+                _disposalToken = _disposalTokenSource.Token;
+
                 _subjectBuffer = subjectBuffer;
                 _textViewOpt = textViewOpt;
                 _dataSource = dataSource;
                 _asyncListener = asyncListener;
 
-                _cancellationSeries = new ReferenceCountedDisposable<CancellationSeries>(new CancellationSeries(_disposalTokenSource.Token));
+                _cancellationSeries = new ReferenceCountedDisposable<CancellationSeries>(new CancellationSeries(_disposalToken));
 
                 _highPriTagsChangedQueue = new AsyncBatchingWorkQueue<NormalizedSnapshotSpanCollection>(
                     TaggerDelay.NearImmediate.ComputeTimeDelay(),
                     ProcessTagsChangedAsync,
                     equalityComparer: null,
                     asyncListener,
-                    _disposalTokenSource.Token);
+                    _disposalToken);
 
                 if (_dataSource.AddedTagNotificationDelay == TaggerDelay.NearImmediate)
                 {
@@ -148,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                         ProcessTagsChangedAsync,
                         equalityComparer: null,
                         asyncListener,
-                        _disposalTokenSource.Token);
+                        _disposalToken);
                 }
 
                 DebugRecordInitialStackTrace();
@@ -199,6 +203,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 // Stop computing any initial tags if we've been asked for them.
                 _disposalTokenSource.Cancel();
+                _disposalTokenSource.Dispose();
                 _cancellationSeries.Dispose();
 
                 _disposed = true;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     // cancel the last piece of computation work and enqueue the next.  This doesn't apply for the very
                     // first tag request we make.  We don't want that to be cancellable as we want that result to be 
                     // shown as soon as possible.
-                    var cancellationToken = initialTags ? _disposalTokenSource.Token : cancellationSeries.Target.CreateNext();
+                    var cancellationToken = initialTags ? _disposalToken : cancellationSeries.Target.CreateNext();
 
                     // Continue after the preceeding task unilaterally.  Note that we pass LazyCancellation so that 
                     // we still wait for that task to complete even if cancelled before we proceed.  This is necessary
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     !this.CachedTagTrees.TryGetValue(buffer, out _))
                 {
                     this.ThreadingContext.JoinableTaskFactory.Run(() =>
-                        this.RecomputeTagsForegroundAsync(initialTags: true, _disposalTokenSource.Token));
+                        this.RecomputeTagsForegroundAsync(initialTags: true, _disposalToken));
                 }
 
                 _firstTagsRequest = false;

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -170,34 +170,34 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
             private void EnqueueWork(bool initialTags)
             {
+                using var cancellationSeries = _cancellationSeries.TryAddReference();
+                if (cancellationSeries is null)
+                {
+                    // Already in the process of disposing
+                    return;
+                }
+
                 lock (_cancellationSeries)
                 {
-                    try
-                    {
-                        // cancel the last piece of computation work and enqueue the next.  This doesn't apply for the very
-                        // first tag request we make.  We don't want that to be cancellable as we want that result to be 
-                        // shown as soon as possible.
-                        var cancellationToken = initialTags ? _disposalTokenSource.Token : _cancellationSeries.CreateNext();
+                    // cancel the last piece of computation work and enqueue the next.  This doesn't apply for the very
+                    // first tag request we make.  We don't want that to be cancellable as we want that result to be 
+                    // shown as soon as possible.
+                    var cancellationToken = initialTags ? _disposalTokenSource.Token : cancellationSeries.Target.CreateNext();
 
-                        // Continue after the preceeding task unilaterally.  Note that we pass LazyCancellation so that 
-                        // we still wait for that task to complete even if cancelled before we proceed.  This is necessary
-                        // as that prior task may mutate state (even if cancelled) so we cannot proceed until we know it
-                        // is completely done.
-                        _eventWorkQueue = _eventWorkQueue.ContinueWithAfterDelayFromAsync(
-                            async _ =>
-                            {
-                                await this.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                                await RecomputeTagsForegroundAsync(initialTags, cancellationToken).ConfigureAwait(false);
-                            },
-                            cancellationToken,
-                            (int)_dataSource.EventChangeDelay.ComputeTimeDelay().TotalMilliseconds,
-                            TaskContinuationOptions.None,
-                            TaskScheduler.Default).CompletesAsyncOperation(_asyncListener.BeginAsyncOperation(nameof(EnqueueWork)));
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        // can happen if our type was disposed and we try to get a new token from _cancellationSeries.
-                    }
+                    // Continue after the preceeding task unilaterally.  Note that we pass LazyCancellation so that 
+                    // we still wait for that task to complete even if cancelled before we proceed.  This is necessary
+                    // as that prior task may mutate state (even if cancelled) so we cannot proceed until we know it
+                    // is completely done.
+                    _eventWorkQueue = _eventWorkQueue.ContinueWithAfterDelayFromAsync(
+                        async _ =>
+                        {
+                            await this.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                            await RecomputeTagsForegroundAsync(initialTags, cancellationToken).ConfigureAwait(false);
+                        },
+                        cancellationToken,
+                        (int)_dataSource.EventChangeDelay.ComputeTimeDelay().TotalMilliseconds,
+                        TaskContinuationOptions.None,
+                        TaskScheduler.Default).CompletesAsyncOperation(_asyncListener.BeginAsyncOperation(nameof(EnqueueWork)));
                 }
             }
 


### PR DESCRIPTION
Fixes an error observed in [integration test logs](https://dev.azure.com/dnceng/public/_build/results?buildId=1175758):

```
06/08/2021 01:28:51 Coordinated Universal Time: Error : 1 :[devenv:7680] Unexpected exception: System.AggregateException: One or more errors occurred. ---> System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'CancellationSeries'.
   at Roslyn.Utilities.CancellationSeries.CreateNext(CancellationToken token) in /_/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs:line 105
   at Microsoft.CodeAnalysis.Editor.Implementation.Classification.CompilationAvailableTaggerEventSource.OnEventSourceChanged(Object sender, TaggerEventArgs args) in /_/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs:line 77
   at Microsoft.CodeAnalysis.Editor.Shared.Tagging.AbstractTaggerEventSource.RaiseChanged() in /_/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs:line 22
   at Microsoft.CodeAnalysis.Editor.Shared.Tagging.TaggerEventSources.WorkspaceChangedEventSource.<.ctor>b__1_0(CancellationToken cancellationToken) in /_/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceChangedEventSource.cs:line 31
   at Roslyn.Utilities.AsyncBatchingDelay.OnNotifyAsync(ImmutableArray`1 _, CancellationToken cancellationToken) in /_/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingDelay.cs:line 41
   at Roslyn.Utilities.AsyncBatchingWorkQueue`1.ProcessNextBatchAsync(CancellationToken cancellationToken) in /_/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue.cs:line 190
   at Roslyn.Utilities.AsyncBatchingWorkQueue`1.<TryKickOffNextBatchTask>b__16_1(Task _) in /_/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue.cs:line 166
   at Roslyn.Utilities.TaskExtensions.<>c__DisplayClass26_1.<ContinueWithAfterDelayFromAsync>b__1(Task`1 _) in /_/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskExtensions.cs:line 502
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---
   at Microsoft.CodeAnalysis.ErrorReporting.WatsonExtensions.SetCallstackIfEmpty(Exception exception) in /_/src/VisualStudio/Core/Def/Implementation/Watson/WatsonExtensions.cs:line 110
---> (Inner Exception #0) System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'CancellationSeries'.
   at Roslyn.Utilities.CancellationSeries.CreateNext(CancellationToken token) in /_/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs:line 105
   at Microsoft.CodeAnalysis.Editor.Implementation.Classification.CompilationAvailableTaggerEventSource.OnEventSourceChanged(Object sender, TaggerEventArgs args) in /_/src/EditorFeatures/Core/Implementation/Classification/CompilationAvailableTaggerEventSource.cs:line 77
   at Microsoft.CodeAnalysis.Editor.Shared.Tagging.AbstractTaggerEventSource.RaiseChanged() in /_/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs:line 22
   at Microsoft.CodeAnalysis.Editor.Shared.Tagging.TaggerEventSources.WorkspaceChangedEventSource.<.ctor>b__1_0(CancellationToken cancellationToken) in /_/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.WorkspaceChangedEventSource.cs:line 31
   at Roslyn.Utilities.AsyncBatchingDelay.OnNotifyAsync(ImmutableArray`1 _, CancellationToken cancellationToken) in /_/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingDelay.cs:line 41
   at Roslyn.Utilities.AsyncBatchingWorkQueue`1.ProcessNextBatchAsync(CancellationToken cancellationToken) in /_/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue.cs:line 190
   at Roslyn.Utilities.AsyncBatchingWorkQueue`1.<TryKickOffNextBatchTask>b__16_1(Task _) in /_/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue.cs:line 166
   at Roslyn.Utilities.TaskExtensions.<>c__DisplayClass26_1.<ContinueWithAfterDelayFromAsync>b__1(Task`1 _) in /_/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskExtensions.cs:line 502
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()<---
```