### PR TITLE
Fix GoToBase/GoToImplementation/FAR/InheritanceMargin for static abstract member

### DIFF
--- a/src/EditorFeatures/CSharp/InheritanceMargin/CSharpInheritanceMarginService.cs
+++ b/src/EditorFeatures/CSharp/InheritanceMargin/CSharpInheritanceMarginService.cs
@@ -43,7 +43,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.InheritanceMargin
                         SyntaxKind.MethodDeclaration,
                         SyntaxKind.PropertyDeclaration,
                         SyntaxKind.EventDeclaration,
-                        SyntaxKind.IndexerDeclaration))
+                        SyntaxKind.IndexerDeclaration,
+                        SyntaxKind.OperatorDeclaration))
                     {
                         builder.Add(member);
                     }
@@ -69,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.InheritanceMargin
                 VariableDeclaratorSyntax variableDeclaratorNode => variableDeclaratorNode.Identifier,
                 TypeDeclarationSyntax baseTypeDeclarationNode => baseTypeDeclarationNode.Identifier,
                 IndexerDeclarationSyntax indexerDeclarationNode => indexerDeclarationNode.ThisKeyword,
+                OperatorDeclarationSyntax operatorDeclarationNode => operatorDeclarationNode.OperatorToken,
                 // Shouldn't reach here since the input declaration nodes are coming from GetMembers() method above
                 _ => throw ExceptionUtilities.UnexpectedValue(declarationNode),
             };

--- a/src/EditorFeatures/CSharp/InheritanceMargin/CSharpInheritanceMarginService.cs
+++ b/src/EditorFeatures/CSharp/InheritanceMargin/CSharpInheritanceMarginService.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.InheritanceMargin
                         SyntaxKind.PropertyDeclaration,
                         SyntaxKind.EventDeclaration,
                         SyntaxKind.IndexerDeclaration,
-                        SyntaxKind.OperatorDeclaration))
+                        SyntaxKind.OperatorDeclaration,
+                        SyntaxKind.ConversionOperatorDeclaration))
                     {
                         builder.Add(member);
                     }
@@ -71,6 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.InheritanceMargin
                 TypeDeclarationSyntax baseTypeDeclarationNode => baseTypeDeclarationNode.Identifier,
                 IndexerDeclarationSyntax indexerDeclarationNode => indexerDeclarationNode.ThisKeyword,
                 OperatorDeclarationSyntax operatorDeclarationNode => operatorDeclarationNode.OperatorToken,
+                ConversionOperatorDeclarationSyntax conversionOperatorDeclarationNode => conversionOperatorDeclarationNode.Type.GetFirstToken(),
                 // Shouldn't reach here since the input declaration nodes are coming from GetMembers() method above
                 _ => throw ExceptionUtilities.UnexpectedValue(declarationNode),
             };

--- a/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
@@ -87,13 +87,16 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
         private static bool CanHaveInheritanceTarget(ISymbol symbol)
         {
-            if (symbol.IsStatic)
+            if (symbol is INamedTypeSymbol)
             {
-                return false;
+                return !symbol.IsStatic;
             }
 
-            if (symbol is INamedTypeSymbol or IEventSymbol or IPropertySymbol
-                or IMethodSymbol { MethodKind: MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation })
+            if (symbol is IEventSymbol or IPropertySymbol
+                or IMethodSymbol
+                {
+                    MethodKind: MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation or MethodKind.UserDefinedOperator
+                })
             {
                 return true;
             }

--- a/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             }
 
             if (symbol is INamedTypeSymbol or IEventSymbol or IPropertySymbol
-                || symbol is IMethodSymbol { MethodKind: MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation })
+                or IMethodSymbol { MethodKind: MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation })
             {
                 return true;
             }

--- a/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
@@ -92,8 +92,8 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 return false;
             }
 
-            if (symbol is INamedTypeSymbol or IEventSymbol or IPropertySymbol ||
-                symbol.IsOrdinaryMethod())
+            if (symbol is INamedTypeSymbol or IEventSymbol or IPropertySymbol
+                || symbol is IMethodSymbol { MethodKind: MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation })
             {
                 return true;
             }

--- a/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/AbstractInheritanceMarginService.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             if (symbol is IEventSymbol or IPropertySymbol
                 or IMethodSymbol
                 {
-                    MethodKind: MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation or MethodKind.UserDefinedOperator
+                    MethodKind: MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation or MethodKind.UserDefinedOperator or MethodKind.Conversion
                 })
             {
                 return true;

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -1048,42 +1048,26 @@ abstract class {|target1:AbsBar|} : IBar<int>
                 itemForFooInAbsBar);
         }
 
