### PR TITLE
LSIF support for hover

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -14,6 +14,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -94,8 +95,8 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                 var taggedText = await _hint.GetDescriptionAsync(document, cancellationToken).ConfigureAwait(false);
                 if (!taggedText.IsDefaultOrEmpty)
                 {
-                    return Implementation.IntelliSense.Helpers.BuildInteractiveTextElements(
-                        taggedText, document, _threadingContext, _streamingPresenter);
+                    var context = new IntellisenseQuickInfoBuilderContext(document, _threadingContext, _streamingPresenter);
+                    return Implementation.IntelliSense.Helpers.BuildInteractiveTextElements(taggedText, context);
                 }
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Experiments;
@@ -373,7 +374,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var description = await service.GetDescriptionAsync(document, roslynItem, cancellationToken).ConfigureAwait(false);
 
-            var elements = IntelliSense.Helpers.BuildInteractiveTextElements(description.TaggedParts, document, ThreadingContext, _streamingPresenter).ToArray();
+            var context = new IntellisenseQuickInfoBuilderContext(document, ThreadingContext, _streamingPresenter);
+            var elements = IntelliSense.Helpers.BuildInteractiveTextElements(description.TaggedParts, context).ToArray();
             if (elements.Length == 0)
             {
                 return new ClassifiedTextElement();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
@@ -22,20 +22,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
     {
         internal static IReadOnlyCollection<object> BuildInteractiveTextElements(
             ImmutableArray<TaggedText> taggedTexts,
-            Document document,
-            IThreadingContext threadingContext,
-            Lazy<IStreamingFindUsagesPresenter> streamingPresenter)
+            IntellisenseQuickInfoBuilderContext? context)
         {
             var index = 0;
-            return BuildInteractiveTextElements(taggedTexts, ref index, document, threadingContext, streamingPresenter);
+            return BuildInteractiveTextElements(taggedTexts, ref index, context);
         }
 
         private static IReadOnlyCollection<object> BuildInteractiveTextElements(
             ImmutableArray<TaggedText> taggedTexts,
             ref int index,
-            Document document,
-            IThreadingContext? threadingContext,
-            Lazy<IStreamingFindUsagesPresenter>? streamingPresenter)
+            IntellisenseQuickInfoBuilderContext? context)
         {
             // This method produces a sequence of zero or more paragraphs
             var paragraphs = new List<object>();
@@ -67,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                     }
 
                     index++;
