### PR TITLE
Add binding redirect for EnvDTE

### DIFF
--- a/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
   <ItemGroup Label="PkgDef">
     <PkgDefBindingRedirect Include="System.ValueTuple.dll" FusionName="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"/>
+    <PkgDefBindingRedirect Include="EnvDTE.dll" FusionName="EnvDTE, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
   </ItemGroup>
   <ItemGroup>
     <!--


### PR DESCRIPTION
devenv.exe.config has binding redirect:

```
        <dependentAssembly>
          <assemblyIdentity name="EnvDTE" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
          <bindingRedirect oldVersion="7.0.3300.0" newVersion="8.0.0.0"/>
        </dependentAssembly>
```

The actual shipping binary is 17.0.0.0.

We need to either update our references to 17.0.0.0 or VS needs to fix the redirect.

Meanwhile this workaround unblocks F5.