### PR TITLE
Flatten various incremental contexts:

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -17,18 +17,15 @@ Microsoft.CodeAnalysis.IIncrementalGenerator
 Microsoft.CodeAnalysis.IIncrementalGenerator.Initialize(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context) -> void
 Microsoft.CodeAnalysis.IMethodSymbol.IsPartialDefinition.get -> bool
 Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.AdditionalTextsProvider.get -> Microsoft.CodeAnalysis.IncrementalValuesProvider<Microsoft.CodeAnalysis.AdditionalText!>
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.AnalyzerConfigOptionsProvider.get -> Microsoft.CodeAnalysis.IncrementalValueProvider<Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider!>
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.CompilationProvider.get -> Microsoft.CodeAnalysis.IncrementalValueProvider<Microsoft.CodeAnalysis.Compilation!>
 Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.IncrementalGeneratorInitializationContext() -> void
-Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.RegisterExecutionPipeline(System.Action<Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext>! callback) -> void
-Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.RegisterForPostInitialization(System.Action<Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext>! callback) -> void
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.AdditionalTextsProvider.get -> Microsoft.CodeAnalysis.IncrementalValuesProvider<Microsoft.CodeAnalysis.AdditionalText!>
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.AnalyzerConfigOptionsProvider.get -> Microsoft.CodeAnalysis.IncrementalValueProvider<Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider!>
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.CompilationProvider.get -> Microsoft.CodeAnalysis.IncrementalValueProvider<Microsoft.CodeAnalysis.Compilation!>
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.IncrementalGeneratorPipelineContext() -> void
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.ParseOptionsProvider.get -> Microsoft.CodeAnalysis.IncrementalValueProvider<Microsoft.CodeAnalysis.ParseOptions!>
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.RegisterSourceOutput<TSource>(Microsoft.CodeAnalysis.IncrementalValueProvider<TSource> source, System.Action<Microsoft.CodeAnalysis.SourceProductionContext, TSource>! action) -> void
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.RegisterSourceOutput<TSource>(Microsoft.CodeAnalysis.IncrementalValuesProvider<TSource> source, System.Action<Microsoft.CodeAnalysis.SourceProductionContext, TSource>! action) -> void
-Microsoft.CodeAnalysis.IncrementalGeneratorPipelineContext.SyntaxProvider.get -> Microsoft.CodeAnalysis.SyntaxValueProvider
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.ParseOptionsProvider.get -> Microsoft.CodeAnalysis.IncrementalValueProvider<Microsoft.CodeAnalysis.ParseOptions!>
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.RegisterPostInitializationOutput(System.Action<Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext>! callback) -> void
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.RegisterSourceOutput<TSource>(Microsoft.CodeAnalysis.IncrementalValueProvider<TSource> source, System.Action<Microsoft.CodeAnalysis.SourceProductionContext, TSource>! action) -> void
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.RegisterSourceOutput<TSource>(Microsoft.CodeAnalysis.IncrementalValuesProvider<TSource> source, System.Action<Microsoft.CodeAnalysis.SourceProductionContext, TSource>! action) -> void
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.SyntaxProvider.get -> Microsoft.CodeAnalysis.SyntaxValueProvider
 Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext
 Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext.AddSource(string! hintName, Microsoft.CodeAnalysis.Text.SourceText! sourceText) -> void
 Microsoft.CodeAnalysis.IncrementalGeneratorPostInitializationContext.AddSource(string! hintName, string! source) -> void

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorInfo.cs
@@ -12,11 +12,11 @@ namespace Microsoft.CodeAnalysis
 
         internal Action<IncrementalGeneratorPostInitializationContext>? PostInitCallback { get; }
 
-        internal Action<IncrementalGeneratorPipelineContext>? PipelineCallback { get; }
+        internal Action<IncrementalGeneratorInitializationContext>? PipelineCallback { get; }
 
         internal bool Initialized { get; }
 
