### PR TITLE
Remove IRazorDocumentOptionsService inheritance interface

### DIFF
--- a/src/Tools/ExternalAccess/Razor/IRazorDocumentOptionsService.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorDocumentOptionsService.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    internal interface IRazorDocumentOptionsService : IDocumentService
+    internal interface IRazorDocumentOptionsService
     {
         Task<IRazorDocumentOptions> GetOptionsForDocumentAsync(Document document, CancellationToken cancellationToken);
     }


### PR DESCRIPTION
Follow-up from https://github.com/dotnet/roslyn/pull/53879.
I made an error since IDocumentService is unneeded (since we go through MEF now instead) and also inaccessible from the Razor side. 🤦‍♀️