### PR TITLE
Share more data in the SyntaxTreeIndex

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -708,6 +708,17 @@ End Class", Async Function(w)
             End Function)
         End Function
 
+        <Theory>
+        <CombinatorialData>
+        Public Async Function TestFindAbstractMethod(testHost As TestHost, composition As Composition) As Task
+            Await TestAsync(testHost, composition, "MustInherit Class A
+Public MustOverride Sub M()
+End Class", Async Function(w)
+                Dim item = (Await _aggregator.GetItemsAsync("M")).Single
+                VerifyNavigateToResultItem(item, "M", "[|M|]()", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPublic, additionalInfo:=String.Format(FeaturesResources.in_0_project_1, "A", "Test"))
+            End Function)
+        End Function
+
         <WorkItem(1111131, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1111131")>
         <Theory>
         <CombinatorialData>

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 {
                     // We don't need arity to recover symbol if we already have SymbolKeyData or it's 0.
                     // (but it still needed below to decide whether to show generic suffix)
-                    builder.Add(TypeAritySuffixName, AbstractDeclaredSymbolInfoFactoryService.GetMetadataAritySuffix(arity));
+                    builder.Add(TypeAritySuffixName, ArityUtilities.GetMetadataAritySuffix(arity));
                 }
 
                 properties = builder.ToImmutableDictionaryAndFree();

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -583,7 +583,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     case GenericNameSyntax genericNameNode:
                         var name = genericNameNode.Identifier.Text;
                         var arity = genericNameNode.Arity;
-                        simpleTypeName = arity == 0 ? name : name + GetMetadataAritySuffix(arity);
+                        simpleTypeName = arity == 0 ? name : name + ArityUtilities.GetMetadataAritySuffix(arity);
                         return true;
 
                     case PredefinedTypeSyntax predefinedTypeNode:

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -156,7 +156,6 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         protected override void AddDeclaredSymbolInfosWorker(
             MemberDeclarationSyntax node,
             StringTable stringTable,
-            string rootNamespace,
             ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
             Dictionary<string, string> aliases,
             Dictionary<string, ArrayBuilder<int>> extensionMethodInfo,

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
     [ExportLanguageService(typeof(IDeclaredSymbolInfoFactoryService), LanguageNames.CSharp), Shared]
     internal class CSharpDeclaredSymbolInfoFactoryService : AbstractDeclaredSymbolInfoFactoryService<
         CompilationUnitSyntax,
+        UsingDirectiveSyntax,
         NamespaceDeclarationSyntax,
         TypeDeclarationSyntax,
         EnumDeclarationSyntax,
@@ -356,6 +357,12 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         protected override IEnumerable<MemberDeclarationSyntax> GetChildren(EnumDeclarationSyntax node)
             => node.Members;
 
+        protected override SyntaxList<UsingDirectiveSyntax> GetUsingAliases(CompilationUnitSyntax node)
+            => node.Usings;
+
+        protected override SyntaxList<UsingDirectiveSyntax> GetUsingAliases(NamespaceDeclarationSyntax node)
+            => node.Usings;
+
         private static bool IsNestedType(BaseTypeDeclarationSyntax typeDecl)
             => typeDecl.Parent is BaseTypeDeclarationSyntax;
 
@@ -534,9 +541,10 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         protected override string GetRootNamespace(CompilationOptions compilationOptions)
             => string.Empty;
 
-        public override bool TryGetAliasesFromUsingDirective(SyntaxNode node, out ImmutableArray<(string aliasName, string name)> aliases)
+        protected override bool TryGetAliasesFromUsingDirective(
+            UsingDirectiveSyntax usingDirectiveNode, out ImmutableArray<(string aliasName, string name)> aliases)
         {
-            if (node is UsingDirectiveSyntax usingDirectiveNode && usingDirectiveNode.Alias != null)
+            if (usingDirectiveNode.Alias != null)
             {
                 if (TryGetSimpleTypeName(usingDirectiveNode.Alias.Name, typeParameterNames: null, out var aliasName, out _) &&
                     TryGetSimpleTypeName(usingDirectiveNode.Name, typeParameterNames: null, out var name, out _))

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -558,7 +558,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             return false;
         }
 
-        protected override string GetReceiverTypeName(SyntaxNode node)
+        protected override string GetReceiverTypeName(MemberDeclarationSyntax node)
         {
             var methodDeclaration = (MethodDeclarationSyntax)node;
             Debug.Assert(IsExtensionMethod(methodDeclaration));

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -160,6 +160,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
             Dictionary<string, string> aliases,
             Dictionary<string, ArrayBuilder<int>> extensionMethodInfo,
+            string containerDisplayName,
+            string fullyQualifiedContainerName,
             CancellationToken cancellationToken)
         {
             // If this is a part of partial type that only contains nested types, then we don't make an info type for
@@ -186,8 +188,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         stringTable,
                         typeDecl.Identifier.ValueText,
                         GetTypeParameterSuffix(typeDecl.TypeParameterList),
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         typeDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
                         node.Kind() switch
                         {
@@ -208,8 +210,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
                         enumDecl.Identifier.ValueText, null,
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         enumDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
                         DeclaredSymbolInfoKind.Enum,
                         GetAccessibility(enumDecl, enumDecl.Modifiers),
@@ -223,8 +225,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         stringTable,
                         ctorDecl.Identifier.ValueText,
                         GetConstructorSuffix(ctorDecl),
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         ctorDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
                         DeclaredSymbolInfoKind.Constructor,
                         GetAccessibility(ctorDecl, ctorDecl.Modifiers),
@@ -238,8 +240,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         stringTable,
                         delegateDecl.Identifier.ValueText,
                         GetTypeParameterSuffix(delegateDecl.TypeParameterList),
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         delegateDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
                         DeclaredSymbolInfoKind.Delegate,
                         GetAccessibility(delegateDecl, delegateDecl.Modifiers),
@@ -251,8 +253,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
                         enumMember.Identifier.ValueText, null,
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         enumMember.Modifiers.Any(SyntaxKind.PartialKeyword),
                         DeclaredSymbolInfoKind.EnumMember,
                         Accessibility.Public,
@@ -264,8 +266,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
                         eventDecl.Identifier.ValueText, null,
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         eventDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
                         DeclaredSymbolInfoKind.Event,
                         GetAccessibility(eventDecl, eventDecl.Modifiers),
@@ -277,8 +279,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
                         "this", GetIndexerSuffix(indexerDecl),
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         indexerDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
                         DeclaredSymbolInfoKind.Indexer,
                         GetAccessibility(indexerDecl, indexerDecl.Modifiers),
@@ -291,8 +293,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
                         method.Identifier.ValueText, GetMethodSuffix(method),
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         method.Modifiers.Any(SyntaxKind.PartialKeyword),
                         isExtensionMethod ? DeclaredSymbolInfoKind.ExtensionMethod : DeclaredSymbolInfoKind.Method,
                         GetAccessibility(method, method.Modifiers),
@@ -308,8 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
                         property.Identifier.ValueText, null,
-                        GetContainerDisplayName(node.Parent),
-                        GetFullyQualifiedContainerName(node.Parent),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
                         property.Modifiers.Any(SyntaxKind.PartialKeyword),
                         DeclaredSymbolInfoKind.Property,
                         GetAccessibility(property, property.Modifiers),
@@ -330,8 +332,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                             stringTable,
                             variableDeclarator.Identifier.ValueText, null,
-                            GetContainerDisplayName(fieldDeclaration.Parent),
-                            GetFullyQualifiedContainerName(fieldDeclaration.Parent),
+                            containerDisplayName,
+                            fullyQualifiedContainerName,
                             fieldDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword),
                             kind,
                             GetAccessibility(fieldDeclaration, fieldDeclaration.Modifiers),
@@ -453,10 +455,10 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             }
         }
 
-        private static string GetContainerDisplayName(SyntaxNode node)
+        protected override string GetContainerDisplayName(MemberDeclarationSyntax node)
             => CSharpSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeTypeParameters);
 
-        private static string GetFullyQualifiedContainerName(SyntaxNode node)
+        protected override string GetFullyQualifiedContainerName(MemberDeclarationSyntax node, string rootNamespace)
             => CSharpSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeNamespaces);
 
         private static Accessibility GetAccessibility(SyntaxNode node, SyntaxTokenList modifiers)

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -85,6 +85,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             bool loadOnly,
             CancellationToken cancellationToken)
         {
+            if (!document.SupportsSyntaxTree)
+                return null;
+
             // See if we already cached an index with this direct document index.  If so we can just
             // return it with no additional work.
             if (!s_documentToIndex.TryGetValue(document, out var index))

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -45,6 +45,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         public static async Task PrecalculateAsync(Document document, CancellationToken cancellationToken)
         {
+            if (!document.SupportsSyntaxTree)
+                return;
+
             using (Logger.LogBlock(FunctionId.SyntaxTreeIndex_Precalculate, cancellationToken))
             {
                 Debug.Assert(document.IsFromPrimaryBranch());
@@ -108,6 +111,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             bool loadOnly,
             CancellationToken cancellationToken)
         {
+            if (!document.SupportsSyntaxTree)
+                return null;
+
             var checksum = await GetChecksumAsync(document, cancellationToken).ConfigureAwait(false);
 
             // Check if we have an index for a previous version of this document.  If our

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         // `rootNamespace` is required for VB projects that has non-global namespace as root namespace,
         // otherwise we would not be able to get correct data from syntax.
-        void AddDeclaredSymbolInfos(Document document, SyntaxNode node, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string?> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, CancellationToken cancellationToken);
+        void AddDeclaredSymbolInfos(Document document, SyntaxNode root, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string?> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, CancellationToken cancellationToken);
 
         bool TryGetAliasesFromUsingDirective(SyntaxNode node, out ImmutableArray<(string aliasName, string name)> aliases);
     }
@@ -205,16 +205,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         }
                     }
 