-        internal GeneratorInfo(SyntaxContextReceiverCreator? receiverCreator, Action<IncrementalGeneratorPostInitializationContext>? postInitCallback, Action<IncrementalGeneratorPipelineContext>? pipelineCallback)
+        internal GeneratorInfo(SyntaxContextReceiverCreator? receiverCreator, Action<IncrementalGeneratorPostInitializationContext>? postInitCallback, Action<IncrementalGeneratorInitializationContext>? pipelineCallback)
         {
             SyntaxContextReceiverCreator = receiverCreator;
             PostInitCallback = postInitCallback;
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
 
             internal Action<IncrementalGeneratorPostInitializationContext>? PostInitCallback { get; set; }
 
-            internal Action<IncrementalGeneratorPipelineContext>? PipelineCallback { get; set; }
+            internal Action<IncrementalGeneratorInitializationContext>? PipelineCallback { get; set; }
 
             public GeneratorInfo ToImmutable() => new GeneratorInfo(SyntaxContextReceiverCreator, PostInitCallback, PipelineCallback);
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -13,11 +13,6 @@ namespace Microsoft.CodeAnalysis
     internal readonly struct GeneratorState
     {
         /// <summary>
-        /// Gets an uninitialized generator state
-        /// </summary>
-        internal static GeneratorState Uninitialized;
-
-        /// <summary>
         /// Creates a new generator state that just contains information
         /// </summary>
         public GeneratorState(GeneratorInfo info)
@@ -59,6 +54,7 @@ namespace Microsoft.CodeAnalysis
 
         private GeneratorState(GeneratorInfo info, ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<ISyntaxInputNode> inputNodes, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, ImmutableArray<GeneratedSyntaxTree> generatedTrees, ImmutableArray<Diagnostic> diagnostics, Exception? exception)
         {
+            this.Initialized = true;
             this.PostInitTrees = postInitTrees;
             this.InputNodes = inputNodes;
             this.OutputNodes = outputNodes;
@@ -67,6 +63,8 @@ namespace Microsoft.CodeAnalysis
             this.Diagnostics = diagnostics;
             this.Exception = exception;
         }
+
+        internal bool Initialized { get; }
 
         internal ImmutableArray<GeneratedSyntaxTree> PostInitTrees { get; }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorOutputNode.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -13,6 +14,14 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal interface IIncrementalGeneratorOutputNode
     {
-        void AppendOutputs(IncrementalExecutionContext context);
+        void AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken);
+
+        IncrementalGeneratorOutputKind Kind { get; }
+    }
+
+    internal enum IncrementalGeneratorOutputKind
+    {
+        Source,
+        PostInit
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorOutputNode.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal interface IIncrementalGeneratorOutputNode
     {
-        void AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken);
-
         IncrementalGeneratorOutputKind Kind { get; }
+
+        void AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken);
     }
 
     internal enum IncrementalGeneratorOutputKind

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/PostInitOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/PostInitOutputNode.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal class PostInitOutputNode : IIncrementalGeneratorOutputNode
+    internal sealed class PostInitOutputNode : IIncrementalGeneratorOutputNode
     {
         private readonly Action<IncrementalGeneratorPostInitializationContext> _callback;
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/PostInitOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/PostInitOutputNode.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal class PostInitOutputNode : IIncrementalGeneratorOutputNode
+    {
+        private readonly Action<IncrementalGeneratorPostInitializationContext> _callback;
+
+        public PostInitOutputNode(Action<IncrementalGeneratorPostInitializationContext> callback)
+        {
+            _callback = callback;
+        }
+
+        public IncrementalGeneratorOutputKind Kind => IncrementalGeneratorOutputKind.PostInit;
+
+        public void AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken)
+        {
+            _callback(new IncrementalGeneratorPostInitializationContext(context.Sources, cancellationToken));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -23,6 +24,8 @@ namespace Microsoft.CodeAnalysis
             _source = source;
             _action = action;
         }
+
+        public IncrementalGeneratorOutputKind Kind => IncrementalGeneratorOutputKind.Source;
 
         public NodeStateTable<TOutput> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<TOutput> previousTable, CancellationToken cancellationToken)
         {
@@ -71,9 +74,10 @@ namespace Microsoft.CodeAnalysis
 
         void IIncrementalGeneratorNode<TOutput>.RegisterOutput(IIncrementalGeneratorOutputNode output) => throw ExceptionUtilities.Unreachable;
 
-        public void AppendOutputs(IncrementalExecutionContext context)
+        public void AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken)
         {
             // get our own state table
+            Debug.Assert(context.TableBuilder is object);
             var table = context.TableBuilder.GetLatestStateTableForNode(this);
 
             // add each non-removed entry to the context

--- a/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
@@ -42,13 +42,28 @@ namespace Microsoft.CodeAnalysis
             return (input, token) => userFunction.WrapUserFunction()(input, token).ToImmutableArray();
         }
 
