### PR TITLE
'with' on anonymous type needs to lower values

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -183,7 +183,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(left.MemberSymbol is not null);
 
                     // We evaluate the values provided in source first
-                    BoundLocal valueTemp = _factory.StoreToTemp(assignment.Right, out BoundAssignmentOperator boundAssignmentToTemp);
+                    var rewrittenRight = (BoundExpression)Visit(assignment.Right)!;
+                    BoundLocal valueTemp = _factory.StoreToTemp(rewrittenRight, out BoundAssignmentOperator boundAssignmentToTemp);
                     temps.Add(valueTemp.LocalSymbol);
                     sideEffects.Add(boundAssignmentToTemp);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(left.MemberSymbol is not null);
 
                     // We evaluate the values provided in source first
-                    var rewrittenRight = (BoundExpression)Visit(assignment.Right)!;
+                    var rewrittenRight = VisitExpression(assignment.Right);
                     BoundLocal valueTemp = _factory.StoreToTemp(rewrittenRight, out BoundAssignmentOperator boundAssignmentToTemp);
                     temps.Add(valueTemp.LocalSymbol);
                     sideEffects.Add(boundAssignmentToTemp);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -10003,8 +10003,8 @@ var adjusted = x with { Property = x.Property + 2 };
 System.Console.WriteLine(adjusted);
 ";
             var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
-            comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "{ Property = 44 }");
+            var verifier = CompileAndVerify(comp, expectedOutput: "{ Property = 44 }");
+            verifier.VerifyDiagnostics();
         }
 
         [Fact, WorkItem(53849, "https://github.com/dotnet/roslyn/issues/53849")]
@@ -10018,8 +10018,8 @@ var adjusted = container with { Item = x with { Property = x.Property + 2 } };
 System.Console.WriteLine(adjusted);
 ";
             var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
-            comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "{ Item = { Property = 44 } }");
+            var verifier = CompileAndVerify(comp, expectedOutput: "{ Item = { Property = 44 } }");
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -9993,6 +9993,35 @@ Block[B3] - Exit
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(src, expectedFlowGraph, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
         }
 
+        [Fact, WorkItem(53849, "https://github.com/dotnet/roslyn/issues/53849")]
+        public void WithExpr_AnonymousType_ValueIsLoweredToo()
+        {
+            var src = @"
+var x = new { Property = 42 };
+var adjusted = x with { Property = x.Property + 2 };
+
+System.Console.WriteLine(adjusted);
+";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "{ Property = 44 }");
+        }
+
+        [Fact, WorkItem(53849, "https://github.com/dotnet/roslyn/issues/53849")]
+        public void WithExpr_AnonymousType_ValueIsLoweredToo_NestedWith()
+        {
+            var src = @"
+var x = new { Property = 42 };
+var container = new { Item = x };
+var adjusted = container with { Item = x with { Property = x.Property + 2 } };
+
+System.Console.WriteLine(adjusted);
+";
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "{ Item = { Property = 44 } }");
+        }
+
         [Fact]
         public void AttributesOnPrimaryConstructorParameters_01()
         {


### PR DESCRIPTION
Fixing an embarrassing bug (forgot to lower the sub-expressions in this case)...

Fixes https://github.com/dotnet/roslyn/issues/53849
Relates to record structs feature: https://github.com/dotnet/roslyn/issues/51199 (test plan)