### PR TITLE
Move PR validation logic from the official build to a separate yml

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -18,20 +18,18 @@ variables:
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
 
-  # If the pipeline is running in dnceng:
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # Get access token with $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw from DotNet-VSTS-Infra-Access
   # Get $dotnetfeed-storage-access-key-1 from DotNet-Blob-Feed
   # Get $microsoft-symbol-server-pat and $symweb-symbol-server-pat from DotNet-Symbol-Server-Pats
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - group: DotNet-Blob-Feed
-    - group: DotNet-Symbol-Server-Pats
-    - group: DotNet-Versions-Publish
-    - group: DotNet-VSTS-Infra-Access
-    - group: DotNet-DevDiv-Insertion-Workflow-Variables
-    - name: _DevDivDropAccessToken
-      value: $(dn-bot-devdiv-drop-rw-code-rw)
+  - group: DotNet-Blob-Feed
+  - group: DotNet-Symbol-Server-Pats
+  - group: DotNet-Versions-Publish
+  - group: DotNet-VSTS-Infra-Access
+  - group: DotNet-DevDiv-Insertion-Workflow-Variables
+  - name: _DevDivDropAccessToken
+    value: $(dn-bot-devdiv-drop-rw-code-rw)
 
 stages:
 - stage: build
@@ -47,11 +45,9 @@ stages:
   - job: OfficialBuild
     displayName: Official Build
     timeoutInMinutes: 360
