### PR TITLE
Don't include trivia in caller argument expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -791,7 +791,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CheckFeatureAvailability(syntax.ArgumentList, MessageID.IDS_FeatureCallerArgumentExpression, diagnostics);
                 parameterType = GetSpecialType(SpecialType.System_String, diagnostics, syntax);
                 kind = TypedConstantKind.Primitive;
-                defaultValue = syntax.ArgumentList.Arguments[argumentIndex].Expression.ToString();
+                defaultValue = syntax.ArgumentList.Arguments[argumentIndex].Expression.ToStringWithoutTrivia();
             }
             else if (defaultConstantValue == ConstantValue.NotAvailable)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1378,7 +1378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // PROTOTYPE(caller-expr): Do we need to support VB?
 
                     var argument = argumentsBuilder[argumentIndex];
-                    defaultValue = new BoundLiteral(syntax, ConstantValue.Create(argument.Syntax.ToString()), Compilation.GetSpecialType(SpecialType.System_String)) { WasCompilerGenerated = true };
+                    defaultValue = new BoundLiteral(syntax, ConstantValue.Create(argument.Syntax.ToStringWithoutTrivia()), Compilation.GetSpecialType(SpecialType.System_String)) { WasCompilerGenerated = true };
                 }
                 else if (defaultConstantValue == ConstantValue.NotAvailable)
                 {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -279,6 +280,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return false;
+        }
+
+        internal static string ToStringWithoutTrivia(this SyntaxNode node)
+        {
+            var builder = new StringBuilder();
+            foreach (var token in node.DescendantTokens())
+            {
+                if (token.LeadingTrivia.Any(SyntaxKind.WhitespaceTrivia))
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append(token.WithoutTrivia().Text);
+
+                if (token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
+                {
+                    builder.Append(' ');
+                }
+            }
+
+            // Don't include leading trivia from first node or trailing trivia from last node.
+            return builder.ToString().Trim();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -47,7 +47,6 @@ class Program
         [ConditionalFact(typeof(CoreClrOnly))]
         public void TestGoodCallerArgumentExpressionAttribute_ExpressionHasTrivia()
         {
-            // PROTOTYPE(caller-expr): What should the expected output be?
             string source = @"
 using System;
 using System.Runtime.CompilerServices;
@@ -71,9 +70,7 @@ class Program
 
             var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview);
             compilation.VerifyDiagnostics();
-            CompileAndVerify(compilation, expectedOutput:
-@"123 /* comment */ +
-               5");
+            CompileAndVerify(compilation, expectedOutput: "123 + 5");
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]
@@ -453,7 +450,6 @@ public class Program
         [ConditionalFact(typeof(CoreClrOnly))]
         public void TestGoodCallerArgumentExpressionAttribute_ExpressionHasTrivia_Attribute()
         {
-            // PROTOTYPE(caller-expr): What should the expected output be?
             string source = @"
 using System;
 using System.Reflection;
@@ -483,9 +479,7 @@ public class Program
 
             var compilation = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview);
             compilation.VerifyDiagnostics();
-            CompileAndVerify(compilation, expectedOutput:
-@"123 /* comment */ +
-               5");
+            CompileAndVerify(compilation, expectedOutput: "123 + 5");
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]


### PR DESCRIPTION
Proposal: dotnet/csharplang#287
Test plan: https://github.com/dotnet/roslyn/issues/52745

Addresses part of LDM notes: https://github.com/dotnet/csharplang/blob/main/meetings/2021/LDM-2021-06-14.md