### PR TITLE
Order Razor options service

### DIFF
--- a/src/Tools/ExternalAccess/Razor/IRazorDocumentOptionsService.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorDocumentOptionsService.cs
@@ -4,7 +4,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {

--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -40,6 +40,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(VisualStudioEditorNewPackagesVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/src/Tools/ExternalAccess/Razor/RazorDocumentOptionsProviderFactory.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentOptionsProviderFactory.cs
@@ -3,17 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Composition;
+using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
-    [Shared]
     [Export(typeof(IDocumentOptionsProviderFactory))]
+    [Order(Before = PredefinedDocumentOptionsProviderNames.EditorConfig)]
     internal sealed class RazorDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
         private readonly Lazy<IRazorDocumentOptionsService> _innerRazorDocumentOptionsService;


### PR DESCRIPTION
Razor's options service should take precedence before the .editorconfig options service. Otherwise, if a user has an .editorconfig in a Razor project and the .editorconfig is configured with C# settings, those settings will override the settings from the Razor options service.

This change will not affect non-Razor scenarios, since the Razor options service only affects Razor files.