### PR TITLE
Documentation typos

### DIFF
--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            // WARANING: do not touch any state fields outside the lock.
+            // WARNING: do not touch any state fields outside the lock.
             var solution = fileInfo.Workspace.CurrentSolution;
             var project = solution.GetProject(fileInfo.SourceProjectId);
             if (project == null)

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
             If (context.IsAnyExpressionContext OrElse context.IsSingleLineStatementContext OrElse context.IsNameOfContext) AndAlso
                 targetToken.GetInnermostDeclarationContext().IsKind(SyntaxKind.ClassBlock, SyntaxKind.StructureBlock) Then
 
-                ' Preselect the Me kewyord when the target type is the same 
+                ' Preselect the Me keyword when the target type is the same
                 ' as the enclosing type symbol of the body we're typing in
 
                 Dim priority = MatchPriority.Default

--- a/src/Workspaces/Core/Portable/Differencing/AbstractSyntaxComparer.cs
+++ b/src/Workspaces/Core/Portable/Differencing/AbstractSyntaxComparer.cs
@@ -23,10 +23,10 @@ namespace Microsoft.CodeAnalysis.Differencing
         private readonly IEnumerable<SyntaxNode>? _oldRootChildren;
         private readonly IEnumerable<SyntaxNode>? _newRootChildren;
 
-        // This comparer can operate in two modes: 
+        // This comparer can operate in two modes:
         // * Top level syntax, which looks at member declarations, but doesn't look inside method bodies etc.
         // * Statement syntax, which looks into member bodies and descends through all statements and expressions
-        // This flag is used where there needs to be a disctinction made between how these are treated
+        // This flag is used where there needs to be a distinction made between how these are treated
         protected readonly bool _compareStatementSyntax;
 
         internal AbstractSyntaxComparer(


### PR DESCRIPTION
Minor typos:
- WARANING -> WARNING
- kewyord -> keyword
- disctinction -> distinction