### PR TITLE
Simplify unnecessary condition

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -606,7 +606,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         var constructorArguments = attribute.CommonConstructorArguments;
                         Debug.Assert(constructorArguments.Length == 1);
-                        if (constructorArguments[0].TryDecodeValue(SpecialType.System_String, out string value))
+                        if (constructorArguments[0].TryDecodeValue(SpecialType.System_String, out string parameterName))
                         {
                             var parameters = ContainingSymbol.GetParameters();
                             for (int i = 0; i < parameters.Length; i++)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -605,8 +605,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (!attribute.HasErrors)
                     {
                         var constructorArguments = attribute.CommonConstructorArguments;
-                        var parameterName = constructorArguments.Length == 1 && constructorArguments[0].TryDecodeValue(SpecialType.System_String, out string value) ? value : null;
-                        if (parameterName is string)
+                        Debug.Assert(constructorArguments.Length == 1);
+                        if (constructorArguments[0].TryDecodeValue(SpecialType.System_String, out string value))
                         {
                             var parameters = ContainingSymbol.GetParameters();
                             for (int i = 0; i < parameters.Length; i++)


### PR DESCRIPTION
I think the length should be guaranteed to be `1` in this code path since we check for `AttributeDescription.CallerArgumentExpressionAttribute`.

Note: I initially wrote it that way since it was nearly a copy/paste from other code here:

https://github.com/dotnet/roslyn/blob/1f5c03e44f37438fd55913c0c134e9c8c8ed084e/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs#L776-L782

If my thought is correct, the other code could be simplified as well.
