### PR TITLE
Simplify language version check for some analyzers

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
@@ -31,17 +31,20 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
         }
 
         protected override void InitializeWorker(AnalysisContext context)
-            => context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.SwitchStatement);
+            => context.RegisterCompilationStartAction(context =>
+            {
+                if (((CSharpCompilation)context.Compilation).LanguageVersion < LanguageVersion.CSharp8)
+                {
+                    return;
+                }
+
+                context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.SwitchStatement);
+            });
 
         private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
         {
             var switchStatement = context.Node;
             var syntaxTree = switchStatement.SyntaxTree;
-
-            if (((CSharpParseOptions)syntaxTree.Options).LanguageVersion < LanguageVersion.CSharp8)
-            {
-                return;
-            }
 
             var options = context.Options;
             var cancellationToken = context.CancellationToken;

--- a/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticDiagnosticAnalyzer.cs
@@ -30,8 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
         protected override void InitializeWorker(AnalysisContext context)
             => context.RegisterCompilationStartAction(context =>
             {
-                // All trees are expected to have the same language version. So make the check only once in compilation start .
-                if (context.Compilation.SyntaxTrees.FirstOrDefault() is SyntaxTree tree && MakeLocalFunctionStaticHelper.IsStaticLocalFunctionSupported(tree))
+                if (MakeLocalFunctionStaticHelper.IsStaticLocalFunctionSupported(((CSharpCompilation)context.Compilation).LanguageVersion))
                 {
                     context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.LocalFunctionStatement);
                 }

--- a/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
 {
     internal static class MakeLocalFunctionStaticHelper
     {
-        public static bool IsStaticLocalFunctionSupported(SyntaxTree tree)
-            => tree.Options is CSharpParseOptions csharpOption && csharpOption.LanguageVersion >= LanguageVersion.CSharp8;
+        public static bool IsStaticLocalFunctionSupported(LanguageVersion languageVersion)
+            => languageVersion >= LanguageVersion.CSharp8;
 
         private static bool TryGetDataFlowAnalysis(LocalFunctionStatementSyntax localFunction, SemanticModel semanticModel, [NotNullWhen(returnValue: true)] out DataFlowAnalysis? dataFlow)
         {

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryDiscardDesignation/CSharpRemoveUnnecessaryDiscardDesignationDiagnosticAnalyzer.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
 {
@@ -32,15 +30,19 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryDiscardDesignation
 
         protected override void InitializeWorker(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(AnalyzeDiscardDesignation, SyntaxKind.DiscardDesignation);
+            context.RegisterCompilationStartAction(context =>
+            {
+                if (((CSharpCompilation)context.Compilation).LanguageVersion < LanguageVersion.CSharp9)
+                {
+                    return;
+                }
+
+                context.RegisterSyntaxNodeAction(AnalyzeDiscardDesignation, SyntaxKind.DiscardDesignation);
+            });
         }
 
         private void AnalyzeDiscardDesignation(SyntaxNodeAnalysisContext context)
         {
-            var syntaxTree = context.SemanticModel.SyntaxTree;
-            if (((CSharpParseOptions)syntaxTree.Options).LanguageVersion < LanguageVersion.CSharp9)
-                return;
-
             var discard = (DiscardDesignationSyntax)context.Node;
             if (discard.Parent is DeclarationPatternSyntax)
             {

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
             ExpressionStatementSyntax,
             VariableDeclaratorSyntax>
     {
-        protected override bool AreCollectionInitializersSupported(SyntaxNodeAnalysisContext context)
-            => ((CSharpParseOptions)context.Node.SyntaxTree.Options).LanguageVersion >= LanguageVersion.CSharp3;
+        protected override bool AreCollectionInitializersSupported(Compilation compilation)
+            => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp3;
 
         protected override ISyntaxFacts GetSyntaxFacts() => CSharpSyntaxFacts.Instance;
     }

--- a/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -32,7 +30,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         protected override void InitializeWorker(AnalysisContext context)
-            => context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression);
+            => context.RegisterCompilationStartAction(context =>
+            {
+                if (((CSharpCompilation)context.Compilation).LanguageVersion < LanguageVersion.CSharp7)
+                {
+                    return;
+                }
+
+                context.RegisterSyntaxNodeAction(n => AnalyzeSyntax(n), SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression);
+            });
 
         private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
         {
@@ -40,11 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
 
             var semanticModel = context.SemanticModel;
             var syntaxTree = semanticModel.SyntaxTree;
-
-            if (((CSharpParseOptions)syntaxTree.Options).LanguageVersion < LanguageVersion.CSharp7)
-            {
-                return;
-            }
 
             var option = context.Options.GetOption(CodeStyleOptions2.PreferIsNullCheckOverReferenceEqualityMethod, semanticModel.Language, syntaxTree, cancellationToken);
             if (!option.Value)

--- a/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.cs
@@ -17,11 +17,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
         {
         }
 
-        protected override bool IsLanguageVersionSupported(ParseOptions options)
-            => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp7;
+        protected override bool IsLanguageVersionSupported(Compilation compilation)
+            => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp7;
 
-        protected override bool IsUnconstrainedGenericSupported(ParseOptions options)
-            => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp8;
+        protected override bool IsUnconstrainedGenericSupported(Compilation compilation)
+            => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp8;
 
         protected override ISyntaxFacts GetSyntaxFacts()
             => CSharpSyntaxFacts.Instance;

--- a/src/Analyzers/CSharp/Analyzers/UseNullPropagation/CSharpUseNullPropagationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseNullPropagation/CSharpUseNullPropagationDiagnosticAnalyzer.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseNullPropagation
             ConditionalAccessExpressionSyntax,
             ElementAccessExpressionSyntax>
     {
-        protected override bool ShouldAnalyze(ParseOptions options)
-            => ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp6;
+        protected override bool ShouldAnalyze(Compilation compilation)
+            => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
 
         protected override ISyntaxFacts GetSyntaxFacts()
             => CSharpSyntaxFacts.Instance;

--- a/src/Analyzers/CSharp/Analyzers/UseObjectInitializer/CSharpUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseObjectInitializer/CSharpUseObjectInitializerDiagnosticAnalyzer.cs
@@ -23,11 +23,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseObjectInitializer
     {
         protected override bool FadeOutOperatorToken => true;
 
-        protected override bool AreObjectInitializersSupported(SyntaxNodeAnalysisContext context)
+        protected override bool AreObjectInitializersSupported(Compilation compilation)
         {
             // object initializers are only available in C# 3.0 and above.  Don't offer this refactoring
             // in projects targeting a lesser version.
-            return ((CSharpParseOptions)context.Node.SyntaxTree.Options).LanguageVersion >= LanguageVersion.CSharp3;
+            return ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp3;
         }
 
         protected override ISyntaxFacts GetSyntaxFacts() => CSharpSyntaxFacts.Instance;

--- a/src/Analyzers/CSharp/Analyzers/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
@@ -20,10 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseThrowExpression
         {
         }
 
-        protected override bool IsSupported(ParseOptions options)
+        protected override bool IsSupported(Compilation compilation)
         {
-            var csOptions = (CSharpParseOptions)options;
-            return csOptions.LanguageVersion >= LanguageVersion.CSharp7;
+            return ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp7;
         }
 
         protected override bool IsInExpressionTree(SemanticModel semanticModel, SyntaxNode node, INamedTypeSymbol expressionTypeOpt, CancellationToken cancellationToken)

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -47,6 +47,11 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 
         private void OnCompilationStart(CompilationStartAnalysisContext context)
         {
+            if (!AreCollectionInitializersSupported(context.Compilation))
+            {
+                return;
+            }
+
             var ienumerableType = context.Compilation.GetTypeByMetadataName(typeof(IEnumerable).FullName!);
             if (ienumerableType != null)
             {
@@ -57,15 +62,10 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             }
         }
 
-        protected abstract bool AreCollectionInitializersSupported(SyntaxNodeAnalysisContext context);
+        protected abstract bool AreCollectionInitializersSupported(Compilation compilation);
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context, INamedTypeSymbol ienumerableType)
         {
-            if (!AreCollectionInitializersSupported(context))
-            {
-                return;
-            }
-
             var semanticModel = context.SemanticModel;
             var objectCreationExpression = (TObjectCreationExpressionSyntax)context.Node;
             var language = objectCreationExpression.Language;

--- a/src/Analyzers/Core/Analyzers/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseIsNullCheck/AbstractUseIsNullForReferenceEqualsDiagnosticAnalyzer.cs
@@ -29,10 +29,10 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         protected override void InitializeWorker(AnalysisContext context)
-            => context.RegisterCompilationStartAction(compilationContext =>
+            => context.RegisterCompilationStartAction(context =>
             {
-                var objectType = compilationContext.Compilation.GetSpecialType(SpecialType.System_Object);
-                if (objectType != null)
+                var objectType = context.Compilation.GetSpecialType(SpecialType.System_Object);
+                if (objectType != null && IsLanguageVersionSupported(context.Compilation))
                 {
                     var referenceEqualsMethod = objectType.GetMembers(nameof(ReferenceEquals))
                                                           .OfType<IMethodSymbol>()
@@ -41,27 +41,23 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                     if (referenceEqualsMethod != null)
                     {
                         var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
+                        var unconstraintedGenericSupported = IsUnconstrainedGenericSupported(context.Compilation);
                         context.RegisterSyntaxNodeAction(
-                            c => AnalyzeSyntax(c, referenceEqualsMethod),
+                            c => AnalyzeSyntax(c, referenceEqualsMethod, unconstraintedGenericSupported),
                             syntaxKinds.Convert<TLanguageKindEnum>(syntaxKinds.InvocationExpression));
                     }
                 }
             });
 
-        protected abstract bool IsLanguageVersionSupported(ParseOptions options);
-        protected abstract bool IsUnconstrainedGenericSupported(ParseOptions options);
+        protected abstract bool IsLanguageVersionSupported(Compilation compilation);
+        protected abstract bool IsUnconstrainedGenericSupported(Compilation compilation);
         protected abstract ISyntaxFacts GetSyntaxFacts();
 
-        private void AnalyzeSyntax(SyntaxNodeAnalysisContext context, IMethodSymbol referenceEqualsMethod)
+        private void AnalyzeSyntax(SyntaxNodeAnalysisContext context, IMethodSymbol referenceEqualsMethod, bool unconstraintedGenericSupported)
         {
             var cancellationToken = context.CancellationToken;
 
             var semanticModel = context.SemanticModel;
-            var syntaxTree = semanticModel.SyntaxTree;
-            if (!IsLanguageVersionSupported(syntaxTree.Options))
-            {
-                return;
-            }
 
             var option = context.GetOption(CodeStyleOptions2.PreferIsNullCheckOverReferenceEqualityMethod, semanticModel.Language);
             if (!option.Value)
@@ -125,7 +121,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                 // HasReferenceTypeConstraint returns false for base type constraint.
                 // IsReferenceType returns true.
 
-                if (!genericParameterSymbol.IsReferenceType && !IsUnconstrainedGenericSupported(syntaxTree.Options))
+                if (!genericParameterSymbol.IsReferenceType && !unconstraintedGenericSupported)
                 {
                     // Needs special casing for C# as long as
                     // 'is null' over unconstrained generic is implemented in C# 8.

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -42,21 +42,24 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
         protected override void InitializeWorker(AnalysisContext context)
         {
             var syntaxKinds = GetSyntaxFacts().SyntaxKinds;
-            context.RegisterSyntaxNodeAction(
-                AnalyzeNode, syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.ObjectCreationExpression));
+            context.RegisterCompilationStartAction(context =>
+            {
+                if (!AreObjectInitializersSupported(context.Compilation))
+                {
+                    return;
+                }
+
+                context.RegisterSyntaxNodeAction(
+                    AnalyzeNode, syntaxKinds.Convert<TSyntaxKind>(syntaxKinds.ObjectCreationExpression));
+            });
         }
 
-        protected abstract bool AreObjectInitializersSupported(SyntaxNodeAnalysisContext context);
+        protected abstract bool AreObjectInitializersSupported(Compilation compilation);
 
         protected abstract bool IsValidContainingStatement(TStatementSyntax node);
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            if (!AreObjectInitializersSupported(context))
-            {
-                return;
-            }
-
             var objectCreationExpression = (TObjectCreationExpressionSyntax)context.Node;
             var language = objectCreationExpression.Language;
             var option = context.GetOption(CodeStyleOptions2.PreferObjectInitializer, language);

--- a/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -52,12 +52,17 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-        protected abstract bool IsSupported(ParseOptions options);
+        protected abstract bool IsSupported(Compilation compilation);
 
         protected override void InitializeWorker(AnalysisContext context)
         {
             context.RegisterCompilationStartAction(startContext =>
             {
+                if (!IsSupported(startContext.Compilation))
+                {
+                    return;
+                }
+
                 var expressionTypeOpt = startContext.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
                 startContext.RegisterOperationAction(operationContext => AnalyzeOperation(operationContext, expressionTypeOpt), OperationKind.Throw);
             });
@@ -65,12 +70,6 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
 
         private void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol expressionTypeOpt)
         {
-            var syntaxTree = context.Operation.Syntax.SyntaxTree;
-            if (!IsSupported(syntaxTree.Options))
-            {
-                return;
-            }
-
             var cancellationToken = context.CancellationToken;
 
             var throwOperation = (IThrowOperation)context.Operation;

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             ExpressionStatementSyntax,
             VariableDeclaratorSyntax)
 
-        Protected Overrides Function AreCollectionInitializersSupported(context As SyntaxNodeAnalysisContext) As Boolean
+        Protected Overrides Function AreCollectionInitializersSupported(compilation As Compilation) As Boolean
             Return True
         End Function
 

--- a/src/Analyzers/VisualBasic/Analyzers/UseIsNullCheck/VisualBasicUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseIsNullCheck/VisualBasicUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.vb
@@ -16,11 +16,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNullCheck
             MyBase.New(VisualBasicAnalyzersResources.Use_Is_Nothing_check)
         End Sub
 
-        Protected Overrides Function IsLanguageVersionSupported(options As ParseOptions) As Boolean
+        Protected Overrides Function IsLanguageVersionSupported(compilation As Compilation) As Boolean
             Return True
         End Function
 
-        Protected Overrides Function IsUnconstrainedGenericSupported(options As ParseOptions) As Boolean
+        Protected Overrides Function IsUnconstrainedGenericSupported(compilation As Compilation) As Boolean
             Return True
         End Function
 

--- a/src/Analyzers/VisualBasic/Analyzers/UseNullPropagation/VisualBasicUseNullPropagationDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseNullPropagation/VisualBasicUseNullPropagationDiagnosticAnalyzer.vb
@@ -22,8 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseNullPropagation
             ConditionalAccessExpressionSyntax,
             InvocationExpressionSyntax)
 
-        Protected Overrides Function ShouldAnalyze(options As ParseOptions) As Boolean
-            Return DirectCast(options, VisualBasicParseOptions).LanguageVersion >= LanguageVersion.VisualBasic14
+        Protected Overrides Function ShouldAnalyze(compilation As Compilation) As Boolean
+            Return DirectCast(compilation, VisualBasicCompilation).LanguageVersion >= LanguageVersion.VisualBasic14
         End Function
 
         Protected Overrides Function GetSyntaxFacts() As ISyntaxFacts

--- a/src/Analyzers/VisualBasic/Analyzers/UseObjectInitializer/VisualBasicUseObjectInitializerDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseObjectInitializer/VisualBasicUseObjectInitializerDiagnosticAnalyzer.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseObjectInitializer
             End Get
         End Property
 
-        Protected Overrides Function AreObjectInitializersSupported(context As SyntaxNodeAnalysisContext) As Boolean
+        Protected Overrides Function AreObjectInitializersSupported(compilation As Compilation) As Boolean
             'Object Initializers are supported in all the versions of Visual Basic we support
             Return True
         End Function

--- a/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticCodeRefactoringProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
             var (document, textSpan, cancellationToken) = context;
 
             var syntaxTree = (await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false))!;
-            if (!MakeLocalFunctionStaticHelper.IsStaticLocalFunctionSupported(syntaxTree))
+            if (!MakeLocalFunctionStaticHelper.IsStaticLocalFunctionSupported(((CSharpParseOptions)syntaxTree.Options).LanguageVersion))
             {
                 return;
             }

--- a/src/Features/CSharp/Portable/MakeLocalFunctionStatic/PassInCapturedVariablesAsArgumentsCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeLocalFunctionStatic/PassInCapturedVariablesAsArgumentsCodeFixProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
 
             // Even when the language version doesn't support staic local function, the compiler will still
             // generate this error. So we need to check to make sure we don't provide incorrect fix.
-            if (!MakeLocalFunctionStaticHelper.IsStaticLocalFunctionSupported(root.SyntaxTree))
+            if (!MakeLocalFunctionStaticHelper.IsStaticLocalFunctionSupported(((CSharpParseOptions)root.SyntaxTree.Options).LanguageVersion))
             {
                 return;
             }


### PR DESCRIPTION
I haven't done this for every analyzer, just few of them.

The idea is to do the check in compilation start rather than in callbacks