### PR TITLE
Convert switch arms with their own binder

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var oldCase = source.SwitchArms[i];
                 var oldValue = oldCase.Value;
-                var binder = GetBinder(oldCase.Syntax);
+                var binder = GetRequiredBinder(oldCase.Syntax);
                 var newValue =
                     targetTyped
                     ? binder.CreateConversion(oldValue.Syntax, oldValue, underlyingConversions[i], isCast: false, conversionGroupOpt: null, destination, diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -339,8 +339,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0, n = source.SwitchArms.Length; i < n; i++)
             {
                 var oldCase = source.SwitchArms[i];
-                var oldValue = oldCase.Value;
+                Debug.Assert(oldCase.Syntax is SwitchExpressionArmSyntax);
                 var binder = GetRequiredBinder(oldCase.Syntax);
+                var oldValue = oldCase.Value;
                 var newValue =
                     targetTyped
                     ? binder.CreateConversion(oldValue.Syntax, oldValue, underlyingConversions[i], isCast: false, conversionGroupOpt: null, destination, diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -340,10 +340,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var oldCase = source.SwitchArms[i];
                 var oldValue = oldCase.Value;
+                var binder = GetBinder(oldCase.Syntax);
                 var newValue =
                     targetTyped
-                    ? CreateConversion(oldValue.Syntax, oldValue, underlyingConversions[i], isCast: false, conversionGroupOpt: null, destination, diagnostics)
-                    : GenerateConversionForAssignment(destination, oldValue, diagnostics);
+                    ? binder.CreateConversion(oldValue.Syntax, oldValue, underlyingConversions[i], isCast: false, conversionGroupOpt: null, destination, diagnostics)
+                    : binder.GenerateConversionForAssignment(destination, oldValue, diagnostics);
                 var newCase = (oldValue == newValue) ? oldCase :
                     new BoundSwitchExpressionArm(oldCase.Syntax, oldCase.Locals, oldCase.Pattern, oldCase.WhenClause, newValue, oldCase.Label, oldCase.HasErrors);
                 builder.Add(newCase);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
@@ -4666,9 +4666,11 @@ public class C : System.Attribute
             var source = @"
 using static System.Console;
 
+var c0 = 0 switch { 1 => new C(), int n => new() { n = n } };
 C c1 = 1 switch { int n => new() { n = n } };
 C c2 = 2 switch { int n => n switch { int u => new() { n = n + u } } };
 
+Write(c0.n);
 Write(c1.n);
 Write(c2.n);
 
@@ -4679,7 +4681,7 @@ class C
 ";
             var compilation = CreateCompilation(source);
             compilation.VerifyDiagnostics();
-            CompileAndVerify(compilation, expectedOutput: "14");
+            CompileAndVerify(compilation, expectedOutput: "014");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
@@ -4659,5 +4659,27 @@ public class C : System.Attribute
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "new()").WithArguments("c", "C.C(C)").WithLocation(2, 4)
                 );
         }
+
+        [Fact, WorkItem(54193, "https://github.com/dotnet/roslyn/issues/54193")]
+        public void InSwitchExpression()
+        {
+            var source = @"
+using static System.Console;
+
+C c1 = 1 switch { int n => new() { n = n } };
+C c2 = 2 switch { int n => n switch { int u => new() { n = n + u } } };
+
+Write(c1.n);
+Write(c2.n);
+
+class C 
+{
+    public int n;
+}
+";
+            var compilation = CreateCompilation(source);
+            compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "14");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
@@ -4680,8 +4680,8 @@ class C
 }
 ";
             var compilation = CreateCompilation(source);
-            compilation.VerifyDiagnostics();
-            CompileAndVerify(compilation, expectedOutput: "014");
+            CompileAndVerify(compilation, expectedOutput: "014")
+                .VerifyDiagnostics();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/54193