### PR TITLE
Fix missing telemetry message

### DIFF
--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
@@ -55,15 +55,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 
         public void LogBlockStart(FunctionId functionId, LogMessage logMessage, int blockId, CancellationToken cancellationToken)
         {
-            if (!(logMessage is KeyValueLogMessage kvLogMessage))
-            {
-                return;
-            }
-
             try
             {
                 // guard us from exception thrown by telemetry
-                _pendingScopes[blockId] = CreateAndStartScope(kvLogMessage.Kind, functionId);
+                var kind = GetKind(logMessage);
+
+                _pendingScopes[blockId] = CreateAndStartScope(kind, functionId);
             }
             catch
             {
@@ -72,22 +69,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 
         public void LogBlockEnd(FunctionId functionId, LogMessage logMessage, int blockId, int delta, CancellationToken cancellationToken)
         {
-            if (!(logMessage is KeyValueLogMessage kvLogMessage))
-            {
-                return;
-            }
-
             try
             {
                 // guard us from exception thrown by telemetry
-                var kind = kvLogMessage.Kind;
+                var kind = GetKind(logMessage);
+
                 switch (kind)
                 {
                     case LogType.Trace:
-                        EndScope<OperationEvent>(functionId, blockId, kvLogMessage, cancellationToken);
+                        EndScope<OperationEvent>(functionId, blockId, logMessage, cancellationToken);
                         return;
                     case LogType.UserAction:
-                        EndScope<UserTaskEvent>(functionId, blockId, kvLogMessage, cancellationToken);
+                        EndScope<UserTaskEvent>(functionId, blockId, logMessage, cancellationToken);
                         return;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(kind);
@@ -98,7 +91,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             }
         }
 
-        private void EndScope<T>(FunctionId functionId, int blockId, KeyValueLogMessage kvLogMessage, CancellationToken cancellationToken)
+        private static LogType GetKind(LogMessage logMessage)
+            => logMessage is KeyValueLogMessage kvLogMessage
+                                ? kvLogMessage.Kind
+                                : logMessage.LogLevel switch
+                                {
+                                    >= LogLevel.Information => LogType.UserAction,
+                                    _ => LogType.Trace
+                                };
+
+
+        private void EndScope<T>(FunctionId functionId, int blockId, LogMessage logMessage, CancellationToken cancellationToken)
             where T : OperationEvent
         {
             if (!_pendingScopes.TryRemove(blockId, out var value))
@@ -109,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 
             var operation = (TelemetryScope<T>)value;
 
-            AppendProperties(operation.EndEvent, functionId, kvLogMessage);
+            UpdateEvent(operation.EndEvent, functionId, logMessage);
             operation.End(cancellationToken.IsCancellationRequested ? TelemetryResult.UserCancel : TelemetryResult.Success);
         }
 
@@ -132,9 +135,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             var eventName = functionId.GetEventName();
             var telemetryEvent = new TelemetryEvent(eventName);
 
+            return UpdateEvent(telemetryEvent, functionId, logMessage);
+        }
+
+        private static TelemetryEvent UpdateEvent(TelemetryEvent telemetryEvent, FunctionId functionId, LogMessage logMessage)
+        {
             if (logMessage is KeyValueLogMessage kvLogMessage)
             {
                 telemetryEvent = AppendProperties(telemetryEvent, functionId, kvLogMessage);
+            }
+            else
+            {
+                var message = logMessage.GetMessage();
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    var propertyName = functionId.GetPropertyName("Message");
+                    telemetryEvent.Properties.Add(propertyName, message);
+                }
             }
 
             return telemetryEvent;

--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryLogger.cs
@@ -4,11 +4,9 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.VisualStudio.Telemetry;
 using Roslyn.Utilities;
@@ -99,7 +97,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                                     >= LogLevel.Information => LogType.UserAction,
                                     _ => LogType.Trace
                                 };
-
 
         private void EndScope<T>(FunctionId functionId, int blockId, LogMessage logMessage, CancellationToken cancellationToken)
             where T : OperationEvent


### PR DESCRIPTION
Update the VSTelemetryLogger to include the message property of LogMessage if the message is not a KeyValueMessage