-//        [Fact]
-//        public Task Test()
-//        {
-//            var markup = @"
-//interface {|target:I1|}<T> where T : I1<T>
-//{
-//    static abstract int operator +(T i1);
-//}
-
-//public class {|target1:Class1|} : I1<Class1>
-//{
-//    public static int operator +(Class1 i) => 1;
-//}";
-//            return VerifyInSingleDocumentAsync(
-//                markup,
-//                LanguageNames.CSharp);
-//        }
-
         [Fact]
         public Task TestStaticAbstractMemberInterface()
         {
             var markup = @"
-interface {|target:I1|}<T> where T : I1<T>
+interface {|target5:I1|}<T> where T : I1<T>
 {
-    static abstract void M1();
-    static abstract int P1 { get; set; }
-    static abstract event EventHandler e1;
-    static abstract int operator +(T i1);
+    static abstract void {|target4:M1|}();
+    static abstract int {|target7:P1|} { get; set; }
+    static abstract event EventHandler {|target9:e1|};
+    static abstract int operator {|target11:+|}(T i1);
+    static abstract implicit operator {|target12:int|}(T i1);
 }
 
 public class {|target1:Class1|} : I1<Class1>
 {
-    public static int {|target3:P1|} { get => 1; set { } }
-    public static event EventHandler {|target4:e1|};
     public static void {|target2:M1|}() {}
-    public static int operator +(C1 i) => 1;
+    public static int {|target6:P1|} { get => 1; set { } }
+    public static event EventHandler {|target8:e1|};
+    public static int operator {|target10:+|}(Class1 i) => 1;
+    public static implicit operator {|target13:int|}(Class1 i) => 0;
 }";
             var itemForI1 = new TestInheritanceMemberItem(
                 lineNumber: 2,
@@ -1097,32 +1081,88 @@ public class {|target1:Class1|} : I1<Class1>
                 lineNumber: 4,
                 memberName: "void I1<T>.M1()",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void Class1.M1()",
+                        targetSymbolDisplayName: "static void Class1.M1()",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.Implemented)));
+
+            var itemForAbsClass1 = new TestInheritanceMemberItem(
+                lineNumber: 11,
+                memberName: "class Class1",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "interface I1<T>",
+                        locationTag: "target5",
+                        relationship: InheritanceRelationship.Implementing)));
+
+            var itemForM1InClass1 = new TestInheritanceMemberItem(
+                lineNumber: 13,
+                memberName: "static void Class1.M1()",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "void I1<T>.M1()",
+                        locationTag: "target4",
+                        relationship: InheritanceRelationship.Implementing)));
 
             var itemForP1InI1 = new TestInheritanceMemberItem(
                 lineNumber: 5,
                 memberName: "int I1<T>.P1 { get; set; }",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void I1<T>.P1 { get; set; }",
-                        locationTag: "target3",
+                        targetSymbolDisplayName: "static int Class1.P1 { get; set; }",
+                        locationTag: "target6",
                         relationship: InheritanceRelationship.Implemented)));
+
+            var itemForP1InClass1 = new TestInheritanceMemberItem(
+                lineNumber: 14,
+                memberName: "static int Class1.P1 { get; set; }",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "int I1<T>.P1 { get; set; }",
+                        locationTag: "target7",
+                        relationship: InheritanceRelationship.Implementing)));
 
             var itemForE1InI1 = new TestInheritanceMemberItem(
                 lineNumber: 6,
                 memberName: "event EventHandler I1<T>.e1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "event EventHandler Class1.e1",
-                        locationTag: "target4",
+                        targetSymbolDisplayName: "static event EventHandler Class1.e1",
+                        locationTag: "target8",
                         relationship: InheritanceRelationship.Implemented)));
 
