### PR TITLE
Use segmented collection for faster declaration cache

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -4333,7 +4333,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (SingleTypeDeclaration typeDecl in current.Declarations)
                 {
-                    if (typeDecl.MemberNames.Contains(_name))
+                    if (typeDecl.MemberNames.ContainsKey(_name))
                     {
                         return true;
                     }

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.cs
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 mergedRoot,
                 n => n == name,
                 filter,
-                t => t.MemberNames.Contains(name),
+                t => t.MemberNames.ContainsKey(name),
                 cancellationToken);
         }
 
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 mergedRoot, predicate, filter,
                 t =>
                 {
-                    foreach (var name in t.MemberNames)
+                    foreach (var (name, _) in t.MemberNames)
                     {
                         if (predicate(name))
                         {

--- a/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (_lazyMemberNames == null)
                 {
-                    var names = UnionCollection<string>.Create(this.Declarations, d => d.MemberNames);
+                    var names = UnionCollection<string>.Create(this.Declarations, d => d.MemberNames.Keys);
                     Interlocked.CompareExchange(ref _lazyMemberNames, names, null);
                 }
 

--- a/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeDeclarationFlags declFlags,
             SyntaxReference syntaxReference,
             SourceLocation nameLocation,
-            ImmutableHashSet<string> memberNames,
+            ImmutableSegmentedDictionary<string, VoidResult> memberNames,
             ImmutableArray<SingleTypeDeclaration> children,
             ImmutableArray<Diagnostic> diagnostics)
             : base(name, syntaxReference, nameLocation, diagnostics)
@@ -100,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public ImmutableHashSet<string> MemberNames { get; }
+        public ImmutableSegmentedDictionary<string, VoidResult> MemberNames { get; }
 
         public bool AnyMemberHasExtensionMethodSyntax
         {

--- a/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionaryBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableSegmentedDictionaryBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Collections
+{
+    internal static class ImmutableSegmentedDictionaryBuilderExtensions
+    {
+        public static bool TryAdd<T>(
+            this ImmutableSegmentedDictionary<T, VoidResult>.Builder dictionary,
+            T value)
+            where T : notnull
+        {
+#if NETCOREAPP
+            return dictionary.TryAdd(value, default);
+#else
+            if (dictionary.ContainsKey(value))
+                return false;
+
+            dictionary[value] = default;
+            return true;
+#endif
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/VoidResult.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/VoidResult.cs
@@ -7,5 +7,5 @@ namespace Roslyn.Utilities
     /// <summary>
     /// Explicitly indicates result is void
     /// </summary>
-    internal struct VoidResult { }
+    internal readonly struct VoidResult { }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Singleton.Enumerator`1.cs" Link="InternalUtilities\SpecializedCollections.Singleton.Enumerator`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\StringExtensions.cs" Link="InternalUtilities\StringExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ValueTaskFactory.cs" Link="InternalUtilities\ValueTaskFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\VoidResult.cs" Link="InternalUtilities\VoidResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\YieldAwaitableExtensions.cs" Link="InternalUtilities\YieldAwaitableExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Syntax\SyntaxTreeExtensions.cs" Link="Syntax\SyntaxTreeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\Collections\ImmutableArrayExtensions.cs" Link="Collections\ImmutableArrayExtensions.cs" />
@@ -453,7 +454,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ValuesSources\WeaklyCachedRecoverableValueSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ValuesSources\WeaklyCachedValueSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ValuesSources\WeakValueSource.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Utilities\VoidResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\WeakEventHandler.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Ideally `ImmutableSegmentedHashSet<string>` would be used, but this type is not currently available. As an interim solution, `ImmutableSegmentedDictionary<string, VoidResult>` is used as a set.

This addresses 10-20% of the allocation load in [AB#1343268](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1343268), where GC is a significant contributor to slowness.