### PR TITLE
Add functionality to enable skipping analyzers for implicitly trigger…

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ErrorString.resx
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.resx
@@ -214,4 +214,7 @@
   <data name="General_UnableToReadFile" xml:space="preserve">
     <value>File "{0}" could not be read: {1}</value>
   </data>
+  <data name="ImplicitlySkipAnalyzersMessage" xml:space="preserve">
+    <value>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</value>
+  </data>
 </root>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -82,11 +82,11 @@
                such as from 'Run Tests' or 'Start Debugging', we implicitly skip analyzers to speed up the build.
                We only do so by default when 'TreatWarningsAsErrors' is not 'true'. For the scenario where
 			         'TreatWarningsAsErrors' is 'true', users can explicitly enable this functionality by setting
-			         'OptimizeIndirectlyTriggeredBuildInsideVisualStudio' to 'true'.
+			         'OptimizeImplicitlyTriggeredBuild' to 'true'.
     -->
     <PropertyGroup Condition="'$(_SkipAnalyzers)' == '' and
-                              '$(IsIndirectlyTriggeredBuildInsideVisualStudio)' == 'true' and
-                              ('$(TreatWarningsAsErrors)' != 'true' or '$(OptimizeIndirectlyTriggeredBuildInsideVisualStudio)' == 'true')">
+                              '$(IsImplicitlyTriggeredBuild)' == 'true' and
+                              ('$(TreatWarningsAsErrors)' != 'true' or '$(OptimizeImplicitlyTriggeredBuild)' == 'true')">
       <_ImplicitlySkipAnalyzers>true</_ImplicitlySkipAnalyzers>
       <_SkipAnalyzers>true</_SkipAnalyzers>
     </PropertyGroup>
@@ -97,22 +97,22 @@
 
     <!-- Semaphore file to indicate the time stamp for last build with skipAnalyzers flag. -->
     <PropertyGroup>
-      <LastBuildWithSkipAnalyzers>$(IntermediateOutputPath)$(MSBuildProjectFile).BuildWithSkipAnalyzers</LastBuildWithSkipAnalyzers>
+      <_LastBuildWithSkipAnalyzers>$(IntermediateOutputPath)$(MSBuildProjectFile).BuildWithSkipAnalyzers</_LastBuildWithSkipAnalyzers>
     </PropertyGroup>
 
-    <!-- 'LastBuildWithSkipAnalyzers' semaphore file, if exists, is passed as custom additional file input to builds without skipAnalyzers flag to ensure correct incremental builds. 
-	       Additionally, we need to pass this file as an 'UpToDateCheckInput' item with 'Kind = IndirectBuild' for project system's fast-upto-date check to work correctly.
+    <!-- '_LastBuildWithSkipAnalyzers' semaphore file, if exists, is passed as custom additional file input to builds without skipAnalyzers flag to ensure correct incremental builds. 
+	       Additionally, we need to pass this file as an 'UpToDateCheckInput' item with 'Kind = ImplicitBuild' for project system's fast-upto-date check to work correctly.
 		     See https://github.com/dotnet/project-system/issues/7290 for details.
 	  -->
-    <ItemGroup Condition="Exists('$(LastBuildWithSkipAnalyzers)')">
-      <CustomAdditionalCompileInputs Include="$(LastBuildWithSkipAnalyzers)" Condition="'$(_SkipAnalyzers)' != 'true'"/>
-      <UpToDateCheckInput Include="$(LastBuildWithSkipAnalyzers)" Kind="IndirectBuild"/>
+    <ItemGroup Condition="Exists('$(_LastBuildWithSkipAnalyzers)')">
+      <CustomAdditionalCompileInputs Include="$(_LastBuildWithSkipAnalyzers)" Condition="'$(_SkipAnalyzers)' != 'true'"/>
+      <UpToDateCheckInput Include="$(_LastBuildWithSkipAnalyzers)" Kind="ImplicitBuild"/>
     </ItemGroup>
   </Target>
 
   <!-- We touch and create a semaphore file after build to indicate the time stamp for last build with skipAnalyzers flag. -->
   <Target Name="_TouchLastBuildWithSkipAnalyzers" Condition="'$(_SkipAnalyzers)' == 'true'" AfterTargets="CoreCompile">
