### PR TITLE
Allow snippet format in XAML compeltion

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Features/Completion/XamlCompletionItem.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Completion/XamlCompletionItem.cs
@@ -27,5 +27,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Completion
         public ISymbol Symbol { get; set; }
         public XamlEventDescription? EventDescription { get; set; }
         public bool RetriggerCompletion { get; set; }
+        public bool InsertSnippet { get; set; }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Features/Completion/XamlCompletionItem.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Completion/XamlCompletionItem.cs
@@ -27,6 +27,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Completion
         public ISymbol Symbol { get; set; }
         public XamlEventDescription? EventDescription { get; set; }
         public bool RetriggerCompletion { get; set; }
-        public bool InsertSnippet { get; set; }
+        public bool IsSnippet { get; set; }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
 
         /// <summary>
         /// Gets the name of the language client (displayed in yellow bars).
+        /// When updating the string of Name, please make sure to update the same string in Microsoft.VisualStudio.LanguageServer.Client.ExperimentalSnippetSupport.AllowList
         /// </summary>
         public override string Name => "XAML Language Server Client (Experimental)";
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
@@ -93,6 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 Kind = GetItemKind(xamlCompletion.Kind),
                 Description = xamlCompletion.Description,
                 Icon = xamlCompletion.Icon,
+                InsertTextFormat = xamlCompletion.InsertSnippet ? InsertTextFormat.Snippet : InsertTextFormat.Plaintext,
                 Data = new CompletionResolveData { ProjectGuid = documentId.ProjectId.Id, DocumentGuid = documentId.Id, Position = position, DisplayText = xamlCompletion.DisplayText }
             };
 
@@ -119,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 // Retriger completion after commit
                 item.Command = s_retriggerCompletionCommand;
             }
-
+ 
             return item;
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 // Retriger completion after commit
                 item.Command = s_retriggerCompletionCommand;
             }
- 
+
             return item;
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionHandler.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 Kind = GetItemKind(xamlCompletion.Kind),
                 Description = xamlCompletion.Description,
                 Icon = xamlCompletion.Icon,
-                InsertTextFormat = xamlCompletion.InsertSnippet ? InsertTextFormat.Snippet : InsertTextFormat.Plaintext,
+                InsertTextFormat = xamlCompletion.IsSnippet ? InsertTextFormat.Snippet : InsertTextFormat.Plaintext,
                 Data = new CompletionResolveData { ProjectGuid = documentId.ProjectId.Id, DocumentGuid = documentId.Id, Position = position, DisplayText = xamlCompletion.DisplayText }
             };
 


### PR DESCRIPTION
This change gives XAML language service the capability to tell LSP completion whether the inset text format is snippet or just plaintext. So we will be able to do completions like inserting ="|" when committing a XAML attribute.