-            var itemForAbsClass1 = new TestInheritanceMemberItem(
-                lineNumber: 10,
-                memberName: "class Class1",
+            var itemForE1InClass1 = new TestInheritanceMemberItem(
+                lineNumber: 15,
+                memberName: "static event EventHandler Class1.e1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface I1<T>",
-                        locationTag: "target",
+                        targetSymbolDisplayName: "event EventHandler I1<T>.e1",
+                        locationTag: "target9",
+                        relationship: InheritanceRelationship.Implementing)));
+
+            var itemForPlusOperatorInI1 = new TestInheritanceMemberItem(
+                lineNumber: 7,
+                memberName: "int I1<T>.operator +(T)",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "static int Class1.operator +(Class1)",
+                        locationTag: "target10",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForPlusOperatorInClass1 = new TestInheritanceMemberItem(
+                lineNumber: 16,
+                memberName: "static int Class1.operator +(Class1)",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "int I1<T>.operator +(T)",
+                        locationTag: "target11",
+                        relationship: InheritanceRelationship.Implementing)));
+
+            var itemForIntOperatorInI1 = new TestInheritanceMemberItem(
+                lineNumber: 8,
+                memberName: "I1<T>.implicit operator int(T)",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "static Class1.implicit operator int(Class1)",
+                        locationTag: "target13",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForIntOperatorInClass1 = new TestInheritanceMemberItem(
+                lineNumber: 17,
+                memberName: "static Class1.implicit operator int(Class1)",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "I1<T>.implicit operator int(T)",
+                        locationTag: "target12",
                         relationship: InheritanceRelationship.Implementing)));
 
             return VerifyInSingleDocumentAsync(
@@ -1131,8 +1171,15 @@ public class {|target1:Class1|} : I1<Class1>
                 itemForI1,
                 itemForAbsClass1,
                 itemForM1InI1,
+                itemForM1InClass1,
                 itemForP1InI1,
-                itemForE1InI1);
+                itemForP1InClass1,
+                itemForE1InI1,
+                itemForE1InClass1,
+                itemForPlusOperatorInI1,
+                itemForPlusOperatorInClass1,
+                itemForIntOperatorInI1,
+                itemForIntOperatorInClass1);
         }
 
         #endregion

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
     public class InheritanceMarginTests
     {
         private const string SearchAreaTag = "SeachTag";
+        private static readonly string s_lessThanToken = SecurityElement.Escape("<");
+        private static readonly string s_greaterThanToken = SecurityElement.Escape(">");
 
         #region Helpers
 
@@ -33,6 +35,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
             string languageName,
             params TestInheritanceMemberItem[] memberItems)
         {
+            // Escapse < and > for xml
+            markup = markup.Replace("<", s_lessThanToken).Replace(">", s_greaterThanToken);
+
             var workspaceFile = $@"
 <Workspace>
    <Project Language=""{languageName}"" CommonReferences=""true"">
@@ -138,12 +143,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
     <Project Language=""{markup1.languageName}"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <ProjectReference>Assembly2</ProjectReference>
         <Document>
-            {markup1.markupInProject1}
+            {markup1.markupInProject1.Replace("<", s_lessThanToken).Replace(">", s_greaterThanToken)}
         </Document>
     </Project>
     <Project Language=""{markup2.languageName}"" AssemblyName=""Assembly2"" CommonReferences=""true"">
         <Document>
-            {markup2.markupInProject2}
+            {markup2.markupInProject2.Replace("<", s_lessThanToken).Replace(">", s_greaterThanToken)}
         </Document>
     </Project>
 </Workspace>";
@@ -933,18 +938,16 @@ public class {|target5:Bar2|} : Bar1, IBar
         [Fact]
         public Task TestCSharpFindGenericsBaseType()
         {
-            var lessThanToken = SecurityElement.Escape("<");
-            var greaterThanToken = SecurityElement.Escape(">");
-            var markup = $@"
-public interface {{|target2:IBar|}}{lessThanToken}T{greaterThanToken}
-{{
-    void {{|target4:Foo|}}();
-}}
+            var markup = @"
+public interface {|target2:IBar|}<T>
+{
+    void {|target4:Foo|}();
+}
 
-public class {{|target1:Bar2|}} : IBar{lessThanToken}int{greaterThanToken}, IBar{lessThanToken}string{greaterThanToken}
-{{
-    public void {{|target3:Foo|}}();
-}}";
+public class {|target1:Bar2|} : IBar<int>, IBar<string>
+{
+    public void {|target3:Foo|}();
+}";
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
@@ -992,21 +995,19 @@ public class {{|target1:Bar2|}} : IBar{lessThanToken}int{greaterThanToken}, IBar
         [Fact]
         public Task TestCSharpExplicitInterfaceImplementation()
         {
-            var lessThanToken = SecurityElement.Escape("<");
-            var greaterThanToken = SecurityElement.Escape(">");
-            var markup = $@"
-interface {{|target2:IBar|}}{lessThanToken}T{greaterThanToken}
-{{
-    void {{|target3:Foo|}}(T t);
-}}
+            var markup = @"
+interface {|target2:IBar|}<T>
+{
+    void {|target3:Foo|}(T t);
+}
 
-abstract class {{|target1:AbsBar|}} : IBar{lessThanToken}int{greaterThanToken}
-{{
-    void IBar{lessThanToken}int{greaterThanToken}.{{|target4:Foo|}}(int t)
-    {{
+abstract class {|target1:AbsBar|} : IBar<int>
+{
+    void IBar<int>.{|target4:Foo|}(int t)
+    {
         throw new System.NotImplementedException();
-    }}
-}}";
+    }
+}";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
                 memberName: "interface IBar<T>",

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -1048,6 +1048,24 @@ abstract class {|target1:AbsBar|} : IBar<int>
                 itemForFooInAbsBar);
         }
 
+//        [Fact]
+//        public Task Test()
+//        {
+//            var markup = @"
+//interface {|target:I1|}<T> where T : I1<T>
+//{
+//    static abstract int operator +(T i1);
+//}
+
+//public class {|target1:Class1|} : I1<Class1>
+//{
+//    public static int operator +(Class1 i) => 1;
+//}";
+//            return VerifyInSingleDocumentAsync(
+//                markup,
+//                LanguageNames.CSharp);
+//        }
+
         [Fact]
         public Task TestStaticAbstractMemberInterface()
         {

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -1048,6 +1048,75 @@ abstract class {|target1:AbsBar|} : IBar<int>
                 itemForFooInAbsBar);
         }
 
