### PR TITLE
Fix make static to not drop trivia

### DIFF
--- a/src/EditorFeatures/CSharpTest/MakeMemberStatic/MakeMemberStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeMemberStatic/MakeMemberStaticTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.MakeMemberStatic;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MakeMemberStatic
@@ -30,6 +31,25 @@ public static class Foo
 public static class Foo
 {
     static int i;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        [WorkItem(54202, "https://github.com/dotnet/roslyn/issues/54202")]
+        public async Task TestTrivia()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"
+public static class Foo
+{
+    // comment
+    readonly int {|CS0708:i|};
+}",
+@"
+public static class Foo
+{
+    // comment
+    readonly static int i;
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/MakeMemberStatic/MakeMemberStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeMemberStatic/MakeMemberStaticTests.cs
@@ -49,7 +49,7 @@ public static class Foo
 public static class Foo
 {
     // comment
-    readonly static int i;
+    static readonly int i;
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/MakeMemberStatic/MakeMemberStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeMemberStatic/MakeMemberStaticTests.cs
@@ -2,37 +2,29 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using Microsoft.CodeAnalysis.CSharp.MakeMemberStatic;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.MakeMemberStatic;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MakeMemberStatic
 {
-    public class MakeMemberStaticTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    using VerifyCS = CSharpCodeFixVerifier<
+        EmptyDiagnosticAnalyzer,
+        CSharpMakeMemberStaticCodeFixProvider>;
+
+    public class MakeMemberStaticTests
     {
-        public MakeMemberStaticTests(ITestOutputHelper logger)
-          : base(logger)
-        {
-        }
-
-        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (null, new CSharpMakeMemberStaticCodeFixProvider());
-
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
         public async Task TestField()
         {
-            await TestInRegularAndScript1Async(
+            await VerifyCS.VerifyCodeFixAsync(
 @"
 public static class Foo
 {
-    int [||]i;
+    int {|CS0708:i|};
 }",
 @"
 public static class Foo
@@ -44,11 +36,11 @@ public static class Foo
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
         public async Task TestMethod()
         {
-            await TestInRegularAndScript1Async(
+            await VerifyCS.VerifyCodeFixAsync(
 @"
 public static class Foo
 {
-    void [||]M() { }
+    void {|CS0708:M|}() { }
 }",
 @"
 public static class Foo
@@ -60,11 +52,11 @@ public static class Foo
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
         public async Task TestProperty()
         {
-            await TestInRegularAndScript1Async(
+            await VerifyCS.VerifyCodeFixAsync(
 @"
 public static class Foo
 {
-    object [||]P { get; set; }
+    object {|CS0708:P|} { get; set; }
 }",
 @"
 public static class Foo
@@ -76,11 +68,11 @@ public static class Foo
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
         public async Task TestEventField()
         {
-            await TestInRegularAndScript1Async(
+            await VerifyCS.VerifyCodeFixAsync(
 @"
 public static class Foo
 {
-    event System.Action [||]E;
+    event System.Action {|CS0708:E|};
 }",
 @"
 public static class Foo
@@ -92,15 +84,15 @@ public static class Foo
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
         public async Task FixAll()
         {
-            await TestInRegularAndScript1Async(
+            await VerifyCS.VerifyCodeFixAsync(
 @"namespace NS
 {
     public static class Foo
     {
-        int {|FixAllInDocument:|}i;
-        void M() { }
-        object P { get; set; }
-        event System.Action E;
+        int {|CS0708:i|};
+        void {|CS0708:M|}() { }
+        object {|CS0708:P|} { get; set; }
+        event System.Action {|CS0708:E|};
     }
 }",
 @"namespace NS

--- a/src/Features/CSharp/Portable/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MakeMemberStatic;
 
 namespace Microsoft.CodeAnalysis.CSharp.MakeMemberStatic
@@ -18,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMemberStatic
     internal sealed class CSharpMakeMemberStaticCodeFixProvider : AbstractMakeMemberStaticCodeFixProvider
     {
         [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpMakeMemberStaticCodeFixProvider()
         {
         }

--- a/src/Features/CSharp/Portable/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
@@ -36,10 +36,10 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMemberStatic
                 return true;
             }
 
-            if (node.IsKind(SyntaxKind.VariableDeclarator))
+            if (node.IsKind(SyntaxKind.VariableDeclarator) && node.Parent is VariableDeclarationSyntax { Parent: FieldDeclarationSyntax or EventFieldDeclarationSyntax })
             {
-                memberDeclaration = node.FirstAncestorOrSelf<MemberDeclarationSyntax>(a => a.IsKind(SyntaxKind.FieldDeclaration) || a.IsKind(SyntaxKind.EventFieldDeclaration));
-                return memberDeclaration is not null;
+                memberDeclaration = node.Parent.Parent;
+                return true;
             }
 
             memberDeclaration = null;

--- a/src/Features/Core/Portable/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -18,12 +17,12 @@ namespace Microsoft.CodeAnalysis.MakeMemberStatic
     {
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.Compile;
 
-        protected abstract bool IsValidMemberNode([NotNullWhen(true)] SyntaxNode? node);
+        protected abstract bool IsValidMemberNode(SyntaxNode node);
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             if (context.Diagnostics.Length == 1 &&
-                IsValidMemberNode(context.Diagnostics[0].Location?.FindNode(context.CancellationToken)))
+                IsValidMemberNode(context.Diagnostics[0].Location.FindNode(context.CancellationToken)))
             {
                 context.RegisterCodeFix(
                     new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics[0], c)),
@@ -38,7 +37,7 @@ namespace Microsoft.CodeAnalysis.MakeMemberStatic
         {
             for (var i = 0; i < diagnostics.Length; i++)
             {
-                var declaration = diagnostics[i].Location?.FindNode(cancellationToken);
+                var declaration = diagnostics[i].Location.FindNode(cancellationToken);
 
                 if (IsValidMemberNode(declaration))
                 {

--- a/src/Features/Core/Portable/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -17,12 +18,12 @@ namespace Microsoft.CodeAnalysis.MakeMemberStatic
     {
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.Compile;
 
-        protected abstract bool IsValidMemberNode(SyntaxNode node);
+        protected abstract bool TryGetMemberDeclaration(SyntaxNode node, [NotNullWhen(true)] out SyntaxNode? memberDeclaration);
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             if (context.Diagnostics.Length == 1 &&
-                IsValidMemberNode(context.Diagnostics[0].Location.FindNode(context.CancellationToken)))
+                TryGetMemberDeclaration(context.Diagnostics[0].Location.FindNode(context.CancellationToken), out _))
             {
                 context.RegisterCodeFix(
                     new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics[0], c)),
@@ -39,10 +40,11 @@ namespace Microsoft.CodeAnalysis.MakeMemberStatic
             {
                 var declaration = diagnostics[i].Location.FindNode(cancellationToken);
 
-                if (IsValidMemberNode(declaration))
+                if (TryGetMemberDeclaration(declaration, out var memberDeclaration))
                 {
-                    editor.ReplaceNode(declaration,
-                        (currentDeclaration, generator) => generator.WithModifiers(currentDeclaration, DeclarationModifiers.Static));
+                    var generator = SyntaxGenerator.GetGenerator(document);
+                    var newNode = generator.WithModifiers(memberDeclaration, generator.GetModifiers(declaration).WithIsStatic(true));
+                    editor.ReplaceNode(declaration, newNode);
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/54202

First commit is just a cleanup.
Second commit fixes the above issue as well as fixing dropping other modifiers.

Why the old code wasn't working? No idea tbh, I tried to dig into it but wasn't able to find the root cause. I found that SyntaxGenerator is more happy with declarations rather than declarators.