### PR TITLE
Report a hidden diagnostics instead of a warning when a using conflicts with a global using from another file.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6701,4 +6701,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>'UnmanagedCallersOnly' method '{0}' cannot implement interface member '{1}' in type '{2}'</value>
     <comment>UnmanagedCallersOnly is not localizable.</comment>
   </data>
+  <data name="HDN_DuplicateWithGlobalUsing" xml:space="preserve">
+    <value>The using directive for '{0}' appeared previously as global using</value>
+  </data>
+  <data name="HDN_DuplicateWithGlobalUsing_Title" xml:space="preserve">
+    <value>The using directive appeared previously as global using</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1956,6 +1956,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AbstractConversionNotInvolvingContainedType = 8931,
         ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod = 8932,
 
+        HDN_DuplicateWithGlobalUsing = 8933,
+
         #endregion
 
 

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -309,6 +309,7 @@
             {
                 case ErrorCode.HDN_UnusedUsingDirective:
                 case ErrorCode.HDN_UnusedExternAlias:
+                case ErrorCode.HDN_DuplicateWithGlobalUsing:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">{0} má atribut UnmanagedCallersOnly a nedá se převést na typ delegáta. Pro tuto metodu získejte ukazatel na funkci.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">kovariantní návratové hodnoty</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">"{0}" ist mit dem Attribut "UnmanagedCallersOnly" versehen und kann nicht in einen Delegattyp konvertiert werden. Rufen Sie einen Funktionszeiger auf diese Methode ab.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">Covariante Rückgaben</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">' {0} ' tiene un atributo ' UnmanagedCallersOnly ' y no se puede convertir en un tipo de delegado. Obtenga un puntero de función a este método.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">valores devueltos de covariante</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">'{0}' est attribué avec 'UnmanagedCallersOnly' et ne peut pas être converti en type délégué. Obtenez un pointeur de fonction vers cette méthode.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">retours covariants</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">'{0}', a cui è assegnato l'attributo 'UnmanagedCallersOnly', non può essere convertito in un tipo delegato. Ottenere un puntatore a funzione per questo metodo.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">tipi restituiti covarianti</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">'{0}' は 'UnmanagedCallersOnly' 属性が設定されているため、デリゲート型に変換できません。このメソッドへの関数ポインターを取得してください。</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">covariant の戻り値</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">'{0}'에는 'UnmanagedCallersOnly' 특성이 지정되어 있으며 이 항목은 대리자 형식으로 변환할 수 없습니다. 이 메서드에 대한 함수 포인터를 가져오세요.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">공변(covariant) 반환</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">Element „{0}” ma atrybut „UnmanagedCallersOnly” i nie można go przekonwertować na typ delegowany. Uzyskaj wskaźnik funkcji do tej metody.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">zwroty kowariantne</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">'{0}' foi atribuído com 'UnmanagedCallersOnly' e não pode ser convertido em um tipo delegado. Obtenha um ponteiro de função para esse método.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">retornos de covariante</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">"{0}" имеет атрибут "UnmanagedCallersOnly" и не может быть преобразован в тип делегата. Получите указатель на функцию для этого метода.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">ковариантные возвращаемые значения</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">'{0}', 'UnmanagedCallersOnly' özniteliğine sahip ve temsilci türüne dönüştürülemez. Bu yöntem için bir işlev işaretçisi edinin.</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">birlikte değişken dönüşler</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">“{0}”使用 "UnmanagedCallersOnly" 进行特性化，无法转换为委托类型。请获取指向此方法的函数指针。</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">协变返回</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1062,6 +1062,16 @@
         <target state="translated">'{0}' 使用 'UnmanagedCallersOnly' 屬性化，因此無法轉換為委派類型。取得此方法的函式指標。</target>
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing">
+        <source>The using directive for '{0}' appeared previously as global using</source>
+        <target state="new">The using directive for '{0}' appeared previously as global using</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HDN_DuplicateWithGlobalUsing_Title">
+        <source>The using directive appeared previously as global using</source>
+        <target state="new">The using directive appeared previously as global using</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">Covariant 傳回</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GlobalUsingDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GlobalUsingDirectiveTests.cs
@@ -2538,44 +2538,73 @@ class C2 {}
 
             var expected1 = new[]
             {
-                // (3000,14): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // (3000,14): hidden CS8933: The using directive for 'C2' appeared previously as global using
                 // using static C2;
-                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
             };
 
-            comp2.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected1);
+            CompileAndVerify(comp2).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected1);
 
             var comp3 = CreateCompilation(new[] { source3 + source4, source5, source6 }, parseOptions: TestOptions.RegularPreview);
 
