### PR TITLE
AdornmentManager Abstraction

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManagerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManagerProvider.cs
@@ -18,9 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
         IWpfTextViewCreationListener
         where TTag : GraphicsTag
     {
-        private readonly IThreadingContext _threadingContext;
-        private readonly IViewTagAggregatorFactoryService _tagAggregatorFactoryService;
-        private readonly IAsynchronousOperationListener _asyncListener;
+        protected readonly IThreadingContext _threadingContext;
+        protected readonly IViewTagAggregatorFactoryService _tagAggregatorFactoryService;
+        protected readonly IAsynchronousOperationListener _asyncListener;
 
         protected AbstractAdornmentManagerProvider(
             IThreadingContext threadingContext,
@@ -35,20 +35,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
         protected abstract string FeatureAttributeName { get; }
         protected abstract string AdornmentLayerName { get; }
 
-        public void TextViewCreated(IWpfTextView textView)
-        {
-            if (textView == null)
-            {
-                throw new ArgumentNullException(nameof(textView));
-            }
-
-            if (!textView.TextBuffer.GetFeatureOnOffOption(EditorComponentOnOffOptions.Adornment))
-            {
-                return;
-            }
-
-            // the manager keeps itself alive by listening to text view events.
-            AdornmentManager<TTag>.Create(_threadingContext, textView, _tagAggregatorFactoryService, _asyncListener, AdornmentLayerName);
-        }
+        public abstract void TextViewCreated(IWpfTextView textView);
     }
 }