-                    var nestedElements = BuildInteractiveTextElements(taggedTexts, ref index, document, threadingContext, streamingPresenter);
+                    var nestedElements = BuildInteractiveTextElements(taggedTexts, ref index, context);
                     if (nestedElements.Count <= 1)
                     {
                         currentParagraph.Add(new ContainerElement(
@@ -136,8 +132,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                 {
                     // This is tagged text getting added to the current line we are building.
                     var style = GetClassifiedTextRunStyle(part.Style);
-                    if (part.NavigationTarget is object && streamingPresenter != null && threadingContext != null)
+                    if (part.NavigationTarget is object &&
+                        context?.ThreadingContext is ThreadingContext threadingContext &&
+                        context.StreamingPresenter is Lazy<IStreamingFindUsagesPresenter> streamingPresenter)
                     {
+                        var document = context.Document;
                         if (Uri.TryCreate(part.NavigationTarget, UriKind.Absolute, out var absoluteUri))
                         {
                             var target = new QuickInfoHyperLink(document.Project.Solution.Workspace, absoluteUri);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilderContext.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilderContext.cs
@@ -8,6 +8,9 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
+    /// <summary>
+    /// Context to build content for quick info item for intellisense.
+    /// </summary>
     internal sealed class IntellisenseQuickInfoBuilderContext
     {
         public IntellisenseQuickInfoBuilderContext(

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilderContext.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilderContext.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
+{
+    internal sealed class IntellisenseQuickInfoBuilderContext
+    {
+        public IntellisenseQuickInfoBuilderContext(
+            Document document,
+            IThreadingContext? threadingContext,
+            Lazy<IStreamingFindUsagesPresenter>? streamingPresenter)
+        {
+            Document = document;
+            ThreadingContext = threadingContext;
+            StreamingPresenter = streamingPresenter;
+        }
+
+        public Document Document { get; }
+        public IThreadingContext? ThreadingContext { get; }
+        public Lazy<IStreamingFindUsagesPresenter>? StreamingPresenter { get; }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return text.Lines.GetPosition(linePosition);
         }
 
-        public static bool HasVisualStudioLspCapability(this ClientCapabilities clientCapabilities)
+        public static bool HasVisualStudioLspCapability(this ClientCapabilities? clientCapabilities)
         {
             if (clientCapabilities is VSClientCapabilities vsClientCapabilities)
             {

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -640,6 +640,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         }
 
         public static LSP.MarkupContent GetDocumentationMarkupContent(ImmutableArray<TaggedText> tags, Document document, bool featureSupportsMarkdown)
+            => GetDocumentationMarkupContent(tags, document.Project.Language, featureSupportsMarkdown);
+
+        public static LSP.MarkupContent GetDocumentationMarkupContent(ImmutableArray<TaggedText> tags, string language, bool featureSupportsMarkdown)
         {
             if (!featureSupportsMarkdown)
             {
@@ -657,7 +660,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 switch (taggedText.Tag)
                 {
                     case TextTags.CodeBlockStart:
-                        var codeBlockLanguageName = GetCodeBlockLanguageName(document);
+                        var codeBlockLanguageName = GetCodeBlockLanguageName(language);
                         builder.Append($"```{codeBlockLanguageName}{Environment.NewLine}");
                         builder.Append(taggedText.Text);
                         isInCodeBlock = true;
@@ -686,13 +689,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 Value = builder.ToString(),
             };
 
-            static string GetCodeBlockLanguageName(Document document)
+            static string GetCodeBlockLanguageName(string language)
             {
-                return document.Project.Language switch
+                return language switch
                 {
                     (LanguageNames.CSharp) => CSharpMarkdownLanguageName,
                     (LanguageNames.VisualBasic) => VisualBasicMarkdownLanguageName,
-                    _ => throw new InvalidOperationException($"{document.Project.Language} is not supported"),
+                    _ => throw new InvalidOperationException($"{language} is not supported"),
                 };
             }
 

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,6 +63,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             HostLanguageServices languageServices,
             CancellationToken cancellationToken)
         {
+            Debug.Assert(semanticModel.Language == LanguageNames.CSharp || semanticModel.Language == LanguageNames.VisualBasic);
+
+            // Get the quick info service to compute quick info.
+            // This code path is only invoked for C# and VB, so we can directly cast to QuickInfoServiceWithProviders.
             var quickInfoService = (QuickInfoServiceWithProviders)languageServices.GetRequiredService<QuickInfoService>();
             var info = await quickInfoService.GetQuickInfoAsync(languageServices.WorkspaceServices.Workspace, semanticModel, position, cancellationToken).ConfigureAwait(false);
             if (info == null)

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.QuickInfo;
@@ -51,44 +52,70 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return null;
             }
 
-            var hover = await GetHoverAsync(info, document, context.ClientCapabilities, cancellationToken).ConfigureAwait(false);
-            return hover;
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            return await GetHoverAsync(info, text, document.Project.Language, document, context.ClientCapabilities, cancellationToken).ConfigureAwait(false);
+        }
 
-            static async Task<Hover> GetHoverAsync(QuickInfoItem info, Document document, ClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        internal static async Task<Hover?> GetHoverAsync(
+            SemanticModel semanticModel,
+            int position,
+            HostLanguageServices languageServices,
+            CancellationToken cancellationToken)
+        {
+            var quickInfoService = (QuickInfoServiceWithProviders)languageServices.GetRequiredService<QuickInfoService>();
+            var info = await quickInfoService.GetQuickInfoAsync(languageServices.WorkspaceServices.Workspace, semanticModel, position, cancellationToken).ConfigureAwait(false);
+            if (info == null)
             {
-                var supportsVSExtensions = clientCapabilities.HasVisualStudioLspCapability();
-
-                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                if (supportsVSExtensions)
-                {
-                    return new VSHover
-                    {
-                        Range = ProtocolConversions.TextSpanToRange(info.Span, text),
-                        Contents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(string.Empty),
-                        // Build the classified text without navigation actions - they are not serializable.
-                        // TODO - Switch to markup content once it supports classifications.
-                        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
-                        RawContent = await IntellisenseQuickInfoBuilder.BuildContentWithoutNavigationActionsAsync(info, document, cancellationToken).ConfigureAwait(false)
-                    };
-                }
-                else
-                {
-                    return new Hover
-                    {
-                        Range = ProtocolConversions.TextSpanToRange(info.Span, text),
-                        Contents = GetContents(info, document, clientCapabilities),
-                    };
-                }
+                return null;
             }
 
-            static MarkupContent GetContents(QuickInfoItem info, Document document, ClientCapabilities clientCapabilities)
+            var text = await semanticModel.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            return await GetHoverAsync(info, text, semanticModel.Language, document: null, clientCapabilities: null, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task<Hover> GetHoverAsync(
+            QuickInfoItem info,
+            SourceText text,
+            string language,
+            Document? document,
+            ClientCapabilities? clientCapabilities,
+            CancellationToken cancellationToken)
+        {
+            var supportsVSExtensions = clientCapabilities.HasVisualStudioLspCapability();
+
+            if (supportsVSExtensions)
+            {
+                var context = document != null
+                    ? new IntellisenseQuickInfoBuilderContext(document, threadingContext: null, streamingPresenter: null)
+                    : null;
+                return new VSHover
+                {
+                    Range = ProtocolConversions.TextSpanToRange(info.Span, text),
+                    Contents = new SumType<SumType<string, MarkedString>, SumType<string, MarkedString>[], MarkupContent>(string.Empty),
+                    // Build the classified text without navigation actions - they are not serializable.
+                    // TODO - Switch to markup content once it supports classifications.
+                    // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918138
+                    RawContent = await IntellisenseQuickInfoBuilder.BuildContentWithoutNavigationActionsAsync(info, context, cancellationToken).ConfigureAwait(false)
+                };
+            }
+            else
+            {
+                return new Hover
+                {
+                    Range = ProtocolConversions.TextSpanToRange(info.Span, text),
+                    Contents = GetContents(info, language, clientCapabilities),
+                };
+            }
+
+            // Local functions.
+            static MarkupContent GetContents(QuickInfoItem info, string language, ClientCapabilities? clientCapabilities)
             {
                 var clientSupportsMarkdown = clientCapabilities?.TextDocument?.Hover?.ContentFormat.Contains(MarkupKind.Markdown) == true;
                 // Insert line breaks in between sections to ensure we get double spacing between sections.
                 var tags = info.Sections
                     .SelectMany(section => section.TaggedParts.Add(new TaggedText(TextTags.LineBreak, Environment.NewLine)))
                     .ToImmutableArray();
-                return ProtocolConversions.GetDocumentationMarkupContent(tags, document, clientSupportsMarkdown);
+                return ProtocolConversions.GetDocumentationMarkupContent(tags, language, clientSupportsMarkdown);
             }
         }
     }

--- a/src/Features/Lsif/Generator/Graph/HoverResult.cs
+++ b/src/Features/Lsif/Generator/Graph/HoverResult.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
+{
+    /// <summary>
+    /// Represents a foverResult vertex for serialization. See https://github.com/Microsoft/language-server-protocol/blob/main/indexFormat/specification.md#more-about-request-textdocumenthover for further details.
+    /// </summary>
+    internal sealed class HoverResult : Vertex
+    {
+        [JsonProperty("result")]
+        public Hover Result { get; }
+
+        public HoverResult(Hover result, IdFactory idFactory)
+            : base(label: "hoverResult", idFactory)
+        {
+            Result = result;
+        }
+    }
+}

--- a/src/Features/Lsif/GeneratorTest/HoverTests.vb
+++ b/src/Features/Lsif/GeneratorTest/HoverTests.vb
@@ -1,0 +1,122 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.LanguageServer.Protocol
+
+Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
+    <UseExportProvider>
+    Public NotInheritable Class HoverTests
+        Private Const TestProjectAssemblyName As String = "TestProject"
+
+        <Theory>
+        <InlineData("class [|C|] { string s; }", "class C")>
+        <InlineData("class C { void [|M|]() { } }", "void C.M()")>
+        <InlineData("class C { string [|s|]; }", "(field) string C.s")>
+        <InlineData("class C { void M(string [|s|]) { M(s); } }", "(parameter) string s")>
+        <InlineData("class C { void M(string s) { string [|local|] = """"; } }", "(local variable) string local")>
+        <InlineData("
+class C
+{
+    /// <summary>Doc Comment</summary>
+    void [|M|]() { }
+}",
+"void C.M()
+Doc Comment")>
+        Public Async Function TestDefinition(code As String, expectedHoverContents As String) As Task
+            Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
+                TestWorkspace.CreateWorkspace(
+                    <Workspace>
+                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                            <Document Name="A.cs" FilePath="Z:\A.cs">
+                                <%= code %>
+                            </Document>
+                        </Project>
+                    </Workspace>))
+
+            Dim rangeVertex = Await lsif.GetSelectedRangeAsync()
+            Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
+            Dim hoverVertex = lsif.GetLinkedVertices(Of Graph.HoverResult)(resultSetVertex, Methods.TextDocumentHoverName).SingleOrDefault()
+            Dim hoverMarkupContent = DirectCast(hoverVertex.Result.Contents.Value, MarkupContent)
+
+            Assert.Equal(MarkupKind.PlainText, hoverMarkupContent.Kind)
+            Assert.Equal(expectedHoverContents + Environment.NewLine, hoverMarkupContent.Value)
+        End Function
+
+        <Theory>
+        <InlineData("class C { [|string|] s; }", "class System.String")>
+        <InlineData("class C { void M() { [|M|](); } }", "void C.M()")>
+        <InlineData("class C { void M(string s) { M([|s|]); } }", "(parameter) string s")>
+        <InlineData("class C { void M(string s) { string local = """"; M([|local|]); } }", "(local variable) string local")>
+        <InlineData("using [|S|] = System.String;", "class System.String")>
+        <InlineData("class C { [|global|]::System.String s; }", "<global namespace>")>
+        <InlineData("
+class C
+{
+    /// <see cref=""C.[|M|]()"" />
+    void M() { }
+}",
+"void C.M()")>
+        Public Async Function TestReference(code As String, expectedHoverContents As String) As Task
+            Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
+                TestWorkspace.CreateWorkspace(
+                    <Workspace>
+                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                            <Document Name="A.cs" FilePath="Z:\A.cs">
+                                <%= code %>
+                            </Document>
+                        </Project>
+                    </Workspace>))
+
+            Dim rangeVertex = Await lsif.GetSelectedRangeAsync()
+            Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
+            Dim hoverVertex = lsif.GetLinkedVertices(Of Graph.HoverResult)(resultSetVertex, Methods.TextDocumentHoverName).SingleOrDefault()
+            Dim hoverMarkupContent = DirectCast(hoverVertex.Result.Contents.Value, MarkupContent)
+
+            Assert.Equal(MarkupKind.PlainText, hoverMarkupContent.Kind)
+            Assert.Equal(expectedHoverContents + Environment.NewLine, hoverMarkupContent.Value)
+        End Function
+
+        <Fact>
+        Public Async Function ToplevelResultsInMultipleFiles() As Task
+            Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
+                TestWorkspace.CreateWorkspace(
+                    <Workspace>
+                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                            <Document Name="A.cs" FilePath="Z:\A.cs">
+                                class A { [|string|] s; }
+                            </Document>
+                            <Document Name="B.cs" FilePath="Z:\B.cs">
+                                class B { [|string|] s; }
+                            </Document>
+                            <Document Name="C.cs" FilePath="Z:\C.cs">
+                                class C { [|string|] s; }
+                            </Document>
+                            <Document Name="D.cs" FilePath="Z:\D.cs">
+                                class D { [|string|] s; }
+                            </Document>
+                            <Document Name="E.cs" FilePath="Z:\E.cs">
+                                class E { [|string|] s; }
+                            </Document>
+                        </Project>
+                    </Workspace>))
+
+            Dim hoverVertex As Graph.HoverResult = Nothing
+            For Each rangeVertex In Await lsif.GetSelectedRangesAsync()
+                Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
+                Dim vertex = lsif.GetLinkedVertices(Of Graph.HoverResult)(resultSetVertex, Methods.TextDocumentHoverName).Single()
+                If hoverVertex Is Nothing Then
+                    hoverVertex = vertex
+                Else
+                    Assert.Same(hoverVertex, vertex)
+                End If
+            Next
+
+            Dim hoverMarkupContent = DirectCast(hoverVertex.Result.Contents.Value, MarkupContent)
+            Assert.Equal(MarkupKind.PlainText, hoverMarkupContent.Kind)
+            Assert.Equal("class System.String" + Environment.NewLine, hoverMarkupContent.Value)
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
This change builds on top of #53520, which refactored the quick info service to work at the compiler layer.
This PR adds support to the LSIF generator to invoke into quick info service to compute the hover information and adds the hover result to the LSIF graph.