### PR TITLE
Disable dev17 integration tests in CI

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -1,18 +1,20 @@
-# Branches that trigger a build on commit
-trigger:
-- main
-- main-vs-deps
-- release/*
-- features/*
-- demos/*
+## Temporarily disabling integration tests in CI in dev17 until we have a public preview to run them on
 
-# Branches that trigger builds on PR
-pr:
-- main
-- main-vs-deps
-- release/*
-- features/*
-- demos/*
+# # Branches that trigger a build on commit
+# trigger:
+# - main
+# - main-vs-deps
+# - release/*
+# - features/*
+# - demos/*
+
+# # Branches that trigger builds on PR
+# pr:
+# - main
+# - main-vs-deps
+# - release/*
+# - features/*
+# - demos/*
 
 jobs:
 - job: VS_Integration

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -1,15 +1,16 @@
-## Temporarily disabling integration tests in CI in dev17 until we have a public preview to run them on
 
-# # Branches that trigger a build on commit
-# trigger:
+# Branches that trigger a build on commit
+
+# Temporarily disabling integration tests in CI in dev17 until we have a public preview to run them on
+trigger: none
 # - main
 # - main-vs-deps
 # - release/*
 # - features/*
 # - demos/*
 
-# # Branches that trigger builds on PR
-# pr:
+# Branches that trigger builds on PR
+pr: none
 # - main
 # - main-vs-deps
 # - release/*

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -1,4 +1,3 @@
-
 # Branches that trigger a build on commit
 
 # Temporarily disabling integration tests in CI in dev17 until we have a public preview to run them on


### PR DESCRIPTION
The integration tests don't work in dev17 because we don't have an integration queue with dev17 installed. The checks have been made optional, but even the failure of optional checks seems to prevent our auto merge from working, which interrupts/delays code flow from Roslyn to VS.

Let's completely disable the checks for the time being until it becomes possible to run the integration tests in a public CI environment.