-    <Touch AlwaysCreate="true" Files="$(LastBuildWithSkipAnalyzers)"/>
+    <Touch AlwaysCreate="true" Files="$(_LastBuildWithSkipAnalyzers)"/>
   </Target>
 
   <!--

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -50,10 +50,17 @@
     </PropertyGroup>
   </Target>
 
+  <!--
+    ========================
+    SkipAnalyzers Support
+    ========================
+    
+    -->
   <Target Name="_ComputeSkipAnalyzers" BeforeTargets="CoreCompile">
-    <!-- First, force clear non-user facing property '_SkipAnalyzers'. -->
+    <!-- First, force clear non-user facing properties '_SkipAnalyzers' and '_ImplicitlySkipAnalyzers'. -->
     <PropertyGroup>
       <_SkipAnalyzers></_SkipAnalyzers>
+      <_ImplicitlySkipAnalyzers></_ImplicitlySkipAnalyzers>
     </PropertyGroup>
 
     <!--
@@ -70,6 +77,42 @@
                               ('$(RunAnalyzers)' == '' and '$(RunAnalyzersDuringBuild)' == 'false')">
       <_SkipAnalyzers>true</_SkipAnalyzers>
     </PropertyGroup>
+
+    <!-- PERF: For builds which are indirectly triggered inside Visual Studio from commands 
+               such as from 'Run Tests' or 'Start Debugging', we implicitly skip analyzers to speed up the build.
+               We only do so by default when 'TreatWarningsAsErrors' is not 'true'. For the scenario where
+			         'TreatWarningsAsErrors' is 'true', users can explicitly enable this functionality by setting
+			         'OptimizeIndirectlyTriggeredBuildInsideVisualStudio' to 'true'.
+    -->
+    <PropertyGroup Condition="'$(_SkipAnalyzers)' == '' and
+                              '$(IsIndirectlyTriggeredBuildInsideVisualStudio)' == 'true' and
+                              ('$(TreatWarningsAsErrors)' != 'true' or '$(OptimizeIndirectlyTriggeredBuildInsideVisualStudio)' == 'true')">
+      <_ImplicitlySkipAnalyzers>true</_ImplicitlySkipAnalyzers>
+      <_SkipAnalyzers>true</_SkipAnalyzers>
+    </PropertyGroup>
+
+    <!-- Display a message to inform the users about us implicitly skipping analyzers for speeding up indirect builds. -->
+    <Message Condition="'$(_ImplicitlySkipAnalyzers)' == 'true'"
+             Text="Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers." Importance="High" />
+
+    <!-- Semaphore file to indicate the time stamp for last build with skipAnalyzers flag. -->
+    <PropertyGroup>
+      <LastBuildWithSkipAnalyzers>$(IntermediateOutputPath)$(MSBuildProjectFile).BuildWithSkipAnalyzers</LastBuildWithSkipAnalyzers>
+    </PropertyGroup>
+
+    <!-- 'LastBuildWithSkipAnalyzers' semaphore file, if exists, is passed as custom additional file input to builds without skipAnalyzers flag to ensure correct incremental builds. 
+	       Additionally, we need to pass this file as an 'UpToDateCheckInput' item with 'Kind = IndirectBuild' for project system's fast-upto-date check to work correctly.
+		     See https://github.com/dotnet/project-system/issues/7290 for details.
+	  -->
+    <ItemGroup Condition="Exists('$(LastBuildWithSkipAnalyzers)')">
+      <CustomAdditionalCompileInputs Include="$(LastBuildWithSkipAnalyzers)" Condition="'$(_SkipAnalyzers)' != 'true'"/>
+      <UpToDateCheckInput Include="$(LastBuildWithSkipAnalyzers)" Kind="IndirectBuild"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- We touch and create a semaphore file after build to indicate the time stamp for last build with skipAnalyzers flag. -->
+  <Target Name="_TouchLastBuildWithSkipAnalyzers" Condition="'$(_SkipAnalyzers)' == 'true'" AfterTargets="CoreCompile">
+    <Touch AlwaysCreate="true" Files="$(LastBuildWithSkipAnalyzers)"/>
   </Target>
 
   <!--

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -56,6 +56,8 @@
     ========================
     
     -->
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.ShowMessageForImplicitlySkipAnalyzers" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
+
   <Target Name="_ComputeSkipAnalyzers" BeforeTargets="CoreCompile">
     <!-- First, force clear non-user facing properties '_SkipAnalyzers' and '_ImplicitlySkipAnalyzers'. -->
     <PropertyGroup>