-        internal static Action<TInput1, TInput2> WrapUserAction<TInput1, TInput2>(this Action<TInput1, TInput2> userFunction)
+        internal static Action<TInput> WrapUserAction<TInput>(this Action<TInput> userAction)
+        {
+            return input =>
+            {
+                try
+                {
+                    userAction(input);
+                }
+                catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
+                {
+                    throw new UserFunctionException(e);
+                }
+            };
+        }
+
+        internal static Action<TInput1, TInput2> WrapUserAction<TInput1, TInput2>(this Action<TInput1, TInput2> userAction)
         {
             return (input1, input2) =>
             {
                 try
                 {
-                    userFunction(input1, input2);
+                    userAction(input1, input2);
                 }
                 catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
                 {

--- a/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
@@ -86,40 +86,28 @@ namespace Roslyn.Test.Utilities.TestGenerators
 
     }
 
-    internal sealed class IncrementalCallbackGenerator : IIncrementalGenerator
-    {
-        private readonly Action<IncrementalGeneratorInitializationContext> _onInit;
-
-        public IncrementalCallbackGenerator(Action<IncrementalGeneratorInitializationContext> onInit)
-        {
-            _onInit = onInit;
-        }
-
-        public void Initialize(IncrementalGeneratorInitializationContext context) => _onInit(context);
-    }
-
     internal sealed class PipelineCallbackGenerator : IIncrementalGenerator
     {
-        private readonly Action<IncrementalGeneratorPipelineContext> _registerPipelineCallback;
+        private readonly Action<IncrementalGeneratorInitializationContext> _registerPipelineCallback;
 
-        public PipelineCallbackGenerator(Action<IncrementalGeneratorPipelineContext> registerPipelineCallback)
+        public PipelineCallbackGenerator(Action<IncrementalGeneratorInitializationContext> registerPipelineCallback)
         {
             _registerPipelineCallback = registerPipelineCallback;
         }
 
-        public void Initialize(IncrementalGeneratorInitializationContext context) => context.RegisterExecutionPipeline(_registerPipelineCallback);
+        public void Initialize(IncrementalGeneratorInitializationContext context) => _registerPipelineCallback(context);
     }
 
     internal sealed class PipelineCallbackGenerator2 : IIncrementalGenerator
     {
-        private readonly Action<IncrementalGeneratorPipelineContext> _registerPipelineCallback;
+        private readonly Action<IncrementalGeneratorInitializationContext> _registerPipelineCallback;
 
-        public PipelineCallbackGenerator2(Action<IncrementalGeneratorPipelineContext> registerPipelineCallback)
+        public PipelineCallbackGenerator2(Action<IncrementalGeneratorInitializationContext> registerPipelineCallback)
         {
             _registerPipelineCallback = registerPipelineCallback;
         }
 
-        public void Initialize(IncrementalGeneratorInitializationContext context) => context.RegisterExecutionPipeline(_registerPipelineCallback);
+        public void Initialize(IncrementalGeneratorInitializationContext context) => _registerPipelineCallback(context);
     }
 
     internal sealed class IncrementalAndSourceCallbackGenerator : CallbackGenerator, IIncrementalGenerator

--- a/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
+++ b/src/Workspaces/CoreTestUtilities/GenerateFileForEachAdditionalFileWithContentsCommented.cs
@@ -25,13 +25,10 @@ namespace Roslyn.Test.Utilities
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            context.RegisterExecutionPipeline(context =>
-            {
-                context.RegisterSourceOutput(context.AdditionalTextsProvider, (context, additionalText) =>
-                    context.AddSource(
-                        GetGeneratedFileName(additionalText.Path),
-                        GenerateSourceForAdditionalFile(additionalText, context.CancellationToken)));
-            });
+            context.RegisterSourceOutput(context.AdditionalTextsProvider, (context, additionalText) =>
+                context.AddSource(
+                    GetGeneratedFileName(additionalText.Path),
+                    GenerateSourceForAdditionalFile(additionalText, context.CancellationToken)));
         }
 
         private SourceText GenerateSourceForAdditionalFile(AdditionalText file, CancellationToken cancellationToken)


### PR DESCRIPTION
- Make post init be another kind of output
- Remove the post init callback
- Add IncrementalGeneratorOutputKind to distinguish output node types
- Update tests

Agreed as part of API review. 

Closes https://github.com/dotnet/roslyn/issues/54109