--- a/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManagerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManagerProvider.cs
@@ -18,23 +18,38 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
         IWpfTextViewCreationListener
         where TTag : GraphicsTag
     {
-        protected readonly IThreadingContext _threadingContext;
-        protected readonly IViewTagAggregatorFactoryService _tagAggregatorFactoryService;
-        protected readonly IAsynchronousOperationListener _asyncListener;
+        protected readonly IThreadingContext ThreadingContext;
+        protected readonly IViewTagAggregatorFactoryService TagAggregatorFactoryService;
+        protected readonly IAsynchronousOperationListener AsyncListener;
 
         protected AbstractAdornmentManagerProvider(
             IThreadingContext threadingContext,
             IViewTagAggregatorFactoryService tagAggregatorFactoryService,
             IAsynchronousOperationListenerProvider listenerProvider)
         {
-            _threadingContext = threadingContext;
-            _tagAggregatorFactoryService = tagAggregatorFactoryService;
-            _asyncListener = listenerProvider.GetListener(this.FeatureAttributeName);
+            ThreadingContext = threadingContext;
+            TagAggregatorFactoryService = tagAggregatorFactoryService;
+            AsyncListener = listenerProvider.GetListener(this.FeatureAttributeName);
         }
 
         protected abstract string FeatureAttributeName { get; }
         protected abstract string AdornmentLayerName { get; }
 
-        public abstract void TextViewCreated(IWpfTextView textView);
+        protected abstract void CreateAdornmentManager(IWpfTextView textView);
+
+        public void TextViewCreated(IWpfTextView textView)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            if (!textView.TextBuffer.GetFeatureOnOffOption(EditorComponentOnOffOptions.Adornment))
+            {
+                return;
+            }
+
+            CreateAdornmentManager(textView);
+        }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManager.cs
@@ -6,8 +6,10 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Adornments;
 using Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.LineSeparators
 {
@@ -16,6 +18,99 @@ namespace Microsoft.CodeAnalysis.Editor.LineSeparators
         public LineSeparatorAdornmentManager(IThreadingContext threadingContext, IWpfTextView textView, IViewTagAggregatorFactoryService tagAggregatorFactoryService, IAsynchronousOperationListener asyncListener, string adornmentLayerName)
             : base(threadingContext, textView, tagAggregatorFactoryService, asyncListener, adornmentLayerName)
         {
+        }
+
+        /// <summary>
+        /// MUST BE CALLED ON UI THREAD!!!!   This method touches WPF.
+        /// 
+        /// This is where we apply visuals to the text. 
+        /// 
+        /// It happens when another region of the view becomes visible or there is a change in tags.
+        /// For us the end result is the same - get tags from tagger and update visuals correspondingly.
+        /// </summary>        
+        protected override void UpdateSpans_CallOnlyOnUIThread(NormalizedSnapshotSpanCollection changedSpanCollection, bool removeOldTags)
+        {
+            Contract.ThrowIfNull(changedSpanCollection);
+
+            // this method should only run on UI thread as we do WPF here.
+            Contract.ThrowIfFalse(TextView.VisualElement.Dispatcher.CheckAccess());
+
+            var viewSnapshot = TextView.TextSnapshot;
+            var visualSnapshot = TextView.VisualSnapshot;
+
+            var viewLines = TextView.TextViewLines;
+            if (viewLines == null || viewLines.Count == 0)
+            {
+                return; // nothing to draw on
+            }
+
+            // removing is a separate pass from adding so that new stuff is not removed.
+            if (removeOldTags)
+            {
+                foreach (var changedSpan in changedSpanCollection)
+                {
+                    // is there any effect on the view?
+                    if (viewLines.IntersectsBufferSpan(changedSpan))
+                    {
+                        AdornmentLayer.RemoveAdornmentsByVisualSpan(changedSpan);
+                    }
+                }
+            }
+
+            foreach (var changedSpan in changedSpanCollection)
+            {
+                // is there any effect on the view?
+                if (!viewLines.IntersectsBufferSpan(changedSpan))
+                {
+                    continue;
+                }
+
+                var tagSpans = TagAggregator.GetTags(changedSpan);
+                foreach (var tagMappingSpan in tagSpans)
+                {
+                    // We don't want to draw line separators if they would intersect a collapsed outlining
+                    // region.  So we test if we can map the start of the line separator up to our visual 
+                    // snapshot. If we can't, then we just skip it.
+                    var point = tagMappingSpan.Span.Start.GetPoint(changedSpan.Snapshot, PositionAffinity.Predecessor);
+                    if (point == null)
+                    {
+                        continue;
+                    }
+
+                    var mappedPoint = TextView.BufferGraph.MapUpToSnapshot(
+                        point.Value, PointTrackingMode.Negative, PositionAffinity.Predecessor, TextView.VisualSnapshot);
+                    if (mappedPoint == null)
+                    {
+                        continue;
+                    }
+
+                    if (!TryMapToSingleSnapshotSpan(tagMappingSpan.Span, viewSnapshot, out var span))
+                    {
+                        continue;
+                    }
+
+                    if (!viewLines.IntersectsBufferSpan(span))
+                    {
+                        // span is outside of the view so we will not get geometry for it, but may 
+                        // spent a lot of time trying.
+                        continue;
+                    }
+
+                    // add the visual to the adornment layer.
+                    var geometry = viewLines.GetMarkerGeometry(span);
+                    if (geometry != null)
+                    {
+                        var tag = tagMappingSpan.Tag;
+                        var graphicsResult = tag.GetGraphics(TextView, geometry);
+                        AdornmentLayer.AddAdornment(
+                            behavior: AdornmentPositioningBehavior.TextRelative,
+                            visualSpan: span,
+                            tag: tag,
+                            adornment: graphicsResult.VisualElement,
+                            removedCallback: delegate { graphicsResult.Dispose(); });
+                    }
+                }
+            }
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManager.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Editor.Implementation.Adornments;
+using Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Tagging;
+
+namespace Microsoft.CodeAnalysis.Editor.LineSeparators
+{
+    internal class LineSeparatorAdornmentManager : AdornmentManager<LineSeparatorTag>
+    {
+        public LineSeparatorAdornmentManager(IThreadingContext threadingContext, IWpfTextView textView, IViewTagAggregatorFactoryService tagAggregatorFactoryService, IAsynchronousOperationListener asyncListener, string adornmentLayerName)
+            : base(threadingContext, textView, tagAggregatorFactoryService, asyncListener, adornmentLayerName)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManager.cs
@@ -15,7 +15,8 @@ namespace Microsoft.CodeAnalysis.Editor.LineSeparators
 {
     internal class LineSeparatorAdornmentManager : AdornmentManager<LineSeparatorTag>
     {
-        public LineSeparatorAdornmentManager(IThreadingContext threadingContext, IWpfTextView textView, IViewTagAggregatorFactoryService tagAggregatorFactoryService, IAsynchronousOperationListener asyncListener, string adornmentLayerName)
+        public LineSeparatorAdornmentManager(IThreadingContext threadingContext, IWpfTextView textView,
+            IViewTagAggregatorFactoryService tagAggregatorFactoryService, IAsynchronousOperationListener asyncListener, string adornmentLayerName)
             : base(threadingContext, textView, tagAggregatorFactoryService, asyncListener, adornmentLayerName)
         {
         }

--- a/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManagerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManagerProvider.cs
@@ -7,6 +7,9 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Implementation.Adornments;
+using Microsoft.CodeAnalysis.Editor.LineSeparators;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -49,5 +52,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
 
         protected override string FeatureAttributeName => FeatureAttribute.LineSeparators;
         protected override string AdornmentLayerName => LayerName;
+
+        public override void TextViewCreated(IWpfTextView textView)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            if (!textView.TextBuffer.GetFeatureOnOffOption(EditorComponentOnOffOptions.Adornment))
+            {
+                return;
+            }
+
+            _ = new LineSeparatorAdornmentManager(_threadingContext, textView, _tagAggregatorFactoryService, _asyncListener, AdornmentLayerName);
+            // the manager keeps itself alive by listening to text view events.
+        }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManagerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/LineSeparators/LineSeparatorAdornmentManagerProvider.cs
@@ -53,20 +53,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
         protected override string FeatureAttributeName => FeatureAttribute.LineSeparators;
         protected override string AdornmentLayerName => LayerName;
 
-        public override void TextViewCreated(IWpfTextView textView)
+        protected override void CreateAdornmentManager(IWpfTextView textView)
         {
-            if (textView == null)
-            {
-                throw new ArgumentNullException(nameof(textView));
-            }
-
-            if (!textView.TextBuffer.GetFeatureOnOffOption(EditorComponentOnOffOptions.Adornment))
-            {
-                return;
-            }
-
-            _ = new LineSeparatorAdornmentManager(_threadingContext, textView, _tagAggregatorFactoryService, _asyncListener, AdornmentLayerName);
             // the manager keeps itself alive by listening to text view events.
+            _ = new LineSeparatorAdornmentManager(ThreadingContext, textView, TagAggregatorFactoryService, AsyncListener, AdornmentLayerName);
         }
     }
 }


### PR DESCRIPTION
Hola!

I separated out the work that was done to make the adornment manager abstract in its own PR. This was done so it could be reused for the inline diagnostics feature. 
The line separator feature needed some updates per this change.