### PR TITLE
Implicitly skip analyzers only for SDK style projects

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -85,9 +85,11 @@
                We only do so by default when 'TreatWarningsAsErrors' is not 'true'. For the scenario where
 			         'TreatWarningsAsErrors' is 'true', users can explicitly enable this functionality by setting
 			         'OptimizeImplicitlyTriggeredBuild' to 'true'.
+               NOTE: This feature is currently supported only for SDK-style projects, i.e. UsingMicrosoftNETSdk = true.
     -->
     <PropertyGroup Condition="'$(_SkipAnalyzers)' == '' and
                               '$(IsImplicitlyTriggeredBuild)' == 'true' and
+                              '$(UsingMicrosoftNETSdk)' == 'true' and
                               ('$(TreatWarningsAsErrors)' != 'true' or '$(OptimizeImplicitlyTriggeredBuild)' == 'true')">
       <_ImplicitlySkipAnalyzers>true</_ImplicitlySkipAnalyzers>
       <_SkipAnalyzers>true</_SkipAnalyzers>

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -720,12 +720,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             [CombinatorialValues(true, false, null)] bool? runAnalyzers,
             [CombinatorialValues(true, false, null)] bool? implicitBuild,
             [CombinatorialValues(true, false, null)] bool? treatWarningsAsErrors,
-            [CombinatorialValues(true, false, null)] bool? optimizeImplicitBuild)
+            [CombinatorialValues(true, false, null)] bool? optimizeImplicitBuild,
+            [CombinatorialValues(true, null)] bool? sdkStyleProject)
         {
             var runAnalyzersPropertyGroupString = getPropertyGroup("RunAnalyzers", runAnalyzers);
             var implicitBuildPropertyGroupString = getPropertyGroup("IsImplicitlyTriggeredBuild", implicitBuild);
             var treatWarningsAsErrorsPropertyGroupString = getPropertyGroup("TreatWarningsAsErrors", treatWarningsAsErrors);
             var optimizeImplicitBuildPropertyGroupString = getPropertyGroup("OptimizeImplicitlyTriggeredBuild", optimizeImplicitBuild);
+            var sdkStyleProjectPropertyGroupString = getPropertyGroup("UsingMicrosoftNETSdk", sdkStyleProject);
 
             XmlReader xmlReader = XmlReader.Create(new StringReader($@"
 <Project>
@@ -735,6 +737,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {implicitBuildPropertyGroupString}
 {treatWarningsAsErrorsPropertyGroupString}
 {optimizeImplicitBuildPropertyGroupString}
+{sdkStyleProjectPropertyGroupString}
+
 
 </Project>
 "));
@@ -747,6 +751,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             var analyzersEnabled = runAnalyzers ?? true;
             var expectedImplicitlySkippedAnalyzers = analyzersEnabled &&
                 implicitBuild == true &&
+                sdkStyleProject == true &&
                 (treatWarningsAsErrors != true || optimizeImplicitBuild == true);
             var expectedImplicitlySkippedAnalyzersValue = expectedImplicitlySkippedAnalyzers ? "true" : "";
             var actualImplicitlySkippedAnalyzersValue = instance.GetPropertyValue("_ImplicitlySkipAnalyzers");


### PR DESCRIPTION
Restrict the functionality added in #54143 to only kick in for SDK style projects. This feature needs work in the project system for upto-date check to work correctly, and we are currently only commited to doing this work for CPS/SDK style projects.