### PR TITLE
Minor display change (spacing) in ExceptionHelper

### DIFF
--- a/src/Compilers/Test/Core/ExceptionHelper.cs
+++ b/src/Compilers/Test/Core/ExceptionHelper.cs
@@ -58,7 +58,7 @@ namespace Roslyn.Test.Utilities
             {
                 sb.Append("Expected: ");
                 sb.AppendLine(expectedOutput);
-                sb.Append("Actual:   ");
+                sb.Append("Actual: ");
                 sb.AppendLine(actualOutput);
             }
             else


### PR DESCRIPTION
It's very very minor, but it was distracting me a little bit when the runtime behavior I'm testing involves spaces.