-                    // We've received a number of error reports where DeclaredSymbolInfo.GetSymbolAsync() will
-                    // crash because the document's syntax root doesn't contain the span of the node returned
-                    // by TryGetDeclaredSymbolInfo().  There are two possibilities for this crash:
-                    //   1) syntaxFacts.TryGetDeclaredSymbolInfo() is returning a bad span, or
-                    //   2) Document.GetSyntaxRootAsync() (called from DeclaredSymbolInfo.GetSymbolAsync) is
-                    //      returning a bad syntax root that doesn't represent the original parsed document.
-                    // By adding the `root.FullSpan.Contains()` check below, if we get similar crash reports in
-                    // the future then we know the problem lies in (2).  If, however, the problem is really in
-                    // TryGetDeclaredSymbolInfo, then this will at least prevent us from returning bad spans
-                    // and will prevent the crash from occurring.
                     infoFactory.AddDeclaredSymbolInfos(
                         document, root, declaredSymbolInfos, usingAliases, extensionMethodInfo, cancellationToken);
                 }

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// on `node` should return a `DeclaredSymbolInfo` of kind `ExtensionMethod`. 
         /// If the return value is null, then it means this is a "complex" method (as described at <see cref="SyntaxTreeIndex.ExtensionMethodInfo"/>).
         /// </summary>