@@ -92,8 +94,7 @@
     </PropertyGroup>
 
     <!-- Display a message to inform the users about us implicitly skipping analyzers for speeding up indirect builds. -->
-    <Message Condition="'$(_ImplicitlySkipAnalyzers)' == 'true'"
-             Text="Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers." Importance="High" />
+    <ShowMessageForImplicitlySkipAnalyzers Condition="'$(_ImplicitlySkipAnalyzers)' == 'true'"/>
 
     <!-- Semaphore file to indicate the time stamp for last build with skipAnalyzers flag. -->
     <PropertyGroup>

--- a/src/Compilers/Core/MSBuildTask/ShowMessageForImplicitlySkipAnalyzers.cs
+++ b/src/Compilers/Core/MSBuildTask/ShowMessageForImplicitlySkipAnalyzers.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    /// <summary>
+    /// Logs a localizable message for implicitly skipping analyzers for implicitly triggered builds.
+    /// </summary>
+    public sealed class ShowMessageForImplicitlySkipAnalyzers : Task
+    {
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, ErrorString.ImplicitlySkipAnalyzersMessage);
+            return true;
+        }
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.cs.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.cs.xlf
@@ -99,6 +99,11 @@
         <target state="translated">Soubor {0} se nepovedlo přečíst: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Sdílená kompilace se nepovedla, použije se znovu nástroj: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.de.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.de.xlf
@@ -99,6 +99,11 @@
         <target state="translated">Die Datei "{0}" konnte nicht gelesen werden: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Fehler bei der freigegebenen Kompilierung. Fallback auf folgendes Tool: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.es.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.es.xlf
@@ -99,6 +99,11 @@
         <target state="translated">No se pudo leer el archivo "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Error de la compilación compartida. Se recurre a la herramienta: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.fr.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.fr.xlf
@@ -99,6 +99,11 @@
         <target state="translated">Impossible de lire le fichier "{0}" : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Échec de la compilation partagée ; retour à l'outil : {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.it.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.it.xlf
@@ -99,6 +99,11 @@
         <target state="translated">Non è stato possibile leggere il file "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">La compilazione condivisa non è riuscita. Verrà eseguito il fallback allo strumento: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.ja.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.ja.xlf
@@ -99,6 +99,11 @@
         <target state="translated">ファイル "{0}" を読み取ることができませんでした: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">共有コンパイルに失敗しました。ツールにフォールバックします: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.ko.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.ko.xlf