-    # Conditionally set build pool so we can share this YAML when building with different pipeline
     pool:
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Server.Amd64.VS2017
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2017
 
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
@@ -77,8 +73,7 @@ stages:
       displayName: Merge main-vs-deps into source branch
       inputs:
         filePath: 'scripts\merge-vs-deps.ps1'
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          arguments: '-accessToken $(dn-bot-dnceng-build-rw-code-rw)'
+        arguments: '-accessToken $(dn-bot-dnceng-build-rw-code-rw)'
       condition: and(succeeded(), eq(variables['SourceBranchName'], 'main'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
@@ -91,8 +86,7 @@ stages:
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
     - task: NuGetAuthenticate@0
       inputs:
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering
+        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering
 
     # Needed because the build fails the NuGet Tools restore without it
     - task: UseDotNet@2
@@ -116,9 +110,7 @@ stages:
       inputs:
         signType: $(SignType)
         zipSources: false
-        # If running in dnceng, we need to use a feed different from default
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
       condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
 
     - task: PowerShell@2
@@ -227,9 +219,8 @@ stages:
         command: push
         packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
         allowPackageConflicts: true
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
+        nuGetFeedType: external
+        publishFeedCredentials: 'DevDiv - VS package feed'
       condition: succeeded()
 
     # Publish an artifact that the RoslynInsertionTool is able to find by its name.
@@ -267,9 +258,8 @@ stages:
       publishUsingPipelines: true
       dependsOn:
         - OfficialBuild
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        pool:
-          vmImage: vs2017-win2016
+      pool:
+        vmImage: vs2017-win2016
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -279,12 +279,6 @@ stages:
       # https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false
       enableSourceLinkValidation: false
-      # It's important that post-build stages are depends on 'SetValidateDependency' stage instead of 'build',
-      # since we don't want to publish validation build.
-      validateDependsOn:
-        - SetValidateDependency
-      dependsOn:
-        - SetValidateDependency
       # Enable SDL validation, passing through values from the 'DotNet-Roslyn-SDLValidation-Params' group.
       SDLValidationParameters:
         enable: true

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -56,6 +56,7 @@ stages:
         tags: |
           PRValidationBuild
           PRNumber:$(PRNumber)
+          CommitSHA:$(CommitSHA)
       condition: succeeded()
 
     - task: PowerShell@2

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -116,11 +116,7 @@ stages:
                    /p:VisualStudioDropName=$(VisualStudio.DropName)
                    /p:DotNetSignType=$(SignType)
                    /p:DotNetPublishToBlobFeed=false
-                   /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                   /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
                    /p:PublishToSymbolServer=false
-                   /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                   /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                    /p:DotnetPublishUsingPipelines=false
       condition: succeeded()

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -23,10 +23,9 @@ variables:
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # If the pipeline is running in DevDiv, the account has access to the VS drop storage.
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-GitHub-Versions-Repo-Write
-  - ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-    - group: DotNet-GitHub-Versions-Repo-Write
-    - name: _DevDivDropAccessToken
-      value: $(System.AccessToken)
+  - group: DotNet-GitHub-Versions-Repo-Write
+  - name: _DevDivDropAccessToken
+    value: $(System.AccessToken)
 
 stages:
 - stage: build
@@ -39,12 +38,11 @@ stages:
     timeoutInMinutes: 360
     # Conditionally set build pool so we can share this YAML when building with different pipeline
     pool:
-      ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-        name: VSEngSS-MicroBuild2017
-        demands:
-        - msbuild
-        - visualstudio
-        - DotNetFramework
+      name: VSEngSS-MicroBuild2017
+      demands:
+      - msbuild
+      - visualstudio
+      - DotNetFramework
 
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
@@ -77,8 +75,7 @@ stages:
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
     - task: NuGetAuthenticate@0
       inputs:
-        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-          nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
 
     # Needed to restore the Microsoft.DevDiv.Optimization.Data.PowerShell package
     - task: NuGetCommand@2
@@ -94,9 +91,6 @@ stages:
       inputs:
         signType: $(SignType)
         zipSources: false
-        # If running in dnceng, we need to use a feed different from default
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
       condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
 
     - task: PowerShell@2
@@ -183,9 +177,8 @@ stages:
         command: push
         packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
         allowPackageConflicts: true
-        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-          feedsToUse: config
-          publishVstsFeed: '97a41293-2972-4f48-8c0e-05493ae82010'
+        feedsToUse: config
+        publishVstsFeed: '97a41293-2972-4f48-8c0e-05493ae82010'
       condition: succeeded()
 
     # Publish an artifact that the RoslynInsertionTool is able to find by its name.

--- a/azure-pipelines-validation.yml
+++ b/azure-pipelines-validation.yml
@@ -5,10 +5,12 @@ resources:
 # Variables defined in yml cannot be overridden at queue time instead overrideable variables must be defined in the web gui.
 # Commenting out until AzDO supports something like the runtime parameters outlined here: https://github.com/Microsoft/azure-pipelines-yaml/pull/129
 #variables:
-#  SignType: real
-#  SkipTests: false
+#  SignType: test
+#  SkipTests: true
 #  SkipApplyOptimizationData: false
 #  IbcDrop: 'default'
+#  PRNumber: 'REQUIRED'
+#  CommitSHA: 'REQUIRED'
 
 # The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
@@ -18,40 +20,31 @@ variables:
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
 
-  # If the pipeline is running in dnceng:
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
-  # Get access token with $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw from DotNet-VSTS-Infra-Access
-  # Get $dotnetfeed-storage-access-key-1 from DotNet-Blob-Feed
-  # Get $microsoft-symbol-server-pat and $symweb-symbol-server-pat from DotNet-Symbol-Server-Pats
-  # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - group: DotNet-Blob-Feed
-    - group: DotNet-Symbol-Server-Pats
-    - group: DotNet-Versions-Publish
-    - group: DotNet-VSTS-Infra-Access
-    - group: DotNet-DevDiv-Insertion-Workflow-Variables
+  # If the pipeline is running in DevDiv, the account has access to the VS drop storage.
+  # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-GitHub-Versions-Repo-Write
+  - ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+    - group: DotNet-GitHub-Versions-Repo-Write
     - name: _DevDivDropAccessToken
-      value: $(dn-bot-devdiv-drop-rw-code-rw)
+      value: $(System.AccessToken)
 
 stages:
 - stage: build
   displayName: Build and Test
 
   jobs:
-  - template: /eng/common/templates/job/onelocbuild.yml
-    parameters:
-      CreatePr: false
-      LclSource: lclFilesfromPackage
-      LclPackageId: 'LCL-JUNO-PROD-ROSLYN'
 
-  - job: OfficialBuild
-    displayName: Official Build
+  - job: OfficialTestBuild
+    displayName: Official Test Build
     timeoutInMinutes: 360
     # Conditionally set build pool so we can share this YAML when building with different pipeline
     pool:
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Server.Amd64.VS2017
+      ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+        name: VSEngSS-MicroBuild2017
+        demands:
+        - msbuild
+        - visualstudio
+        - DotNetFramework
 
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
@@ -59,27 +52,20 @@ stages:
       condition: succeeded()
 
     - task: tagBuildOrRelease@0
-      displayName: Tag official build
-      inputs:
-        type: 'Build'
-        tags: 'OfficialBuild'
-      condition: and(succeeded(), endsWith(variables['SourceBranchName'], '-vs-deps'))
-
-    - task: tagBuildOrRelease@0
-      displayName: Tag main validation build
+      displayName: Tag PR validation build
       inputs:
         type: 'Build'
         tags: |
-          MainValidationBuild
-      condition: and(succeeded(), eq(variables['SourceBranchName'], 'main'))
+          PRValidationBuild
+          PRNumber:$(PRNumber)
+      condition: succeeded()
 
     - task: PowerShell@2
-      displayName: Merge main-vs-deps into source branch
+      displayName: Setup branch for insertion validation
       inputs:
-        filePath: 'scripts\merge-vs-deps.ps1'
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          arguments: '-accessToken $(dn-bot-dnceng-build-rw-code-rw)'
-      condition: and(succeeded(), eq(variables['SourceBranchName'], 'main'))
+        filePath: 'eng\setup-pr-validation.ps1'
+        arguments: '-sourceBranchName $(SourceBranchName) -prNumber $(PRNumber) -commitSHA $(CommitSHA)'
+      condition: succeeded()
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
@@ -91,16 +77,8 @@ stages:
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
     - task: NuGetAuthenticate@0
       inputs:
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering
-
-    # Needed because the build fails the NuGet Tools restore without it
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
-      inputs:
-        packageType: sdk
-        useGlobalJson: true
-        workingDirectory: '$(Build.SourcesDirectory)'
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
 
     # Needed to restore the Microsoft.DevDiv.Optimization.Data.PowerShell package
     - task: NuGetCommand@2
@@ -142,36 +120,14 @@ stages:
                    /p:RepositoryName=$(Build.Repository.Name)
                    /p:VisualStudioDropName=$(VisualStudio.DropName)
                    /p:DotNetSignType=$(SignType)
-                   /p:DotNetPublishToBlobFeed=true
+                   /p:DotNetPublishToBlobFeed=false
                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                    /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                   /p:PublishToSymbolServer=true
+                   /p:PublishToSymbolServer=false
                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                   /p:DotnetPublishUsingPipelines=true
-      condition: succeeded()
-
-    - task: PowerShell@2
-      displayName: Publish Assets
-      inputs:
-        filePath: 'eng\publish-assets.ps1'
-        arguments: '-configuration $(BuildConfiguration) -branchName "$(SourceBranchName)"'
-      condition: succeeded()
-
-    # Publish OptProf configuration files
-    # The env variable is required to enable cross account access using PAT (dnceng -> devdiv)
-    - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
-      env:
-        ARTIFACTSERVICES_DROP_PAT: $(_DevDivDropAccessToken)
-      inputs:
-        dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)'
-        sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
-        toLowerCase: false
-        usePat: false
-        retentionDays: 90
-      displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
+                   /p:DotnetPublishUsingPipelines=false
       condition: succeeded()
 
     # Publish OptProf generated JSON files as a build artifact. This allows for easy inspection from
@@ -227,9 +183,9 @@ stages:
         command: push
         packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
         allowPackageConflicts: true
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          feedsToUse: config
+          publishVstsFeed: '97a41293-2972-4f48-8c0e-05493ae82010'
       condition: succeeded()
 
     # Publish an artifact that the RoslynInsertionTool is able to find by its name.
@@ -238,15 +194,6 @@ stages:
       inputs:
         PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
         ArtifactName: 'VSSetup'
-      condition: succeeded()
-
-    # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
-    # arcade templates depend on the name.
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Artifact Packages
-      inputs:
-        PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
-        ArtifactName: 'PackageArtifacts'
       condition: succeeded()
 
     # Publish Asset Manifests for Build Asset Registry job
@@ -260,42 +207,3 @@ stages:
     - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
       displayName: Perform Cleanup Tasks
       condition: succeededOrFailed()
-
-  # Publish to Build Asset Registry
-  - template: /eng/common/templates/job/publish-build-assets.yml
-    parameters:
-      publishUsingPipelines: true
-      dependsOn:
-        - OfficialBuild
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        pool:
-          vmImage: vs2017-win2016
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      # Symbol validation is not entirely reliable as of yet, so should be turned off until
-      # https://github.com/dotnet/arcade/issues/2871 is resolved.
-      enableSymbolValidation: false
-      enableSourceLinkValidation: false
-      # It's important that post-build stages are depends on 'SetValidateDependency' stage instead of 'build',
-      # since we don't want to publish validation build.
-      validateDependsOn:
-        - SetValidateDependency
-      dependsOn:
-        - SetValidateDependency
-      # Enable SDL validation, passing through values from the 'DotNet-Roslyn-SDLValidation-Params' group.
-      SDLValidationParameters:
-        enable: true
-        params: >-
-          -SourceToolsList @("policheck","credscan")
-          -TsaInstanceURL $(_TsaInstanceURL)
-          -TsaProjectName $(_TsaProjectName)
-          -TsaNotificationEmail $(_TsaNotificationEmail)
-          -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-          -TsaBugAreaPath $(_TsaBugAreaPath)
-          -TsaIterationPath $(_TsaIterationPath)
-          -TsaRepositoryName $(_TsaRepositoryName)
-          -TsaCodebaseName $(_TsaCodebaseName)
-          -TsaPublish $True

--- a/eng/setup-pr-validation.ps1
+++ b/eng/setup-pr-validation.ps1
@@ -1,24 +1,40 @@
 [CmdletBinding(PositionalBinding=$false)]
 param (
   [string]$sourceBranchName,
-  [string]$prNumber)
+  [string]$prNumber,
+  [string]$commitSHA)
 