-            var expected2 = new[]
-            {
+            CompileAndVerify(comp3).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,21): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // global using static C2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(2000, 21),
+                // (3000,14): hidden CS8933: The using directive for 'C2' appeared previously as global using
+                // using static C2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
+                );
+
+            var comp4 = CreateCompilation(new[] { source3 + source5, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp4).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (3000,14): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // using static C2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
+                );
+
+            var comp5 = CreateCompilation(new[] { source3 + source4 + source5, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp5).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
                 // (2000,21): warning CS0105: The using directive for 'C2' appeared previously in this namespace
                 // global using static C2;
                 Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(2000, 21),
                 // (3000,14): warning CS0105: The using directive for 'C2' appeared previously in this namespace
                 // using static C2;
                 Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
-            };
-
-            comp3.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected2);
-
-            var comp4 = CreateCompilation(new[] { source3 + source5, source6 }, parseOptions: TestOptions.RegularPreview);
-            comp4.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected1);
-
-            var comp5 = CreateCompilation(new[] { source3 + source4 + source5, source6 }, parseOptions: TestOptions.RegularPreview);
-            comp5.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected2);
+                );
 
             var comp6 = CreateCompilation(new[] { source3, source4, source5, source6 }, parseOptions: TestOptions.RegularPreview);
-            comp6.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected2);
+            CompileAndVerify(comp6).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,21): hidden CS8933: The using directive for 'C2' appeared previously as global using
+                // global using static C2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(2000, 21),
+                // (3000,14): hidden CS8933: The using directive for 'C2' appeared previously as global using
+                // using static C2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
+                );
 
             var comp7 = CreateCompilation(new[] { source3 + source5, source4, source6 }, parseOptions: TestOptions.RegularPreview);
-            comp7.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected2);
+            CompileAndVerify(comp7).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,21): hidden CS8933: The using directive for 'C2' appeared previously as global using
+                // global using static C2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(2000, 21),
+                // (3000,14): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // using static C2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
+                );
 
             var comp8 = CreateCompilation(new[] { source5, source3, source6 }, parseOptions: TestOptions.RegularPreview);
-            comp8.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected1);
+            CompileAndVerify(comp8).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected1);
 
             var comp9 = CreateCompilation(new[] { source5, source3, source4, source6 }, parseOptions: TestOptions.RegularPreview);
-            comp9.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected2);
+            CompileAndVerify(comp9).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,21): hidden CS8933: The using directive for 'C2' appeared previously as global using
+                // global using static C2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(2000, 21),
+                // (3000,14): hidden CS8933: The using directive for 'C2' appeared previously as global using
+                // using static C2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(3000, 14)
+                );
         }
 
         [Fact]
@@ -2593,16 +2622,16 @@ class C2 {}
 ";
             var comp2 = CreateCompilation(new[] { source2, source3 }, parseOptions: TestOptions.RegularPreview);
             comp2.GetSemanticModel(comp2.SyntaxTrees[1]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
-                // (2000,21): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // (2000,21): hidden CS8933: The using directive for 'C2' appeared previously as global using
                 // global using static C2;
-                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(2000, 21)
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(2000, 21)
                 );
 
             comp2 = CreateCompilation(new[] { source3, source2 }, parseOptions: TestOptions.RegularPreview);
             comp2.GetSemanticModel(comp2.SyntaxTrees[1]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
-                // (1000,21): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // (1000,21): hidden CS8933: The using directive for 'C2' appeared previously as global using
                 // global using static C2;
-                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(1000, 21)
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(1000, 21)
                 );
         }
 
@@ -2623,9 +2652,9 @@ class C2 {}
 
             var expected = new[]
             {
-                // (1000,14): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // (1000,14): hidden CS8933: The using directive for 'C2' appeared previously as global using
                 // using static C2;
-                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(1000, 14)
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "C2").WithArguments("C2").WithLocation(1000, 14)
             };
 
             comp2.GetSemanticModel(comp2.SyntaxTrees[1]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected);
@@ -2634,7 +2663,165 @@ class C2 {}
             comp2.GetSemanticModel(comp2.SyntaxTrees[0]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected);
 
             comp2 = CreateCompilation(source2 + source3, parseOptions: TestOptions.RegularPreview);