+        [Fact]
+        public Task TestStaticAbstractMemberInterface()
+        {
+            var markup = @"
+interface {|target:I1|}<T> where T : I1<T>
+{
+    static abstract void M1();
+    static abstract int P1 { get; set; }
+    static abstract event EventHandler e1;
+    static abstract int operator +(T i1);
+}
+
+public class {|target1:Class1|} : I1<Class1>
+{
+    public static int {|target3:P1|} { get => 1; set { } }
+    public static event EventHandler {|target4:e1|};
+    public static void {|target2:M1|}() {}
+    public static int operator +(C1 i) => 1;
+}";
+            var itemForI1 = new TestInheritanceMemberItem(
+                lineNumber: 2,
+                memberName: "interface I1<T>",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "class Class1",
+                        locationTag: "target1",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForM1InI1 = new TestInheritanceMemberItem(
+                lineNumber: 4,
+                memberName: "void I1<T>.M1()",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "void Class1.M1()",
+                        locationTag: "target2",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForP1InI1 = new TestInheritanceMemberItem(
+                lineNumber: 5,
+                memberName: "int I1<T>.P1 { get; set; }",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "void I1<T>.P1 { get; set; }",
+                        locationTag: "target3",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForE1InI1 = new TestInheritanceMemberItem(
+                lineNumber: 6,
+                memberName: "event EventHandler I1<T>.e1",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "event EventHandler Class1.e1",
+                        locationTag: "target4",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForAbsClass1 = new TestInheritanceMemberItem(
+                lineNumber: 10,
+                memberName: "class Class1",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "interface I1<T>",
+                        locationTag: "target",
+                        relationship: InheritanceRelationship.Implementing)));
+
+            return VerifyInSingleDocumentAsync(
+                markup,
+                LanguageNames.CSharp,
+                itemForI1,
+                itemForAbsClass1,
+                itemForM1InI1,
+                itemForP1InI1,
+                itemForE1InI1);
+        }
+
         #endregion
 
         #region TestsForVisualBasic

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -22,8 +21,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
     public class InheritanceMarginTests
     {
         private const string SearchAreaTag = "SeachTag";
-        private static readonly string s_lessThanToken = SecurityElement.Escape("<");
-        private static readonly string s_greaterThanToken = SecurityElement.Escape(">");
 
         #region Helpers
 
@@ -35,8 +32,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
             string languageName,
             params TestInheritanceMemberItem[] memberItems)
         {
-            // Escapse < and > for xml
-            markup = markup.Replace("<", s_lessThanToken).Replace(">", s_greaterThanToken);
+            markup = @$"<![CDATA[
+{markup}]]>";
 
             var workspaceFile = $@"
 <Workspace>
@@ -143,12 +140,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
     <Project Language=""{markup1.languageName}"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <ProjectReference>Assembly2</ProjectReference>
         <Document>
-            {markup1.markupInProject1.Replace("<", s_lessThanToken).Replace(">", s_greaterThanToken)}
+            <![CDATA[
+                {markup1.markupInProject1}]]>
         </Document>
     </Project>
     <Project Language=""{markup2.languageName}"" AssemblyName=""Assembly2"" CommonReferences=""true"">
         <Document>
-            {markup2.markupInProject2.Replace("<", s_lessThanToken).Replace(">", s_greaterThanToken)}
+            <![CDATA[
+                {markup2.markupInProject2}]]>
         </Document>
     </Project>
 </Workspace>";

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -989,6 +989,65 @@ public class {{|target1:Bar2|}} : IBar{lessThanToken}int{greaterThanToken}, IBar
                 itemForFooInBar2);
         }
 