-try {  
-    # name and email are only used for merge commit, it doesn't really matter what we put in there.    
+try {
+    # name and email are only used for merge commit, it doesn't really matter what we put in there.
     git config user.name "RoslynValidation"
-    git config user.email "validation@roslyn.net"   
-    
+    git config user.email "validation@roslyn.net"
+
     if ($sourceBranchName -notlike '*-vs-deps') {
       Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $sourceBranchName, which is not a vs-deps branch."
     }
+
+    Write-Host "Validating the PR head matches the specified commit SHA ($commitSHA)..."
+    if ($commitSHA.Length -lt 7) {
+      Write-Host "##vso[task.LogIssue type=error;]The PR Commit SHA must be at least 7 characters long."
+      exit 1
+    }
+
+    Write-Host "Getting the hash of refs/pull/$prNumber/head..."
+    $remoteRef = git ls-remote origin refs/pull/$prNumber/head
+    Write-Host ($remoteRef | Out-String)
+
+    $prHeadSHA = $remoteRef.Split()[0]
+    if (!$prHeadSHA.StartsWith($commitSHA)) {
+      Write-Host "##vso[task.LogIssue type=error;]The PR's Head SHA ($prHeadSHA) does not begin with the specified commit SHA ($commitSHA). Unreviewed changes may have been pushed to the PR."
+      exit 1
+    }
+
     Write-Host "Setting up the build for PR validation by merging refs/pull/$prNumber/merge into $sourceBranchName..."
     git pull origin refs/pull/$prNumber/merge
     if (!$?) {
       Write-Host "##vso[task.LogIssue type=error;]Merging branch refs/pull/$prNumber/merge failed."
       exit 1
     }
-    Write-Host "Getting the hash of refs/pull/$prNumber/head..."
-    Write-Host ((git ls-remote origin refs/pull/$prNumber/head) | Out-String)
 }
 catch {
   Write-Host $_


### PR DESCRIPTION
- Removes the ability to run the Official build on DevDiv
- Removes the Set Build Number step since we can use the given build number
- Removes the PR validation into its own yml to run in its own pipeline
- Requires the PR's head SHA to be provided and match when running PR Validation. 

cc: @genlu, @RikkiGibson 

Test PR validation with too short SHA: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4865094&view=results
Test PR validation with invalid SHA: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4865097&view=results
Test PR validation with correct SHA: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4865173&view=results
Test official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1184266&view=results