-        protected abstract string GetReceiverTypeName(SyntaxNode node);
+        protected abstract string GetReceiverTypeName(TMemberDeclarationSyntax node);
         protected abstract bool TryGetAliasesFromUsingDirective(TUsingDirectiveSyntax node, out ImmutableArray<(string aliasName, string name)> aliases);
         protected abstract string GetRootNamespace(CompilationOptions compilationOptions);
 

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -189,8 +189,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
             if (memberDeclaration is TNamespaceDeclarationSyntax namespaceDeclaration)
             {
-                containerDisplayName = GetContainerDisplayName(memberDeclaration);
-                fullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
+                var innerContainerDisplayName = GetContainerDisplayName(memberDeclaration);
+                var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
 
                 foreach (var usingAlias in GetUsingAliases(namespaceDeclaration))
                 {
@@ -199,21 +199,33 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 }
 
                 foreach (var child in GetChildren(namespaceDeclaration))
-                    AddDeclaredSymbolInfos(memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
+                {
+                    AddDeclaredSymbolInfos(
+                        memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo,
+                        innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
+                }
             }
             else if (memberDeclaration is TTypeDeclarationSyntax baseTypeDeclaration)
             {
-                containerDisplayName = GetContainerDisplayName(memberDeclaration);
-                fullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
+                var innerContainerDisplayName = GetContainerDisplayName(memberDeclaration);
+                var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 foreach (var child in GetChildren(baseTypeDeclaration))
-                    AddDeclaredSymbolInfos(memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
+                {
+                    AddDeclaredSymbolInfos(
+                        memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo,
+                        innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
+                }
             }
             else if (memberDeclaration is TEnumDeclarationSyntax enumDeclaration)
             {
-                containerDisplayName = GetContainerDisplayName(memberDeclaration);
-                fullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
+                var innerContainerDisplayName = GetContainerDisplayName(memberDeclaration);
+                var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 foreach (var child in GetChildren(enumDeclaration))
-                    AddDeclaredSymbolInfos(memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
+                {
+                    AddDeclaredSymbolInfos(
+                        memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo,
+                        innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
+                }
             }
 
             AddDeclaredSymbolInfosWorker(

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -144,8 +144,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             }
         }
 
-        public async Task AddDeclaredSymbolInfosAsync(
+        public void AddDeclaredSymbolInfos(
             Document document,
+            SyntaxNode root,
             ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
             Dictionary<string, string> aliases,
             Dictionary<string, ArrayBuilder<int>> extensionMethodInfo,
@@ -155,9 +156,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             var stringTable = SyntaxTreeIndex.GetStringTable(project);
             var rootNamespace = this.GetRootNamespace(project.CompilationOptions);
 
-            var root = (TCompilationUnitSyntax)await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            foreach (var child in GetChildren(root))
+            foreach (var child in GetChildren((TCompilationUnitSyntax)root))
                 AddDeclaredSymbolInfos(child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, "", "", cancellationToken);
         }
 

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         protected abstract string GetFullyQualifiedContainerName(TMemberDeclarationSyntax memberDeclaration, string rootNamespace);
 
         protected abstract void AddDeclaredSymbolInfosWorker(
-            TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
+            SyntaxNode container, TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
         /// <summary>
         /// Get the name of the target type of specified extension method declaration. 
         /// The node provided must be an extension method declaration,  i.e. calling `TryGetDeclaredSymbolInfo()` 
@@ -157,10 +157,11 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             var rootNamespace = this.GetRootNamespace(project.CompilationOptions);
 
             foreach (var child in GetChildren((TCompilationUnitSyntax)root))
-                AddDeclaredSymbolInfos(child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, "", "", cancellationToken);
+                AddDeclaredSymbolInfos(root, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, "", "", cancellationToken);
         }
 
         private void AddDeclaredSymbolInfos(
+            SyntaxNode container,
             TMemberDeclarationSyntax memberDeclaration,
             StringTable stringTable,
             string rootNamespace,
@@ -178,24 +179,25 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 containerDisplayName = GetContainerDisplayName(memberDeclaration);
                 fullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 foreach (var child in GetChildren(namespaceDeclaration))
-                    AddDeclaredSymbolInfos(child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
+                    AddDeclaredSymbolInfos(memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
             }
             else if (memberDeclaration is TTypeDeclarationSyntax baseTypeDeclaration)
             {
                 containerDisplayName = GetContainerDisplayName(memberDeclaration);
                 fullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 foreach (var child in GetChildren(baseTypeDeclaration))
-                    AddDeclaredSymbolInfos(child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
+                    AddDeclaredSymbolInfos(memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
             }
             else if (memberDeclaration is TEnumDeclarationSyntax enumDeclaration)
             {
                 containerDisplayName = GetContainerDisplayName(memberDeclaration);
                 fullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 foreach (var child in GetChildren(enumDeclaration))
-                    AddDeclaredSymbolInfos(child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
+                    AddDeclaredSymbolInfos(memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo, containerDisplayName, fullyQualifiedContainerName, cancellationToken);
             }
 
             AddDeclaredSymbolInfosWorker(
+                container,
                 memberDeclaration,
                 stringTable,
                 declaredSymbolInfos,

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -31,9 +31,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         where TEnumDeclarationSyntax : TMemberDeclarationSyntax
         where TMemberDeclarationSyntax : SyntaxNode
     {
-        private const string GenericTypeNameManglingString = "`";
-        private static readonly string[] s_aritySuffixesOneToNine = { "`1", "`2", "`3", "`4", "`5", "`6", "`7", "`8", "`9" };
-
         private static readonly ObjectPool<List<Dictionary<string, string>>> s_aliasMapListPool
             = SharedPools.Default<List<Dictionary<string, string>>>();
 
@@ -93,7 +90,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 return ValueTupleName;
             }
             // A ValueTuple can have up to 8 type parameters.
-            return ValueTupleName + GetMetadataAritySuffix(elementCount > 8 ? 8 : elementCount);
+            return ValueTupleName + ArityUtilities.GetMetadataAritySuffix(elementCount > 8 ? 8 : elementCount);
         }
 
         protected static void FreeAliasMapList(List<Dictionary<string, string>> list)
@@ -141,14 +138,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             {
                 builder[i] = stringTable.Add(builder[i]);
             }
-        }
-
-        public static string GetMetadataAritySuffix(int arity)
-        {
-            Debug.Assert(arity > 0);
-            return (arity <= s_aritySuffixesOneToNine.Length)
-                ? s_aritySuffixesOneToNine[arity - 1]
-                : string.Concat(GenericTypeNameManglingString, arity.ToString(CultureInfo.InvariantCulture));
         }
 
         public async Task AddDeclaredSymbolInfosAsync(

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         protected abstract string GetFullyQualifiedContainerName(TMemberDeclarationSyntax memberDeclaration, string rootNamespace);
 
         protected abstract void AddDeclaredSymbolInfosWorker(
-            TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, string rootNamespace, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
+            TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
         /// <summary>
         /// Get the name of the target type of specified extension method declaration. 
         /// The node provided must be an extension method declaration,  i.e. calling `TryGetDeclaredSymbolInfo()` 
@@ -199,7 +199,6 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             AddDeclaredSymbolInfosWorker(
                 memberDeclaration,
                 stringTable,
-                rootNamespace,
                 declaredSymbolInfos,
                 aliases,
                 extensionMethodInfo,

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/ArityUtilities.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/ArityUtilities.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Microsoft.CodeAnalysis.LanguageServices
+{
+    internal static class ArityUtilities
+    {
+        private const string GenericTypeNameManglingString = "`";
+        private static readonly string[] s_aritySuffixesOneToNine = { "`1", "`2", "`3", "`4", "`5", "`6", "`7", "`8", "`9" };
+
+        public static string GetMetadataAritySuffix(int arity)
+        {
+            Debug.Assert(arity > 0);
+            return (arity <= s_aritySuffixesOneToNine.Length)
+                ? s_aritySuffixesOneToNine[arity - 1]
+                : string.Concat(GenericTypeNameManglingString, arity.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -724,9 +724,10 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     foreach (var document in documents)
                     {
                         if (_documentsIdsToBeCheckedForConflict.Contains(document.Id))
-                        {
                             continue;
-                        }
+
+                        if (!document.SupportsSyntaxTree)
+                            continue;
 
                         var info = await SyntaxTreeIndex.GetRequiredIndexAsync(document, _cancellationToken).ConfigureAwait(false);
                         if (info.ProbablyContainsEscapedIdentifier(_originalText))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
@@ -440,7 +440,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         public static bool IsReturnStatement(this ISyntaxFacts syntaxFacts, [NotNullWhen(true)] SyntaxNode node)
             => node?.RawKind == syntaxFacts.SyntaxKinds.ReturnStatement;
 
-        public static bool IsUsingStatement(this ISyntaxFacts syntaxFacts, [NotNullWhen(true)] SyntaxNode node)
+        public static bool IsUsingStatement(this ISyntaxFacts syntaxFacts, [NotNullWhen(true)] SyntaxNode? node)
             => node?.RawKind == syntaxFacts.SyntaxKinds.UsingStatement;
 
         #endregion

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -19,6 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
     Friend Class VisualBasicDeclaredSymbolInfoFactoryService
         Inherits AbstractDeclaredSymbolInfoFactoryService(Of
             CompilationUnitSyntax,
+            ImportsStatementSyntax,
             NamespaceBlockSyntax,
             TypeBlockSyntax,
             EnumBlockSyntax,
@@ -318,6 +319,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Return node.Members
         End Function
 
+        Protected Overrides Function GetUsingAliases(node As CompilationUnitSyntax) As SyntaxList(Of ImportsStatementSyntax)
+            Return node.Imports
+        End Function
+
+        Protected Overrides Function GetUsingAliases(node As NamespaceBlockSyntax) As SyntaxList(Of ImportsStatementSyntax)
+            Return Nothing
+        End Function
+
         Private Shared Function IsExtensionMethod(node As MethodStatementSyntax) As Boolean
             Dim parameterCount = node.ParameterList?.Parameters.Count
 
@@ -494,12 +503,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Return CreateReceiverTypeString(targetTypeName, isArray)
         End Function
 
-        Public Overrides Function TryGetAliasesFromUsingDirective(node As SyntaxNode, ByRef aliases As ImmutableArray(Of (aliasName As String, name As String))) As Boolean
-
-            Dim importStatement = TryCast(node, ImportsStatementSyntax)
+        Protected Overrides Function TryGetAliasesFromUsingDirective(importStatement As ImportsStatementSyntax, ByRef aliases As ImmutableArray(Of (aliasName As String, name As String))) As Boolean
             Dim builder = ArrayBuilder(Of (String, String)).GetInstance()
 
-            If (importStatement IsNot Nothing) Then
+            If importStatement IsNot Nothing Then
                 For Each importsClause In importStatement.ImportsClauses
 
                     If importsClause.Kind = SyntaxKind.SimpleImportsClause Then

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -331,7 +331,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Dim parameterCount = node.ParameterList?.Parameters.Count
 
             ' Extension method must have at least one parameter and declared inside a module
-            If Not parameterCount.HasValue OrElse parameterCount.Value = 0 OrElse TypeOf node.Parent IsNot ModuleBlockSyntax Then
+            If Not parameterCount.HasValue OrElse parameterCount.Value = 0 OrElse TypeOf node.Parent?.Parent IsNot ModuleBlockSyntax Then
                 Return False
             End If
 
@@ -491,15 +491,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Next
         End Sub
 
-        Protected Overrides Function GetReceiverTypeName(node As SyntaxNode) As String
-            Dim funcDecl = CType(node, MethodBlockSyntax)
-            Debug.Assert(IsExtensionMethod(funcDecl.SubOrFunctionStatement))
+        Protected Overrides Function GetReceiverTypeName(node As StatementSyntax) As String
+            Dim funcDecl = DirectCast(node, MethodStatementSyntax)
+            Debug.Assert(IsExtensionMethod(funcDecl))
 
-            Dim typeParameterNames = funcDecl.SubOrFunctionStatement.TypeParameterList?.Parameters.SelectAsArray(Function(p) p.Identifier.Text)
+            Dim typeParameterNames = funcDecl.TypeParameterList?.Parameters.SelectAsArray(Function(p) p.Identifier.Text)
             Dim targetTypeName As String = Nothing
             Dim isArray As Boolean = False
 
-            TryGetSimpleTypeNameWorker(funcDecl.BlockStatement.ParameterList.Parameters(0).AsClause?.Type, typeParameterNames, targetTypeName, isArray)
+            TryGetSimpleTypeNameWorker(funcDecl.ParameterList.Parameters(0).AsClause?.Type, typeParameterNames, targetTypeName, isArray)
             Return CreateReceiverTypeString(targetTypeName, isArray)
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -125,7 +125,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
         Protected Overrides Sub AddDeclaredSymbolInfosWorker(
                 node As StatementSyntax,
                 stringTable As StringTable,
-                rootNamespace As String,
                 declaredSymbolInfos As ArrayBuilder(Of DeclaredSymbolInfo),
                 aliases As Dictionary(Of String, String),
                 extensionMethodInfo As Dictionary(Of String, ArrayBuilder(Of Integer)),

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -248,6 +248,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                     Return
                 Case SyntaxKind.FunctionBlock, SyntaxKind.SubBlock
                     Dim funcDecl = CType(node, MethodBlockSyntax)
+                    Dim isExtension = IsExtensionMethod(funcDecl)
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
                         funcDecl.SubOrFunctionStatement.Identifier.ValueText,
@@ -255,12 +256,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                         GetContainerDisplayName(node.Parent),
                         GetFullyQualifiedContainerName(node.Parent, rootNamespace),
                         funcDecl.SubOrFunctionStatement.Modifiers.Any(SyntaxKind.PartialKeyword),
-                        If(IsExtensionMethod(funcDecl), DeclaredSymbolInfoKind.ExtensionMethod, DeclaredSymbolInfoKind.Method),
+                        If(isExtension, DeclaredSymbolInfoKind.ExtensionMethod, DeclaredSymbolInfoKind.Method),
                         GetAccessibility(node, funcDecl.SubOrFunctionStatement.Modifiers),
                         funcDecl.SubOrFunctionStatement.Identifier.Span,
                         ImmutableArray(Of String).Empty,
                         parameterCount:=If(funcDecl.SubOrFunctionStatement.ParameterList?.Parameters.Count, 0),
                         typeParameterCount:=If(funcDecl.SubOrFunctionStatement.TypeParameterList?.Parameters.Count, 0)))
+                    If isExtension Then
+                        AddExtensionMethodInfo(funcDecl, aliases, declaredSymbolInfos.Count - 1, extensionMethodInfo)
+                    End If
                     Return
                 Case SyntaxKind.PropertyStatement
                     Dim propertyDecl = CType(node, PropertyStatementSyntax)

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -543,7 +543,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                 Dim genericName = DirectCast(node, GenericNameSyntax)
                 Dim name = genericName.Identifier.Text
                 Dim arity = genericName.Arity
-                simpleTypeName = If(arity = 0, name, name + GetMetadataAritySuffix(arity))
+                simpleTypeName = If(arity = 0, name, name + ArityUtilities.GetMetadataAritySuffix(arity))
                 Return True
 
             ElseIf TypeOf node Is QualifiedNameSyntax Then


### PR DESCRIPTION
I recommend reviewing this one commit at a time.  The two main changes are:

1. instead of descending into all nodes in a tree and seeing which can become DeclaredSymbolInfo, we do an explicit loop over the top level items in a file that produce these.
2. as we descend into the top level items we compute and cache once strings that will be used by all children.  this saves a lot of wasted duplicate string allocations.