+            comp2.GetSemanticModel(comp2.SyntaxTrees[0]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (1000,14): warning CS0105: The using directive for 'C2' appeared previously in this namespace
+                // using static C2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "C2").WithArguments("C2").WithLocation(1000, 14)
+                );
+        }
+
+        [Fact]
+        public void UsingConfictWithGlobalUsing_04()
+        {
+            var source3 = @"
+#line 1000
+global using N2;
+";
+            var source4 = @"
+#line 2000
+global using N2;
+";
+            var source5 = @"
+#line 3000
+using N2;
+";
+            var source6 = @"
+namespace N2 { class C2 {} }
+";
+            var comp2 = CreateCompilation(new[] { source3, source5, source6 }, parseOptions: TestOptions.RegularPreview);
+
+            var expected1 = new[]
+            {
+                // (3000,7): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(3000, 7)
+            };
+
+            CompileAndVerify(comp2).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected1);
+
+            var comp3 = CreateCompilation(new[] { source3 + source4, source5, source6 }, parseOptions: TestOptions.RegularPreview);
+
+            CompileAndVerify(comp3).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,14): warning CS0105: The using directive for 'N2' appeared previously in this namespace
+                // global using N2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "N2").WithArguments("N2").WithLocation(2000, 14),
+                // (3000,7): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(3000, 7)
+                );
+
+            var comp4 = CreateCompilation(new[] { source3 + source5, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp4).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (3000,7): warning CS0105: The using directive for 'N2' appeared previously in this namespace
+                // using N2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "N2").WithArguments("N2").WithLocation(3000, 7)
+                );
+
+            var comp5 = CreateCompilation(new[] { source3 + source4 + source5, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp5).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,14): warning CS0105: The using directive for 'N2' appeared previously in this namespace
+                // global using N2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "N2").WithArguments("N2").WithLocation(2000, 14),
+                // (3000,7): warning CS0105: The using directive for 'N2' appeared previously in this namespace
+                // using N2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "N2").WithArguments("N2").WithLocation(3000, 7)
+                );
+
+            var comp6 = CreateCompilation(new[] { source3, source4, source5, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp6).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,14): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // global using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(2000, 14),
+                // (3000,7): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(3000, 7)
+                );
+
+            var comp7 = CreateCompilation(new[] { source3 + source5, source4, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp7).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,14): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // global using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(2000, 14),
+                // (3000,7): warning CS0105: The using directive for 'N2' appeared previously in this namespace
+                // using N2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "N2").WithArguments("N2").WithLocation(3000, 7)
+                );
+
+            var comp8 = CreateCompilation(new[] { source5, source3, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp8).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected1);
+
+            var comp9 = CreateCompilation(new[] { source5, source3, source4, source6 }, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp9).Diagnostics.Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,14): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // global using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(2000, 14),
+                // (3000,7): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(3000, 7)
+                );
+        }
+
+        [Fact]
+        public void UsingConfictWithGlobalUsing_05()
+        {
+            var source2 = @"
+#line 1000
+global using N2;
+";
+            var source3 = @"
+#line 2000
+global using N2;
+
+namespace N2 { class C2 {} }
+";
+            var comp2 = CreateCompilation(new[] { source2, source3 }, parseOptions: TestOptions.RegularPreview);
+            comp2.GetSemanticModel(comp2.SyntaxTrees[1]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (2000,14): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // global using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(2000, 14)
+                );
+
+            comp2 = CreateCompilation(new[] { source3, source2 }, parseOptions: TestOptions.RegularPreview);
+            comp2.GetSemanticModel(comp2.SyntaxTrees[1]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (1000,14): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // global using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(1000, 14)
+                );
+        }
+
+        [Fact]
+        public void UsingConfictWithGlobalUsing_06()
+        {
+            var source2 = @"
+global using N2;
+";
+            var source3 = @"
+#line 1000
+using N2;
+#line default
+
+namespace N2 { class C2 {} }
+";
+            var comp2 = CreateCompilation(new[] { source2, source3 }, parseOptions: TestOptions.RegularPreview);
+
+            var expected = new[]
+            {
+                // (1000,7): hidden CS8933: The using directive for 'N2' appeared previously as global using
+                // using N2;
+                Diagnostic(ErrorCode.HDN_DuplicateWithGlobalUsing, "N2").WithArguments("N2").WithLocation(1000, 7)
+            };
+
+            comp2.GetSemanticModel(comp2.SyntaxTrees[1]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected);
+
+            comp2 = CreateCompilation(new[] { source3, source2 }, parseOptions: TestOptions.RegularPreview);
             comp2.GetSemanticModel(comp2.SyntaxTrees[0]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(expected);
+
+            comp2 = CreateCompilation(source2 + source3, parseOptions: TestOptions.RegularPreview);
+            comp2.GetSemanticModel(comp2.SyntaxTrees[0]).GetDeclarationDiagnostics().Where(d => d.Code != (int)ErrorCode.HDN_UnusedUsingDirective).Verify(
+                // (1000,7): warning CS0105: The using directive for 'N2' appeared previously in this namespace
+                // using N2;
+                Diagnostic(ErrorCode.WRN_DuplicateUsing, "N2").WithArguments("N2").WithLocation(1000, 7)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/51307