### PR TITLE
Handle typeparamref correctly when used with inheritdoc

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6862,6 +6862,36 @@ void $$M(int x, int y) { }";
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestInheritdocWithTypeParamRef()
+        {
+            var markup =
+@"
+public class Program
+{
+    public static void Main() => _ = new Test<int>().$$Clone();
+}
+
+public class Test<T> : ICloneable<Test<T>>
+{
+	/// <inheritdoc/>
+	public Test<T> Clone() => new();
+}
+
+/// <summary>A type that has clonable instances.</summary>
+/// <typeparam name=""T"">The type of instances that can be cloned.</typeparam>
+public interface ICloneable<T>
+{
+    /// <summary>Clones a <typeparamref name=""T""/>.</summary>
+    /// <returns>A clone of the <typeparamref name=""T""/>.</returns>
+    public T Clone();
+}";
+
+            await TestInClassAsync(markup,
+                MainDescription("Test<int> Test<int>.Clone()"),
+                Documentation("Clones a Test<int>"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestInheritdocCycle1()
         {
             var markup =

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6888,7 +6888,7 @@ public interface ICloneable<T>
 
             await TestInClassAsync(markup,
                 MainDescription("Test<int> Test<int>.Clone()"),
-                Documentation("Clones a Test<T>"));
+                Documentation("Clones a Test<T>."));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6888,7 +6888,7 @@ public interface ICloneable<T>
 
             await TestInClassAsync(markup,
                 MainDescription("Test<int> Test<int>.Clone()"),
-                Documentation("Clones a Test<int>"));
+                Documentation("Clones a Test<T>"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -441,6 +441,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                         public T Clone();
                     }
                 */
+                // Note: there is no way to cref an instantiated generic type. See https://github.com/dotnet/csharplang/issues/401
                 var typeParameterRefs = document.Descendants(DocumentationCommentXmlNames.TypeParameterReferenceElementName).ToImmutableArray();
                 foreach (var typeParameterRef in typeParameterRefs)
                 {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -424,6 +424,43 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     }
                 }
 
+                // Consider the following code, we want Test<int>.Clone to say "Clones a Test<int>" instead of "Clones a int", thus
+                // we rewrite `typeparamref`s as cref pointing to the correct type:
+                /*
+                    public class Test<T> : ICloneable<Test<T>>
+                    {
+                        /// <inheritdoc/>
+                        public Test<T> Clone() => new();
+                    }
+
+                    /// <summary>A type that has clonable instances.</summary>
+                    /// <typeparam name="T">The type of instances that can be cloned.</typeparam>
+                    public interface ICloneable<T>
+                    {
+                        /// <summary>Clones a <typeparamref name="T"/>.</summary>
+                        public T Clone();
+                    }
+                */
+                var typeParameterRefs = document.Descendants(DocumentationCommentXmlNames.TypeParameterReferenceElementName).ToImmutableArray();
+                foreach (var typeParameterRef in typeParameterRefs)
+                {
+                    if (typeParameterRef.Attribute(DocumentationCommentXmlNames.NameAttributeName) is var typeParamName)
+                    {
+                        var index = symbol.OriginalDefinition.GetAllTypeParameters().IndexOf(p => p.Name == typeParamName.Value);
+                        if (index >= 0)
+                        {
+                            var typeArgs = symbol.GetAllTypeArguments();
+                            if (index < typeArgs.Length)
+                            {
+                                var docId = typeArgs[index].GetDocumentationCommentId();
+                                var replacement = new XElement(DocumentationCommentXmlNames.SeeElementName);
+                                replacement.SetAttributeValue(DocumentationCommentXmlNames.CrefAttributeName, docId);
+                                typeParameterRef.ReplaceWith(replacement);
+                            }
+                        }
+                    }
+                }
+
                 var loadedElements = TrySelectNodes(document, xpathValue);
                 if (loadedElements is null)
                 {


### PR DESCRIPTION
Fixes #54069

The result here isn't as fully expected. See https://github.com/Youssef1313/roslyn/commit/984c295a322d50cb01e3c8ada4714cf667a3e6ed#r52265917