### PR TITLE
Add nullable ref annotations to SyntaxFactory

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
     public partial class IfStatementSyntax
     {
-        public IfStatementSyntax Update(SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax @else)
+        public IfStatementSyntax Update(SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
             => Update(AttributeLists, ifKeyword, openParenToken, condition, closeParenToken, statement, @else);
     }
 }
@@ -17,10 +17,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     public partial class SyntaxFactory
     {
-        public static IfStatementSyntax IfStatement(ExpressionSyntax condition, StatementSyntax statement, ElseClauseSyntax @else)
+        public static IfStatementSyntax IfStatement(ExpressionSyntax condition, StatementSyntax statement, ElseClauseSyntax? @else)
             => IfStatement(attributeLists: default, condition, statement, @else);
 
-        public static IfStatementSyntax IfStatement(SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax @else)
+        public static IfStatementSyntax IfStatement(SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
             => IfStatement(attributeLists: default, ifKeyword, openParenToken, condition, closeParenToken, statement, @else);
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/PropertyDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/PropertyDeclarationSyntax.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     // backwards compatibility for API extension
     public sealed partial class AccessorDeclarationSyntax : CSharpSyntaxNode
     {
-        public AccessorDeclarationSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken keyword, BlockSyntax body, SyntaxToken semicolonToken)
+        public AccessorDeclarationSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken keyword, BlockSyntax? body, SyntaxToken semicolonToken)
             => Update(attributeLists, modifiers, keyword, body, expressionBody: null, semicolonToken);
     }
 }
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     public partial class SyntaxFactory
     {
         /// <summary>Creates a new AccessorDeclarationSyntax instance.</summary>
-        public static AccessorDeclarationSyntax AccessorDeclaration(SyntaxKind kind, BlockSyntax body)
+        public static AccessorDeclarationSyntax AccessorDeclaration(SyntaxKind kind, BlockSyntax? body)
         {
             return SyntaxFactory.AccessorDeclaration(kind, default(SyntaxList<AttributeListSyntax>), default(SyntaxTokenList), SyntaxFactory.Token(GetAccessorDeclarationKeywordKind(kind)), body, expressionBody: null, default(SyntaxToken));
         }

--- a/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ReturnStatementSyntax.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
     public partial class ReturnStatementSyntax
     {
-        public ReturnStatementSyntax Update(SyntaxToken returnKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
+        public ReturnStatementSyntax Update(SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)
             => Update(AttributeLists, returnKeyword, expression, semicolonToken);
     }
 }
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     public partial class SyntaxFactory
     {
-        public static ReturnStatementSyntax ReturnStatement(SyntaxToken returnKeyword, ExpressionSyntax expression, SyntaxToken semicolonToken)
+        public static ReturnStatementSyntax ReturnStatement(SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)
             => ReturnStatement(attributeLists: default, returnKeyword, expression, semicolonToken);
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -1402,7 +1402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="nodes">A sequence of syntax nodes.</param>
         /// <param name="separators">A sequence of token to be interleaved between the nodes. The number of tokens must
         /// be one less than the number of nodes.</param>
-        public static SeparatedSyntaxList<TNode> SeparatedList<TNode>(IEnumerable<TNode> nodes, IEnumerable<SyntaxToken> separators) where TNode : SyntaxNode
+        public static SeparatedSyntaxList<TNode> SeparatedList<TNode>(IEnumerable<TNode>? nodes, IEnumerable<SyntaxToken>? separators) where TNode : SyntaxNode
         {
             // Interleave the nodes and the separators.  The number of separators must be equal to or 1 less than the number of nodes or
             // an argument exception is thrown.


### PR DESCRIPTION
The overloads these were calling allow for null values.

There are probably many more like this that I didn't happen to run into. I recommend an audit around the pattern where these bugs were found.