@@ -99,6 +99,11 @@
         <target state="translated">"{0}" 파일을 읽을 수 없습니다. {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">공유 컴파일 실패, 다음 도구로 변경 중: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.pl.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.pl.xlf
@@ -99,6 +99,11 @@
         <target state="translated">Nie można odczytać pliku „{0}”: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Udostępniona kompilacja nie powiodła się; nastąpi powrót do narzędzia: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.pt-BR.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.pt-BR.xlf
@@ -99,6 +99,11 @@
         <target state="translated">Não foi possível ler o arquivo "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Compilação compartilhada com falha; fazendo fallback para a ferramenta: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.ru.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.ru.xlf
@@ -99,6 +99,11 @@
         <target state="translated">Не удалось считать файл "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Сбой общей компиляции; возврат к средству {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.tr.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.tr.xlf
@@ -99,6 +99,11 @@
         <target state="translated">"{0}" dosyası okunamadı: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">Paylaşılan derleme başarısız oldu; önceki araca dönülüyor: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.zh-Hans.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.zh-Hans.xlf
@@ -99,6 +99,11 @@
         <target state="translated">无法读取文件 "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">共享编译失败; 回到工具: {0}</target>

--- a/src/Compilers/Core/MSBuildTask/xlf/ErrorString.zh-Hant.xlf
+++ b/src/Compilers/Core/MSBuildTask/xlf/ErrorString.zh-Hant.xlf
@@ -99,6 +99,11 @@
         <target state="translated">無法讀取檔案 "{0}": {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplicitlySkipAnalyzersMessage">
+        <source>Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</source>
+        <target state="new">Skipping analyzers to speed up the build. You can execute 'Build' or 'Rebuild' command to run analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SharedCompilationFallback">
         <source>Shared compilation failed; falling back to tool: {0}</source>
         <target state="translated">共用編譯失敗; 將回到工具: {0}</target>

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {
-    public class TargetTests
+    public class TargetTests : TestBase
     {
         [Fact]
         public void GenerateEditorConfigShouldNotRunWhenNoPropertiesOrMetadata()
@@ -714,6 +714,138 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             }
         }
 
+        [Theory, CombinatorialData]
+        [WorkItem(1337109, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1337109")]
+        public void TestImplicitlySkipAnalyzers(
+            [CombinatorialValues(true, false, null)] bool? runAnalyzers,
+            [CombinatorialValues(true, false, null)] bool? indirectBuild,
+            [CombinatorialValues(true, false, null)] bool? treatWarningsAsErrors,
+            [CombinatorialValues(true, false, null)] bool? optimizeIndirectBuild)
+        {
+            var runAnalyzersPropertyGroupString = getPropertyGroup("RunAnalyzers", runAnalyzers);
+            var indirectBuildPropertyGroupString = getPropertyGroup("IsIndirectlyTriggeredBuildInsideVisualStudio", indirectBuild);
+            var treatWarningsAsErrorsPropertyGroupString = getPropertyGroup("TreatWarningsAsErrors", treatWarningsAsErrors);
+            var optimizeIndirectBuildPropertyGroupString = getPropertyGroup("OptimizeIndirectlyTriggeredBuildInsideVisualStudio", optimizeIndirectBuild);
+
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <Import Project=""Microsoft.Managed.Core.targets"" />
+
+{runAnalyzersPropertyGroupString}
+{indirectBuildPropertyGroupString}
+{treatWarningsAsErrorsPropertyGroupString}
+{optimizeIndirectBuildPropertyGroupString}
+
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+
+            bool runSuccess = instance.Build(target: "_ComputeSkipAnalyzers", GetTestLoggers());
+            Assert.True(runSuccess);
+
+            var analyzersEnabled = runAnalyzers ?? true;
+            var expectedImplicitlySkippedAnalyzers = analyzersEnabled &&
+                indirectBuild == true &&
+                (treatWarningsAsErrors != true || optimizeIndirectBuild == true);
+            var expectedImplicitlySkippedAnalyzersValue = expectedImplicitlySkippedAnalyzers ? "true" : "";
+            var actualImplicitlySkippedAnalyzersValue = instance.GetPropertyValue("_ImplicitlySkipAnalyzers");
+            Assert.Equal(expectedImplicitlySkippedAnalyzersValue, actualImplicitlySkippedAnalyzersValue);
+
+            var expectedSkipAnalyzersValue = !analyzersEnabled || expectedImplicitlySkippedAnalyzers ? "true" : "";
+            var actualSkipAnalyzersValue = instance.GetPropertyValue("_SkipAnalyzers");
+            Assert.Equal(expectedSkipAnalyzersValue, actualSkipAnalyzersValue);
+            return;
+
+            static string getPropertyGroup(string propertyName, bool? propertyValue)
+            {
+                if (!propertyValue.HasValue)
+                {
+                    return string.Empty;
+                }
+
+                return $@"
+    <PropertyGroup>
+        <{propertyName}>{propertyValue.Value}</{propertyName}>
+    </PropertyGroup>";
+            }
+        }
+
+        [Theory, CombinatorialData]
+        [WorkItem(1337109, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1337109")]
+        public void TestLastBuildWithSkipAnalyzers(
+            [CombinatorialValues(true, false, null)] bool? runAnalyzers,
+            bool lastBuildWithSkipAnalyzersFileExists)
+        {
+            var runAnalyzersPropertyGroupString = getPropertyGroup("RunAnalyzers", runAnalyzers);
+            var intermediatePathDir = Temp.CreateDirectory();
+            var intermediatePath = intermediatePathDir + Path.DirectorySeparatorChar.ToString();
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <Import Project=""Microsoft.Managed.Core.targets"" />
+
+{runAnalyzersPropertyGroupString}
+
+    <PropertyGroup>
+        <IntermediateOutputPath>{intermediatePath}</IntermediateOutputPath>
+    </PropertyGroup>
+
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+
+            var msbuildProjectFileName = instance.GetPropertyValue("MSBuildProjectFile");
+            var expectedLastBuildWithSkipAnalyzers = intermediatePath + msbuildProjectFileName + ".BuildWithSkipAnalyzers";
+            if (lastBuildWithSkipAnalyzersFileExists)
+            {
+                _ = intermediatePathDir.CreateFile(msbuildProjectFileName + ".BuildWithSkipAnalyzers");
+            }
+
+            bool runSuccess = instance.Build(target: "_ComputeSkipAnalyzers", GetTestLoggers());
+            Assert.True(runSuccess);
+
+            var actualLastBuildWithSkipAnalyzers = instance.GetPropertyValue("LastBuildWithSkipAnalyzers");
+            Assert.Equal(expectedLastBuildWithSkipAnalyzers, actualLastBuildWithSkipAnalyzers);
+
+            var skipAnalyzers = !(runAnalyzers ?? true);
+            var expectedCustomAdditionalCompileInput = lastBuildWithSkipAnalyzersFileExists && !skipAnalyzers;
+
+            var items = instance.GetItems("CustomAdditionalCompileInputs");
+            var expectedItemCount = expectedCustomAdditionalCompileInput ? 1 : 0;
+            Assert.Equal(expectedItemCount, items.Count);
+            if (expectedCustomAdditionalCompileInput)
+            {
+                Assert.Equal(expectedLastBuildWithSkipAnalyzers, items.Single().EvaluatedInclude);
+            }
+
+            var expectedUpToDateCheckInput = lastBuildWithSkipAnalyzersFileExists;
+            items = instance.GetItems("UpToDateCheckInput");
+            expectedItemCount = expectedUpToDateCheckInput ? 1 : 0;
+            Assert.Equal(expectedItemCount, items.Count);
+            if (expectedUpToDateCheckInput)
+            {
+                var item = items.Single();
+                Assert.Equal(expectedLastBuildWithSkipAnalyzers, item.EvaluatedInclude);
+                Assert.Equal("IndirectBuild", item.GetMetadataValue("Kind"));
+            }
+
+            return;
+
+            static string getPropertyGroup(string propertyName, bool? propertyValue)
+            {
+                if (!propertyValue.HasValue)
+                {
+                    return string.Empty;
+                }
+
+                return $@"
+    <PropertyGroup>
+        <{propertyName}>{propertyValue.Value}</{propertyName}>
+    </PropertyGroup>";
+            }
+        }
+
         [Fact]
         public void ProjectCapabilityIsNotAddedWhenRoslynComponentIsUnspecified()
         {
@@ -767,6 +899,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             addTask(proj, "MakeDir", new()
             {
                 { "Directories", "System.String[]" }
+            });
+
+            // dummy Message task
+            addTask(proj, "Message", new()
+            {
+                { "Text", "System.String" },
+                { "Importance", "System.String" }
             });
 
             // create an instance and return it


### PR DESCRIPTION
…ed builds inside Visual Studio

Work towards [AB#1337109](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1337109)

## Overview

For builds which are implicitly triggered inside Visual Studio from commands such as 'Run Tests' or 'Start Debugging', we implicitly skip analyzers to speed up these builds.

Such builds will set a special property `IsImplicitlyTriggeredBuild` to `true`, which guards the implicit skip analyzers logic. We display a special message to inform the users about us implicitly skipping analyzers to speed up the build. Note this message was provided to us by the UX team.

To enable MSBuild's incremental build logic and project system's fast-upto-date check logic to work correctly, we create/touch a special semaphore file to indicate the time stamp for last build with skipAnalyzers flag. This semaphore file is passed as a custom additional file input to builds without skipAnalyzers flag to ensure correct incremental builds. Additionally, we pass this file as an 'UpToDateCheckInput' item for project system's fast-upto-date check.

## Testing

[AB#1337109](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1337109) requires few more WIP PRs to go through to work end-to-end:
1. Changes on Unit testing repo (Run tests and Debug tests commands) and Start Debugging command to set `IsImplicitlyTriggeredBuild` to `true` for builds indirectly triggered from these commands. I am working on these changes.
2. Change to project-system repo to update the fast-upto-date check logic to work correctly. @drewnoakes is driving that work.

I was able to locally build bits with both the above changes + changes from this PR and verify end-to-end functioning of this feature for Run Tests/Debug Tests command. Demo provided below.

## Demo

![ImplicitlySkipAnalyzersForIndirectBuilds](https://user-images.githubusercontent.com/10605811/122260183-9871cd80-cef0-11eb-9d12-e105f828eec5.gif)