+        [Fact]
+        public Task TestCSharpExplicitInterfaceImplementation()
+        {
+            var lessThanToken = SecurityElement.Escape("<");
+            var greaterThanToken = SecurityElement.Escape(">");
+            var markup = $@"
+interface {{|target2:IBar|}}{lessThanToken}T{greaterThanToken}
+{{
+    void {{|target3:Foo|}}(T t);
+}}
+
+abstract class {{|target1:AbsBar|}} : IBar{lessThanToken}int{greaterThanToken}
+{{
+    void IBar{lessThanToken}int{greaterThanToken}.{{|target4:Foo|}}(int t)
+    {{
+        throw new System.NotImplementedException();
+    }}
+}}";
+            var itemForIBar = new TestInheritanceMemberItem(
+                lineNumber: 2,
+                memberName: "interface IBar<T>",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "class AbsBar",
+                        locationTag: "target1",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForFooInIBar = new TestInheritanceMemberItem(
+                lineNumber: 4,
+                memberName: "void IBar<T>.Foo(T)",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "void AbsBar.IBar<int>.Foo(int)",
+                        locationTag: "target4",
+                        relationship: InheritanceRelationship.Implemented)));
+
+            var itemForAbsBar = new TestInheritanceMemberItem(
+                lineNumber: 7,
+                memberName: "class AbsBar",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "interface IBar<T>",
+                        locationTag: "target2",
+                        relationship: InheritanceRelationship.Implementing)));
+
+            var itemForFooInAbsBar = new TestInheritanceMemberItem(
+                lineNumber: 9,
+                memberName: "void AbsBar.IBar<int>.Foo(int)",
+                targets: ImmutableArray.Create(new TargetInfo(
+                        targetSymbolDisplayName: "void IBar<T>.Foo(T)",
+                        locationTag: "target3",
+                        relationship: InheritanceRelationship.Implementing)));
+
+            return VerifyInSingleDocumentAsync(
+                markup,
+                LanguageNames.CSharp,
+                itemForIBar,
+                itemForFooInIBar,
+                itemForAbsBar,
+                itemForFooInAbsBar);
+        }
+
         #endregion
 
         #region TestsForVisualBasic

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.EventSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.EventSymbols.vb
@@ -316,5 +316,150 @@ End Interface
 </Workspace>
             Await TestAPIAndFeature(input, kind, host)
         End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestStaticAbstractEventInInterface(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
+        <Document>
+interface I3
+{
+    abstract static event System.Action {|Definition:E$$3|};
+}
+
+class C3_1 : I3
+{
+    public static event System.Action {|Definition:E3|};
+}
+
+class C3_2 : I3
+{
+    static event System.Action I3.{|Definition:E3|}
+    {
+        add { }
+        remove { }
+    }
+}        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestStaticAbstractEventViaFeature1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
+        <Document>
+interface I3
+{
+    abstract static event System.Action {|Definition:E3|};
+}
+
+class C3_1 : I3
+{
+    public static event System.Action {|Definition:E$$3|};
+}
+
+class C3_2 : I3
+{
+    static event System.Action I3.E3
+    {
+        add { }
+        remove { }
+    }
+}        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestStaticAbstractEventViaFeature2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
+        <Document>
+interface I3
+{
+    abstract static event System.Action {|Definition:E3|};
+}
+
+class C3_1 : I3
+{
+    public static event System.Action E3;
+}
+
+class C3_2 : I3
+{
+    static event System.Action I3.{|Definition:E$$3|}
+    {
+        add { }
+        remove { }
+    }
+}        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestStaticAbstractEventViaAPI1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
+        <Document>
+interface I3
+{
+    abstract static event System.Action {|Definition:E3|};
+}
+
+class C3_1 : I3
+{
+    public static event System.Action {|Definition:E3|};
+}
+
+class C3_2 : I3
+{
+    static event System.Action I3.{|Definition:E$$3|}
+    {
+        add { }
+        remove { }
+    }
+}        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestStaticAbstractEventViaAPI2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
+        <Document>
+interface I3
+{
+    abstract static event System.Action {|Definition:E3|};
+}
+
+class C3_1 : I3
+{
+    public static event System.Action {|Definition:E$$3|};
+}
+
+class C3_2 : I3
+{
+    static event System.Action I3.{|Definition:E3|}
+    {
+        add { }
+        remove { }
+    }
+}        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
@@ -483,5 +483,140 @@ class B
             Await TestAPIAndFeature(input, kind, host)
         End Function
 
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorInInterface(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I5<T> where T : I5<T>
+{
+    abstract static implicit operator {|Definition:i$$nt|}(T x);
+}
+
+class C5_1 : I5<C5_1>
+{
+    public static implicit operator {|Definition:int|}(C5_1 x) => default;
+}
+
+class C5_2 : I5<C5_2>
+{
+
+    static implicit I5<C5_2>.operator {|Definition:int|}(C5_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaFeature1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I5<T> where T : I5<T>
+{
+    abstract static implicit operator {|Definition:int|}(T x);
+}
+
+class C5_1 : I5<C5_1>
+{
+    public static implicit operator {|Definition:i$$nt|}(C5_1 x) => default;
+}
+
+class C5_2 : I5<C5_2>
+{
+    static implicit I5<C5_2>.operator int(C5_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaFeature2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I5<T> where T : I5<T>
+{
+    abstract static implicit operator {|Definition:int|}(T x);
+}
+
+class C5_1 : I5<C5_1>
+{
+    public static implicit operator int(C5_1 x) => default;
+}
+
+class C5_2 : I5<C5_2>
+{
+    static implicit I5<C5_2>.operator {|Definition:i$$nt|}(C5_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaAPI1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I5<T> where T : I5<T>
+{
+    abstract static implicit operator {|Definition:int|}(T x);
+}
+
+class C5_1 : I5<C5_1>
+{
+    public static implicit operator {|Definition:int|}(C5_1 x) => default;
+}
+
+class C5_2 : I5<C5_2>
+{
+    static implicit I5<C5_2>.operator {|Definition:i$$nt|}(C5_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaAPI2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I5<T> where T : I5<T>
+{
+    abstract static implicit operator {|Definition:int|}(T x);
+}
+
+class C5_1 : I5<C5_1>
+{
+    public static implicit operator {|Definition:in$$t|}(C5_1 x) => default;
+}
+
+class C5_2 : I5<C5_2>
+{
+    static implicit I5<C5_2>.operator {|Definition:int|}(C5_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
@@ -502,7 +502,6 @@ class C5_1 : I5<C5_1>
 
 class C5_2 : I5<C5_2>
 {
-
     static implicit I5<C5_2>.operator {|Definition:int|}(C5_2 x) => default;
 }]]>
         </Document>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OperatorSymbols.vb
@@ -484,7 +484,7 @@ class B
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpStaticAbstractOperatorInInterface(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestCSharpStaticAbstractConversionOperatorInInterface(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -512,7 +512,7 @@ class C5_2 : I5<C5_2>
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpStaticAbstractOperatorViaFeature1(host As TestHost) As Task
+        Public Async Function TestCSharpStaticAbstractConversionOperatorViaFeature1(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -539,7 +539,7 @@ class C5_2 : I5<C5_2>
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpStaticAbstractOperatorViaFeature2(host As TestHost) As Task
+        Public Async Function TestCSharpStaticAbstractConversionOperatorViaFeature2(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -566,7 +566,7 @@ class C5_2 : I5<C5_2>
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpStaticAbstractOperatorViaAPI1(host As TestHost) As Task
+        Public Async Function TestCSharpStaticAbstractConversionOperatorViaApi1(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -593,7 +593,7 @@ class C5_2 : I5<C5_2>
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSharpStaticAbstractOperatorViaAPI2(host As TestHost) As Task
+        Public Async Function TestCSharpStaticAbstractConversionOperatorViaApi2(host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -617,6 +617,141 @@ class C5_2 : I5<C5_2>
     </Project>
 </Workspace>
             Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorInInterface(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I4<T> where T : I4<T>
+{
+    abstract static int operator {|Definition:+$$|}(T x);
+}
+
+class C4_1 : I4<C4_1>
+{
+    public static int operator {|Definition:+|}(C4_1 x) => default;
+}
+
+class C4_2 : I4<C4_2>
+{
+    static int I4<C4_2>.operator {|Definition:+|}(C4_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaApi1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I4<T> where T : I4<T>
+{
+    abstract static int operator {|Definition:+|}(T x);
+}
+
+class C4_1 : I4<C4_1>
+{
+    public static int operator {|Definition:$$+|}(C4_1 x) => default;
+}
+
+class C4_2 : I4<C4_2>
+{
+    static int I4<C4_2>.operator {|Definition:+|}(C4_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaApi2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I4<T> where T : I4<T>
+{
+    abstract static int operator {|Definition:+|}(T x);
+}
+
+class C4_1 : I4<C4_1>
+{
+    public static int operator {|Definition:+|}(C4_1 x) => default;
+}
+
+class C4_2 : I4<C4_2>
+{
+    static int I4<C4_2>.operator {|Definition:$$+|}(C4_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaFeature1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I4<T> where T : I4<T>
+{
+    abstract static int operator {|Definition:+|}(T x);
+}
+
+class C4_1 : I4<C4_1>
+{
+    public static int operator {|Definition:$$+|}(C4_1 x) => default;
+}
+
+class C4_2 : I4<C4_2>
+{
+    static int I4<C4_2>.operator +(C4_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharpStaticAbstractOperatorViaFeature2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            <![CDATA[
+interface I4<T> where T : I4<T>
+{
+    abstract static int operator {|Definition:+|}(T x);
+}
+
+class C4_1 : I4<C4_1>
+{
+    public static int operator +(C4_1 x) => default;
+}
+
+class C4_2 : I4<C4_2>
+{
+    static int I4<C4_2>.operator {|Definition:$$+|}(C4_2 x) => default;
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -3786,5 +3786,125 @@ End Class
 </Workspace>
             Await TestStreamingFeature(input, host)
         End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestMemberStaticAbstractMethodFromInterface(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            static abstract void {|Definition:M$$1|}();
+        }
+        class C1_1 : I1
+        {
+            public static void {|Definition:M1|}() { }
+        }
+        class C1_2 : I1
+        {
+            static void I1.{|Definition:M1|}() { }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestDerivedMemberStaticAbstractMethodViaFeature1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            static abstract void {|Definition:M1|}();
+        }
+        class C1_1 : I1
+        {
+            public static void {|Definition:M$$1|}() { }
+        }
+        class C1_2 : I1
+        {
+            static void I1.M1() { }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestDerivedMemberStaticAbstractMethodViaFeature2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            static abstract void {|Definition:M1|}();
+        }
+        class C1_1 : I1
+        {
+            public static void M1() { }
+        }
+        class C1_2 : I1
+        {
+            static void I1.{|Definition:M$$1|}() { }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestDerivedMemberStaticAbstractMethodViaAPI1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            static abstract void {|Definition:M1|}();
+        }
+        class C1_1 : I1
+        {
+            public static void {|Definition:M$$1|}() { }
+        }
+        class C1_2 : I1
+        {
+            static void I1.{|Definition:M1|}() { }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestDerivedMemberStaticAbstractMethodViaAPI2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        interface I1
+        {
+            static abstract void {|Definition:M1|}();
+        }
+        class C1_1 : I1
+        {
+            public static void {|Definition:M1|}() { }
+        }
+        class C1_2 : I1
+        {
+            static void I1.{|Definition:M$$1|}() { }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -1084,5 +1084,135 @@ namespace ConsoleApplication22
 </Workspace>
             Await TestAPIAndFeature(input, kind, host)
         End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_AbstractStaticPropertyInInterface(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I2
+{
+    abstract static int {|Definition:P$$2|} { get; set; }
+}
+
+class C2_1 : I2
+{
+    public static int {|Definition:P2|} { get; set; }
+}
+
+class C2_2 : I2
+{
+    static int I2.{|Definition:P2|} { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_AbstractStaticPropertyViaFeature1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I2
+{
+    abstract static int {|Definition:P2|} { get; set; }
+}
+
+class C2_1 : I2
+{
+    public static int {|Definition:P$$2|} { get; set; }
+}
+
+class C2_2 : I2
+{
+    static int I2.P2 { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_AbstractStaticPropertyViaFeature2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I2
+{
+    abstract static int {|Definition:P2|} { get; set; }
+}
+
+class C2_1 : I2
+{
+    public static int P2 { get; set; }
+}
+
+class C2_2 : I2
+{
+    static int I2.{|Definition:P$$2|} { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestStreamingFeature(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_AbstractStaticPropertyViaAPI1(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I2
+{
+    abstract static int {|Definition:P2|} { get; set; }
+}
+
+class C2_1 : I2
+{
+    public static int {|Definition:P2|} { get; set; }
+}
+
+class C2_2 : I2
+{
+    static int I2.{|Definition:P$$2|} { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_AbstractStaticPropertyViaAPI2(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I2
+{
+    abstract static int {|Definition:P2|} { get; set; }
+}
+
+class C2_1 : I2
+{
+    public static int {|Definition:P$$2|} { get; set; }
+}
+
+class C2_2 : I2
+{
+    static int I2.{|Definition:P2|} { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPI(input, host)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractMethodOrPropertyOrEventSymbolReferenceFinder.cs
@@ -26,10 +26,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             FindReferencesCascadeDirection cascadeDirection,
             CancellationToken cancellationToken)
         {
-            // Static methods can't cascade.
-            if (symbol.IsStatic)
-                return ImmutableArray<(ISymbol symbol, FindReferencesCascadeDirection cascadeDirection)>.Empty;
-
             if (symbol.IsImplementableMember())
             {
                 // We have an interface method.  Walk down the inheritance hierarchy and find all implementations of

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ExplicitConversionSymbolReferenceFinder.cs
@@ -12,10 +12,10 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 {
-    internal partial class ExplicitConversionSymbolReferenceFinder : AbstractReferenceFinder<IMethodSymbol>
+    internal partial class ExplicitConversionSymbolReferenceFinder : AbstractMethodOrPropertyOrEventSymbolReferenceFinder<IMethodSymbol>
     {
         protected override bool CanFind(IMethodSymbol symbol)
-            => symbol is { MethodKind: MethodKind.Conversion, Name: WellKnownMemberNames.ExplicitConversionName } &&
+            => symbol is { MethodKind: MethodKind.Conversion, Name: WellKnownMemberNames.ExplicitConversionName or WellKnownMemberNames.ImplicitConversionName } &&
                GetUnderlyingNamedType(symbol.ReturnType) is not null;
 
         private static INamedTypeSymbol? GetUnderlyingNamedType(ITypeSymbol symbol)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 {
-    internal class OperatorSymbolReferenceFinder : AbstractReferenceFinder<IMethodSymbol>
+    internal class OperatorSymbolReferenceFinder : AbstractMethodOrPropertyOrEventSymbolReferenceFinder<IMethodSymbol>
     {
         protected override bool CanFind(IMethodSymbol symbol)
             => symbol.MethodKind == MethodKind.UserDefinedOperator;

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             ISymbol symbol, Solution solution, IImmutableSet<Project> projects = null, CancellationToken cancellationToken = default)
         {
             // Member can only implement interface members if it is an explicit member, or if it is
-            // public and non static.
+            // public
             if (symbol != null)
             {
                 var explicitImplementations = symbol.ExplicitInterfaceImplementations();
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     return explicitImplementations;
                 }
                 else if (
-                    symbol.DeclaredAccessibility == Accessibility.Public && !symbol.IsStatic &&
+                    symbol.DeclaredAccessibility == Accessibility.Public &&
                     (symbol.ContainingType.TypeKind == TypeKind.Class || symbol.ContainingType.TypeKind == TypeKind.Struct))
                 {
                     // Interface implementation is a tricky thing.  A method may implement an interface

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -170,7 +170,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 from baseType in typeSymbol.GetBaseTypesAndThis()
                 from member in baseType.GetMembers(constructedInterfaceMember.Name).OfType<TSymbol>()
                 where member.DeclaredAccessibility == Accessibility.Public &&
-                      !member.IsStatic &&
                       SignatureComparer.Instance.HaveSameSignatureAndConstraintsAndReturnTypeAndAccessors(member, constructedInterfaceMember, syntaxFacts.IsCaseSensitive)
                 select member;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
@@ -137,7 +137,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     var methodSymbol = (IMethodSymbol)symbol;
                     if (methodSymbol.MethodKind == MethodKind.Ordinary ||
                         methodSymbol.MethodKind == MethodKind.PropertyGet ||
-                        methodSymbol.MethodKind == MethodKind.PropertySet)
+                        methodSymbol.MethodKind == MethodKind.PropertySet ||
+                        methodSymbol.MethodKind == MethodKind.UserDefinedOperator)
                     {
                         return true;
                     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
@@ -138,7 +138,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     if (methodSymbol.MethodKind == MethodKind.Ordinary ||
                         methodSymbol.MethodKind == MethodKind.PropertyGet ||
                         methodSymbol.MethodKind == MethodKind.PropertySet ||
-                        methodSymbol.MethodKind == MethodKind.UserDefinedOperator)
+                        methodSymbol.MethodKind == MethodKind.UserDefinedOperator ||
+                        methodSymbol.MethodKind == MethodKind.Conversion)
                     {
                         return true;
                     }


### PR DESCRIPTION
Fix part of this issue: https://github.com/dotnet/roslyn/issues/52221
All the fixes are in GoToBase/GoToImplementation/FAR/InheritanceMargin