### PR TITLE
Update official build number in separate job

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -41,6 +41,26 @@ variables:
       value: $(dn-bot-devdiv-drop-rw-code-rw)
 
 stages:
+- stage: setup
+  displayName: Build Setup
+
+  jobs:
+  - job: SetBuildNumber
+    pool:
+      vmImage: vs2017-win2016
+    steps:
+    # Make sure our two pipelines generate builds with distinct build numbers to avoid confliction.
+    # i.e. DevDiv builds will have even rev# whereas dnceng builds will be odd.
+    - task: PowerShell@2
+      displayName: Update BuildNumber
+      inputs:
+        filePath: 'eng\update-build-number.ps1'
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven even'
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven odd'
+      condition: eq(variables['System.JobAttempt'], '1')
+
 - stage: build
   displayName: Build and Test
 
@@ -69,18 +89,6 @@ stages:
         queue: BuildPool.Server.Amd64.VS2017
 
     steps:
-    # Make sure our two pipelines generate builds with distinct build numbers to avoid confliction.
-    # i.e. DevDiv builds will have even rev# whereas dnceng builds will be odd.
-    - task: PowerShell@2
-      displayName: Update BuildNumber
-      inputs:
-        filePath: 'eng\update-build-number.ps1'
-        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-          arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven even'
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          arguments: '-buildNumber $(Build.BuildNumber) -oddOrEven odd'
-      condition: eq(variables['System.JobAttempt'], '1')
-
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable
       condition: succeeded()


### PR DESCRIPTION
Fixes issues with the build number not being finalized prior to running the OneLoc and SourceBuild jobs.

Test Build - https://dev.azure.com/dnceng/internal/_build/results?buildId=1184105&view=results (Microsoft Only)

cc: @RikkiGibson 