### PR TITLE
Add support for InterpolatedStringBuilderArgumentAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case TypeKind.Enum:
                 case TypeKind.Struct:
                 case TypeKind.Class when !type.IsAnonymousType: // We don't want to enable object creation with unspeakable types
-                    return BindClassCreationExpression(syntax, type.Name, typeNode: syntax, (NamedTypeSymbol)type, arguments, diagnostics, node.InitializerOpt, wasTargetTyped: true);
+                    return BindClassCreationExpression(syntax, type.Name, typeNode: syntax, (NamedTypeSymbol)type, arguments, diagnostics, overloadResolutionSucceeded: out _, node.InitializerOpt, wasTargetTyped: true);
                 case TypeKind.TypeParameter:
                     return BindTypeParameterCreationExpression(syntax, (TypeParameterSymbol)type, arguments, node.InitializerOpt, typeSyntax: syntax, diagnostics);
                 case TypeKind.Delegate:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case TypeKind.Enum:
                 case TypeKind.Struct:
                 case TypeKind.Class when !type.IsAnonymousType: // We don't want to enable object creation with unspeakable types
-                    return BindClassCreationExpression(syntax, type.Name, typeNode: syntax, (NamedTypeSymbol)type, arguments, diagnostics, overloadResolutionSucceeded: out _, node.InitializerOpt, wasTargetTyped: true);
+                    return BindClassCreationExpression(syntax, type.Name, typeNode: syntax, (NamedTypeSymbol)type, arguments, diagnostics, node.InitializerOpt, wasTargetTyped: true);
                 case TypeKind.TypeParameter:
                     return BindTypeParameterCreationExpression(syntax, (TypeParameterSymbol)type, arguments, node.InitializerOpt, typeSyntax: syntax, diagnostics);
                 case TypeKind.Delegate:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2957,10 +2957,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return argument;
         }
 
+#nullable enable
         private void CoerceArguments<TMember>(
             MemberResolutionResult<TMember> methodResult,
             ArrayBuilder<BoundExpression> arguments,
-            BindingDiagnosticBag diagnostics)
+            BindingDiagnosticBag diagnostics,
+            TypeSymbol? receiverType,
+            RefKind? receiverRefKind)
             where TMember : Symbol
         {
             var result = methodResult.Result;
@@ -2973,18 +2976,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var kind = result.ConversionForArg(arg);
                 BoundExpression argument = arguments[arg];
 
+                if (kind.IsInterpolatedStringHandler)
+                {
+                    Debug.Assert(argument is BoundUnconvertedInterpolatedString);
+                    TypeWithAnnotations parameterTypeWithAnnotations = GetCorrespondingParameterTypeWithAnnotations(ref result, parameters, arg);
+                    reportUnsafeIfNeeded(methodResult, diagnostics, argument, parameterTypeWithAnnotations);
+                    arguments[arg] = BindInterpolatedStringHandlerInMemberCall((BoundUnconvertedInterpolatedString)argument, arguments, parameters, ref result, arg, receiverType, receiverRefKind, diagnostics);
+                }
                 // https://github.com/dotnet/roslyn/issues/37119 : should we create an (Identity) conversion when the kind is Identity but the types differ?
-                if (!kind.IsIdentity)
+                else if (!kind.IsIdentity)
                 {
                     TypeWithAnnotations parameterTypeWithAnnotations = GetCorrespondingParameterTypeWithAnnotations(ref result, parameters, arg);
-
-                    // NOTE: for some reason, dev10 doesn't report this for indexer accesses.
-                    if (!methodResult.Member.IsIndexer() && !argument.HasAnyErrors && parameterTypeWithAnnotations.Type.IsUnsafe())
-                    {
-                        // CONSIDER: dev10 uses the call syntax, but this seems clearer.
-                        ReportUnsafeIfNotAllowed(argument.Syntax, diagnostics);
-                        //CONSIDER: Return a bad expression so that HasErrors is true?
-                    }
+                    reportUnsafeIfNeeded(methodResult, diagnostics, argument, parameterTypeWithAnnotations);
 
                     arguments[arg] = CreateConversion(argument.Syntax, argument, kind, isCast: false, conversionGroupOpt: null, parameterTypeWithAnnotations.Type, diagnostics);
                 }
@@ -3007,7 +3010,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (argument.NeedsToBeConverted())
                 {
                     Debug.Assert(kind.IsIdentity);
-                    if (argument is BoundTupleLiteral sourceTuple)
+                    if (argument is BoundTupleLiteral)
                     {
                         TypeWithAnnotations parameterTypeWithAnnotations = GetCorrespondingParameterTypeWithAnnotations(ref result, parameters, arg);
                         // CreateConversion reports tuple literal name mismatches, and constructs the expected pattern of bound nodes.
@@ -3019,7 +3022,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
+
+            void reportUnsafeIfNeeded(MemberResolutionResult<TMember> methodResult, BindingDiagnosticBag diagnostics, BoundExpression argument, TypeWithAnnotations parameterTypeWithAnnotations)
+            {
+                // NOTE: for some reason, dev10 doesn't report this for indexer accesses.
+                if (!methodResult.Member.IsIndexer() && !argument.HasAnyErrors && parameterTypeWithAnnotations.Type.IsUnsafe())
+                {
+                    // CONSIDER: dev10 uses the call syntax, but this seems clearer.
+                    ReportUnsafeIfNotAllowed(argument.Syntax, diagnostics);
+                    //CONSIDER: Return a bad expression so that HasErrors is true?
+                }
+            }
         }
+
+        private static ParameterSymbol GetCorrespondingParameter(ref MemberAnalysisResult result, ImmutableArray<ParameterSymbol> parameters, int arg)
+        {
+            int paramNum = result.ParameterFromArgument(arg);
+            return parameters[paramNum];
+        }
+#nullable disable
 
         private static TypeWithAnnotations GetCorrespondingParameterTypeWithAnnotations(ref MemberAnalysisResult result, ImmutableArray<ParameterSymbol> parameters, int arg)
         {
@@ -4392,7 +4413,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, diagnostics);
                 }
 
-                return BindClassCreationExpression(node, typeName, node.Type, type, analyzedArguments, diagnostics, node.Initializer, initializerType);
+                return BindClassCreationExpression(node, typeName, node.Type, type, analyzedArguments, diagnostics, overloadResolutionSucceeded: out _, node.Initializer, initializerType);
             }
             finally
             {
@@ -4406,9 +4427,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression MakeConstructorInvocation(
             NamedTypeSymbol type,
-            ImmutableArray<BoundExpression> arguments,
+            ArrayBuilder<BoundExpression> arguments,
+            ArrayBuilder<RefKind> refKinds,
             SyntaxNode node,
-            BindingDiagnosticBag diagnostics)
+            BindingDiagnosticBag diagnostics,
+            out bool overloadResolutionSucceeded)
         {
             Debug.Assert(type.TypeKind is TypeKind.Class or TypeKind.Struct);
             var analyzedArguments = AnalyzedArguments.GetInstance();
@@ -4416,14 +4439,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             try
             {
                 analyzedArguments.Arguments.AddRange(arguments);
+                analyzedArguments.RefKinds.AddRange(refKinds);
 
                 if (type.IsStatic)
                 {
+                    overloadResolutionSucceeded = false;
                     diagnostics.Add(ErrorCode.ERR_InstantiatingStaticClass, node.Location, type);
                     return MakeBadExpressionForObjectCreation(node, type, analyzedArguments, initializerOpt: null, typeSyntax: null, diagnostics, wasCompilerGenerated: true);
                 }
 
-                var creation = BindClassCreationExpression(node, type.Name, node, type, analyzedArguments, diagnostics);
+                var creation = BindClassCreationExpression(node, type.Name, node, type, analyzedArguments, diagnostics, out overloadResolutionSucceeded);
                 creation.WasCompilerGenerated = true;
                 return creation;
             }
@@ -5216,6 +5241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NamedTypeSymbol type,
             AnalyzedArguments analyzedArguments,
             BindingDiagnosticBag diagnostics,
+            out bool overloadResolutionSucceeded,
             InitializerExpressionSyntax initializerSyntaxOpt = null,
             TypeSymbol initializerTypeOpt = null,
             bool wasTargetTyped = false)
@@ -5265,6 +5291,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hasErrors);
                 }
 
+                overloadResolutionSucceeded = overloadResolutionResult.Succeeded;
                 overloadResolutionResult.Free();
                 if (result != null)
                 {
@@ -5272,19 +5299,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            MemberResolutionResult<MethodSymbol> memberResolutionResult;
-            ImmutableArray<MethodSymbol> candidateConstructors;
 
-            if (TryPerformConstructorOverloadResolution(
+            overloadResolutionSucceeded = TryPerformConstructorOverloadResolution(
                 type,
                 analyzedArguments,
                 typeName,
                 typeNode.Location,
                 hasErrors, //don't cascade in these cases
                 diagnostics,
-                out memberResolutionResult,
-                out candidateConstructors,
-                allowProtectedConstructorsOfBaseType: false))
+                out MemberResolutionResult<MethodSymbol> memberResolutionResult,
+                out ImmutableArray<MethodSymbol> candidateConstructors,
+                allowProtectedConstructorsOfBaseType: false);
+
+            if (overloadResolutionSucceeded)
             {
                 var method = memberResolutionResult.Member;
 
@@ -5479,6 +5506,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     coClassType,
                     analyzedArguments,
                     diagnostics,
+                    overloadResolutionSucceeded: out _,
                     initializerOpt,
                     interfaceType,
                     wasTargetTyped);
@@ -5668,7 +5696,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (succeededIgnoringAccessibility)
             {
-                this.CoerceArguments<MethodSymbol>(result.ValidResult, analyzedArguments.Arguments, diagnostics);
+                this.CoerceArguments<MethodSymbol>(result.ValidResult, analyzedArguments.Arguments, diagnostics, receiverType: null, receiverRefKind: null);
             }
 
             // Fill in the out parameter with the result, if there was one; it might be inaccessible.
@@ -7821,7 +7849,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 MemberResolutionResult<PropertySymbol> resolutionResult = overloadResolutionResult.ValidResult;
                 PropertySymbol property = resolutionResult.Member;
-                this.CoerceArguments<PropertySymbol>(resolutionResult, analyzedArguments.Arguments, diagnostics);
+                this.CoerceArguments<PropertySymbol>(resolutionResult, analyzedArguments.Arguments, diagnostics, receiverOpt?.Type, receiverOpt?.GetRefKind());
 
                 var isExpanded = resolutionResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
                 var argsToParams = resolutionResult.Result.ArgsToParamsOpt;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -634,7 +634,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var parameter = GetCorrespondingParameter(ref memberAnalysisResult, parameters, originalParameterIndex);
                     if (parameter.IsOptional)
                     {
-                        // Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.
+                        // Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.
                         diagnostics.Add(
                             ErrorCode.ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified,
                             unconvertedString.Syntax.Location,
@@ -651,7 +651,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var parameter = GetCorrespondingParameter(ref memberAnalysisResult, parameters, argumentIndex);
                     if (argumentIndex > interpolatedStringArgNum)
                     {
-                        // Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.
+                        // Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.
                         diagnostics.Add(
                             ErrorCode.ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString,
                             arguments[argumentIndex].Syntax.Location,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -643,7 +643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // If it is optional, then they could otherwise not specify the parameter and that's an error
                             var originalParameterIndex = handlerParameterIndexes[i];
                             var parameter = parameters[originalParameterIndex];
-                            if (parameter.IsOptional || parameter.IsParams)
+                            if (parameter.IsOptional || OverloadResolution.IsValidParamsParameter(parameter))
                             {
                                 // Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.
                                 diagnostics.Add(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -196,8 +196,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundInterpolatedString BindUnconvertedInterpolatedStringToHandlerType(BoundUnconvertedInterpolatedString unconvertedInterpolatedString, NamedTypeSymbol interpolatedStringHandlerType, BindingDiagnosticBag diagnostics, bool isHandlerConversion)
+        private BoundInterpolatedString BindUnconvertedInterpolatedStringToHandlerType(
+            BoundUnconvertedInterpolatedString unconvertedInterpolatedString,
+            NamedTypeSymbol interpolatedStringHandlerType,
+            BindingDiagnosticBag diagnostics,
+            bool isHandlerConversion,
+            ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> additionalConstructorArguments = default,
+            ImmutableArray<RefKind> refKinds = default)
         {
+            Debug.Assert(additionalConstructorArguments.IsDefault
+                ? refKinds.IsDefault
+                : additionalConstructorArguments.Length == refKinds.Length);
             ReportUseSite(interpolatedStringHandlerType, diagnostics, unconvertedInterpolatedString.Syntax);
 
             // We satisfy the conditions for using an interpolated string builder. Bind all the builder calls unconditionally, so that if
@@ -271,26 +280,119 @@ namespace Microsoft.CodeAnalysis.CSharp
             conversionDiagnostics?.Free();
 
             var intType = GetSpecialType(SpecialType.System_Int32, diagnostics, unconvertedInterpolatedString.Syntax);
-            var arguments = ImmutableArray.Create<BoundExpression>(
-                new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(baseStringLength), intType) { WasCompilerGenerated = true },
-                new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(numFormatHoles), intType) { WasCompilerGenerated = true });
+            int constructorArgumentLength = 2 + (additionalConstructorArguments.IsDefault ? 0 : additionalConstructorArguments.Length);
+            var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(constructorArgumentLength);
+            populateArguments(unconvertedInterpolatedString, additionalConstructorArguments, baseStringLength, numFormatHoles, intType, argumentsBuilder);
 
-            // PROTOTYPE(interp-string): Support optional out param for whether the builder was created successfully and passing in other required args
-            BoundExpression createExpression = MakeConstructorInvocation(interpolatedStringHandlerType, arguments, unconvertedInterpolatedString.Syntax, diagnostics);
+            var refKindsBuilder = ArrayBuilder<RefKind>.GetInstance(constructorArgumentLength);
+            refKindsBuilder.Add(RefKind.None);
+            refKindsBuilder.Add(RefKind.None);
+
+            if (!refKinds.IsDefault)
+            {
+                refKindsBuilder.AddRange(refKinds);
+            }
+
+            var nonOutConstructorDiagnostics = BindingDiagnosticBag.GetInstance(template: diagnostics);
+            BoundExpression constructorCall;
+            BoundExpression nonOutConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, nonOutConstructorDiagnostics, out bool overloadResolutionSucceeded);
+            if (!overloadResolutionSucceeded)
+            {
+                // MakeConstructorInvocation can call CoerceArguments on the builder if overload resolution succeeded ignoring accessibility, which
+                // could still end up not succeeding, and that would end up changing the arguments. So we want to clear and repopulate.
+                argumentsBuilder.Clear();
+
+                // Try again with an out parameter. Note that we intentionally use `diagnostics` for resolving System.Boolean, because we want to
+                // track that we're using the type no matter what.
+                var boolType = GetSpecialType(SpecialType.System_Boolean, diagnostics, unconvertedInterpolatedString.Syntax);
+                var trailingConstructorValidityPlaceholder = new BoundInterpolatedStringArgumentPlaceholder(unconvertedInterpolatedString.Syntax, BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter, boolType);
+                var outConstructorAdditionalArguments = additionalConstructorArguments.NullToEmpty().Add(trailingConstructorValidityPlaceholder);
+                populateArguments(unconvertedInterpolatedString, outConstructorAdditionalArguments, baseStringLength, numFormatHoles, intType, argumentsBuilder);
+
+                refKindsBuilder.Add(RefKind.Out);
+
+                var outConstructorDiagnostics = BindingDiagnosticBag.GetInstance(template: diagnostics);
+                var outConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, outConstructorDiagnostics, out overloadResolutionSucceeded);
+
+                if (overloadResolutionSucceeded)
+                {
+                    // We successfully bound the out version, so set all the final data based on that binding
+                    constructorCall = outConstructorCall;
+                    diagnostics.AddRangeAndFree(outConstructorDiagnostics);
+                    nonOutConstructorDiagnostics.Free();
+                    additionalConstructorArguments = outConstructorAdditionalArguments;
+                }
+                else
+                {
+                    // We'll attempt to figure out which failure was "best" by looking to see if one failed to bind because it couldn't find
+                    // a constructor with the correct number of arguments. We presume that, if one failed for this reason and the other failed
+                    // for a different reason, that different reason is the one the user will want to know about. If both or neither failed
+                    // because of this error, we'll report everything.
+
+                    var nonOutConstructorHasArityError = nonOutConstructorDiagnostics.DiagnosticBag?.AsEnumerableWithoutResolution().Any(d => (ErrorCode)d.Code == ErrorCode.ERR_BadCtorArgCount) ?? false;
+                    var outConstructorHasArityError = outConstructorDiagnostics.DiagnosticBag?.AsEnumerableWithoutResolution().Any(d => (ErrorCode)d.Code == ErrorCode.ERR_BadCtorArgCount) ?? false;
+
+                    switch ((nonOutConstructorHasArityError, outConstructorHasArityError))
+                    {
+                        case (true, false):
+                            constructorCall = outConstructorCall;
+                            additionalConstructorArguments = outConstructorAdditionalArguments;
+                            diagnostics.AddRangeAndFree(outConstructorDiagnostics);
+                            nonOutConstructorDiagnostics.Free();
+                            break;
+                        case (false, true):
+                            constructorCall = nonOutConstructorCall;
+                            diagnostics.AddRangeAndFree(nonOutConstructorDiagnostics);
+                            outConstructorDiagnostics.Free();
+                            break;
+                        default:
+                            // For the final output binding info, we'll go with the shorter constructor in the absence of any tiebreaker,
+                            // but we'll report all diagnostics
+                            constructorCall = nonOutConstructorCall;
+                            diagnostics.AddRangeAndFree(nonOutConstructorDiagnostics);
+                            diagnostics.AddRangeAndFree(outConstructorDiagnostics);
+                            break;
+
+                    }
+                }
+            }
+            else
+            {
+                diagnostics.AddRangeAndFree(nonOutConstructorDiagnostics);
+                constructorCall = nonOutConstructorCall;
+            }
+
+            argumentsBuilder.Free();
+            refKindsBuilder.Free();
+
             // PROTOTYPE(interp-string): Support dynamic
-            Debug.Assert(createExpression.HasErrors || createExpression is BoundObjectCreationExpression);
+            Debug.Assert(constructorCall.HasErrors || constructorCall is BoundObjectCreationExpression);
 
             return new BoundInterpolatedString(
                 unconvertedInterpolatedString.Syntax,
                 new InterpolatedStringHandlerData(
                     interpolatedStringHandlerType,
-                    createExpression,
+                    constructorCall,
                     usesBoolReturn,
-                    LocalScopeDepth),
+                    LocalScopeDepth,
+                    additionalConstructorArguments.NullToEmpty()),
                 appendCalls,
                 unconvertedInterpolatedString.ConstantValue,
                 unconvertedInterpolatedString.Type,
                 unconvertedInterpolatedString.HasErrors);
+
+            static void populateArguments(BoundUnconvertedInterpolatedString unconvertedInterpolatedString, ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> additionalConstructorArguments, int baseStringLength, int numFormatHoles, NamedTypeSymbol intType, ArrayBuilder<BoundExpression> argumentsBuilder)
+            {
+                // literalLength
+                argumentsBuilder.Add(new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(baseStringLength), intType) { WasCompilerGenerated = true });
+                // formattedCount
+                argumentsBuilder.Add(new BoundLiteral(unconvertedInterpolatedString.Syntax, ConstantValue.Create(numFormatHoles), intType) { WasCompilerGenerated = true });
+                // Any other arguments from the call site
+                if (!additionalConstructorArguments.IsDefault)
+                {
+                    argumentsBuilder.AddRange(additionalConstructorArguments);
+                }
+            }
         }
 
         private ImmutableArray<BoundExpression> BindInterpolatedStringParts(BoundUnconvertedInterpolatedString unconvertedInterpolatedString, BindingDiagnosticBag diagnostics)
@@ -426,6 +528,179 @@ namespace Microsoft.CodeAnalysis.CSharp
             argumentsBuilder.Free();
             parameterNamesAndLocationsBuilder.Free();
             return (builderAppendCalls.ToImmutableAndFree(), builderPatternExpectsBool ?? false);
+        }
+
+        private BoundExpression BindInterpolatedStringHandlerInMemberCall(
+            BoundUnconvertedInterpolatedString unconvertedString,
+            ArrayBuilder<BoundExpression> arguments,
+            ImmutableArray<ParameterSymbol> parameters,
+            ref MemberAnalysisResult memberAnalysisResult,
+            int interpolatedStringArgNum,
+            TypeSymbol? receiverType,
+            RefKind? receiverRefKind,
+            BindingDiagnosticBag diagnostics)
+        {
+            var interpolatedStringConversion = memberAnalysisResult.ConversionForArg(interpolatedStringArgNum);
+            Debug.Assert(interpolatedStringConversion.IsInterpolatedStringHandler);
+            var interpolatedStringParameter = GetCorrespondingParameter(ref memberAnalysisResult, parameters, interpolatedStringArgNum);
+            Debug.Assert(interpolatedStringParameter.Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true });
+
+            if (interpolatedStringParameter.HasInterpolatedStringHandlerArgumentError)
+            {
+                // The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.
+                diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerArgumentAttributeMalformed, unconvertedString.Syntax.Location, interpolatedStringParameter, interpolatedStringParameter.Type);
+                return CreateConversion(
+                    unconvertedString.Syntax,
+                    unconvertedString,
+                    interpolatedStringConversion,
+                    isCast: false,
+                    conversionGroupOpt: null,
+                    wasCompilerGenerated: false,
+                    interpolatedStringParameter.Type,
+                    diagnostics,
+                    hasErrors: true);
+            }
+
+            var handlerParameterIndexes = interpolatedStringParameter.InterpolatedStringHandlerArgumentIndexes;
+            if (handlerParameterIndexes.IsEmpty)
+            {
+                // No arguments, fall back to the standard conversion steps.
+                return CreateConversion(
+                    unconvertedString.Syntax,
+                    unconvertedString,
+                    interpolatedStringConversion,
+                    isCast: false,
+                    conversionGroupOpt: null,
+                    interpolatedStringParameter.Type,
+                    diagnostics);
+            }
+
+            // We need to find the appropriate argument expression for every expected parameter, and error on any that occur after the current parameter
+
+            ImmutableArray<int> handlerArgumentIndexes;
+
+            if (memberAnalysisResult.ArgsToParamsOpt.IsDefault && arguments.Count == parameters.Length)
+            {
+                // No parameters are missing and no remapped indexes, we can just use the original indexes
+                handlerArgumentIndexes = handlerParameterIndexes;
+            }
+            else
+            {
+                // Args and parameters were reordered via named parameters, or parameters are missing. Find the correct argument index for each parameter.
+                var handlerArgumentIndexesBuilder = ArrayBuilder<int>.GetInstance(handlerParameterIndexes.Length, fillWithValue: BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter);
+                for (int argumentIndex = 0; argumentIndex < arguments.Count; argumentIndex++)
+                {
+                    // The index in the original parameter list we're looking to match up.
+                    var argumentParameterIndex = memberAnalysisResult.ParameterFromArgument(argumentIndex);
+                    for (int handlerParameterIndex = 0; handlerParameterIndex < handlerParameterIndexes.Length; handlerParameterIndex++)
+                    {
+                        // Is the original parameter index of the current argument the parameter index that was specified in the attribute?
+                        if (argumentParameterIndex == handlerParameterIndexes[handlerParameterIndex])
+                        {
+                            // We can't just bail out on the first match: users can duplicate parameters in attributes, causing the same value to be passed twice.
+                            Debug.Assert(handlerArgumentIndexesBuilder[handlerParameterIndex] == BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter);
+                            handlerArgumentIndexesBuilder[handlerParameterIndex] = argumentIndex;
+                        }
+                    }
+                }
+
+                handlerArgumentIndexes = handlerArgumentIndexesBuilder.ToImmutableAndFree();
+            }
+
+            var argumentPlaceholdersBuilder = ArrayBuilder<BoundInterpolatedStringArgumentPlaceholder>.GetInstance(handlerArgumentIndexes.Length);
+            var argumentRefKindsBuilder = ArrayBuilder<RefKind>.GetInstance(handlerArgumentIndexes.Length);
+            bool hasErrors = false;
+
+            // Now, go through all the specified arguments and see if any were specified _after_ the interpolated string, and construct
+            // a set of placeholders for overload resolution.
+            for (int i = 0; i < handlerArgumentIndexes.Length; i++)
+            {
+                int argumentIndex = handlerArgumentIndexes[i];
+                Debug.Assert(argumentIndex != interpolatedStringArgNum);
+
+                RefKind refKind;
+                TypeSymbol placeholderType;
+                if (argumentIndex == BoundInterpolatedStringArgumentPlaceholder.InstanceParameter)
+                {
+                    Debug.Assert(receiverRefKind != null && receiverType is not null);
+                    refKind = receiverRefKind.GetValueOrDefault();
+                    placeholderType = receiverType;
+                }
+                else if (argumentIndex == BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter)
+                {
+                    // Don't error if the parameter isn't optional: the user will already have an error for missing an optional parameter or overload resolution failed.
+                    // If it is optional, then they could otherwise not specify the parameter and that's an error
+                    var originalParameterIndex = handlerParameterIndexes[i];
+                    var parameter = GetCorrespondingParameter(ref memberAnalysisResult, parameters, originalParameterIndex);
+                    if (parameter.IsOptional)
+                    {
+                        // Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.
+                        diagnostics.Add(
+                            ErrorCode.ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified,
+                            unconvertedString.Syntax.Location,
+                            parameter.Name,
+                            interpolatedStringParameter.Name);
+                        hasErrors = true;
+                    }
+
+                    refKind = parameter.RefKind;
+                    placeholderType = parameter.Type;
+                }
+                else
+                {
+                    var parameter = GetCorrespondingParameter(ref memberAnalysisResult, parameters, argumentIndex);
+                    if (argumentIndex > interpolatedStringArgNum)
+                    {
+                        // Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.
+                        diagnostics.Add(
+                            ErrorCode.ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString,
+                            arguments[argumentIndex].Syntax.Location,
+                            parameter.Name,
+                            interpolatedStringParameter.Name);
+                        hasErrors = true;
+                    }
+
+                    refKind = parameter.RefKind;
+                    placeholderType = parameter.Type;
+                }
+
+                var placeholderSyntax = argumentIndex switch
+                {
+                    BoundInterpolatedStringArgumentPlaceholder.InstanceParameter or BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter => unconvertedString.Syntax,
+                    >= 0 => arguments[argumentIndex].Syntax,
+                    _ => throw ExceptionUtilities.UnexpectedValue(argumentIndex)
+                };
+
+                argumentPlaceholdersBuilder.Add(
+                    new BoundInterpolatedStringArgumentPlaceholder(
+                        placeholderSyntax,
+                        argumentIndex,
+                        placeholderType,
+                        hasErrors: argumentIndex == BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter));
+                // We use the parameter refkind, rather than what the argument was actually passed with, because that will suppress duplicated errors
+                // about arguments being passed with the wrong RefKind. The user will have already gotten an error about mismatched RefKinds or it will
+                // be a place where refkinds are allowed to differ
+                argumentRefKindsBuilder.Add(refKind);
+            }
+
+            var interpolatedString = BindUnconvertedInterpolatedStringToHandlerType(
+                unconvertedString,
+                (NamedTypeSymbol)interpolatedStringParameter.Type,
+                diagnostics,
+                isHandlerConversion: true,
+                additionalConstructorArguments: argumentPlaceholdersBuilder.ToImmutableAndFree(),
+                refKinds: argumentRefKindsBuilder.ToImmutableAndFree());
+
+            return new BoundConversion(
+                interpolatedString.Syntax,
+                interpolatedString,
+                interpolatedStringConversion,
+                @checked: CheckOverflowAtRuntime,
+                explicitCastInCode: false,
+                conversionGroupOpt: null,
+                constantValueOpt: null,
+                interpolatedStringParameter.Type,
+                hasErrors || interpolatedString.HasErrors);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -295,8 +295,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var nonOutConstructorDiagnostics = BindingDiagnosticBag.GetInstance(template: diagnostics);
             BoundExpression constructorCall;
-            BoundExpression nonOutConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, nonOutConstructorDiagnostics, out bool overloadResolutionSucceeded);
-            if (!overloadResolutionSucceeded)
+            BoundExpression nonOutConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, nonOutConstructorDiagnostics);
+            if (nonOutConstructorCall is not BoundObjectCreationExpression { ResultKind: LookupResultKind.Viable })
             {
                 // MakeConstructorInvocation can call CoerceArguments on the builder if overload resolution succeeded ignoring accessibility, which
                 // could still end up not succeeding, and that would end up changing the arguments. So we want to clear and repopulate.
@@ -312,9 +312,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 refKindsBuilder.Add(RefKind.Out);
 
                 var outConstructorDiagnostics = BindingDiagnosticBag.GetInstance(template: diagnostics);
-                var outConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, outConstructorDiagnostics, out overloadResolutionSucceeded);
+                var outConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, outConstructorDiagnostics);
 
-                if (overloadResolutionSucceeded)
+                if (outConstructorCall is BoundObjectCreationExpression { ResultKind: LookupResultKind.Viable })
                 {
                     // We successfully bound the out version, so set all the final data based on that binding
                     constructorCall = outConstructorCall;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -643,7 +643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // If it is optional, then they could otherwise not specify the parameter and that's an error
                             var originalParameterIndex = handlerParameterIndexes[i];
                             var parameter = parameters[originalParameterIndex];
-                            if (parameter.IsOptional || OverloadResolution.IsValidParamsParameter(parameter))
+                            if (parameter.IsOptional || (originalParameterIndex + 1 == parameters.Length && OverloadResolution.IsValidParamsParameter(parameter)))
                             {
                                 // Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.
                                 diagnostics.Add(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1009,13 +1009,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var methodResult = result.ValidResult;
             var returnType = methodResult.Member.ReturnType;
-            this.CoerceArguments(methodResult, analyzedArguments.Arguments, diagnostics);
-
             var method = methodResult.Member;
-            var expanded = methodResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
-            var argsToParams = methodResult.Result.ArgsToParamsOpt;
-
-            BindDefaultArguments(node, method.Parameters, analyzedArguments.Arguments, analyzedArguments.RefKinds, ref argsToParams, out var defaultArguments, expanded, enableCallerInfo: true, diagnostics);
 
             // It is possible that overload resolution succeeded, but we have chosen an
             // instance method and we're in a static method. A careful reading of the
@@ -1025,6 +1019,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // overload resolution.
 
             var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
+
+            this.CoerceArguments(methodResult, analyzedArguments.Arguments, diagnostics, receiver?.Type, receiver?.GetRefKind());
+
+            var expanded = methodResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
+            var argsToParams = methodResult.Result.ArgsToParamsOpt;
+
+            BindDefaultArguments(node, method.Parameters, analyzedArguments.Arguments, analyzedArguments.RefKinds, ref argsToParams, out var defaultArguments, expanded, enableCallerInfo: true, diagnostics);
 
             // Note: we specifically want to do final validation (7.6.5.1) without checking delegate compatibility (15.2),
             // so we're calling MethodGroupFinalValidation directly, rather than via MethodGroupConversionHasErrors.
@@ -2011,7 +2012,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             CoerceArguments(
                 methodResult,
                 analyzedArguments.Arguments,
-                diagnostics);
+                diagnostics,
+                boundExpression.Type,
+                boundExpression.GetRefKind());
 
             var args = analyzedArguments.Arguments.ToImmutable();
             var refKinds = analyzedArguments.RefKinds.ToImmutableOrNull();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -2014,7 +2014,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 analyzedArguments.Arguments,
                 diagnostics,
                 receiverType: null,
-                receiverRefKind: default);
+                receiverRefKind: null);
 
             var args = analyzedArguments.Arguments.ToImmutable();
             var refKinds = analyzedArguments.RefKinds.ToImmutableOrNull();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -2013,8 +2013,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodResult,
                 analyzedArguments.Arguments,
                 diagnostics,
-                boundExpression.Type,
-                boundExpression.GetRefKind());
+                receiverType: null,
+                receiverRefKind: default);
 
             var args = analyzedArguments.Arguments.ToImmutable();
             var refKinds = analyzedArguments.RefKinds.ToImmutableOrNull();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -842,7 +842,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             AnalyzedArguments analyzedArguments = AnalyzedArguments.GetInstance();
             analyzedArguments.Arguments.AddRange(args);
-            var result = BindClassCreationExpression(node, toCreate.Name, node, toCreate, analyzedArguments, diagnostics, overloadResolutionSucceeded: out _);
+            var result = BindClassCreationExpression(node, toCreate.Name, node, toCreate, analyzedArguments, diagnostics);
             result.WasCompilerGenerated = true;
             analyzedArguments.Free();
             return result;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -842,7 +842,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             AnalyzedArguments analyzedArguments = AnalyzedArguments.GetInstance();
             analyzedArguments.Arguments.AddRange(args);
-            var result = BindClassCreationExpression(node, toCreate.Name, node, toCreate, analyzedArguments, diagnostics);
+            var result = BindClassCreationExpression(node, toCreate.Name, node, toCreate, analyzedArguments, diagnostics, overloadResolutionSucceeded: out _);
             result.WasCompilerGenerated = true;
             analyzedArguments.Free();
             return result;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1030,9 +1030,10 @@ outerDefault:
         }
 
         public static bool IsValidParamsParameter(ParameterSymbol final)
-            // Note: we need to confirm the "arrayness" on the original definition because
-            // it's possible that the type becomes an array as a result of substitution.
-            => final.IsParams && ((ParameterSymbol)final.OriginalDefinition).Type.IsSZArray();
+        {
+            Debug.Assert((object)final == final.ContainingSymbol.GetParameters().Last());
+            return final.IsParams && ((ParameterSymbol)final.OriginalDefinition).Type.IsSZArray();
+        }
 
         /// <summary>
         /// Does <paramref name="moreDerivedOverride"/> override <paramref name="member"/> or the

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1025,11 +1025,14 @@ outerDefault:
                 return false;
             }
 
+            ParameterSymbol final = member.GetParameters().Last();
+            return IsValidParamsParameter(final);
+        }
+
+        public static bool IsValidParamsParameter(ParameterSymbol final)
             // Note: we need to confirm the "arrayness" on the original definition because
             // it's possible that the type becomes an array as a result of substitution.
-            ParameterSymbol final = member.GetParameters().Last();
-            return final.IsParams && ((ParameterSymbol)final.OriginalDefinition).Type.IsSZArray();
-        }
+            => final.IsParams && ((ParameterSymbol)final.OriginalDefinition).Type.IsSZArray();
 
         /// <summary>
         /// Does <paramref name="moreDerivedOverride"/> override <paramref name="member"/> or the

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundInterpolatedStringArgumentPlaceholder.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundInterpolatedStringArgumentPlaceholder.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class BoundInterpolatedStringArgumentPlaceholder
+    {
+        public const int InstanceParameter = -1;
+        public const int TrailingConstructorValidityParameter = -2;
+        public const int UnspecifiedParameter = -3;
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2025,6 +2025,9 @@
        from expression can occur. -->
   <Node Name="BoundInterpolatedStringArgumentPlaceholder" Base="BoundValuePlaceholderBase">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow" />
+    <!-- The index in the containing member of the argument this is the placeholder for. Should be a positive number or
+         one of the constants in the other part of the partial class. -->
+    <Field Name="ArgumentIndex" Type="int" />
   </Node>
 
   <Node Name="BoundStringInsert" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2022,7 +2022,7 @@
 
   <!-- A typed expression placeholder for the arguments to the constructor call for an interpolated string handler
        conversion. We intentionally use a placeholder for overload resolution here to ensure that no conversion
-       from expression can occur. -->
+       from expression can occur. This node is only used for intermediate binding and does not survive local rewriting. -->
   <Node Name="BoundInterpolatedStringArgumentPlaceholder" Base="BoundValuePlaceholderBase">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow" />
     <!-- The index in the containing member of the argument this is the placeholder for. Should be a positive number or

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
@@ -10,21 +11,38 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal readonly struct InterpolatedStringHandlerData
     {
         public readonly TypeSymbol BuilderType;
-        public readonly BoundExpression? Construction;
+        public readonly BoundExpression Construction;
         public readonly bool UsesBoolReturns;
         /// <summary>
         /// The scope of the expression that contained the interpolated string during initial binding. This is used to determine the SafeToEscape rules
         /// for the builder during lowering.
         /// </summary>
         public readonly uint ScopeOfContainingExpression;
+        /// <summary>
+        /// The placeholders that are used for <see cref="Construction"/>.
+        /// </summary>
+        public readonly ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> ArgumentPlaceholders;
 
-        public InterpolatedStringHandlerData(TypeSymbol builderType, BoundExpression? construction, bool usesBoolReturns, uint scopeOfContainingExpression)
+        public bool HasTrailingHandlerValidityParameter => ArgumentPlaceholders.Length > 0 && ArgumentPlaceholders[^1].ArgumentIndex == BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter;
+
+        public InterpolatedStringHandlerData(TypeSymbol builderType, BoundExpression construction, bool usesBoolReturns, uint scopeOfContainingExpression, ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> placeholders)
         {
             Debug.Assert(construction is BoundObjectCreationExpression or BoundDynamicObjectCreationExpression or BoundBadExpression);
+            Debug.Assert(!placeholders.IsDefault);
+            // Only the last placeholder should be the out parameter.
+            Debug.Assert(placeholders.IsEmpty || placeholders.AsSpan()[..^1].All(item => item.ArgumentIndex != BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter));
             BuilderType = builderType;
             Construction = construction;
             UsesBoolReturns = usesBoolReturns;
             ScopeOfContainingExpression = scopeOfContainingExpression;
+            ArgumentPlaceholders = placeholders;
         }
+
+        /// <summary>
+        /// Simple helper method to get the object creation expression for this data. This should only be used in
+        /// scenarios where the data in <see cref="Construction"/> is known to be valid, or it will throw.
+        /// </summary>
+        public readonly BoundObjectCreationExpression GetValidConstructor()
+            => (BoundObjectCreationExpression)Construction;
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(construction is BoundObjectCreationExpression or BoundDynamicObjectCreationExpression or BoundBadExpression);
             Debug.Assert(!placeholders.IsDefault);
-            // Only the last placeholder should be the out parameter.
+            // Only the last placeholder may be the out parameter.
             Debug.Assert(placeholders.IsEmpty || placeholders.AsSpan()[..^1].All(item => item.ArgumentIndex != BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter));
             BuilderType = builderType;
             Construction = construction;

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6681,4 +6681,17 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>InterpolatedStringHandlerArgumentAttribute arguments cannot refer to the parameter the attribute is used on.</value>
     <comment>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</comment>
   </data>
+  <data name="ERR_InterpolatedStringHandlerArgumentAttributeMalformed" xml:space="preserve">
+    <value>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</value>
+    <comment>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</comment>
+  </data>
+  <data name="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString" xml:space="preserve">
+    <value>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</value>
+  </data>
+  <data name="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified" xml:space="preserve">
+    <value>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</value>
+  </data>
+  <data name="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion" xml:space="preserve">
+    <value>An expression tree may not contain an interpolated string handler conversion.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6686,10 +6686,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <comment>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</comment>
   </data>
   <data name="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString" xml:space="preserve">
-    <value>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</value>
+    <value>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</value>
   </data>
   <data name="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified" xml:space="preserve">
-    <value>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</value>
+    <value>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</value>
   </data>
   <data name="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion" xml:space="preserve">
     <value>An expression tree may not contain an interpolated string handler conversion.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1949,6 +1949,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments = 9008,
         WRN_ParameterOccursAfterInterpolatedStringHandlerParameter = 9009,
         ERR_CannotUseSelfAsInterpolatedStringHandlerArgument = 9010,
+        ERR_InterpolatedStringHandlerArgumentAttributeMalformed = 9011,
+        ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString = 9012,
+        ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified = 9013,
+        ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion = 9014,
 
         #endregion diagnostics introduced for C# 10.0
 

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -7267,32 +7267,36 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundInterpolatedStringArgumentPlaceholder : BoundValuePlaceholderBase
     {
-        public BoundInterpolatedStringArgumentPlaceholder(SyntaxNode syntax, TypeSymbol type, bool hasErrors)
+        public BoundInterpolatedStringArgumentPlaceholder(SyntaxNode syntax, int argumentIndex, TypeSymbol type, bool hasErrors)
             : base(BoundKind.InterpolatedStringArgumentPlaceholder, syntax, type, hasErrors)
         {
 
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
+            this.ArgumentIndex = argumentIndex;
         }
 
-        public BoundInterpolatedStringArgumentPlaceholder(SyntaxNode syntax, TypeSymbol type)
+        public BoundInterpolatedStringArgumentPlaceholder(SyntaxNode syntax, int argumentIndex, TypeSymbol type)
             : base(BoundKind.InterpolatedStringArgumentPlaceholder, syntax, type)
         {
 
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
+            this.ArgumentIndex = argumentIndex;
         }
 
 
         public new TypeSymbol Type => base.Type!;
+
+        public int ArgumentIndex { get; }
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitInterpolatedStringArgumentPlaceholder(this);
 
-        public BoundInterpolatedStringArgumentPlaceholder Update(TypeSymbol type)
+        public BoundInterpolatedStringArgumentPlaceholder Update(int argumentIndex, TypeSymbol type)
         {
-            if (!TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (argumentIndex != this.ArgumentIndex || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundInterpolatedStringArgumentPlaceholder(this.Syntax, type, this.HasErrors);
+                var result = new BoundInterpolatedStringArgumentPlaceholder(this.Syntax, argumentIndex, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -10894,7 +10898,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitInterpolatedStringArgumentPlaceholder(BoundInterpolatedStringArgumentPlaceholder node)
         {
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(type);
+            return node.Update(node.ArgumentIndex, type);
         }
         public override BoundNode? VisitStringInsert(BoundStringInsert node)
         {
@@ -13194,7 +13198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            BoundInterpolatedStringArgumentPlaceholder updatedNode = node.Update(infoAndType.Type!);
+            BoundInterpolatedStringArgumentPlaceholder updatedNode = node.Update(node.ArgumentIndex, infoAndType.Type!);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -15127,6 +15131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         );
         public override TreeDumperNode VisitInterpolatedStringArgumentPlaceholder(BoundInterpolatedStringArgumentPlaceholder node, object? arg) => new TreeDumperNode("interpolatedStringArgumentPlaceholder", null, new TreeDumperNode[]
         {
+            new TreeDumperNode("argumentIndex", node.ArgumentIndex, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -710,6 +710,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     break;
 
+                case ConversionKind.InterpolatedStringHandler:
+                    if (_inExpressionLambda)
+                    {
+                        Error(ErrorCode.ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion, node);
+                    }
+                    break;
+
                 default:
                     break;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -1030,6 +1030,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
+            public override BoundNode? VisitInterpolatedStringArgumentPlaceholder(BoundInterpolatedStringArgumentPlaceholder node)
+            {
+                Fail(node);
+                return null;
+            }
+
             private void Fail(BoundNode node)
             {
                 Debug.Assert(false, $"Bound nodes of kind {node.Kind} should not survive past local rewriting");

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -442,19 +442,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(removed);
         }
 
-        private void RemovePlaceholderReplacementIfPresent(BoundValuePlaceholderBase placeholder)
-        {
-            Debug.Assert(placeholder is { });
-            Debug.Assert(_placeholderReplacementMapDoNotUseDirectly is { });
-            _ = _placeholderReplacementMapDoNotUseDirectly.Remove(placeholder);
-        }
-
-        private bool HasPlaceholderReplacement(BoundValuePlaceholderBase placeholder)
-        {
-            Debug.Assert(placeholder is not null);
-            return _placeholderReplacementMapDoNotUseDirectly?.ContainsKey(placeholder) ?? false;
-        }
-
         public sealed override BoundNode VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
             // OutDeconstructVarPendingInference nodes are only used within initial binding, but don't survive past that stage

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -442,6 +442,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(removed);
         }
 
+        private void RemovePlaceholderReplacementIfPresent(BoundValuePlaceholderBase placeholder)
+        {
+            Debug.Assert(placeholder is { });
+            Debug.Assert(_placeholderReplacementMapDoNotUseDirectly is { });
+            _ = _placeholderReplacementMapDoNotUseDirectly.Remove(placeholder);
+        }
+
         private bool HasPlaceholderReplacement(BoundValuePlaceholderBase placeholder)
         {
             Debug.Assert(placeholder is not null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AnonymousObjectCreation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AnonymousObjectCreation.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitAnonymousObjectCreationExpression(BoundAnonymousObjectCreationExpression node)
         {
+            // We should never encounter an interpolated string handler conversion that was implicitly inferred, because
+            // there are no target types for an anonymous object creation.
+            AssertNoImplicitInterpolatedStringHandlerConversions(node.Arguments);
             // Rewrite the arguments.
             var rewrittenArguments = VisitList(node.Arguments);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -316,10 +316,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arguments,
                 property,
                 argsToParamsOpt,
-                ref argumentRefKindsOpt,
+                argumentRefKindsOpt,
                 ref rewrittenReceiver,
                 out ArrayBuilder<LocalSymbol>? argTempsBuilder,
-                out BitVector positionsAssignedToTemp,
                 receiverIsArgumentSideEffectSequence: out _);
 
             arguments = MakeArguments(
@@ -330,7 +329,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt,
                 ref argumentRefKindsOpt,
                 ref argTempsBuilder,
-                positionsAssignedToTemp,
                 invokedAsExtensionMethod: false,
                 enableCallerInfo: ThreeState.True);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -312,7 +312,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             arguments = VisitArguments(
-                syntax,
                 arguments,
                 property,
                 argsToParamsOpt,
@@ -331,7 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 invokedAsExtensionMethod: false,
                 enableCallerInfo: ThreeState.True);
 
-            var argTemps = argTempsBuilder?.ToImmutableAndFree() ?? default;
+            var argTemps = argTempsBuilder.ToImmutableAndFree();
 
             if (used)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -312,18 +311,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                     rewrittenRight);
             }
 
-            ImmutableArray<LocalSymbol> argTemps;
             arguments = VisitArguments(
+                syntax,
+                arguments,
+                property,
+                argsToParamsOpt,
+                ref argumentRefKindsOpt,
+                ref rewrittenReceiver,
+                out ArrayBuilder<LocalSymbol>? argTempsBuilder,
+                out BitVector positionsAssignedToTemp,
+                receiverIsArgumentSideEffectSequence: out _);
+
+            arguments = MakeArguments(
                 syntax,
                 arguments,
                 property,
                 expanded,
                 argsToParamsOpt,
                 ref argumentRefKindsOpt,
-                out argTemps,
-                ref rewrittenReceiver,
+                ref argTempsBuilder,
+                positionsAssignedToTemp,
                 invokedAsExtensionMethod: false,
                 enableCallerInfo: ThreeState.True);
+
+            var argTemps = argTempsBuilder?.ToImmutableAndFree() ?? default;
 
             if (used)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -318,8 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt,
                 argumentRefKindsOpt,
                 ref rewrittenReceiver,
-                out ArrayBuilder<LocalSymbol>? argTempsBuilder,
-                receiverIsArgumentSideEffectSequence: out _);
+                out ArrayBuilder<LocalSymbol>? argTempsBuilder);
 
             arguments = MakeArguments(
                 syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(temps?.Count is null or > 0);
             return visitedArgumentsBuilder.ToImmutableAndFree();
 
-            void ensureTempTrackingSetup([NotNull]ref ArrayBuilder<LocalSymbol>? temps, ref BitVector positionsAssignedToTemp)
+            void ensureTempTrackingSetup([NotNull] ref ArrayBuilder<LocalSymbol>? temps, ref BitVector positionsAssignedToTemp)
             {
                 if (temps == null)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -682,10 +682,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     foreach (var placeholder in interpolationData.ArgumentPlaceholders)
                     {
-                        if (HasPlaceholderReplacement(placeholder))
-                        {
-                            RemovePlaceholderReplacement(placeholder);
-                        }
+                        RemovePlaceholderReplacementIfPresent(placeholder);
                     }
 
                     // We create a sequence, rather than just directly adding all the expressions to storesToTemps, because this

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -300,7 +300,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<RefKind> argumentRefKinds = indexerAccess.ArgumentRefKindsOpt;
 
             ImmutableArray<BoundExpression> rewrittenArguments = VisitArguments(
-                syntax,
                 indexerAccess.Arguments,
                 indexer,
                 argsToParamsOpt,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.InterpolatedStringHandler:
                     Debug.Assert(node.Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true });
 
-                    (ArrayBuilder<BoundExpression> builderPatternExpressions, BoundLocal handlerLocal) = RewriteToInterpolatedStringHandlerPattern((BoundInterpolatedString)node.Operand);
-                    return _factory.Sequence(ImmutableArray.Create(handlerLocal.LocalSymbol), builderPatternExpressions.ToImmutableAndFree(), handlerLocal);
+                    (ArrayBuilder<BoundExpression> handlerPatternExpressions, BoundLocal handlerLocal) = RewriteToInterpolatedStringHandlerPattern((BoundInterpolatedString)node.Operand);
+                    return _factory.Sequence(ImmutableArray.Create(handlerLocal.LocalSymbol), handlerPatternExpressions.ToImmutableAndFree(), handlerLocal);
                 case ConversionKind.SwitchExpression or ConversionKind.ConditionalExpression:
                     // Skip through target-typed conditionals and switches
                     Debug.Assert(node.Operand is BoundConditionalOperator { WasTargetTyped: true } or BoundConvertedSwitchExpression { WasTargetTyped: true });

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<LocalSymbol>? temps = null;
             rewrittenArgs = MakeArguments(
                 node.Syntax,
-                node.Arguments,
+                rewrittenArgs,
                 functionPointer,
                 expanded: false,
                 argsToParamsOpt: default,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
@@ -28,8 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt: default,
                 argumentRefKindsOpt,
                 ref discardedReceiver,
-                out ArrayBuilder<LocalSymbol>? temps,
-                receiverIsArgumentSideEffectSequence: out _);
+                out ArrayBuilder<LocalSymbol>? temps);
 
             rewrittenArgs = MakeArguments(
                 node.Syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
@@ -18,11 +18,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             // There are target types so we can have handler conversions, but there are no attributes so contexts cannot
             // be involved.
             AssertNoImplicitInterpolatedStringHandlerConversions(node.Arguments, allowConversionsWithNoContext: true);
-            var rewrittenArgs = VisitList(node.Arguments);
-
             MethodSymbol functionPointer = node.FunctionPointer.Signature;
             var argumentRefKindsOpt = node.ArgumentRefKindsOpt;
-            ArrayBuilder<LocalSymbol>? temps = null;
+            BoundExpression? discardedReceiver = null;
+            var rewrittenArgs = VisitArguments(
+                node.Syntax,
+                node.Arguments,
+                functionPointer,
+                argsToParamsOpt: default,
+                argumentRefKindsOpt,
+                ref discardedReceiver,
+                out ArrayBuilder<LocalSymbol>? temps,
+                receiverIsArgumentSideEffectSequence: out _);
+
             rewrittenArgs = MakeArguments(
                 node.Syntax,
                 rewrittenArgs,
@@ -31,7 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt: default,
                 ref argumentRefKindsOpt,
                 ref temps,
-                positionsAssignedToTemp: default,
                 invokedAsExtensionMethod: false,
                 enableCallerInfo: ThreeState.False);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
@@ -22,13 +22,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             var argumentRefKindsOpt = node.ArgumentRefKindsOpt;
             BoundExpression? discardedReceiver = null;
             var rewrittenArgs = VisitArguments(
-                node.Syntax,
                 node.Arguments,
                 functionPointer,
                 argsToParamsOpt: default,
-                argumentRefKindsOpt,
-                ref discardedReceiver,
-                out ArrayBuilder<LocalSymbol>? temps);
+                argumentRefKindsOpt: argumentRefKindsOpt,
+                rewrittenReceiver: ref discardedReceiver,
+                temps: out ArrayBuilder<LocalSymbol>? temps);
 
             rewrittenArgs = MakeArguments(
                 node.Syntax,
@@ -44,9 +43,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(rewrittenExpression != null);
             node = node.Update(rewrittenExpression, rewrittenArgs, argumentRefKindsOpt, node.ResultKind, node.Type);
 
-            if (temps?.Count is null or 0)
+            if (temps.Count == 0)
             {
-                temps?.Free();
+                temps.Free();
                 return node;
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -20,11 +18,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // There are target types so we can have handler conversions, but there are no attributes so contexts cannot
             // be involved.
             AssertNoImplicitInterpolatedStringHandlerConversions(node.Arguments, allowConversionsWithNoContext: true);
+            var rewrittenArgs = VisitList(node.Arguments);
 
             MethodSymbol functionPointer = node.FunctionPointer.Signature;
             var argumentRefKindsOpt = node.ArgumentRefKindsOpt;
             ArrayBuilder<LocalSymbol>? temps = null;
-            ImmutableArray<BoundExpression> rewrittenArgs = MakeArguments(
+            rewrittenArgs = MakeArguments(
                 node.Syntax,
                 node.Arguments,
                 functionPointer,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -126,8 +126,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var getMethod = indexer.GetOwnOrInheritedGetMethod();
                 Debug.Assert(getMethod is not null);
 
-                // We have already lowered each argument, but we may need some additional rewriting for the arguments,
-                // such as generating a params array, re-ordering arguments based on argsToParamsOpt map, inserting arguments for optional parameters, etc.
                 ImmutableArray<BoundExpression> rewrittenArguments = VisitArguments(
                     syntax,
                     arguments,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -130,24 +130,36 @@ namespace Microsoft.CodeAnalysis.CSharp
                     syntax,
                     arguments,
                     indexer,
+                    argsToParamsOpt,
+                    ref argumentRefKindsOpt,
+                    ref rewrittenReceiver!,
+                    out ArrayBuilder<LocalSymbol>? temps,
+                    out BitVector positionsAssignedToTemp,
+                    receiverIsArgumentSideEffectSequence: out _);
+
+                rewrittenArguments = MakeArguments(
+                    syntax,
+                    rewrittenArguments,
+                    indexer,
                     expanded,
                     argsToParamsOpt,
                     ref argumentRefKindsOpt,
-                    out ImmutableArray<LocalSymbol> temps,
-                    ref rewrittenReceiver!,
+                    ref temps,
+                    positionsAssignedToTemp,
                     enableCallerInfo: ThreeState.True);
 
                 BoundExpression call = MakePropertyGetAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, getMethod);
 
-                if (temps.IsDefaultOrEmpty)
+                if (temps?.Count is null or 0)
                 {
+                    temps?.Free();
                     return call;
                 }
                 else
                 {
                     return new BoundSequence(
                         syntax,
-                        temps,
+                        temps.ToImmutableAndFree(),
                         ImmutableArray<BoundExpression>.Empty,
                         call,
                         type);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -127,7 +127,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(getMethod is not null);
 
                 ImmutableArray<BoundExpression> rewrittenArguments = VisitArguments(
-                    syntax,
                     arguments,
                     indexer,
                     argsToParamsOpt,
@@ -147,9 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 BoundExpression call = MakePropertyGetAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, getMethod);
 
-                if (temps?.Count is null or 0)
+                if (temps.Count == 0)
                 {
-                    temps?.Free();
+                    temps.Free();
                     return call;
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -131,10 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     arguments,
                     indexer,
                     argsToParamsOpt,
-                    ref argumentRefKindsOpt,
+                    argumentRefKindsOpt,
                     ref rewrittenReceiver!,
                     out ArrayBuilder<LocalSymbol>? temps,
-                    out BitVector positionsAssignedToTemp,
                     receiverIsArgumentSideEffectSequence: out _);
 
                 rewrittenArguments = MakeArguments(
@@ -145,7 +144,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argsToParamsOpt,
                     ref argumentRefKindsOpt,
                     ref temps,
-                    positionsAssignedToTemp,
                     enableCallerInfo: ThreeState.True);
 
                 BoundExpression call = MakePropertyGetAccess(syntax, rewrittenReceiver, indexer, rewrittenArguments, getMethod);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -133,8 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argsToParamsOpt,
                     argumentRefKindsOpt,
                     ref rewrittenReceiver!,
-                    out ArrayBuilder<LocalSymbol>? temps,
-                    receiverIsArgumentSideEffectSequence: out _);
+                    out ArrayBuilder<LocalSymbol>? temps);
 
                 rewrittenArguments = MakeArguments(
                     syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -40,7 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ImmutableArray<RefKind> argumentRefKindsOpt = node.ArgumentRefKindsOpt;
             ImmutableArray<BoundExpression> rewrittenArguments = VisitArguments(
-                node.Syntax,
                 node.Arguments,
                 node.Constructor,
                 node.ArgsToParamsOpt,
@@ -60,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ref tempsBuilder);
 
             BoundExpression rewrittenObjectCreation;
-            var temps = tempsBuilder?.ToImmutableAndFree() ?? default;
+            var temps = tempsBuilder.ToImmutableAndFree();
 
             if (_inExpressionLambda)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -44,10 +44,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node.Arguments,
                 node.Constructor,
                 node.ArgsToParamsOpt,
-                ref argumentRefKindsOpt,
+                argumentRefKindsOpt,
                 ref receiverDiscard,
                 out ArrayBuilder<LocalSymbol>? tempsBuilder,
-                out BitVector positionsAssignedToTemp,
                 receiverIsArgumentSideEffectSequence: out _);
 
             // We have already lowered each argument, but we may need some additional rewriting for the arguments,
@@ -59,8 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node.Expanded,
                 node.ArgsToParamsOpt,
                 ref argumentRefKindsOpt,
-                ref tempsBuilder,
-                positionsAssignedToTemp);
+                ref tempsBuilder);
 
             BoundExpression rewrittenObjectCreation;
             var temps = tempsBuilder?.ToImmutableAndFree() ?? default;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -46,8 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node.ArgsToParamsOpt,
                 argumentRefKindsOpt,
                 ref receiverDiscard,
-                out ArrayBuilder<LocalSymbol>? tempsBuilder,
-                receiverIsArgumentSideEffectSequence: out _);
+                out ArrayBuilder<LocalSymbol>? tempsBuilder);
 
             // We have already lowered each argument, but we may need some additional rewriting for the arguments,
             // such as generating a params array, re-ordering arguments based on argsToParamsOpt map, etc.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -179,7 +179,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // The receiver for a collection initializer is already a temp, so we don't need to preserve any additional temp stores beyond this method.
             ImmutableArray<BoundExpression> rewrittenArguments = VisitArguments(
-                syntax,
                 initializer.Arguments,
                 addMethod,
                 initializer.ArgsToParamsOpt,
@@ -200,12 +199,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_inExpressionLambda)
             {
-                Debug.Assert(temps?.Count is null or 0);
-                temps?.Free();
+                Debug.Assert(temps.Count == 0);
+                temps.Free();
                 return initializer.Update(addMethod, rewrittenArguments, rewrittenReceiver, expanded: false, argsToParamsOpt: default, defaultArguments: default, initializer.InvokedAsExtensionMethod, initializer.ResultKind, rewrittenType);
             }
 
-            return MakeCall(null, syntax, rewrittenReceiver, addMethod, rewrittenArguments, argumentRefKindsOpt, initializer.InvokedAsExtensionMethod, initializer.ResultKind, addMethod.ReturnType, temps?.ToImmutableAndFree() ?? default);
+            return MakeCall(null, syntax, rewrittenReceiver, addMethod, rewrittenArguments, argumentRefKindsOpt, initializer.InvokedAsExtensionMethod, initializer.ResultKind, addMethod.ReturnType, temps.ToImmutableAndFree());
         }
 
         // Rewrite object initializer member assignments and add them to the result.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -185,8 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initializer.ArgsToParamsOpt,
                 argumentRefKindsOpt,
                 ref rewrittenReceiver,
-                out ArrayBuilder<LocalSymbol>? temps,
-                receiverIsArgumentSideEffectSequence: out _);
+                out ArrayBuilder<LocalSymbol>? temps);
             rewrittenArguments = MakeArguments(syntax, rewrittenArguments, addMethod, initializer.Expanded, initializer.ArgsToParamsOpt, ref argumentRefKindsOpt, ref temps, enableCallerInfo: ThreeState.True);
 
             var rewrittenType = VisitType(initializer.Type);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -183,12 +183,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initializer.Arguments,
                 addMethod,
                 initializer.ArgsToParamsOpt,
-                ref argumentRefKindsOpt,
+                argumentRefKindsOpt,
                 ref rewrittenReceiver,
                 out ArrayBuilder<LocalSymbol>? temps,
-                out BitVector positionsAssignedToTemp,
                 receiverIsArgumentSideEffectSequence: out _);
-            rewrittenArguments = MakeArguments(syntax, rewrittenArguments, addMethod, initializer.Expanded, initializer.ArgsToParamsOpt, ref argumentRefKindsOpt, ref temps, positionsAssignedToTemp, enableCallerInfo: ThreeState.True);
+            rewrittenArguments = MakeArguments(syntax, rewrittenArguments, addMethod, initializer.Expanded, initializer.ArgsToParamsOpt, ref argumentRefKindsOpt, ref temps, enableCallerInfo: ThreeState.True);
 
             var rewrittenType = VisitType(initializer.Type);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -90,10 +90,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     appendCall.Arguments,
                     appendCall.Method,
                     appendCall.ArgsToParamsOpt,
-                    ref argRefKindsOpt,
+                    argRefKindsOpt,
                     ref appendReceiver,
                     out ArrayBuilder<LocalSymbol>? temps,
-                    out BitVector positionsAssignedToTemp,
                     receiverIsArgumentSideEffectSequence: out _);
 
                 var rewrittenAppendCall = MakeArgumentsAndCall(
@@ -108,7 +107,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     appendCall.ResultKind,
                     appendCall.Type,
                     temps,
-                    positionsAssignedToTemp,
                     appendCall);
 
                 Debug.Assert(usesBoolReturn == (appendCall.Type!.SpecialType == SpecialType.System_Boolean));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -92,8 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     appendCall.ArgsToParamsOpt,
                     argRefKindsOpt,
                     ref appendReceiver,
-                    out ArrayBuilder<LocalSymbol>? temps,
-                    receiverIsArgumentSideEffectSequence: out _);
+                    out ArrayBuilder<LocalSymbol>? temps);
 
                 var rewrittenAppendCall = MakeArgumentsAndCall(
                     appendCall.Syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -509,8 +509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodArgumentInfo.ArgsToParamsOpt,
                 resultKind: LookupResultKind.Viable,
                 type: method.ReturnType,
-                temps: null,
-                positionsAssignedToTemp: BitVector.Null);
+                temps: null);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -475,7 +475,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Synthesize a call `expression.Method()`, but with some extra smarts to handle extension methods, and to fill-in optional and params parameters.
+        /// Synthesize a call `expression.Method()`, but with some extra smarts to handle extension methods, and to fill-in optional and params parameters. This call expects that the
+        /// receiver parameter has already been visited.
         /// </summary>
         private BoundExpression MakeCallWithNoExplicitArgument(MethodArgumentInfo methodArgumentInfo, SyntaxNode syntax, BoundExpression? expression, bool assertParametersAreOptional = true)
         {
@@ -493,9 +494,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(!assertParametersAreOptional || method.Parameters.All(p => p.IsOptional || p.IsParams));
                 Debug.Assert(method.ParameterRefKinds.IsDefaultOrEmpty);
             }
+
+            Debug.Assert(methodArgumentInfo.Arguments.All(arg => arg is not BoundConversion { ConversionKind: ConversionKind.InterpolatedStringHandler }));
 #endif
 
-            return MakeCall(
+            return VisitArgumentsAndMakeCall(
                 syntax,
                 expression,
                 method,
@@ -505,7 +508,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 invokedAsExtensionMethod: method.IsExtensionMethod,
                 methodArgumentInfo.ArgsToParamsOpt,
                 resultKind: LookupResultKind.Viable,
-                type: method.ReturnType);
+                type: method.ReturnType,
+                argumentsAreVisited: true);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -498,7 +498,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(methodArgumentInfo.Arguments.All(arg => arg is not BoundConversion { ConversionKind: ConversionKind.InterpolatedStringHandler }));
 #endif
 
-            return VisitArgumentsAndMakeCall(
+            return MakeArgumentsAndCall(
                 syntax,
                 expression,
                 method,
@@ -509,7 +509,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodArgumentInfo.ArgsToParamsOpt,
                 resultKind: LookupResultKind.Viable,
                 type: method.ReturnType,
-                argumentsAreVisited: true);
+                temps: null,
+                positionsAssignedToTemp: BitVector.Null);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -767,13 +767,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 switch (name)
                 {
                     case null:
-                    case "" when ContainingSymbol.IsStatic:
+                    case "" when !ContainingSymbol.RequiresInstanceReceiver() || ContainingSymbol is MethodSymbol { MethodKind: MethodKind.Constructor }:
                         // Invalid data, bail
                         builder.Free();
                         return default;
 
                     case "":
-                        builder.Add(-1);
+                        builder.Add(BoundInterpolatedStringArgumentPlaceholder.InstanceParameter);
                         break;
 
                     default:

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -401,8 +401,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Indexes of the parameters that will be passed to the constructor of the interpolated string handler type
-        /// when an interpolated string handler conversion occurs. An index of -1 means the "this" parameter. These
-        /// indexes are ordered in the order to be passed to the constructor.
+        /// when an interpolated string handler conversion occurs. These indexes are ordered in the order to be passed
+        /// to the constructor.
+        /// <para/>
+        /// Indexes greater than or equal to 0 are references to parameters defined on the containing method or indexer.
+        /// Indexes less than 0 are constants defined on <see cref="BoundInterpolatedStringArgumentPlaceholder"/>.
         /// </summary>
         internal abstract ImmutableArray<int> InterpolatedStringHandlerArgumentIndexes { get; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1154,14 +1154,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (name == "")
                 {
                     // Name refers to the "this" instance parameter.
-                    if (ContainingSymbol.IsStatic)
+                    if (!ContainingSymbol.RequiresInstanceReceiver() || ContainingSymbol is MethodSymbol { MethodKind: MethodKind.Constructor })
                     {
                         // '{0}' is not an instance method, the receiver cannot be an interpolated string handler argument.
                         diagnostics.Add(ErrorCode.ERR_NotInstanceInvalidInterpolatedStringHandlerArgumentName, arguments.AttributeSyntaxOpt.Location, ContainingSymbol);
                         return null;
                     }
 
-                    return (-1, null);
+                    return (BoundInterpolatedStringArgumentPlaceholder.InstanceParameter, null);
                 }
 
                 var parameter = containingSymbolParameters.FirstOrDefault(static (param, name) => string.Equals(param.Name, name, StringComparison.Ordinal), name);
@@ -1184,7 +1184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // Parameter {0} occurs after {1} in the parameter list, but is used as an argument for interpolated string handler conversions.
                     // This will require the caller to reorder parameters with named arguments at the call site. Consider putting the interpolated
                     // string handler parameter after all arguments involved.
-                    diagnostics.Add(ErrorCode.WRN_ParameterOccursAfterInterpolatedStringHandlerParameter, errorLocation, parameter, this);
+                    diagnostics.Add(ErrorCode.WRN_ParameterOccursAfterInterpolatedStringHandlerParameter, errorLocation, parameter.Name, this);
                 }
 
                 return (parameter.Ordinal, parameter);

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Strom výrazů nesmí obsahovat výraz indexu od-do (^).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Strom výrazů možná neobsahuje vzor přístupu indexeru System.Index nebo System.Range.</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Vnitřní chyba v kompilátoru jazyka C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Eine Ausdrucksbaumstruktur darf keinen vom Ende ausgehenden Indexausdruck ("^") enthalten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Eine Ausdrucksbaumstruktur darf keinen System.Index- oder System.Range-Musterindexerzugriff enthalten.</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Interner Fehler im C#-Compiler.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Un árbol de expresión no puede contener una expresión de índice del otro extremo ("^").</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Un árbol de expresión no puede contener un patrón System.Index o un acceso a indizador System.Range.</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Error interno en el compilador de C#.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Une arborescence de l'expression ne peut pas contenir d'expression d'index partant de la fin ('^').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Une arborescence de l'expression ne peut pas contenir de modèle d'accès à l'indexeur System.Index ou System.Range</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Erreur interne dans le compilateur C#.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Un albero delle espressioni non può contenere un'espressione di indice from end ('^').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Un albero delle espressioni non può contenere un accesso a indicizzatore System.Index o System.Range di criterio</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Si è verificato un errore interno nel compilatore C#.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -372,6 +372,11 @@
         <target state="translated">式ツリーに、from-end インデックス ('^') 式を含めることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">式ツリーに、System.Index または System.Range インデクサー アクセスのパターンを含めることはできません</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">C# コンパイラで内部エラーが発生しました。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -372,6 +372,11 @@
         <target state="translated">식 트리에는 내림차순 인덱스('^') 식을 포함할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">식 트리에는 System.Index 또는 System.Range 패턴의 인덱서 액세스를 포함할 수 없습니다.</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">C# 컴파일러의 내부 오류입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Drzewo wyrażeń nie może zawierać wyrażenia „od końca indeksu” („^”).</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Drzewo wyrażenia nie może zawierać dostępu do indeksatora z wzorcem System.Index lub System.Range</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Błąd wewnętrzny w kompilatorze języka C#.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Uma árvore de expressão não pode conter uma expressão de índice de front-end ('^').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Uma árvore de expressão não pode conter um padrão System.Index ou acesso do indexador System.Range</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Erro interno no compilador C#.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Дерево выражений не может содержать выражение индекса, отсчитываемого с конца ("^").</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">Дерево выражения не может содержать доступ к индексатору System.Index или System.Range шаблона.</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">Внутренняя ошибка в компиляторе C#.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -372,6 +372,11 @@
         <target state="translated">İfade ağacı, sondan dizin ('^') ifadesi içeremez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">İfade ağacı, desen System.Index veya System.Range dizin oluşturucu erişimi içeremez</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">C# derleyicisinde iç hata oluştu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -372,6 +372,11 @@
         <target state="translated">表达式树不能包含 from-end 索引("^")表达式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">表达式树不能包含模式 System.Index 或 System.Range 索引器访问</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">C# 编译器中出现内部错误。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -553,13 +553,13 @@
         <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
-        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but the corresponding argument is specified after the interpolated string expression. Reorder the arguments to move '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
-        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
-        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
+        <source>Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -372,6 +372,11 @@
         <target state="translated">運算式樹狀架構不可包含 from-end index ('^') 運算式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion">
+        <source>An expression tree may not contain an interpolated string handler conversion.</source>
+        <target state="new">An expression tree may not contain an interpolated string handler conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsPatternIndexOrRangeIndexer">
         <source>An expression tree may not contain a pattern System.Index or System.Range indexer access</source>
         <target state="translated">運算式樹狀架構不可包含 System.Index 或 System.Range 索引子存取模式</target>
@@ -540,6 +545,21 @@
       <trans-unit id="ERR_InternalError">
         <source>Internal error in the C# compiler.</source>
         <target state="translated">C# 編譯器中的內部錯誤。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentAttributeMalformed">
+        <source>The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</source>
+        <target state="new">The InterpolatedStringHandlerArgumentAttribute applied to parameter '{0}' is malformed and cannot be interpreted. Construct an instance of '{1}' manually.</target>
+        <note>InterpolatedStringHandlerArgumentAttribute is a type name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString">
+        <source>Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is an argument to the interpolated string handler conversion on parameter '{1}', but is specified after the interpolated string constant. Reorder the arguments to move '{0}' before '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified">
+        <source>Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</source>
+        <target state="new">Parameter '{0}' is optional, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -7142,17 +7142,17 @@ literal:literal
 {
   // Code size       44 (0x2c)
   .maxstack  7
-  .locals init (int V_0, //i
+  .locals init (string V_0, //s
                 int V_1,
                 string V_2,
                 CustomHandler V_3)
   IL_0000:  ldc.i4.s   10
-  IL_0002:  stloc.0
-  IL_0003:  ldstr      ""arg""
-  IL_0008:  ldloc.0
-  IL_0009:  stloc.1
-  IL_000a:  stloc.2
-  IL_000b:  ldloc.1
+  IL_0002:  ldstr      ""arg""
+  IL_0007:  stloc.0
+  IL_0008:  stloc.1
+  IL_0009:  ldloc.1
+  IL_000a:  ldloc.0
+  IL_000b:  stloc.2
   IL_000c:  ldloc.2
   IL_000d:  ldloca.s   V_3
   IL_000f:  ldc.i4.7
@@ -7173,18 +7173,18 @@ literal:literal
 {
   // Code size       52 (0x34)
   .maxstack  7
-  .locals init (int V_0, //i
+  .locals init (string V_0, //s
                 int V_1,
                 string V_2,
                 CustomHandler V_3,
                 bool V_4)
   IL_0000:  ldc.i4.s   10
-  IL_0002:  stloc.0
-  IL_0003:  ldstr      ""arg""
-  IL_0008:  ldloc.0
-  IL_0009:  stloc.1
-  IL_000a:  stloc.2
-  IL_000b:  ldloc.1
+  IL_0002:  ldstr      ""arg""
+  IL_0007:  stloc.0
+  IL_0008:  stloc.1
+  IL_0009:  ldloc.1
+  IL_000a:  ldloc.0
+  IL_000b:  stloc.2
   IL_000c:  ldloc.2
   IL_000d:  ldc.i4.7
   IL_000e:  ldc.i4.0
@@ -7264,90 +7264,96 @@ o in M
             verifier.VerifyIL("<top-level-statements-entry-point>", (extraConstructorArg == "")
                 ? @"
 {
-  // Code size       63 (0x3f)
+  // Code size       67 (0x43)
   .maxstack  8
-  .locals init (string V_0, //s
-                object V_1, //o
-                int V_2,
-                string& V_3,
-                object& V_4,
-                CustomHandler V_5)
+  .locals init (int V_0, //i
+                string V_1, //s
+                object V_2, //o
+                int& V_3,
+                string& V_4,
+                object& V_5,
+                CustomHandler V_6)
   IL_0000:  ldc.i4.1
-  IL_0001:  ldnull
-  IL_0002:  stloc.0
-  IL_0003:  stloc.2
+  IL_0001:  stloc.0
+  IL_0002:  ldnull
+  IL_0003:  stloc.1
   IL_0004:  ldloca.s   V_0
   IL_0006:  stloc.3
-  IL_0007:  ldloca.s   V_1
-  IL_0009:  stloc.s    V_4
-  IL_000b:  ldloca.s   V_2
-  IL_000d:  ldloc.3
-  IL_000e:  ldloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.0
-  IL_0012:  ldloca.s   V_2
-  IL_0014:  ldloc.3
-  IL_0015:  ldloc.s    V_4
-  IL_0017:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object)""
-  IL_001c:  stloc.s    V_5
-  IL_001e:  ldloca.s   V_5
-  IL_0020:  ldstr      ""literal""
-  IL_0025:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_002a:  pop
-  IL_002b:  ldloc.s    V_5
-  IL_002d:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
-  IL_0032:  ldloc.0
-  IL_0033:  call       ""void System.Console.WriteLine(string)""
-  IL_0038:  ldloc.1
-  IL_0039:  call       ""void System.Console.WriteLine(object)""
-  IL_003e:  ret
+  IL_0007:  ldloc.3
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  stloc.s    V_4
+  IL_000c:  ldloc.s    V_4
+  IL_000e:  ldloca.s   V_2
+  IL_0010:  stloc.s    V_5
+  IL_0012:  ldloc.s    V_5
+  IL_0014:  ldc.i4.7
+  IL_0015:  ldc.i4.0
+  IL_0016:  ldloc.3
+  IL_0017:  ldloc.s    V_4
+  IL_0019:  ldloc.s    V_5
+  IL_001b:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object)""
+  IL_0020:  stloc.s    V_6
+  IL_0022:  ldloca.s   V_6
+  IL_0024:  ldstr      ""literal""
+  IL_0029:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002e:  pop
+  IL_002f:  ldloc.s    V_6
+  IL_0031:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
+  IL_0036:  ldloc.1
+  IL_0037:  call       ""void System.Console.WriteLine(string)""
+  IL_003c:  ldloc.2
+  IL_003d:  call       ""void System.Console.WriteLine(object)""
+  IL_0042:  ret
 }
 "
                 : @"
 {
-  // Code size       72 (0x48)
+  // Code size       76 (0x4c)
   .maxstack  9
-  .locals init (string V_0, //s
-                object V_1, //o
-                int V_2,
-                string& V_3,
-                object& V_4,
-                CustomHandler V_5,
-                bool V_6)
+  .locals init (int V_0, //i
+                string V_1, //s
+                object V_2, //o
+                int& V_3,
+                string& V_4,
+                object& V_5,
+                CustomHandler V_6,
+                bool V_7)
   IL_0000:  ldc.i4.1
-  IL_0001:  ldnull
-  IL_0002:  stloc.0
-  IL_0003:  stloc.2
+  IL_0001:  stloc.0
+  IL_0002:  ldnull
+  IL_0003:  stloc.1
   IL_0004:  ldloca.s   V_0
   IL_0006:  stloc.3
-  IL_0007:  ldloca.s   V_1
-  IL_0009:  stloc.s    V_4
-  IL_000b:  ldloca.s   V_2
-  IL_000d:  ldloc.3
-  IL_000e:  ldloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.0
-  IL_0012:  ldloca.s   V_2
-  IL_0014:  ldloc.3
-  IL_0015:  ldloc.s    V_4
-  IL_0017:  ldloca.s   V_6
-  IL_0019:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object, out bool)""
-  IL_001e:  stloc.s    V_5
-  IL_0020:  ldloc.s    V_6
-  IL_0022:  brfalse.s  IL_0032
-  IL_0024:  ldloca.s   V_5
-  IL_0026:  ldstr      ""literal""
-  IL_002b:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0030:  br.s       IL_0033
-  IL_0032:  ldc.i4.0
-  IL_0033:  pop
-  IL_0034:  ldloc.s    V_5
-  IL_0036:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
-  IL_003b:  ldloc.0
-  IL_003c:  call       ""void System.Console.WriteLine(string)""
-  IL_0041:  ldloc.1
-  IL_0042:  call       ""void System.Console.WriteLine(object)""
-  IL_0047:  ret
+  IL_0007:  ldloc.3
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  stloc.s    V_4
+  IL_000c:  ldloc.s    V_4
+  IL_000e:  ldloca.s   V_2
+  IL_0010:  stloc.s    V_5
+  IL_0012:  ldloc.s    V_5
+  IL_0014:  ldc.i4.7
+  IL_0015:  ldc.i4.0
+  IL_0016:  ldloc.3
+  IL_0017:  ldloc.s    V_4
+  IL_0019:  ldloc.s    V_5
+  IL_001b:  ldloca.s   V_7
+  IL_001d:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object, out bool)""
+  IL_0022:  stloc.s    V_6
+  IL_0024:  ldloc.s    V_7
+  IL_0026:  brfalse.s  IL_0036
+  IL_0028:  ldloca.s   V_6
+  IL_002a:  ldstr      ""literal""
+  IL_002f:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0034:  br.s       IL_0037
+  IL_0036:  ldc.i4.0
+  IL_0037:  pop
+  IL_0038:  ldloc.s    V_6
+  IL_003a:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
+  IL_003f:  ldloc.1
+  IL_0040:  call       ""void System.Console.WriteLine(string)""
+  IL_0045:  ldloc.2
+  IL_0046:  call       ""void System.Console.WriteLine(object)""
+  IL_004b:  ret
 }
 ");
 
@@ -7417,20 +7423,20 @@ literal:literal
 {
   // Code size       45 (0x2d)
   .maxstack  7
-  .locals init (int V_0,
-                string V_1,
+  .locals init (string V_0,
+                int V_1,
                 CustomHandler V_2)
   IL_0000:  call       ""int <Program>$.<<Main>$>g__GetInt|0_0()""
-  IL_0005:  stloc.0
-  IL_0006:  call       ""string <Program>$.<<Main>$>g__GetString|0_1()""
-  IL_000b:  stloc.1
-  IL_000c:  ldloc.0
-  IL_000d:  ldloc.1
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  call       ""string <Program>$.<<Main>$>g__GetString|0_1()""
+  IL_000c:  stloc.0
+  IL_000d:  ldloc.0
   IL_000e:  ldloca.s   V_2
   IL_0010:  ldc.i4.7
   IL_0011:  ldc.i4.0
-  IL_0012:  ldloc.1
-  IL_0013:  ldloc.0
+  IL_0012:  ldloc.0
+  IL_0013:  ldloc.1
   IL_0014:  call       ""CustomHandler..ctor(int, int, string, int)""
   IL_0019:  ldloca.s   V_2
   IL_001b:  ldstr      ""literal""
@@ -7445,20 +7451,20 @@ literal:literal
 {
   // Code size       52 (0x34)
   .maxstack  7
-  .locals init (int V_0,
-                string V_1,
+  .locals init (string V_0,
+                int V_1,
                 CustomHandler V_2,
                 bool V_3)
   IL_0000:  call       ""int <Program>$.<<Main>$>g__GetInt|0_0()""
-  IL_0005:  stloc.0
-  IL_0006:  call       ""string <Program>$.<<Main>$>g__GetString|0_1()""
-  IL_000b:  stloc.1
-  IL_000c:  ldloc.0
-  IL_000d:  ldloc.1
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  call       ""string <Program>$.<<Main>$>g__GetString|0_1()""
+  IL_000c:  stloc.0
+  IL_000d:  ldloc.0
   IL_000e:  ldc.i4.7
   IL_000f:  ldc.i4.0
-  IL_0010:  ldloc.1
-  IL_0011:  ldloc.0
+  IL_0010:  ldloc.0
+  IL_0011:  ldloc.1
   IL_0012:  ldloca.s   V_3
   IL_0014:  newobj     ""CustomHandler..ctor(int, int, string, int, out bool)""
   IL_0019:  stloc.2
@@ -7550,74 +7556,80 @@ literal:literal
             verifier.VerifyIL("<top-level-statements-entry-point>", (extraConstructorArg == "")
                 ? @"
 {
-  // Code size       53 (0x35)
+  // Code size       56 (0x38)
   .maxstack  9
-  .locals init (C V_0,
-                string V_1,
+  .locals init (string V_0,
+                C V_1,
                 int V_2,
-                CustomHandler V_3)
+                string V_3,
+                CustomHandler V_4)
   IL_0000:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0005:  stloc.0
-  IL_0006:  call       ""string <Program>$.<<Main>$>g__GetString|0_2()""
-  IL_000b:  stloc.1
-  IL_000c:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1()""
-  IL_0011:  stloc.2
-  IL_0012:  ldloc.0
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
-  IL_0015:  ldloca.s   V_3
-  IL_0017:  ldc.i4.7
-  IL_0018:  ldc.i4.0
-  IL_0019:  ldloc.1
-  IL_001a:  ldloc.0
-  IL_001b:  ldloc.2
-  IL_001c:  call       ""CustomHandler..ctor(int, int, string, C, int)""
-  IL_0021:  ldloca.s   V_3
-  IL_0023:  ldstr      ""literal""
-  IL_0028:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_002d:  pop
-  IL_002e:  ldloc.3
-  IL_002f:  callvirt   ""void C.M(int, string, CustomHandler)""
-  IL_0034:  ret
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  call       ""string <Program>$.<<Main>$>g__GetString|0_2()""
+  IL_000c:  stloc.0
+  IL_000d:  ldloc.0
+  IL_000e:  stloc.3
+  IL_000f:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1()""
+  IL_0014:  stloc.2
+  IL_0015:  ldloc.2
+  IL_0016:  ldloc.3
+  IL_0017:  ldloca.s   V_4
+  IL_0019:  ldc.i4.7
+  IL_001a:  ldc.i4.0
+  IL_001b:  ldloc.0
+  IL_001c:  ldloc.1
+  IL_001d:  ldloc.2
+  IL_001e:  call       ""CustomHandler..ctor(int, int, string, C, int)""
+  IL_0023:  ldloca.s   V_4
+  IL_0025:  ldstr      ""literal""
+  IL_002a:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002f:  pop
+  IL_0030:  ldloc.s    V_4
+  IL_0032:  callvirt   ""void C.M(int, string, CustomHandler)""
+  IL_0037:  ret
 }
 "
                 : @"
 {
-  // Code size       61 (0x3d)
+  // Code size       65 (0x41)
   .maxstack  9
-  .locals init (C V_0,
-                string V_1,
+  .locals init (string V_0,
+                C V_1,
                 int V_2,
-                CustomHandler V_3,
-                bool V_4)
+                string V_3,
+                CustomHandler V_4,
+                bool V_5)
   IL_0000:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0005:  stloc.0
-  IL_0006:  call       ""string <Program>$.<<Main>$>g__GetString|0_2()""
-  IL_000b:  stloc.1
-  IL_000c:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1()""
-  IL_0011:  stloc.2
-  IL_0012:  ldloc.0
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
-  IL_0015:  ldc.i4.7
-  IL_0016:  ldc.i4.0
-  IL_0017:  ldloc.1
-  IL_0018:  ldloc.0
-  IL_0019:  ldloc.2
-  IL_001a:  ldloca.s   V_4
-  IL_001c:  newobj     ""CustomHandler..ctor(int, int, string, C, int, out bool)""
-  IL_0021:  stloc.3
-  IL_0022:  ldloc.s    V_4
-  IL_0024:  brfalse.s  IL_0034
-  IL_0026:  ldloca.s   V_3
-  IL_0028:  ldstr      ""literal""
-  IL_002d:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0032:  br.s       IL_0035
-  IL_0034:  ldc.i4.0
-  IL_0035:  pop
-  IL_0036:  ldloc.3
-  IL_0037:  callvirt   ""void C.M(int, string, CustomHandler)""
-  IL_003c:  ret
+  IL_0005:  stloc.1
+  IL_0006:  ldloc.1
+  IL_0007:  call       ""string <Program>$.<<Main>$>g__GetString|0_2()""
+  IL_000c:  stloc.0
+  IL_000d:  ldloc.0
+  IL_000e:  stloc.3
+  IL_000f:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1()""
+  IL_0014:  stloc.2
+  IL_0015:  ldloc.2
+  IL_0016:  ldloc.3
+  IL_0017:  ldc.i4.7
+  IL_0018:  ldc.i4.0
+  IL_0019:  ldloc.0
+  IL_001a:  ldloc.1
+  IL_001b:  ldloc.2
+  IL_001c:  ldloca.s   V_5
+  IL_001e:  newobj     ""CustomHandler..ctor(int, int, string, C, int, out bool)""
+  IL_0023:  stloc.s    V_4
+  IL_0025:  ldloc.s    V_5
+  IL_0027:  brfalse.s  IL_0037
+  IL_0029:  ldloca.s   V_4
+  IL_002b:  ldstr      ""literal""
+  IL_0030:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0035:  br.s       IL_0038
+  IL_0037:  ldc.i4.0
+  IL_0038:  pop
+  IL_0039:  ldloc.s    V_4
+  IL_003b:  callvirt   ""void C.M(int, string, CustomHandler)""
+  IL_0040:  ret
 }
 ");
 
@@ -7914,9 +7926,9 @@ literal:literal
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldc.i4.s   10
   IL_0007:  stloc.0
-  IL_0008:  ldstr      ""str""
-  IL_000d:  stloc.1
-  IL_000e:  ldloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldstr      ""str""
+  IL_000e:  stloc.1
   IL_000f:  ldloc.1
   IL_0010:  ldloca.s   V_2
   IL_0012:  ldc.i4.7
@@ -7945,9 +7957,9 @@ literal:literal
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldc.i4.s   10
   IL_0007:  stloc.0
-  IL_0008:  ldstr      ""str""
-  IL_000d:  stloc.1
-  IL_000e:  ldloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldstr      ""str""
+  IL_000e:  stloc.1
   IL_000f:  ldloc.1
   IL_0010:  ldc.i4.7
   IL_0011:  ldc.i4.0
@@ -8030,9 +8042,9 @@ literal:literal
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldc.i4.s   10
   IL_0007:  stloc.0
-  IL_0008:  ldstr      ""str""
-  IL_000d:  stloc.1
-  IL_000e:  ldloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldstr      ""str""
+  IL_000e:  stloc.1
   IL_000f:  ldloc.1
   IL_0010:  ldloca.s   V_2
   IL_0012:  ldc.i4.7
@@ -8061,9 +8073,9 @@ literal:literal
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldc.i4.s   10
   IL_0007:  stloc.0
-  IL_0008:  ldstr      ""str""
-  IL_000d:  stloc.1
-  IL_000e:  ldloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldstr      ""str""
+  IL_000e:  stloc.1
   IL_000f:  ldloc.1
   IL_0010:  ldc.i4.7
   IL_0011:  ldc.i4.0
@@ -8142,25 +8154,25 @@ literal:literal
 {
   // Code size       51 (0x33)
   .maxstack  9
-  .locals init (C V_0,
-                int V_1,
+  .locals init (int V_0,
+                C V_1,
                 string V_2,
                 CustomHandler V_3)
   IL_0000:  ldc.i4.5
   IL_0001:  newobj     ""C..ctor(int)""
-  IL_0006:  stloc.0
-  IL_0007:  ldc.i4.s   10
-  IL_0009:  stloc.1
-  IL_000a:  ldstr      ""str""
-  IL_000f:  stloc.2
-  IL_0010:  ldloc.0
-  IL_0011:  ldloc.1
+  IL_0006:  stloc.1
+  IL_0007:  ldloc.1
+  IL_0008:  ldc.i4.s   10
+  IL_000a:  stloc.0
+  IL_000b:  ldloc.0
+  IL_000c:  ldstr      ""str""
+  IL_0011:  stloc.2
   IL_0012:  ldloc.2
   IL_0013:  ldloca.s   V_3
   IL_0015:  ldc.i4.7
   IL_0016:  ldc.i4.0
-  IL_0017:  ldloc.1
-  IL_0018:  ldloc.0
+  IL_0017:  ldloc.0
+  IL_0018:  ldloc.1
   IL_0019:  ldloc.2
   IL_001a:  call       ""CustomHandler..ctor(int, int, int, C, string)""
   IL_001f:  ldloca.s   V_3
@@ -8176,25 +8188,25 @@ literal:literal
 {
   // Code size       59 (0x3b)
   .maxstack  9
-  .locals init (C V_0,
-                int V_1,
+  .locals init (int V_0,
+                C V_1,
                 string V_2,
                 CustomHandler V_3,
                 bool V_4)
   IL_0000:  ldc.i4.5
   IL_0001:  newobj     ""C..ctor(int)""
-  IL_0006:  stloc.0
-  IL_0007:  ldc.i4.s   10
-  IL_0009:  stloc.1
-  IL_000a:  ldstr      ""str""
-  IL_000f:  stloc.2
-  IL_0010:  ldloc.0
-  IL_0011:  ldloc.1
+  IL_0006:  stloc.1
+  IL_0007:  ldloc.1
+  IL_0008:  ldc.i4.s   10
+  IL_000a:  stloc.0
+  IL_000b:  ldloc.0
+  IL_000c:  ldstr      ""str""
+  IL_0011:  stloc.2
   IL_0012:  ldloc.2
   IL_0013:  ldc.i4.7
   IL_0014:  ldc.i4.0
-  IL_0015:  ldloc.1
-  IL_0016:  ldloc.0
+  IL_0015:  ldloc.0
+  IL_0016:  ldloc.1
   IL_0017:  ldloc.2
   IL_0018:  ldloca.s   V_4
   IL_001a:  newobj     ""CustomHandler..ctor(int, int, int, C, string, out bool)""
@@ -8660,7 +8672,7 @@ s2.I:2");
 {
   // Code size       56 (0x38)
   .maxstack  6
-  .locals init (S V_0, //s1
+  .locals init (S V_0, //s2
                 S V_1,
                 S V_2)
   IL_0000:  ldloca.s   V_1
@@ -8669,17 +8681,17 @@ s2.I:2");
   IL_000a:  ldc.i4.1
   IL_000b:  stfld      ""int S.I""
   IL_0010:  ldloc.1
-  IL_0011:  stloc.0
-  IL_0012:  ldloca.s   V_1
-  IL_0014:  initobj    ""S""
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldc.i4.2
-  IL_001d:  stfld      ""int S.I""
-  IL_0022:  ldloc.1
-  IL_0023:  ldloc.0
-  IL_0024:  stloc.1
-  IL_0025:  stloc.2
-  IL_0026:  ldloca.s   V_1
+  IL_0011:  ldloca.s   V_1
+  IL_0013:  initobj    ""S""
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldc.i4.2
+  IL_001c:  stfld      ""int S.I""
+  IL_0021:  ldloc.1
+  IL_0022:  stloc.0
+  IL_0023:  stloc.1
+  IL_0024:  ldloca.s   V_1
+  IL_0026:  ldloc.0
+  IL_0027:  stloc.2
   IL_0028:  ldloc.2
   IL_0029:  ldc.i4.0
   IL_002a:  ldc.i4.0
@@ -8732,6 +8744,130 @@ public partial struct CustomHandler
                 // s1.M(ref s2, $"");
                 Diagnostic(ErrorCode.ERR_BadArgRef, @"$""""").WithArguments("3", "ref").WithLocation(8, 14)
             );
+        }
+
+        [ConditionalFact(typeof(NoIOperationValidation))]
+        public void StructParameter_ByVal()
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+S s = new S { I = 1 };
+
+S.M(s, $"""");
+
+public struct S
+{
+    public int I;
+
+    public static void M(S s, [InterpolatedStringHandlerArgument(""s"")]CustomHandler handler)
+    {
+        Console.WriteLine(""s.I:"" + s.I.ToString());
+    }
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, S s) : this(literalLength, formattedCount)
+    {
+        s.I = 2;
+    }
+}
+";
+
+            var handler = GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false);
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
+
+            var verifier = CompileAndVerify(comp, expectedOutput: @"s.I:1");
+
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       33 (0x21)
+  .maxstack  4
+  .locals init (S V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldc.i4.1
+  IL_000b:  stfld      ""int S.I""
+  IL_0010:  ldloc.0
+  IL_0011:  stloc.0
+  IL_0012:  ldloc.0
+  IL_0013:  ldc.i4.0
+  IL_0014:  ldc.i4.0
+  IL_0015:  ldloc.0
+  IL_0016:  newobj     ""CustomHandler..ctor(int, int, S)""
+  IL_001b:  call       ""void S.M(S, CustomHandler)""
+  IL_0020:  ret
+}
+");
+        }
+
+        [ConditionalFact(typeof(NoIOperationValidation))]
+        public void StructParameter_ByRef()
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+S s = new S { I = 1 };
+
+S.M(ref s, $"""");
+
+public struct S
+{
+    public int I;
+
+    public static void M(ref S s, [InterpolatedStringHandlerArgument(""s"")]CustomHandler handler)
+    {
+        Console.WriteLine(""s.I:"" + s.I.ToString());
+    }
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, ref S s) : this(literalLength, formattedCount)
+    {
+        s.I = 2;
+    }
+}
+";
+
+            var handler = GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false);
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
+
+            var verifier = CompileAndVerify(comp, expectedOutput: @"s.I:2");
+
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       36 (0x24)
+  .maxstack  4
+  .locals init (S V_0, //s
+                S V_1,
+                S& V_2)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  ldc.i4.1
+  IL_000b:  stfld      ""int S.I""
+  IL_0010:  ldloc.1
+  IL_0011:  stloc.0
+  IL_0012:  ldloca.s   V_0
+  IL_0014:  stloc.2
+  IL_0015:  ldloc.2
+  IL_0016:  ldc.i4.0
+  IL_0017:  ldc.i4.0
+  IL_0018:  ldloc.2
+  IL_0019:  newobj     ""CustomHandler..ctor(int, int, ref S)""
+  IL_001e:  call       ""void S.M(ref S, CustomHandler)""
+  IL_0023:  ret
+}
+");
         }
 
         [ConditionalTheory(typeof(NoIOperationValidation))]
@@ -8953,98 +9089,158 @@ format:
             {
                 (useBoolReturns: false, validityParameter: false) => @"
 {
-  // Code size       80 (0x50)
+  // Code size       85 (0x55)
   .maxstack  6
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
-                CustomHandler V_3,
-                CustomHandler V_4)
+                int V_1,
+                C V_2,
+                int V_3,
+                CustomHandler V_4,
+                CustomHandler V_5)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
+  IL_0007:  stloc.2
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloca.s   V_4
-  IL_0011:  ldc.i4.7
-  IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
-  IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_4
-  IL_001c:  ldstr      ""literal""
-  IL_0021:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_0026:  ldloca.s   V_4
-  IL_0028:  ldloc.0
-  IL_0029:  box        ""int""
-  IL_002e:  ldc.i4.0
-  IL_002f:  ldnull
-  IL_0030:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_0035:  ldloc.s    V_4
-  IL_0037:  stloc.3
-  IL_0038:  ldloc.1
-  IL_0039:  ldloc.2
-  IL_003a:  ldloc.3
-  IL_003b:  ldloc.1
-  IL_003c:  ldloc.2
-  IL_003d:  ldloc.3
-  IL_003e:  callvirt   ""int C.this[int, CustomHandler].get""
-  IL_0043:  ldc.i4.2
-  IL_0044:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0049:  add
-  IL_004a:  callvirt   ""void C.this[int, CustomHandler].set""
-  IL_004f:  ret
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  stloc.3
+  IL_0011:  ldloca.s   V_5
+  IL_0013:  ldc.i4.7
+  IL_0014:  ldc.i4.1
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.2
+  IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
+  IL_001c:  ldloca.s   V_5
+  IL_001e:  ldstr      ""literal""
+  IL_0023:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0028:  ldloca.s   V_5
+  IL_002a:  ldloc.0
+  IL_002b:  box        ""int""
+  IL_0030:  ldc.i4.0
+  IL_0031:  ldnull
+  IL_0032:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0037:  ldloc.s    V_5
+  IL_0039:  stloc.s    V_4
+  IL_003b:  ldloc.2
+  IL_003c:  ldloc.3
+  IL_003d:  ldloc.s    V_4
+  IL_003f:  ldloc.2
+  IL_0040:  ldloc.3
+  IL_0041:  ldloc.s    V_4
+  IL_0043:  callvirt   ""int C.this[int, CustomHandler].get""
+  IL_0048:  ldc.i4.2
+  IL_0049:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_004e:  add
+  IL_004f:  callvirt   ""void C.this[int, CustomHandler].set""
+  IL_0054:  ret
 }
 ",
                 (useBoolReturns: false, validityParameter: true) => @"
 {
-  // Code size       91 (0x5b)
+  // Code size       96 (0x60)
   .maxstack  6
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
-                CustomHandler V_3,
+                int V_1,
+                C V_2,
+                int V_3,
                 CustomHandler V_4,
-                bool V_5)
+                CustomHandler V_5,
+                bool V_6)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
+  IL_0007:  stloc.2
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldc.i4.7
-  IL_0010:  ldc.i4.1
-  IL_0011:  ldloc.2
-  IL_0012:  ldloc.1
-  IL_0013:  ldloca.s   V_5
-  IL_0015:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001a:  stloc.s    V_4
-  IL_001c:  ldloc.s    V_5
-  IL_001e:  brfalse.s  IL_003e
-  IL_0020:  ldloca.s   V_4
-  IL_0022:  ldstr      ""literal""
-  IL_0027:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_002c:  ldloca.s   V_4
-  IL_002e:  ldloc.0
-  IL_002f:  box        ""int""
-  IL_0034:  ldc.i4.0
-  IL_0035:  ldnull
-  IL_0036:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_003b:  ldc.i4.1
-  IL_003c:  br.s       IL_003f
-  IL_003e:  ldc.i4.0
-  IL_003f:  pop
-  IL_0040:  ldloc.s    V_4
-  IL_0042:  stloc.3
-  IL_0043:  ldloc.1
-  IL_0044:  ldloc.2
-  IL_0045:  ldloc.3
-  IL_0046:  ldloc.1
-  IL_0047:  ldloc.2
-  IL_0048:  ldloc.3
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  stloc.3
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.1
+  IL_0013:  ldloc.1
+  IL_0014:  ldloc.2
+  IL_0015:  ldloca.s   V_6
+  IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
+  IL_001c:  stloc.s    V_5
+  IL_001e:  ldloc.s    V_6
+  IL_0020:  brfalse.s  IL_0040
+  IL_0022:  ldloca.s   V_5
+  IL_0024:  ldstr      ""literal""
+  IL_0029:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_002e:  ldloca.s   V_5
+  IL_0030:  ldloc.0
+  IL_0031:  box        ""int""
+  IL_0036:  ldc.i4.0
+  IL_0037:  ldnull
+  IL_0038:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_003d:  ldc.i4.1
+  IL_003e:  br.s       IL_0041
+  IL_0040:  ldc.i4.0
+  IL_0041:  pop
+  IL_0042:  ldloc.s    V_5
+  IL_0044:  stloc.s    V_4
+  IL_0046:  ldloc.2
+  IL_0047:  ldloc.3
+  IL_0048:  ldloc.s    V_4
+  IL_004a:  ldloc.2
+  IL_004b:  ldloc.3
+  IL_004c:  ldloc.s    V_4
+  IL_004e:  callvirt   ""int C.this[int, CustomHandler].get""
+  IL_0053:  ldc.i4.2
+  IL_0054:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_0059:  add
+  IL_005a:  callvirt   ""void C.this[int, CustomHandler].set""
+  IL_005f:  ret
+}
+",
+                (useBoolReturns: true, validityParameter: false) => @"
+{
+  // Code size       91 (0x5b)
+  .maxstack  6
+  .locals init (int V_0, //i
+                int V_1,
+                C V_2,
+                int V_3,
+                CustomHandler V_4,
+                CustomHandler V_5)
+  IL_0000:  ldc.i4.3
+  IL_0001:  stloc.0
+  IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
+  IL_0007:  stloc.2
+  IL_0008:  ldc.i4.1
+  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  stloc.3
+  IL_0011:  ldloca.s   V_5
+  IL_0013:  ldc.i4.7
+  IL_0014:  ldc.i4.1
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.2
+  IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
+  IL_001c:  ldloca.s   V_5
+  IL_001e:  ldstr      ""literal""
+  IL_0023:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0028:  brfalse.s  IL_003b
+  IL_002a:  ldloca.s   V_5
+  IL_002c:  ldloc.0
+  IL_002d:  box        ""int""
+  IL_0032:  ldc.i4.0
+  IL_0033:  ldnull
+  IL_0034:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_0039:  br.s       IL_003c
+  IL_003b:  ldc.i4.0
+  IL_003c:  pop
+  IL_003d:  ldloc.s    V_5
+  IL_003f:  stloc.s    V_4
+  IL_0041:  ldloc.2
+  IL_0042:  ldloc.3
+  IL_0043:  ldloc.s    V_4
+  IL_0045:  ldloc.2
+  IL_0046:  ldloc.3
+  IL_0047:  ldloc.s    V_4
   IL_0049:  callvirt   ""int C.this[int, CustomHandler].get""
   IL_004e:  ldc.i4.2
   IL_004f:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
@@ -9053,110 +9249,62 @@ format:
   IL_005a:  ret
 }
 ",
-                (useBoolReturns: true, validityParameter: false) => @"
-{
-  // Code size       86 (0x56)
-  .maxstack  6
-  .locals init (int V_0, //i
-                C V_1,
-                int V_2,
-                CustomHandler V_3,
-                CustomHandler V_4)
-  IL_0000:  ldc.i4.3
-  IL_0001:  stloc.0
-  IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloca.s   V_4
-  IL_0011:  ldc.i4.7
-  IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
-  IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_4
-  IL_001c:  ldstr      ""literal""
-  IL_0021:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0026:  brfalse.s  IL_0039
-  IL_0028:  ldloca.s   V_4
-  IL_002a:  ldloc.0
-  IL_002b:  box        ""int""
-  IL_0030:  ldc.i4.0
-  IL_0031:  ldnull
-  IL_0032:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
-  IL_0037:  br.s       IL_003a
-  IL_0039:  ldc.i4.0
-  IL_003a:  pop
-  IL_003b:  ldloc.s    V_4
-  IL_003d:  stloc.3
-  IL_003e:  ldloc.1
-  IL_003f:  ldloc.2
-  IL_0040:  ldloc.3
-  IL_0041:  ldloc.1
-  IL_0042:  ldloc.2
-  IL_0043:  ldloc.3
-  IL_0044:  callvirt   ""int C.this[int, CustomHandler].get""
-  IL_0049:  ldc.i4.2
-  IL_004a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_004f:  add
-  IL_0050:  callvirt   ""void C.this[int, CustomHandler].set""
-  IL_0055:  ret
-}
-",
                 (useBoolReturns: true, validityParameter: true) => @"
 {
-  // Code size       92 (0x5c)
+  // Code size       97 (0x61)
   .maxstack  6
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
-                CustomHandler V_3,
+                int V_1,
+                C V_2,
+                int V_3,
                 CustomHandler V_4,
-                bool V_5)
+                CustomHandler V_5,
+                bool V_6)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
+  IL_0007:  stloc.2
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldc.i4.7
-  IL_0010:  ldc.i4.1
-  IL_0011:  ldloc.2
-  IL_0012:  ldloc.1
-  IL_0013:  ldloca.s   V_5
-  IL_0015:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001a:  stloc.s    V_4
-  IL_001c:  ldloc.s    V_5
-  IL_001e:  brfalse.s  IL_003f
-  IL_0020:  ldloca.s   V_4
-  IL_0022:  ldstr      ""literal""
-  IL_0027:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_002c:  brfalse.s  IL_003f
-  IL_002e:  ldloca.s   V_4
-  IL_0030:  ldloc.0
-  IL_0031:  box        ""int""
-  IL_0036:  ldc.i4.0
-  IL_0037:  ldnull
-  IL_0038:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
-  IL_003d:  br.s       IL_0040
-  IL_003f:  ldc.i4.0
-  IL_0040:  pop
-  IL_0041:  ldloc.s    V_4
-  IL_0043:  stloc.3
-  IL_0044:  ldloc.1
-  IL_0045:  ldloc.2
-  IL_0046:  ldloc.3
-  IL_0047:  ldloc.1
-  IL_0048:  ldloc.2
-  IL_0049:  ldloc.3
-  IL_004a:  callvirt   ""int C.this[int, CustomHandler].get""
-  IL_004f:  ldc.i4.2
-  IL_0050:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0055:  add
-  IL_0056:  callvirt   ""void C.this[int, CustomHandler].set""
-  IL_005b:  ret
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  stloc.3
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.1
+  IL_0013:  ldloc.1
+  IL_0014:  ldloc.2
+  IL_0015:  ldloca.s   V_6
+  IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
+  IL_001c:  stloc.s    V_5
+  IL_001e:  ldloc.s    V_6
+  IL_0020:  brfalse.s  IL_0041
+  IL_0022:  ldloca.s   V_5
+  IL_0024:  ldstr      ""literal""
+  IL_0029:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002e:  brfalse.s  IL_0041
+  IL_0030:  ldloca.s   V_5
+  IL_0032:  ldloc.0
+  IL_0033:  box        ""int""
+  IL_0038:  ldc.i4.0
+  IL_0039:  ldnull
+  IL_003a:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_003f:  br.s       IL_0042
+  IL_0041:  ldc.i4.0
+  IL_0042:  pop
+  IL_0043:  ldloc.s    V_5
+  IL_0045:  stloc.s    V_4
+  IL_0047:  ldloc.2
+  IL_0048:  ldloc.3
+  IL_0049:  ldloc.s    V_4
+  IL_004b:  ldloc.2
+  IL_004c:  ldloc.3
+  IL_004d:  ldloc.s    V_4
+  IL_004f:  callvirt   ""int C.this[int, CustomHandler].get""
+  IL_0054:  ldc.i4.2
+  IL_0055:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_005a:  add
+  IL_005b:  callvirt   ""void C.this[int, CustomHandler].set""
+  IL_0060:  ret
 }
 ",
             };
@@ -9240,23 +9388,23 @@ GetInt2
   // Code size       72 (0x48)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldloca.s   V_3
   IL_0013:  ldc.i4.7
   IL_0014:  ldc.i4.1
-  IL_0015:  ldloc.2
-  IL_0016:  ldloc.1
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.2
   IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
   IL_001c:  ldloca.s   V_3
   IL_001e:  ldstr      ""literal""
@@ -9283,23 +9431,23 @@ GetInt2
   // Code size       82 (0x52)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3,
                 bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldc.i4.7
   IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
+  IL_0013:  ldloc.1
+  IL_0014:  ldloc.2
   IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
   IL_001c:  stloc.3
@@ -9334,23 +9482,23 @@ GetInt2
   // Code size       78 (0x4e)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldloca.s   V_3
   IL_0013:  ldc.i4.7
   IL_0014:  ldc.i4.1
-  IL_0015:  ldloc.2
-  IL_0016:  ldloc.1
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.2
   IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
   IL_001c:  ldloca.s   V_3
   IL_001e:  ldstr      ""literal""
@@ -9381,23 +9529,23 @@ GetInt2
   // Code size       83 (0x53)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3,
                 bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldc.i4.7
   IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
+  IL_0013:  ldloc.1
+  IL_0014:  ldloc.2
   IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
   IL_001c:  stloc.3
@@ -9505,23 +9653,23 @@ GetInt2
   // Code size       72 (0x48)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldloca.s   V_3
   IL_0013:  ldc.i4.7
   IL_0014:  ldc.i4.1
-  IL_0015:  ldloc.2
-  IL_0016:  ldloc.1
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.2
   IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
   IL_001c:  ldloca.s   V_3
   IL_001e:  ldstr      ""literal""
@@ -9548,23 +9696,23 @@ GetInt2
   // Code size       82 (0x52)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3,
                 bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldc.i4.7
   IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
+  IL_0013:  ldloc.1
+  IL_0014:  ldloc.2
   IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
   IL_001c:  stloc.3
@@ -9599,23 +9747,23 @@ GetInt2
   // Code size       78 (0x4e)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldloca.s   V_3
   IL_0013:  ldc.i4.7
   IL_0014:  ldc.i4.1
-  IL_0015:  ldloc.2
-  IL_0016:  ldloc.1
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.2
   IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
   IL_001c:  ldloca.s   V_3
   IL_001e:  ldstr      ""literal""
@@ -9646,23 +9794,23 @@ GetInt2
   // Code size       83 (0x53)
   .maxstack  7
   .locals init (int V_0, //i
-                C V_1,
-                int V_2,
+                int V_1,
+                C V_2,
                 CustomHandler V_3,
                 bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.1
-  IL_0008:  ldc.i4.1
-  IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.2
-  IL_000f:  ldloc.1
-  IL_0010:  ldloc.2
+  IL_0007:  stloc.2
+  IL_0008:  ldloc.2
+  IL_0009:  ldc.i4.1
+  IL_000a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
   IL_0011:  ldc.i4.7
   IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.2
-  IL_0014:  ldloc.1
+  IL_0013:  ldloc.1
+  IL_0014:  ldloc.2
   IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
   IL_001c:  stloc.3

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -6475,8 +6475,6 @@ int i = 10;
 C.M(i: i, c: $""text"");
 ";
 
-            var badCode = @"C.M($"""", 1);";
-
             var comp = CreateCompilation(new[] { code, goodCode, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
             var verifier = CompileAndVerify(comp, sourceSymbolValidator: validate, symbolValidator: validate, expectedOutput: @"
 i:10
@@ -6491,6 +6489,8 @@ literal:text
             );
 
             verifyIL(verifier);
+
+            var badCode = @"C.M($"""", 1);";
 
             comp = CreateCompilation(new[] { code, badCode, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
@@ -6517,54 +6517,60 @@ literal:text
                 verifier.VerifyIL("<top-level-statements-entry-point>", extraConstructorArg == ""
                     ? @"
 {
-  // Code size       34 (0x22)
+  // Code size       36 (0x24)
   .maxstack  4
-  .locals init (CustomHandler V_0,
-                int V_1)
+  .locals init (int V_0,
+                int V_1,
+                CustomHandler V_2)
   IL_0000:  ldc.i4.s   10
-  IL_0002:  stloc.1
-  IL_0003:  ldloca.s   V_0
-  IL_0005:  ldc.i4.4
-  IL_0006:  ldc.i4.0
-  IL_0007:  ldloc.1
-  IL_0008:  call       ""CustomHandler..ctor(int, int, int)""
-  IL_000d:  ldloca.s   V_0
-  IL_000f:  ldstr      ""text""
-  IL_0014:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0019:  pop
-  IL_001a:  ldloc.0
-  IL_001b:  ldloc.1
-  IL_001c:  call       ""void C.M(CustomHandler, int)""
-  IL_0021:  ret
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  stloc.1
+  IL_0005:  ldloca.s   V_2
+  IL_0007:  ldc.i4.4
+  IL_0008:  ldc.i4.0
+  IL_0009:  ldloc.0
+  IL_000a:  call       ""CustomHandler..ctor(int, int, int)""
+  IL_000f:  ldloca.s   V_2
+  IL_0011:  ldstr      ""text""
+  IL_0016:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_001b:  pop
+  IL_001c:  ldloc.2
+  IL_001d:  ldloc.1
+  IL_001e:  call       ""void C.M(CustomHandler, int)""
+  IL_0023:  ret
 }
 "
                     : @"
 {
-  // Code size       41 (0x29)
+  // Code size       43 (0x2b)
   .maxstack  4
-  .locals init (bool V_0,
-                CustomHandler V_1,
-                int V_2)
+  .locals init (int V_0,
+                int V_1,
+                CustomHandler V_2,
+                bool V_3)
   IL_0000:  ldc.i4.s   10
-  IL_0002:  stloc.2
-  IL_0003:  ldc.i4.4
-  IL_0004:  ldc.i4.0
-  IL_0005:  ldloc.2
-  IL_0006:  ldloca.s   V_0
-  IL_0008:  newobj     ""CustomHandler..ctor(int, int, int, out bool)""
-  IL_000d:  stloc.1
-  IL_000e:  ldloc.0
-  IL_000f:  brfalse.s  IL_001f
-  IL_0011:  ldloca.s   V_1
-  IL_0013:  ldstr      ""text""
-  IL_0018:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_001d:  br.s       IL_0020
-  IL_001f:  ldc.i4.0
-  IL_0020:  pop
-  IL_0021:  ldloc.1
-  IL_0022:  ldloc.2
-  IL_0023:  call       ""void C.M(CustomHandler, int)""
-  IL_0028:  ret
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  stloc.1
+  IL_0005:  ldc.i4.4
+  IL_0006:  ldc.i4.0
+  IL_0007:  ldloc.0
+  IL_0008:  ldloca.s   V_3
+  IL_000a:  newobj     ""CustomHandler..ctor(int, int, int, out bool)""
+  IL_000f:  stloc.2
+  IL_0010:  ldloc.3
+  IL_0011:  brfalse.s  IL_0021
+  IL_0013:  ldloca.s   V_2
+  IL_0015:  ldstr      ""text""
+  IL_001a:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_001f:  br.s       IL_0022
+  IL_0021:  ldc.i4.0
+  IL_0022:  pop
+  IL_0023:  ldloc.2
+  IL_0024:  ldloc.1
+  IL_0025:  call       ""void C.M(CustomHandler, int)""
+  IL_002a:  ret
 }
 ");
             }
@@ -6982,22 +6988,22 @@ literal:2");
                     ? @"
 {
   // Code size       39 (0x27)
-  .maxstack  4
-  .locals init (CustomHandler V_0,
-                int V_1)
+  .maxstack  5
+  .locals init (int V_0,
+                CustomHandler V_1)
   IL_0000:  ldc.i4.s   10
-  IL_0002:  stloc.1
-  IL_0003:  ldloca.s   V_0
-  IL_0005:  ldc.i4.1
-  IL_0006:  ldc.i4.0
-  IL_0007:  ldloc.1
-  IL_0008:  call       ""CustomHandler..ctor(int, int, int)""
-  IL_000d:  ldloca.s   V_0
-  IL_000f:  ldstr      ""2""
-  IL_0014:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0019:  pop
-  IL_001a:  ldloc.1
-  IL_001b:  ldloc.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  ldloca.s   V_1
+  IL_0006:  ldc.i4.1
+  IL_0007:  ldc.i4.0
+  IL_0008:  ldloc.0
+  IL_0009:  call       ""CustomHandler..ctor(int, int, int)""
+  IL_000e:  ldloca.s   V_1
+  IL_0010:  ldstr      ""2""
+  IL_0015:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_001a:  pop
+  IL_001b:  ldloc.1
   IL_001c:  call       ""string C.M(int, CustomHandler)""
   IL_0021:  call       ""void System.Console.WriteLine(string)""
   IL_0026:  ret
@@ -7006,27 +7012,27 @@ literal:2");
     : @"
 {
   // Code size       46 (0x2e)
-  .maxstack  4
-  .locals init (bool V_0,
+  .maxstack  5
+  .locals init (int V_0,
                 CustomHandler V_1,
-                int V_2)
+                bool V_2)
   IL_0000:  ldc.i4.s   10
-  IL_0002:  stloc.2
-  IL_0003:  ldc.i4.1
-  IL_0004:  ldc.i4.0
-  IL_0005:  ldloc.2
-  IL_0006:  ldloca.s   V_0
-  IL_0008:  newobj     ""CustomHandler..ctor(int, int, int, out bool)""
-  IL_000d:  stloc.1
-  IL_000e:  ldloc.0
-  IL_000f:  brfalse.s  IL_001f
-  IL_0011:  ldloca.s   V_1
-  IL_0013:  ldstr      ""2""
-  IL_0018:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_001d:  br.s       IL_0020
-  IL_001f:  ldc.i4.0
-  IL_0020:  pop
-  IL_0021:  ldloc.2
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  ldc.i4.1
+  IL_0005:  ldc.i4.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldloca.s   V_2
+  IL_0009:  newobj     ""CustomHandler..ctor(int, int, int, out bool)""
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.2
+  IL_0010:  brfalse.s  IL_0020
+  IL_0012:  ldloca.s   V_1
+  IL_0014:  ldstr      ""2""
+  IL_0019:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_001e:  br.s       IL_0021
+  IL_0020:  ldc.i4.0
+  IL_0021:  pop
   IL_0022:  ldloc.1
   IL_0023:  call       ""string C.M(int, CustomHandler)""
   IL_0028:  call       ""void System.Console.WriteLine(string)""
@@ -7102,69 +7108,69 @@ literal:literal
                     ? @"
 {
   // Code size       44 (0x2c)
-  .maxstack  5
+  .maxstack  7
   .locals init (int V_0, //i
-                CustomHandler V_1,
-                int V_2,
-                string V_3)
+                int V_1,
+                string V_2,
+                CustomHandler V_3)
   IL_0000:  ldc.i4.s   10
   IL_0002:  stloc.0
   IL_0003:  ldstr      ""arg""
   IL_0008:  ldloc.0
-  IL_0009:  stloc.2
-  IL_000a:  stloc.3
-  IL_000b:  ldloca.s   V_1
-  IL_000d:  ldc.i4.7
-  IL_000e:  ldc.i4.0
-  IL_000f:  ldloc.2
-  IL_0010:  ldloc.3
-  IL_0011:  call       ""CustomHandler..ctor(int, int, int, string)""
-  IL_0016:  ldloca.s   V_1
-  IL_0018:  ldstr      ""literal""
-  IL_001d:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0022:  pop
-  IL_0023:  ldloc.2
-  IL_0024:  ldloc.3
-  IL_0025:  ldloc.1
+  IL_0009:  stloc.1
+  IL_000a:  stloc.2
+  IL_000b:  ldloc.1
+  IL_000c:  ldloc.2
+  IL_000d:  ldloca.s   V_3
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.0
+  IL_0011:  ldloc.1
+  IL_0012:  ldloc.2
+  IL_0013:  call       ""CustomHandler..ctor(int, int, int, string)""
+  IL_0018:  ldloca.s   V_3
+  IL_001a:  ldstr      ""literal""
+  IL_001f:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0024:  pop
+  IL_0025:  ldloc.3
   IL_0026:  call       ""void C.M(int, string, CustomHandler)""
   IL_002b:  ret
 }
 "
                     : @"
 {
-  // Code size       54 (0x36)
-  .maxstack  5
+  // Code size       52 (0x34)
+  .maxstack  7
   .locals init (int V_0, //i
-                bool V_1,
-                CustomHandler V_2,
-                int V_3,
-                string V_4)
+                int V_1,
+                string V_2,
+                CustomHandler V_3,
+                bool V_4)
   IL_0000:  ldc.i4.s   10
   IL_0002:  stloc.0
   IL_0003:  ldstr      ""arg""
   IL_0008:  ldloc.0
-  IL_0009:  stloc.3
-  IL_000a:  stloc.s    V_4
-  IL_000c:  ldc.i4.7
-  IL_000d:  ldc.i4.0
-  IL_000e:  ldloc.3
-  IL_000f:  ldloc.s    V_4
-  IL_0011:  ldloca.s   V_1
+  IL_0009:  stloc.1
+  IL_000a:  stloc.2
+  IL_000b:  ldloc.1
+  IL_000c:  ldloc.2
+  IL_000d:  ldc.i4.7
+  IL_000e:  ldc.i4.0
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldloca.s   V_4
   IL_0013:  newobj     ""CustomHandler..ctor(int, int, int, string, out bool)""
-  IL_0018:  stloc.2
-  IL_0019:  ldloc.1
-  IL_001a:  brfalse.s  IL_002a
-  IL_001c:  ldloca.s   V_2
-  IL_001e:  ldstr      ""literal""
-  IL_0023:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0028:  br.s       IL_002b
-  IL_002a:  ldc.i4.0
-  IL_002b:  pop
-  IL_002c:  ldloc.3
-  IL_002d:  ldloc.s    V_4
-  IL_002f:  ldloc.2
-  IL_0030:  call       ""void C.M(int, string, CustomHandler)""
-  IL_0035:  ret
+  IL_0018:  stloc.3
+  IL_0019:  ldloc.s    V_4
+  IL_001b:  brfalse.s  IL_002b
+  IL_001d:  ldloca.s   V_3
+  IL_001f:  ldstr      ""literal""
+  IL_0024:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0029:  br.s       IL_002c
+  IL_002b:  ldc.i4.0
+  IL_002c:  pop
+  IL_002d:  ldloc.3
+  IL_002e:  call       ""void C.M(int, string, CustomHandler)""
+  IL_0033:  ret
 }
 ");
             }
@@ -7225,84 +7231,96 @@ o in M
             verifier.VerifyIL("<top-level-statements-entry-point>", (extraConstructorArg == "")
                 ? @"
 {
-  // Code size       60 (0x3c)
-  .maxstack  5
+  // Code size       67 (0x43)
+  .maxstack  8
   .locals init (int V_0, //i
                 string V_1, //s
                 object V_2, //o
-                CustomHandler V_3,
-                int& V_4)
+                int& V_3,
+                string& V_4,
+                object& V_5,
+                CustomHandler V_6)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldnull
   IL_0003:  stloc.1
   IL_0004:  ldloca.s   V_0
-  IL_0006:  stloc.s    V_4
-  IL_0008:  ldc.i4.7
-  IL_0009:  ldc.i4.0
-  IL_000a:  ldloc.s    V_4
-  IL_000c:  ldloca.s   V_1
-  IL_000e:  ldloca.s   V_2
-  IL_0010:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object)""
-  IL_0015:  stloc.3
-  IL_0016:  ldloca.s   V_3
-  IL_0018:  ldstr      ""literal""
-  IL_001d:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0022:  pop
-  IL_0023:  ldloc.s    V_4
-  IL_0025:  ldloca.s   V_1
-  IL_0027:  ldloca.s   V_2
-  IL_0029:  ldloc.3
-  IL_002a:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
-  IL_002f:  ldloc.1
-  IL_0030:  call       ""void System.Console.WriteLine(string)""
-  IL_0035:  ldloc.2
-  IL_0036:  call       ""void System.Console.WriteLine(object)""
-  IL_003b:  ret
+  IL_0006:  stloc.3
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  stloc.s    V_4
+  IL_000b:  ldloca.s   V_2
+  IL_000d:  stloc.s    V_5
+  IL_000f:  ldloc.3
+  IL_0010:  ldloc.s    V_4
+  IL_0012:  ldloc.s    V_5
+  IL_0014:  ldc.i4.7
+  IL_0015:  ldc.i4.0
+  IL_0016:  ldloc.3
+  IL_0017:  ldloc.s    V_4
+  IL_0019:  ldloc.s    V_5
+  IL_001b:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object)""
+  IL_0020:  stloc.s    V_6
+  IL_0022:  ldloca.s   V_6
+  IL_0024:  ldstr      ""literal""
+  IL_0029:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002e:  pop
+  IL_002f:  ldloc.s    V_6
+  IL_0031:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
+  IL_0036:  ldloc.1
+  IL_0037:  call       ""void System.Console.WriteLine(string)""
+  IL_003c:  ldloc.2
+  IL_003d:  call       ""void System.Console.WriteLine(object)""
+  IL_0042:  ret
 }
 "
                 : @"
 {
-  // Code size       70 (0x46)
-  .maxstack  6
+  // Code size       76 (0x4c)
+  .maxstack  9
   .locals init (int V_0, //i
                 string V_1, //s
                 object V_2, //o
-                bool V_3,
-                CustomHandler V_4,
-                int& V_5)
+                int& V_3,
+                string& V_4,
+                object& V_5,
+                CustomHandler V_6,
+                bool V_7)
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldnull
   IL_0003:  stloc.1
   IL_0004:  ldloca.s   V_0
-  IL_0006:  stloc.s    V_5
-  IL_0008:  ldc.i4.7
-  IL_0009:  ldc.i4.0
-  IL_000a:  ldloc.s    V_5
-  IL_000c:  ldloca.s   V_1
-  IL_000e:  ldloca.s   V_2
-  IL_0010:  ldloca.s   V_3
-  IL_0012:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object, out bool)""
-  IL_0017:  stloc.s    V_4
-  IL_0019:  ldloc.3
-  IL_001a:  brfalse.s  IL_002a
-  IL_001c:  ldloca.s   V_4
-  IL_001e:  ldstr      ""literal""
-  IL_0023:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0028:  br.s       IL_002b
-  IL_002a:  ldc.i4.0
-  IL_002b:  pop
-  IL_002c:  ldloc.s    V_5
-  IL_002e:  ldloca.s   V_1
-  IL_0030:  ldloca.s   V_2
-  IL_0032:  ldloc.s    V_4
-  IL_0034:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
-  IL_0039:  ldloc.1
-  IL_003a:  call       ""void System.Console.WriteLine(string)""
-  IL_003f:  ldloc.2
-  IL_0040:  call       ""void System.Console.WriteLine(object)""
-  IL_0045:  ret
+  IL_0006:  stloc.3
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  stloc.s    V_4
+  IL_000b:  ldloca.s   V_2
+  IL_000d:  stloc.s    V_5
+  IL_000f:  ldloc.3
+  IL_0010:  ldloc.s    V_4
+  IL_0012:  ldloc.s    V_5
+  IL_0014:  ldc.i4.7
+  IL_0015:  ldc.i4.0
+  IL_0016:  ldloc.3
+  IL_0017:  ldloc.s    V_4
+  IL_0019:  ldloc.s    V_5
+  IL_001b:  ldloca.s   V_7
+  IL_001d:  newobj     ""CustomHandler..ctor(int, int, in int, ref string, out object, out bool)""
+  IL_0022:  stloc.s    V_6
+  IL_0024:  ldloc.s    V_7
+  IL_0026:  brfalse.s  IL_0036
+  IL_0028:  ldloca.s   V_6
+  IL_002a:  ldstr      ""literal""
+  IL_002f:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0034:  br.s       IL_0037
+  IL_0036:  ldc.i4.0
+  IL_0037:  pop
+  IL_0038:  ldloc.s    V_6
+  IL_003a:  call       ""void C.M(in int, ref string, out object, CustomHandler)""
+  IL_003f:  ldloc.1
+  IL_0040:  call       ""void System.Console.WriteLine(string)""
+  IL_0045:  ldloc.2
+  IL_0046:  call       ""void System.Console.WriteLine(object)""
+  IL_004b:  ret
 }
 ");
 
@@ -7371,27 +7389,27 @@ literal:literal
                 ? @"
 {
   // Code size       45 (0x2d)
-  .maxstack  5
-  .locals init (CustomHandler V_0,
-                int V_1,
-                string V_2)
+  .maxstack  7
+  .locals init (int V_0,
+                string V_1,
+                CustomHandler V_2)
   IL_0000:  call       ""int <Program>$.<<Main>$>g__GetInt|0_0()""
-  IL_0005:  stloc.1
+  IL_0005:  stloc.0
   IL_0006:  call       ""string <Program>$.<<Main>$>g__GetString|0_1()""
-  IL_000b:  stloc.2
-  IL_000c:  ldloca.s   V_0
-  IL_000e:  ldc.i4.7
-  IL_000f:  ldc.i4.0
-  IL_0010:  ldloc.2
-  IL_0011:  ldloc.1
-  IL_0012:  call       ""CustomHandler..ctor(int, int, string, int)""
-  IL_0017:  ldloca.s   V_0
-  IL_0019:  ldstr      ""literal""
-  IL_001e:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0023:  pop
-  IL_0024:  ldloc.1
-  IL_0025:  ldloc.2
-  IL_0026:  ldloc.0
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.0
+  IL_000d:  ldloc.1
+  IL_000e:  ldloca.s   V_2
+  IL_0010:  ldc.i4.7
+  IL_0011:  ldc.i4.0
+  IL_0012:  ldloc.1
+  IL_0013:  ldloc.0
+  IL_0014:  call       ""CustomHandler..ctor(int, int, string, int)""
+  IL_0019:  ldloca.s   V_2
+  IL_001b:  ldstr      ""literal""
+  IL_0020:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0025:  pop
+  IL_0026:  ldloc.2
   IL_0027:  call       ""void C.M(int, string, CustomHandler)""
   IL_002c:  ret
 }
@@ -7399,33 +7417,33 @@ literal:literal
                 : @"
 {
   // Code size       52 (0x34)
-  .maxstack  5
-  .locals init (bool V_0,
-                CustomHandler V_1,
-                int V_2,
-                string V_3)
+  .maxstack  7
+  .locals init (int V_0,
+                string V_1,
+                CustomHandler V_2,
+                bool V_3)
   IL_0000:  call       ""int <Program>$.<<Main>$>g__GetInt|0_0()""
-  IL_0005:  stloc.2
+  IL_0005:  stloc.0
   IL_0006:  call       ""string <Program>$.<<Main>$>g__GetString|0_1()""
-  IL_000b:  stloc.3
-  IL_000c:  ldc.i4.7
-  IL_000d:  ldc.i4.0
-  IL_000e:  ldloc.3
-  IL_000f:  ldloc.2
-  IL_0010:  ldloca.s   V_0
-  IL_0012:  newobj     ""CustomHandler..ctor(int, int, string, int, out bool)""
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.0
-  IL_0019:  brfalse.s  IL_0029
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  ldstr      ""literal""
-  IL_0022:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0027:  br.s       IL_002a
-  IL_0029:  ldc.i4.0
-  IL_002a:  pop
-  IL_002b:  ldloc.2
-  IL_002c:  ldloc.3
-  IL_002d:  ldloc.1
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.0
+  IL_000d:  ldloc.1
+  IL_000e:  ldc.i4.7
+  IL_000f:  ldc.i4.0
+  IL_0010:  ldloc.1
+  IL_0011:  ldloc.0
+  IL_0012:  ldloca.s   V_3
+  IL_0014:  newobj     ""CustomHandler..ctor(int, int, string, int, out bool)""
+  IL_0019:  stloc.2
+  IL_001a:  ldloc.3
+  IL_001b:  brfalse.s  IL_002b
+  IL_001d:  ldloca.s   V_2
+  IL_001f:  ldstr      ""literal""
+  IL_0024:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0029:  br.s       IL_002c
+  IL_002b:  ldc.i4.0
+  IL_002c:  pop
+  IL_002d:  ldloc.2
   IL_002e:  call       ""void C.M(int, string, CustomHandler)""
   IL_0033:  ret
 }
@@ -7488,24 +7506,24 @@ literal:literal
                 ? @"
 {
   // Code size       43 (0x2b)
-  .maxstack  5
-  .locals init (CustomHandler V_0,
-                int V_1)
+  .maxstack  7
+  .locals init (int V_0,
+                CustomHandler V_1)
   IL_0000:  call       ""int <Program>$.<<Main>$>g__GetInt|0_0()""
-  IL_0005:  stloc.1
-  IL_0006:  ldloca.s   V_0
-  IL_0008:  ldc.i4.7
-  IL_0009:  ldc.i4.0
-  IL_000a:  ldloc.1
-  IL_000b:  ldloc.1
-  IL_000c:  call       ""CustomHandler..ctor(int, int, int, int)""
-  IL_0011:  ldloca.s   V_0
-  IL_0013:  ldstr      ""literal""
-  IL_0018:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_001d:  pop
-  IL_001e:  ldloc.1
-  IL_001f:  ldstr      """"
-  IL_0024:  ldloc.0
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldstr      """"
+  IL_000c:  ldloca.s   V_1
+  IL_000e:  ldc.i4.7
+  IL_000f:  ldc.i4.0
+  IL_0010:  ldloc.0
+  IL_0011:  ldloc.0
+  IL_0012:  call       ""CustomHandler..ctor(int, int, int, int)""
+  IL_0017:  ldloca.s   V_1
+  IL_0019:  ldstr      ""literal""
+  IL_001e:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0023:  pop
+  IL_0024:  ldloc.1
   IL_0025:  call       ""void C.M(int, string, CustomHandler)""
   IL_002a:  ret
 }
@@ -7513,29 +7531,29 @@ literal:literal
                 : @"
 {
   // Code size       50 (0x32)
-  .maxstack  5
-  .locals init (bool V_0,
+  .maxstack  7
+  .locals init (int V_0,
                 CustomHandler V_1,
-                int V_2)
+                bool V_2)
   IL_0000:  call       ""int <Program>$.<<Main>$>g__GetInt|0_0()""
-  IL_0005:  stloc.2
-  IL_0006:  ldc.i4.7
-  IL_0007:  ldc.i4.0
-  IL_0008:  ldloc.2
-  IL_0009:  ldloc.2
-  IL_000a:  ldloca.s   V_0
-  IL_000c:  newobj     ""CustomHandler..ctor(int, int, int, int, out bool)""
-  IL_0011:  stloc.1
-  IL_0012:  ldloc.0
-  IL_0013:  brfalse.s  IL_0023
-  IL_0015:  ldloca.s   V_1
-  IL_0017:  ldstr      ""literal""
-  IL_001c:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0021:  br.s       IL_0024
-  IL_0023:  ldc.i4.0
-  IL_0024:  pop
-  IL_0025:  ldloc.2
-  IL_0026:  ldstr      """"
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldstr      """"
+  IL_000c:  ldc.i4.7
+  IL_000d:  ldc.i4.0
+  IL_000e:  ldloc.0
+  IL_000f:  ldloc.0
+  IL_0010:  ldloca.s   V_2
+  IL_0012:  newobj     ""CustomHandler..ctor(int, int, int, int, out bool)""
+  IL_0017:  stloc.1
+  IL_0018:  ldloc.2
+  IL_0019:  brfalse.s  IL_0029
+  IL_001b:  ldloca.s   V_1
+  IL_001d:  ldstr      ""literal""
+  IL_0022:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  br.s       IL_002a
+  IL_0029:  ldc.i4.0
+  IL_002a:  pop
   IL_002b:  ldloc.1
   IL_002c:  call       ""void C.M(int, string, CustomHandler)""
   IL_0031:  ret
@@ -7716,56 +7734,68 @@ literal:literal
             verifier.VerifyIL("<top-level-statements-entry-point>", (extraConstructorArg == "")
                 ? @"
 {
-  // Code size       53 (0x35)
-  .maxstack  6
-  .locals init (CustomHandler V_0)
+  // Code size       52 (0x34)
+  .maxstack  8
+  .locals init (int V_0,
+                string V_1,
+                CustomHandler V_2)
   IL_0000:  newobj     ""C..ctor()""
-  IL_0005:  ldloca.s   V_0
-  IL_0007:  ldc.i4.7
-  IL_0008:  ldc.i4.0
-  IL_0009:  ldc.i4.s   10
-  IL_000b:  ldstr      ""str""
-  IL_0010:  call       ""CustomHandler..ctor(int, int, int, string)""
-  IL_0015:  ldloca.s   V_0
-  IL_0017:  ldstr      ""literal""
-  IL_001c:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0021:  pop
-  IL_0022:  ldc.i4.s   10
-  IL_0024:  ldstr      ""str""
-  IL_0029:  ldloc.0
-  IL_002a:  callvirt   ""string C.this[int, string, CustomHandler].get""
-  IL_002f:  call       ""void System.Console.WriteLine(string)""
-  IL_0034:  ret
+  IL_0005:  ldc.i4.s   10
+  IL_0007:  stloc.0
+  IL_0008:  ldstr      ""str""
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.0
+  IL_000f:  ldloc.1
+  IL_0010:  ldloca.s   V_2
+  IL_0012:  ldc.i4.7
+  IL_0013:  ldc.i4.0
+  IL_0014:  ldloc.0
+  IL_0015:  ldloc.1
+  IL_0016:  call       ""CustomHandler..ctor(int, int, int, string)""
+  IL_001b:  ldloca.s   V_2
+  IL_001d:  ldstr      ""literal""
+  IL_0022:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  pop
+  IL_0028:  ldloc.2
+  IL_0029:  callvirt   ""string C.this[int, string, CustomHandler].get""
+  IL_002e:  call       ""void System.Console.WriteLine(string)""
+  IL_0033:  ret
 }
 "
                 : @"
 {
-  // Code size       60 (0x3c)
-  .maxstack  6
-  .locals init (bool V_0,
-                CustomHandler V_1)
+  // Code size       59 (0x3b)
+  .maxstack  8
+  .locals init (int V_0,
+                string V_1,
+                CustomHandler V_2,
+                bool V_3)
   IL_0000:  newobj     ""C..ctor()""
-  IL_0005:  ldc.i4.7
-  IL_0006:  ldc.i4.0
-  IL_0007:  ldc.i4.s   10
-  IL_0009:  ldstr      ""str""
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  newobj     ""CustomHandler..ctor(int, int, int, string, out bool)""
-  IL_0015:  stloc.1
-  IL_0016:  ldloc.0
-  IL_0017:  brfalse.s  IL_0027
-  IL_0019:  ldloca.s   V_1
-  IL_001b:  ldstr      ""literal""
-  IL_0020:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0025:  br.s       IL_0028
-  IL_0027:  ldc.i4.0
-  IL_0028:  pop
-  IL_0029:  ldc.i4.s   10
-  IL_002b:  ldstr      ""str""
-  IL_0030:  ldloc.1
-  IL_0031:  callvirt   ""string C.this[int, string, CustomHandler].get""
-  IL_0036:  call       ""void System.Console.WriteLine(string)""
-  IL_003b:  ret
+  IL_0005:  ldc.i4.s   10
+  IL_0007:  stloc.0
+  IL_0008:  ldstr      ""str""
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.0
+  IL_000f:  ldloc.1
+  IL_0010:  ldc.i4.7
+  IL_0011:  ldc.i4.0
+  IL_0012:  ldloc.0
+  IL_0013:  ldloc.1
+  IL_0014:  ldloca.s   V_3
+  IL_0016:  newobj     ""CustomHandler..ctor(int, int, int, string, out bool)""
+  IL_001b:  stloc.2
+  IL_001c:  ldloc.3
+  IL_001d:  brfalse.s  IL_002d
+  IL_001f:  ldloca.s   V_2
+  IL_0021:  ldstr      ""literal""
+  IL_0026:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002b:  br.s       IL_002e
+  IL_002d:  ldc.i4.0
+  IL_002e:  pop
+  IL_002f:  ldloc.2
+  IL_0030:  callvirt   ""string C.this[int, string, CustomHandler].get""
+  IL_0035:  call       ""void System.Console.WriteLine(string)""
+  IL_003a:  ret
 }
 ");
 
@@ -7820,56 +7850,68 @@ literal:literal
             verifier.VerifyIL("<top-level-statements-entry-point>", (extraConstructorArg == "")
                 ? @"
 {
-  // Code size       53 (0x35)
-  .maxstack  6
-  .locals init (CustomHandler V_0)
+  // Code size       52 (0x34)
+  .maxstack  8
+  .locals init (int V_0,
+                string V_1,
+                CustomHandler V_2)
   IL_0000:  newobj     ""C..ctor()""
-  IL_0005:  ldloca.s   V_0
-  IL_0007:  ldc.i4.7
-  IL_0008:  ldc.i4.0
-  IL_0009:  ldc.i4.s   10
-  IL_000b:  ldstr      ""str""
-  IL_0010:  call       ""CustomHandler..ctor(int, int, int, string)""
-  IL_0015:  ldloca.s   V_0
-  IL_0017:  ldstr      ""literal""
-  IL_001c:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0021:  pop
-  IL_0022:  ldc.i4.s   10
-  IL_0024:  ldstr      ""str""
-  IL_0029:  ldloc.0
-  IL_002a:  ldstr      """"
-  IL_002f:  callvirt   ""void C.this[int, string, CustomHandler].set""
-  IL_0034:  ret
+  IL_0005:  ldc.i4.s   10
+  IL_0007:  stloc.0
+  IL_0008:  ldstr      ""str""
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.0
+  IL_000f:  ldloc.1
+  IL_0010:  ldloca.s   V_2
+  IL_0012:  ldc.i4.7
+  IL_0013:  ldc.i4.0
+  IL_0014:  ldloc.0
+  IL_0015:  ldloc.1
+  IL_0016:  call       ""CustomHandler..ctor(int, int, int, string)""
+  IL_001b:  ldloca.s   V_2
+  IL_001d:  ldstr      ""literal""
+  IL_0022:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0027:  pop
+  IL_0028:  ldloc.2
+  IL_0029:  ldstr      """"
+  IL_002e:  callvirt   ""void C.this[int, string, CustomHandler].set""
+  IL_0033:  ret
 }
 "
                 : @"
 {
-  // Code size       60 (0x3c)
-  .maxstack  6
-  .locals init (bool V_0,
-                CustomHandler V_1)
+  // Code size       59 (0x3b)
+  .maxstack  8
+  .locals init (int V_0,
+                string V_1,
+                CustomHandler V_2,
+                bool V_3)
   IL_0000:  newobj     ""C..ctor()""
-  IL_0005:  ldc.i4.7
-  IL_0006:  ldc.i4.0
-  IL_0007:  ldc.i4.s   10
-  IL_0009:  ldstr      ""str""
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  newobj     ""CustomHandler..ctor(int, int, int, string, out bool)""
-  IL_0015:  stloc.1
-  IL_0016:  ldloc.0
-  IL_0017:  brfalse.s  IL_0027
-  IL_0019:  ldloca.s   V_1
-  IL_001b:  ldstr      ""literal""
-  IL_0020:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0025:  br.s       IL_0028
-  IL_0027:  ldc.i4.0
-  IL_0028:  pop
-  IL_0029:  ldc.i4.s   10
-  IL_002b:  ldstr      ""str""
-  IL_0030:  ldloc.1
-  IL_0031:  ldstr      """"
-  IL_0036:  callvirt   ""void C.this[int, string, CustomHandler].set""
-  IL_003b:  ret
+  IL_0005:  ldc.i4.s   10
+  IL_0007:  stloc.0
+  IL_0008:  ldstr      ""str""
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.0
+  IL_000f:  ldloc.1
+  IL_0010:  ldc.i4.7
+  IL_0011:  ldc.i4.0
+  IL_0012:  ldloc.0
+  IL_0013:  ldloc.1
+  IL_0014:  ldloca.s   V_3
+  IL_0016:  newobj     ""CustomHandler..ctor(int, int, int, string, out bool)""
+  IL_001b:  stloc.2
+  IL_001c:  ldloc.3
+  IL_001d:  brfalse.s  IL_002d
+  IL_001f:  ldloca.s   V_2
+  IL_0021:  ldstr      ""literal""
+  IL_0026:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002b:  br.s       IL_002e
+  IL_002d:  ldc.i4.0
+  IL_002e:  pop
+  IL_002f:  ldloc.2
+  IL_0030:  ldstr      """"
+  IL_0035:  callvirt   ""void C.this[int, string, CustomHandler].set""
+  IL_003a:  ret
 }
 ");
 
@@ -7926,62 +7968,74 @@ literal:literal
             verifier.VerifyIL("<top-level-statements-entry-point>", (extraConstructorArg == "")
                 ? @"
 {
-  // Code size       52 (0x34)
-  .maxstack  6
-  .locals init (CustomHandler V_0,
-                C V_1)
+  // Code size       51 (0x33)
+  .maxstack  9
+  .locals init (C V_0,
+                int V_1,
+                string V_2,
+                CustomHandler V_3)
   IL_0000:  ldc.i4.5
   IL_0001:  newobj     ""C..ctor(int)""
-  IL_0006:  stloc.1
-  IL_0007:  ldloca.s   V_0
-  IL_0009:  ldc.i4.7
-  IL_000a:  ldc.i4.0
-  IL_000b:  ldc.i4.s   10
-  IL_000d:  ldloc.1
-  IL_000e:  ldstr      ""str""
-  IL_0013:  call       ""CustomHandler..ctor(int, int, int, C, string)""
-  IL_0018:  ldloca.s   V_0
-  IL_001a:  ldstr      ""literal""
-  IL_001f:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0024:  pop
-  IL_0025:  ldloc.1
-  IL_0026:  ldc.i4.s   10
-  IL_0028:  ldstr      ""str""
-  IL_002d:  ldloc.0
-  IL_002e:  callvirt   ""void C.M(int, string, CustomHandler)""
-  IL_0033:  ret
+  IL_0006:  stloc.0
+  IL_0007:  ldc.i4.s   10
+  IL_0009:  stloc.1
+  IL_000a:  ldstr      ""str""
+  IL_000f:  stloc.2
+  IL_0010:  ldloc.0
+  IL_0011:  ldloc.1
+  IL_0012:  ldloc.2
+  IL_0013:  ldloca.s   V_3
+  IL_0015:  ldc.i4.7
+  IL_0016:  ldc.i4.0
+  IL_0017:  ldloc.1
+  IL_0018:  ldloc.0
+  IL_0019:  ldloc.2
+  IL_001a:  call       ""CustomHandler..ctor(int, int, int, C, string)""
+  IL_001f:  ldloca.s   V_3
+  IL_0021:  ldstr      ""literal""
+  IL_0026:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002b:  pop
+  IL_002c:  ldloc.3
+  IL_002d:  callvirt   ""void C.M(int, string, CustomHandler)""
+  IL_0032:  ret
 }
 "
                 : @"
 {
   // Code size       59 (0x3b)
-  .maxstack  6
-  .locals init (bool V_0,
-                CustomHandler V_1,
-                C V_2)
+  .maxstack  9
+  .locals init (C V_0,
+                int V_1,
+                string V_2,
+                CustomHandler V_3,
+                bool V_4)
   IL_0000:  ldc.i4.5
   IL_0001:  newobj     ""C..ctor(int)""
-  IL_0006:  stloc.2
-  IL_0007:  ldc.i4.7
-  IL_0008:  ldc.i4.0
-  IL_0009:  ldc.i4.s   10
-  IL_000b:  ldloc.2
-  IL_000c:  ldstr      ""str""
-  IL_0011:  ldloca.s   V_0
-  IL_0013:  newobj     ""CustomHandler..ctor(int, int, int, C, string, out bool)""
-  IL_0018:  stloc.1
-  IL_0019:  ldloc.0
-  IL_001a:  brfalse.s  IL_002a
-  IL_001c:  ldloca.s   V_1
-  IL_001e:  ldstr      ""literal""
-  IL_0023:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0028:  br.s       IL_002b
-  IL_002a:  ldc.i4.0
-  IL_002b:  pop
-  IL_002c:  ldloc.2
-  IL_002d:  ldc.i4.s   10
-  IL_002f:  ldstr      ""str""
-  IL_0034:  ldloc.1
+  IL_0006:  stloc.0
+  IL_0007:  ldc.i4.s   10
+  IL_0009:  stloc.1
+  IL_000a:  ldstr      ""str""
+  IL_000f:  stloc.2
+  IL_0010:  ldloc.0
+  IL_0011:  ldloc.1
+  IL_0012:  ldloc.2
+  IL_0013:  ldc.i4.7
+  IL_0014:  ldc.i4.0
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.0
+  IL_0017:  ldloc.2
+  IL_0018:  ldloca.s   V_4
+  IL_001a:  newobj     ""CustomHandler..ctor(int, int, int, C, string, out bool)""
+  IL_001f:  stloc.3
+  IL_0020:  ldloc.s    V_4
+  IL_0022:  brfalse.s  IL_0032
+  IL_0024:  ldloca.s   V_3
+  IL_0026:  ldstr      ""literal""
+  IL_002b:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0030:  br.s       IL_0033
+  IL_0032:  ldc.i4.0
+  IL_0033:  pop
+  IL_0034:  ldloc.3
   IL_0035:  callvirt   ""void C.M(int, string, CustomHandler)""
   IL_003a:  ret
 }
@@ -8032,23 +8086,26 @@ literal:literal
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size       32 (0x20)
-  .maxstack  4
-  .locals init (CustomHandler V_0)
-  IL_0000:  ldloca.s   V_0
-  IL_0002:  ldc.i4.7
-  IL_0003:  ldc.i4.0
-  IL_0004:  ldc.i4.5
-  IL_0005:  call       ""CustomHandler..ctor(int, int, int)""
-  IL_000a:  ldloca.s   V_0
-  IL_000c:  ldstr      ""literal""
-  IL_0011:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0016:  pop
-  IL_0017:  ldc.i4.5
-  IL_0018:  ldloc.0
-  IL_0019:  newobj     ""C..ctor(int, CustomHandler)""
-  IL_001e:  pop
-  IL_001f:  ret
+  // Code size       34 (0x22)
+  .maxstack  5
+  .locals init (int V_0,
+                CustomHandler V_1)
+  IL_0000:  ldc.i4.5
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldloca.s   V_1
+  IL_0005:  ldc.i4.7
+  IL_0006:  ldc.i4.0
+  IL_0007:  ldloc.0
+  IL_0008:  call       ""CustomHandler..ctor(int, int, int)""
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  ldstr      ""literal""
+  IL_0014:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0019:  pop
+  IL_001a:  ldloc.1
+  IL_001b:  newobj     ""C..ctor(int, CustomHandler)""
+  IL_0020:  pop
+  IL_0021:  ret
 }
 ");
         }
@@ -8108,28 +8165,28 @@ literal:literal
                 ? @"
 {
   // Code size       57 (0x39)
-  .maxstack  3
+  .maxstack  4
   .locals init (C V_0, //c
-                CustomHandler V_1,
-                C& V_2)
+                C& V_1,
+                CustomHandler V_2)
   IL_0000:  ldc.i4.1
   IL_0001:  newobj     ""C..ctor(int)""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
   IL_0009:  call       ""ref C <Program>$.<<Main>$>g__GetC|0_0(ref C)""
-  IL_000e:  stloc.2
-  IL_000f:  ldc.i4.7
-  IL_0010:  ldc.i4.0
-  IL_0011:  ldloc.2
-  IL_0012:  newobj     ""CustomHandler..ctor(int, int, ref C)""
-  IL_0017:  stloc.1
-  IL_0018:  ldloca.s   V_1
-  IL_001a:  ldstr      ""literal""
-  IL_001f:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0024:  pop
-  IL_0025:  ldloc.2
-  IL_0026:  ldind.ref
-  IL_0027:  ldloc.1
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  ldind.ref
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.0
+  IL_0013:  ldloc.1
+  IL_0014:  newobj     ""CustomHandler..ctor(int, int, ref C)""
+  IL_0019:  stloc.2
+  IL_001a:  ldloca.s   V_2
+  IL_001c:  ldstr      ""literal""
+  IL_0021:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0026:  pop
+  IL_0027:  ldloc.2
   IL_0028:  callvirt   ""void C.M(CustomHandler)""
   IL_002d:  ldloc.0
   IL_002e:  ldfld      ""int C.I""
@@ -8140,35 +8197,165 @@ literal:literal
                 : @"
 {
   // Code size       65 (0x41)
-  .maxstack  4
+  .maxstack  5
   .locals init (C V_0, //c
-                bool V_1,
+                C& V_1,
                 CustomHandler V_2,
-                C& V_3)
+                bool V_3)
   IL_0000:  ldc.i4.1
   IL_0001:  newobj     ""C..ctor(int)""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
   IL_0009:  call       ""ref C <Program>$.<<Main>$>g__GetC|0_0(ref C)""
-  IL_000e:  stloc.3
-  IL_000f:  ldc.i4.7
-  IL_0010:  ldc.i4.0
-  IL_0011:  ldloc.3
-  IL_0012:  ldloca.s   V_1
-  IL_0014:  newobj     ""CustomHandler..ctor(int, int, ref C, out bool)""
-  IL_0019:  stloc.2
-  IL_001a:  ldloc.1
-  IL_001b:  brfalse.s  IL_002b
-  IL_001d:  ldloca.s   V_2
-  IL_001f:  ldstr      ""literal""
-  IL_0024:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0029:  br.s       IL_002c
-  IL_002b:  ldc.i4.0
-  IL_002c:  pop
-  IL_002d:  ldloc.3
-  IL_002e:  ldind.ref
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  ldind.ref
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.0
+  IL_0013:  ldloc.1
+  IL_0014:  ldloca.s   V_3
+  IL_0016:  newobj     ""CustomHandler..ctor(int, int, ref C, out bool)""
+  IL_001b:  stloc.2
+  IL_001c:  ldloc.3
+  IL_001d:  brfalse.s  IL_002d
+  IL_001f:  ldloca.s   V_2
+  IL_0021:  ldstr      ""literal""
+  IL_0026:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002b:  br.s       IL_002e
+  IL_002d:  ldc.i4.0
+  IL_002e:  pop
   IL_002f:  ldloc.2
   IL_0030:  callvirt   ""void C.M(CustomHandler)""
+  IL_0035:  ldloc.0
+  IL_0036:  ldfld      ""int C.I""
+  IL_003b:  call       ""void System.Console.WriteLine(int)""
+  IL_0040:  ret
+}
+");
+
+            static void validator(ModuleSymbol module)
+            {
+                var cParam = module.GlobalNamespace.GetTypeMember("C").GetMethod("M").Parameters.Single();
+                AssertEx.Equal("System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute",
+                               cParam.GetAttributes().Single().AttributeClass.ToTestDisplayString());
+                Assert.Equal(new[] { -1 }, cParam.InterpolatedStringHandlerArgumentIndexes);
+            }
+        }
+
+        [ConditionalTheory(typeof(NoIOperationValidation))]
+        [InlineData("")]
+        [InlineData(", out bool success")]
+        public void RefReturningMethodAsReceiver_Success_StructReceiver(string extraConstructorArg)
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+C c = new C(1);
+GetC(ref c).M($""literal"");
+Console.WriteLine(c.I);
+
+ref C GetC(ref C c)
+{
+    Console.WriteLine(""GetC"");
+    return ref c;
+}
+
+public struct C
+{
+    public int I;
+    public C(int i)
+    {
+        I = i;
+    }
+
+    public void M([InterpolatedStringHandlerArgument("""")]CustomHandler c) => Console.WriteLine(c.ToString());
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, ref C c" + extraConstructorArg + @") : this(literalLength, formattedCount)
+    {
+        c = new C(2);
+" + (extraConstructorArg != "" ? "success = true;" : "") + @"
+    }
+}
+";
+
+            var handler = GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: true);
+
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
+            var verifier = CompileAndVerify(comp, sourceSymbolValidator: validator, symbolValidator: validator, verify: ExecutionConditionUtil.IsWindowsDesktop ? Verification.Skipped : Verification.Passes, expectedOutput: @"
+GetC
+literal:literal
+
+2
+");
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", (extraConstructorArg == "")
+                ? @"
+{
+  // Code size       57 (0x39)
+  .maxstack  4
+  .locals init (C V_0, //c
+                C& V_1,
+                CustomHandler V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  call       ""C..ctor(int)""
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       ""ref C <Program>$.<<Main>$>g__GetC|0_0(ref C)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.0
+  IL_0013:  ldloc.1
+  IL_0014:  newobj     ""CustomHandler..ctor(int, int, ref C)""
+  IL_0019:  stloc.2
+  IL_001a:  ldloca.s   V_2
+  IL_001c:  ldstr      ""literal""
+  IL_0021:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0026:  pop
+  IL_0027:  ldloc.2
+  IL_0028:  call       ""void C.M(CustomHandler)""
+  IL_002d:  ldloc.0
+  IL_002e:  ldfld      ""int C.I""
+  IL_0033:  call       ""void System.Console.WriteLine(int)""
+  IL_0038:  ret
+}
+"
+                : @"
+{
+  // Code size       65 (0x41)
+  .maxstack  5
+  .locals init (C V_0, //c
+                C& V_1,
+                CustomHandler V_2,
+                bool V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  call       ""C..ctor(int)""
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       ""ref C <Program>$.<<Main>$>g__GetC|0_0(ref C)""
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.0
+  IL_0013:  ldloc.1
+  IL_0014:  ldloca.s   V_3
+  IL_0016:  newobj     ""CustomHandler..ctor(int, int, ref C, out bool)""
+  IL_001b:  stloc.2
+  IL_001c:  ldloc.3
+  IL_001d:  brfalse.s  IL_002d
+  IL_001f:  ldloca.s   V_2
+  IL_0021:  ldstr      ""literal""
+  IL_0026:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002b:  br.s       IL_002e
+  IL_002d:  ldc.i4.0
+  IL_002e:  pop
+  IL_002f:  ldloc.2
+  IL_0030:  call       ""void C.M(CustomHandler)""
   IL_0035:  ldloc.0
   IL_0036:  ldfld      ""int C.I""
   IL_003b:  call       ""void System.Console.WriteLine(int)""
@@ -8255,7 +8442,127 @@ public partial struct CustomHandler
             );
         }
 
-        [Theory]
+        [ConditionalFact(typeof(NoIOperationValidation))]
+        public void StructReceiver_Rvalue()
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+S s1 = new S { I = 1 };
+S s2 = new S { I = 2 };
+
+s1.M(s2, $"""");
+
+public struct S
+{
+    public int I;
+
+    public void M(S s2, [InterpolatedStringHandlerArgument("""", ""s2"")]CustomHandler handler)
+    {
+        Console.WriteLine(""s1.I:"" + this.I.ToString());
+        Console.WriteLine(""s2.I:"" + s2.I.ToString());
+    }
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, S s1, S s2) : this(literalLength, formattedCount)
+    {
+        s1.I = 3;
+        s2.I = 4;
+    }
+}
+";
+
+            var handler = GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false);
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
+
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+s1.I:1
+s2.I:2");
+
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       56 (0x38)
+  .maxstack  6
+  .locals init (S V_0, //s1
+                S V_1,
+                S V_2)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  ldc.i4.1
+  IL_000b:  stfld      ""int S.I""
+  IL_0010:  ldloc.1
+  IL_0011:  stloc.0
+  IL_0012:  ldloca.s   V_1
+  IL_0014:  initobj    ""S""
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  ldc.i4.2
+  IL_001d:  stfld      ""int S.I""
+  IL_0022:  ldloc.1
+  IL_0023:  ldloc.0
+  IL_0024:  stloc.1
+  IL_0025:  stloc.2
+  IL_0026:  ldloca.s   V_1
+  IL_0028:  ldloc.2
+  IL_0029:  ldc.i4.0
+  IL_002a:  ldc.i4.0
+  IL_002b:  ldloc.1
+  IL_002c:  ldloc.2
+  IL_002d:  newobj     ""CustomHandler..ctor(int, int, S, S)""
+  IL_0032:  call       ""void S.M(S, CustomHandler)""
+  IL_0037:  ret
+}
+");
+        }
+
+        [ConditionalFact(typeof(NoIOperationValidation))]
+        public void StructReceiver_Lvalue()
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+S s1 = new S { I = 1 };
+S s2 = new S { I = 2 };
+
+s1.M(ref s2, $"""");
+
+public struct S
+{
+    public int I;
+
+    public void M(ref S s2, [InterpolatedStringHandlerArgument("""", ""s2"")]CustomHandler handler)
+    {
+        Console.WriteLine(""s1.I:"" + this.I.ToString());
+        Console.WriteLine(""s2.I:"" + s2.I.ToString());
+    }
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, ref S s1, ref S s2) : this(literalLength, formattedCount)
+    {
+        s1.I = 3;
+        s2.I = 4;
+    }
+}
+";
+
+            var handler = GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false);
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(
+                // (8,14): error CS1620: Argument 3 must be passed with the 'ref' keyword
+                // s1.M(ref s2, $"");
+                Diagnostic(ErrorCode.ERR_BadArgRef, @"$""""").WithArguments("3", "ref").WithLocation(8, 14)
+            );
+        }
+
+        [ConditionalTheory(typeof(NoIOperationValidation))]
         [CombinatorialData]
         public void SideEffects(bool useBoolReturns, bool validityParameter)
         {
@@ -8364,24 +8671,24 @@ literal:literal
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
   // Code size       39 (0x27)
-  .maxstack  4
-  .locals init (CustomHandler V_0,
-                double V_1)
+  .maxstack  5
+  .locals init (double V_0,
+                CustomHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  conv.r8
-  IL_0002:  stloc.1
-  IL_0003:  ldloca.s   V_0
-  IL_0005:  ldc.i4.7
-  IL_0006:  ldc.i4.0
-  IL_0007:  ldloc.1
-  IL_0008:  call       ""C C.op_Implicit(double)""
-  IL_000d:  call       ""CustomHandler..ctor(int, int, C)""
-  IL_0012:  ldloca.s   V_0
-  IL_0014:  ldstr      ""literal""
-  IL_0019:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_001e:  pop
-  IL_001f:  ldloc.1
-  IL_0020:  ldloc.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  ldloca.s   V_1
+  IL_0006:  ldc.i4.7
+  IL_0007:  ldc.i4.0
+  IL_0008:  ldloc.0
+  IL_0009:  call       ""C C.op_Implicit(double)""
+  IL_000e:  call       ""CustomHandler..ctor(int, int, C)""
+  IL_0013:  ldloca.s   V_1
+  IL_0015:  ldstr      ""literal""
+  IL_001a:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_001f:  pop
+  IL_0020:  ldloc.1
   IL_0021:  call       ""void C.M(double, CustomHandler)""
   IL_0026:  ret
 }
@@ -8474,77 +8781,81 @@ format:
             {
                 (useBoolReturns: false, validityParameter: false) => @"
 {
-  // Code size       77 (0x4d)
+  // Code size       80 (0x50)
   .maxstack  6
   .locals init (int V_0, //i
-                CustomHandler V_1,
-                C V_2,
-                int V_3)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                CustomHandler V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.2
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.3
-  IL_000f:  ldloca.s   V_1
+  IL_000e:  stloc.2
+  IL_000f:  ldloca.s   V_4
   IL_0011:  ldc.i4.7
   IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.3
-  IL_0014:  ldloc.2
+  IL_0013:  ldloc.2
+  IL_0014:  ldloc.1
   IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_1
+  IL_001a:  ldloca.s   V_4
   IL_001c:  ldstr      ""literal""
   IL_0021:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_0026:  ldloca.s   V_1
+  IL_0026:  ldloca.s   V_4
   IL_0028:  ldloc.0
   IL_0029:  box        ""int""
   IL_002e:  ldc.i4.0
   IL_002f:  ldnull
   IL_0030:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_0035:  ldloc.2
-  IL_0036:  ldloc.3
-  IL_0037:  ldloc.1
-  IL_0038:  ldloc.2
-  IL_0039:  ldloc.3
-  IL_003a:  ldloc.1
-  IL_003b:  callvirt   ""int C.this[int, CustomHandler].get""
-  IL_0040:  ldc.i4.2
-  IL_0041:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0046:  add
-  IL_0047:  callvirt   ""void C.this[int, CustomHandler].set""
-  IL_004c:  ret
+  IL_0035:  ldloc.s    V_4
+  IL_0037:  stloc.3
+  IL_0038:  ldloc.1
+  IL_0039:  ldloc.2
+  IL_003a:  ldloc.3
+  IL_003b:  ldloc.1
+  IL_003c:  ldloc.2
+  IL_003d:  ldloc.3
+  IL_003e:  callvirt   ""int C.this[int, CustomHandler].get""
+  IL_0043:  ldc.i4.2
+  IL_0044:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_0049:  add
+  IL_004a:  callvirt   ""void C.this[int, CustomHandler].set""
+  IL_004f:  ret
 }
 ",
                 (useBoolReturns: false, validityParameter: true) => @"
 {
-  // Code size       90 (0x5a)
+  // Code size       91 (0x5b)
   .maxstack  6
   .locals init (int V_0, //i
-                bool V_1,
-                CustomHandler V_2,
-                C V_3,
-                int V_4)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                CustomHandler V_4,
+                bool V_5)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.3
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.1
-  IL_0012:  ldloc.s    V_4
-  IL_0014:  ldloc.3
-  IL_0015:  ldloca.s   V_1
-  IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.1
+  IL_000e:  stloc.2
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.1
+  IL_0011:  ldloc.2
+  IL_0012:  ldloc.1
+  IL_0013:  ldloca.s   V_5
+  IL_0015:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
+  IL_001a:  stloc.s    V_4
+  IL_001c:  ldloc.s    V_5
   IL_001e:  brfalse.s  IL_003e
-  IL_0020:  ldloca.s   V_2
+  IL_0020:  ldloca.s   V_4
   IL_0022:  ldstr      ""literal""
   IL_0027:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_002c:  ldloca.s   V_2
+  IL_002c:  ldloca.s   V_4
   IL_002e:  ldloc.0
   IL_002f:  box        ""int""
   IL_0034:  ldc.i4.0
@@ -8554,46 +8865,49 @@ format:
   IL_003c:  br.s       IL_003f
   IL_003e:  ldc.i4.0
   IL_003f:  pop
-  IL_0040:  ldloc.3
-  IL_0041:  ldloc.s    V_4
-  IL_0043:  ldloc.2
-  IL_0044:  ldloc.3
-  IL_0045:  ldloc.s    V_4
+  IL_0040:  ldloc.s    V_4
+  IL_0042:  stloc.3
+  IL_0043:  ldloc.1
+  IL_0044:  ldloc.2
+  IL_0045:  ldloc.3
+  IL_0046:  ldloc.1
   IL_0047:  ldloc.2
-  IL_0048:  callvirt   ""int C.this[int, CustomHandler].get""
-  IL_004d:  ldc.i4.2
-  IL_004e:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0053:  add
-  IL_0054:  callvirt   ""void C.this[int, CustomHandler].set""
-  IL_0059:  ret
+  IL_0048:  ldloc.3
+  IL_0049:  callvirt   ""int C.this[int, CustomHandler].get""
+  IL_004e:  ldc.i4.2
+  IL_004f:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_0054:  add
+  IL_0055:  callvirt   ""void C.this[int, CustomHandler].set""
+  IL_005a:  ret
 }
 ",
                 (useBoolReturns: true, validityParameter: false) => @"
 {
-  // Code size       83 (0x53)
+  // Code size       86 (0x56)
   .maxstack  6
   .locals init (int V_0, //i
-                CustomHandler V_1,
-                C V_2,
-                int V_3)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                CustomHandler V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.2
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.3
-  IL_000f:  ldloca.s   V_1
+  IL_000e:  stloc.2
+  IL_000f:  ldloca.s   V_4
   IL_0011:  ldc.i4.7
   IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.3
-  IL_0014:  ldloc.2
+  IL_0013:  ldloc.2
+  IL_0014:  ldloc.1
   IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_1
+  IL_001a:  ldloca.s   V_4
   IL_001c:  ldstr      ""literal""
   IL_0021:  call       ""bool CustomHandler.AppendLiteral(string)""
   IL_0026:  brfalse.s  IL_0039
-  IL_0028:  ldloca.s   V_1
+  IL_0028:  ldloca.s   V_4
   IL_002a:  ldloc.0
   IL_002b:  box        ""int""
   IL_0030:  ldc.i4.0
@@ -8602,50 +8916,53 @@ format:
   IL_0037:  br.s       IL_003a
   IL_0039:  ldc.i4.0
   IL_003a:  pop
-  IL_003b:  ldloc.2
-  IL_003c:  ldloc.3
-  IL_003d:  ldloc.1
-  IL_003e:  ldloc.2
-  IL_003f:  ldloc.3
-  IL_0040:  ldloc.1
-  IL_0041:  callvirt   ""int C.this[int, CustomHandler].get""
-  IL_0046:  ldc.i4.2
-  IL_0047:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_004c:  add
-  IL_004d:  callvirt   ""void C.this[int, CustomHandler].set""
-  IL_0052:  ret
+  IL_003b:  ldloc.s    V_4
+  IL_003d:  stloc.3
+  IL_003e:  ldloc.1
+  IL_003f:  ldloc.2
+  IL_0040:  ldloc.3
+  IL_0041:  ldloc.1
+  IL_0042:  ldloc.2
+  IL_0043:  ldloc.3
+  IL_0044:  callvirt   ""int C.this[int, CustomHandler].get""
+  IL_0049:  ldc.i4.2
+  IL_004a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_004f:  add
+  IL_0050:  callvirt   ""void C.this[int, CustomHandler].set""
+  IL_0055:  ret
 }
 ",
                 (useBoolReturns: true, validityParameter: true) => @"
 {
-  // Code size       91 (0x5b)
+  // Code size       92 (0x5c)
   .maxstack  6
   .locals init (int V_0, //i
-                bool V_1,
-                CustomHandler V_2,
-                C V_3,
-                int V_4)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                CustomHandler V_4,
+                bool V_5)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.3
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.1
-  IL_0012:  ldloc.s    V_4
-  IL_0014:  ldloc.3
-  IL_0015:  ldloca.s   V_1
-  IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.1
+  IL_000e:  stloc.2
+  IL_000f:  ldc.i4.7
+  IL_0010:  ldc.i4.1
+  IL_0011:  ldloc.2
+  IL_0012:  ldloc.1
+  IL_0013:  ldloca.s   V_5
+  IL_0015:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
+  IL_001a:  stloc.s    V_4
+  IL_001c:  ldloc.s    V_5
   IL_001e:  brfalse.s  IL_003f
-  IL_0020:  ldloca.s   V_2
+  IL_0020:  ldloca.s   V_4
   IL_0022:  ldstr      ""literal""
   IL_0027:  call       ""bool CustomHandler.AppendLiteral(string)""
   IL_002c:  brfalse.s  IL_003f
-  IL_002e:  ldloca.s   V_2
+  IL_002e:  ldloca.s   V_4
   IL_0030:  ldloc.0
   IL_0031:  box        ""int""
   IL_0036:  ldc.i4.0
@@ -8654,18 +8971,20 @@ format:
   IL_003d:  br.s       IL_0040
   IL_003f:  ldc.i4.0
   IL_0040:  pop
-  IL_0041:  ldloc.3
-  IL_0042:  ldloc.s    V_4
-  IL_0044:  ldloc.2
-  IL_0045:  ldloc.3
-  IL_0046:  ldloc.s    V_4
+  IL_0041:  ldloc.s    V_4
+  IL_0043:  stloc.3
+  IL_0044:  ldloc.1
+  IL_0045:  ldloc.2
+  IL_0046:  ldloc.3
+  IL_0047:  ldloc.1
   IL_0048:  ldloc.2
-  IL_0049:  callvirt   ""int C.this[int, CustomHandler].get""
-  IL_004e:  ldc.i4.2
-  IL_004f:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0054:  add
-  IL_0055:  callvirt   ""void C.this[int, CustomHandler].set""
-  IL_005a:  ret
+  IL_0049:  ldloc.3
+  IL_004a:  callvirt   ""int C.this[int, CustomHandler].get""
+  IL_004f:  ldc.i4.2
+  IL_0050:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_0055:  add
+  IL_0056:  callvirt   ""void C.this[int, CustomHandler].set""
+  IL_005b:  ret
 }
 ",
             };
@@ -8747,36 +9066,36 @@ GetInt2
                 (useBoolReturns: false, validityParameter: false) => @"
 {
   // Code size       72 (0x48)
-  .maxstack  5
+  .maxstack  7
   .locals init (int V_0, //i
-                CustomHandler V_1,
-                C V_2,
-                int V_3)
+                C V_1,
+                int V_2,
+                CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.2
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.3
-  IL_000f:  ldloca.s   V_1
-  IL_0011:  ldc.i4.7
-  IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.3
-  IL_0014:  ldloc.2
-  IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldstr      ""literal""
-  IL_0021:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_0026:  ldloca.s   V_1
-  IL_0028:  ldloc.0
-  IL_0029:  box        ""int""
-  IL_002e:  ldc.i4.0
-  IL_002f:  ldnull
-  IL_0030:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_0035:  ldloc.2
-  IL_0036:  ldloc.3
-  IL_0037:  ldloc.1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldloca.s   V_3
+  IL_0013:  ldc.i4.7
+  IL_0014:  ldc.i4.1
+  IL_0015:  ldloc.2
+  IL_0016:  ldloc.1
+  IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
+  IL_001c:  ldloca.s   V_3
+  IL_001e:  ldstr      ""literal""
+  IL_0023:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0028:  ldloca.s   V_3
+  IL_002a:  ldloc.0
+  IL_002b:  box        ""int""
+  IL_0030:  ldc.i4.0
+  IL_0031:  ldnull
+  IL_0032:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0037:  ldloc.3
   IL_0038:  callvirt   ""ref int C.this[int, CustomHandler].get""
   IL_003d:  dup
   IL_003e:  ldind.i4
@@ -8789,92 +9108,92 @@ GetInt2
 ",
                 (useBoolReturns: false, validityParameter: true) => @"
 {
-  // Code size       84 (0x54)
-  .maxstack  5
+  // Code size       82 (0x52)
+  .maxstack  7
   .locals init (int V_0, //i
-                bool V_1,
-                CustomHandler V_2,
-                C V_3,
-                int V_4)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.3
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.1
-  IL_0012:  ldloc.s    V_4
-  IL_0014:  ldloc.3
-  IL_0015:  ldloca.s   V_1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.1
+  IL_0013:  ldloc.2
+  IL_0014:  ldloc.1
+  IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.1
-  IL_001e:  brfalse.s  IL_003e
-  IL_0020:  ldloca.s   V_2
-  IL_0022:  ldstr      ""literal""
-  IL_0027:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_002c:  ldloca.s   V_2
-  IL_002e:  ldloc.0
-  IL_002f:  box        ""int""
-  IL_0034:  ldc.i4.0
-  IL_0035:  ldnull
-  IL_0036:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_003b:  ldc.i4.1
-  IL_003c:  br.s       IL_003f
-  IL_003e:  ldc.i4.0
-  IL_003f:  pop
-  IL_0040:  ldloc.3
-  IL_0041:  ldloc.s    V_4
-  IL_0043:  ldloc.2
-  IL_0044:  callvirt   ""ref int C.this[int, CustomHandler].get""
-  IL_0049:  dup
-  IL_004a:  ldind.i4
-  IL_004b:  ldc.i4.2
-  IL_004c:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0051:  add
-  IL_0052:  stind.i4
-  IL_0053:  ret
+  IL_001c:  stloc.3
+  IL_001d:  ldloc.s    V_4
+  IL_001f:  brfalse.s  IL_003f
+  IL_0021:  ldloca.s   V_3
+  IL_0023:  ldstr      ""literal""
+  IL_0028:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_002d:  ldloca.s   V_3
+  IL_002f:  ldloc.0
+  IL_0030:  box        ""int""
+  IL_0035:  ldc.i4.0
+  IL_0036:  ldnull
+  IL_0037:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_003c:  ldc.i4.1
+  IL_003d:  br.s       IL_0040
+  IL_003f:  ldc.i4.0
+  IL_0040:  pop
+  IL_0041:  ldloc.3
+  IL_0042:  callvirt   ""ref int C.this[int, CustomHandler].get""
+  IL_0047:  dup
+  IL_0048:  ldind.i4
+  IL_0049:  ldc.i4.2
+  IL_004a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_004f:  add
+  IL_0050:  stind.i4
+  IL_0051:  ret
 }
 ",
                 (useBoolReturns: true, validityParameter: false) => @"
 {
   // Code size       78 (0x4e)
-  .maxstack  5
+  .maxstack  7
   .locals init (int V_0, //i
-                CustomHandler V_1,
-                C V_2,
-                int V_3)
+                C V_1,
+                int V_2,
+                CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.2
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.3
-  IL_000f:  ldloca.s   V_1
-  IL_0011:  ldc.i4.7
-  IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.3
-  IL_0014:  ldloc.2
-  IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldstr      ""literal""
-  IL_0021:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0026:  brfalse.s  IL_0039
-  IL_0028:  ldloca.s   V_1
-  IL_002a:  ldloc.0
-  IL_002b:  box        ""int""
-  IL_0030:  ldc.i4.0
-  IL_0031:  ldnull
-  IL_0032:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
-  IL_0037:  br.s       IL_003a
-  IL_0039:  ldc.i4.0
-  IL_003a:  pop
-  IL_003b:  ldloc.2
-  IL_003c:  ldloc.3
-  IL_003d:  ldloc.1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldloca.s   V_3
+  IL_0013:  ldc.i4.7
+  IL_0014:  ldc.i4.1
+  IL_0015:  ldloc.2
+  IL_0016:  ldloc.1
+  IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
+  IL_001c:  ldloca.s   V_3
+  IL_001e:  ldstr      ""literal""
+  IL_0023:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0028:  brfalse.s  IL_003b
+  IL_002a:  ldloca.s   V_3
+  IL_002c:  ldloc.0
+  IL_002d:  box        ""int""
+  IL_0032:  ldc.i4.0
+  IL_0033:  ldnull
+  IL_0034:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_0039:  br.s       IL_003c
+  IL_003b:  ldc.i4.0
+  IL_003c:  pop
+  IL_003d:  ldloc.3
   IL_003e:  callvirt   ""ref int C.this[int, CustomHandler].get""
   IL_0043:  dup
   IL_0044:  ldind.i4
@@ -8887,53 +9206,53 @@ GetInt2
 ",
                 (useBoolReturns: true, validityParameter: true) => @"
 {
-  // Code size       85 (0x55)
-  .maxstack  5
+  // Code size       83 (0x53)
+  .maxstack  7
   .locals init (int V_0, //i
-                bool V_1,
-                CustomHandler V_2,
-                C V_3,
-                int V_4)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.3
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.1
-  IL_0012:  ldloc.s    V_4
-  IL_0014:  ldloc.3
-  IL_0015:  ldloca.s   V_1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.1
+  IL_0013:  ldloc.2
+  IL_0014:  ldloc.1
+  IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.1
-  IL_001e:  brfalse.s  IL_003f
-  IL_0020:  ldloca.s   V_2
-  IL_0022:  ldstr      ""literal""
-  IL_0027:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_002c:  brfalse.s  IL_003f
-  IL_002e:  ldloca.s   V_2
-  IL_0030:  ldloc.0
-  IL_0031:  box        ""int""
-  IL_0036:  ldc.i4.0
-  IL_0037:  ldnull
-  IL_0038:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
-  IL_003d:  br.s       IL_0040
-  IL_003f:  ldc.i4.0
-  IL_0040:  pop
-  IL_0041:  ldloc.3
-  IL_0042:  ldloc.s    V_4
-  IL_0044:  ldloc.2
-  IL_0045:  callvirt   ""ref int C.this[int, CustomHandler].get""
-  IL_004a:  dup
-  IL_004b:  ldind.i4
-  IL_004c:  ldc.i4.2
-  IL_004d:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0052:  add
-  IL_0053:  stind.i4
-  IL_0054:  ret
+  IL_001c:  stloc.3
+  IL_001d:  ldloc.s    V_4
+  IL_001f:  brfalse.s  IL_0040
+  IL_0021:  ldloca.s   V_3
+  IL_0023:  ldstr      ""literal""
+  IL_0028:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002d:  brfalse.s  IL_0040
+  IL_002f:  ldloca.s   V_3
+  IL_0031:  ldloc.0
+  IL_0032:  box        ""int""
+  IL_0037:  ldc.i4.0
+  IL_0038:  ldnull
+  IL_0039:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_003e:  br.s       IL_0041
+  IL_0040:  ldc.i4.0
+  IL_0041:  pop
+  IL_0042:  ldloc.3
+  IL_0043:  callvirt   ""ref int C.this[int, CustomHandler].get""
+  IL_0048:  dup
+  IL_0049:  ldind.i4
+  IL_004a:  ldc.i4.2
+  IL_004b:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_0050:  add
+  IL_0051:  stind.i4
+  IL_0052:  ret
 }
 ",
             };
@@ -9012,36 +9331,36 @@ GetInt2
                 (useBoolReturns: false, validityParameter: false) => @"
 {
   // Code size       72 (0x48)
-  .maxstack  5
+  .maxstack  7
   .locals init (int V_0, //i
-                CustomHandler V_1,
-                C V_2,
-                int V_3)
+                C V_1,
+                int V_2,
+                CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.2
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.3
-  IL_000f:  ldloca.s   V_1
-  IL_0011:  ldc.i4.7
-  IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.3
-  IL_0014:  ldloc.2
-  IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldstr      ""literal""
-  IL_0021:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_0026:  ldloca.s   V_1
-  IL_0028:  ldloc.0
-  IL_0029:  box        ""int""
-  IL_002e:  ldc.i4.0
-  IL_002f:  ldnull
-  IL_0030:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_0035:  ldloc.2
-  IL_0036:  ldloc.3
-  IL_0037:  ldloc.1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldloca.s   V_3
+  IL_0013:  ldc.i4.7
+  IL_0014:  ldc.i4.1
+  IL_0015:  ldloc.2
+  IL_0016:  ldloc.1
+  IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
+  IL_001c:  ldloca.s   V_3
+  IL_001e:  ldstr      ""literal""
+  IL_0023:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0028:  ldloca.s   V_3
+  IL_002a:  ldloc.0
+  IL_002b:  box        ""int""
+  IL_0030:  ldc.i4.0
+  IL_0031:  ldnull
+  IL_0032:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0037:  ldloc.3
   IL_0038:  callvirt   ""ref int C.M(int, CustomHandler)""
   IL_003d:  dup
   IL_003e:  ldind.i4
@@ -9054,92 +9373,92 @@ GetInt2
 ",
                 (useBoolReturns: false, validityParameter: true) => @"
 {
-  // Code size       84 (0x54)
-  .maxstack  5
+  // Code size       82 (0x52)
+  .maxstack  7
   .locals init (int V_0, //i
-                bool V_1,
-                CustomHandler V_2,
-                C V_3,
-                int V_4)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.3
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.1
-  IL_0012:  ldloc.s    V_4
-  IL_0014:  ldloc.3
-  IL_0015:  ldloca.s   V_1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.1
+  IL_0013:  ldloc.2
+  IL_0014:  ldloc.1
+  IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.1
-  IL_001e:  brfalse.s  IL_003e
-  IL_0020:  ldloca.s   V_2
-  IL_0022:  ldstr      ""literal""
-  IL_0027:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_002c:  ldloca.s   V_2
-  IL_002e:  ldloc.0
-  IL_002f:  box        ""int""
-  IL_0034:  ldc.i4.0
-  IL_0035:  ldnull
-  IL_0036:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_003b:  ldc.i4.1
-  IL_003c:  br.s       IL_003f
-  IL_003e:  ldc.i4.0
-  IL_003f:  pop
-  IL_0040:  ldloc.3
-  IL_0041:  ldloc.s    V_4
-  IL_0043:  ldloc.2
-  IL_0044:  callvirt   ""ref int C.M(int, CustomHandler)""
-  IL_0049:  dup
-  IL_004a:  ldind.i4
-  IL_004b:  ldc.i4.2
-  IL_004c:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0051:  add
-  IL_0052:  stind.i4
-  IL_0053:  ret
+  IL_001c:  stloc.3
+  IL_001d:  ldloc.s    V_4
+  IL_001f:  brfalse.s  IL_003f
+  IL_0021:  ldloca.s   V_3
+  IL_0023:  ldstr      ""literal""
+  IL_0028:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_002d:  ldloca.s   V_3
+  IL_002f:  ldloc.0
+  IL_0030:  box        ""int""
+  IL_0035:  ldc.i4.0
+  IL_0036:  ldnull
+  IL_0037:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_003c:  ldc.i4.1
+  IL_003d:  br.s       IL_0040
+  IL_003f:  ldc.i4.0
+  IL_0040:  pop
+  IL_0041:  ldloc.3
+  IL_0042:  callvirt   ""ref int C.M(int, CustomHandler)""
+  IL_0047:  dup
+  IL_0048:  ldind.i4
+  IL_0049:  ldc.i4.2
+  IL_004a:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_004f:  add
+  IL_0050:  stind.i4
+  IL_0051:  ret
 }
 ",
                 (useBoolReturns: true, validityParameter: false) => @"
 {
   // Code size       78 (0x4e)
-  .maxstack  5
+  .maxstack  7
   .locals init (int V_0, //i
-                CustomHandler V_1,
-                C V_2,
-                int V_3)
+                C V_1,
+                int V_2,
+                CustomHandler V_3)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.2
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.3
-  IL_000f:  ldloca.s   V_1
-  IL_0011:  ldc.i4.7
-  IL_0012:  ldc.i4.1
-  IL_0013:  ldloc.3
-  IL_0014:  ldloc.2
-  IL_0015:  call       ""CustomHandler..ctor(int, int, int, C)""
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldstr      ""literal""
-  IL_0021:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_0026:  brfalse.s  IL_0039
-  IL_0028:  ldloca.s   V_1
-  IL_002a:  ldloc.0
-  IL_002b:  box        ""int""
-  IL_0030:  ldc.i4.0
-  IL_0031:  ldnull
-  IL_0032:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
-  IL_0037:  br.s       IL_003a
-  IL_0039:  ldc.i4.0
-  IL_003a:  pop
-  IL_003b:  ldloc.2
-  IL_003c:  ldloc.3
-  IL_003d:  ldloc.1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldloca.s   V_3
+  IL_0013:  ldc.i4.7
+  IL_0014:  ldc.i4.1
+  IL_0015:  ldloc.2
+  IL_0016:  ldloc.1
+  IL_0017:  call       ""CustomHandler..ctor(int, int, int, C)""
+  IL_001c:  ldloca.s   V_3
+  IL_001e:  ldstr      ""literal""
+  IL_0023:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_0028:  brfalse.s  IL_003b
+  IL_002a:  ldloca.s   V_3
+  IL_002c:  ldloc.0
+  IL_002d:  box        ""int""
+  IL_0032:  ldc.i4.0
+  IL_0033:  ldnull
+  IL_0034:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_0039:  br.s       IL_003c
+  IL_003b:  ldc.i4.0
+  IL_003c:  pop
+  IL_003d:  ldloc.3
   IL_003e:  callvirt   ""ref int C.M(int, CustomHandler)""
   IL_0043:  dup
   IL_0044:  ldind.i4
@@ -9152,53 +9471,53 @@ GetInt2
 ",
                 (useBoolReturns: true, validityParameter: true) => @"
 {
-  // Code size       85 (0x55)
-  .maxstack  5
+  // Code size       83 (0x53)
+  .maxstack  7
   .locals init (int V_0, //i
-                bool V_1,
-                CustomHandler V_2,
-                C V_3,
-                int V_4)
+                C V_1,
+                int V_2,
+                CustomHandler V_3,
+                bool V_4)
   IL_0000:  ldc.i4.3
   IL_0001:  stloc.0
   IL_0002:  call       ""C <Program>$.<<Main>$>g__GetC|0_0()""
-  IL_0007:  stloc.3
+  IL_0007:  stloc.1
   IL_0008:  ldc.i4.1
   IL_0009:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_000e:  stloc.s    V_4
-  IL_0010:  ldc.i4.7
-  IL_0011:  ldc.i4.1
-  IL_0012:  ldloc.s    V_4
-  IL_0014:  ldloc.3
-  IL_0015:  ldloca.s   V_1
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.2
+  IL_0011:  ldc.i4.7
+  IL_0012:  ldc.i4.1
+  IL_0013:  ldloc.2
+  IL_0014:  ldloc.1
+  IL_0015:  ldloca.s   V_4
   IL_0017:  newobj     ""CustomHandler..ctor(int, int, int, C, out bool)""
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.1
-  IL_001e:  brfalse.s  IL_003f
-  IL_0020:  ldloca.s   V_2
-  IL_0022:  ldstr      ""literal""
-  IL_0027:  call       ""bool CustomHandler.AppendLiteral(string)""
-  IL_002c:  brfalse.s  IL_003f
-  IL_002e:  ldloca.s   V_2
-  IL_0030:  ldloc.0
-  IL_0031:  box        ""int""
-  IL_0036:  ldc.i4.0
-  IL_0037:  ldnull
-  IL_0038:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
-  IL_003d:  br.s       IL_0040
-  IL_003f:  ldc.i4.0
-  IL_0040:  pop
-  IL_0041:  ldloc.3
-  IL_0042:  ldloc.s    V_4
-  IL_0044:  ldloc.2
-  IL_0045:  callvirt   ""ref int C.M(int, CustomHandler)""
-  IL_004a:  dup
-  IL_004b:  ldind.i4
-  IL_004c:  ldc.i4.2
-  IL_004d:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
-  IL_0052:  add
-  IL_0053:  stind.i4
-  IL_0054:  ret
+  IL_001c:  stloc.3
+  IL_001d:  ldloc.s    V_4
+  IL_001f:  brfalse.s  IL_0040
+  IL_0021:  ldloca.s   V_3
+  IL_0023:  ldstr      ""literal""
+  IL_0028:  call       ""bool CustomHandler.AppendLiteral(string)""
+  IL_002d:  brfalse.s  IL_0040
+  IL_002f:  ldloca.s   V_3
+  IL_0031:  ldloc.0
+  IL_0032:  box        ""int""
+  IL_0037:  ldc.i4.0
+  IL_0038:  ldnull
+  IL_0039:  call       ""bool CustomHandler.AppendFormatted(object, int, string)""
+  IL_003e:  br.s       IL_0041
+  IL_0040:  ldc.i4.0
+  IL_0041:  pop
+  IL_0042:  ldloc.3
+  IL_0043:  callvirt   ""ref int C.M(int, CustomHandler)""
+  IL_0048:  dup
+  IL_0049:  ldind.i4
+  IL_004a:  ldc.i4.2
+  IL_004b:  call       ""int <Program>$.<<Main>$>g__GetInt|0_1(int)""
+  IL_0050:  add
+  IL_0051:  stind.i4
+  IL_0052:  ret
 }
 ",
             };
@@ -9254,22 +9573,22 @@ literal:literal
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
   // Code size       37 (0x25)
-  .maxstack  4
-  .locals init (CustomHandler V_0,
-                C V_1)
+  .maxstack  5
+  .locals init (C V_0,
+                CustomHandler V_1)
   IL_0000:  ldc.i4.1
   IL_0001:  newobj     ""C..ctor(int)""
-  IL_0006:  stloc.1
-  IL_0007:  ldloca.s   V_0
-  IL_0009:  ldc.i4.7
-  IL_000a:  ldc.i4.0
-  IL_000b:  ldloc.1
-  IL_000c:  call       ""CustomHandler..ctor(int, int, C)""
-  IL_0011:  ldloca.s   V_0
-  IL_0013:  ldstr      ""literal""
-  IL_0018:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_001d:  ldloc.1
-  IL_001e:  ldloc.0
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  ldloca.s   V_1
+  IL_000a:  ldc.i4.7
+  IL_000b:  ldc.i4.0
+  IL_000c:  ldloc.0
+  IL_000d:  call       ""CustomHandler..ctor(int, int, C)""
+  IL_0012:  ldloca.s   V_1
+  IL_0014:  ldstr      ""literal""
+  IL_0019:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_001e:  ldloc.1
   IL_001f:  callvirt   ""void C.Add(CustomHandler)""
   IL_0024:  ret
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -8096,7 +8096,7 @@ public partial struct CustomHandler
             var handler = GetCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: true);
 
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler }, parseOptions: TestOptions.RegularPreview);
-            var verifier = CompileAndVerify(comp, sourceSymbolValidator: validator, symbolValidator: validator, expectedOutput: @"
+            var verifier = CompileAndVerify(comp, sourceSymbolValidator: validator, symbolValidator: validator, verify: ExecutionConditionUtil.IsWindowsDesktop ? Verification.Skipped : Verification.Passes, expectedOutput: @"
 GetC
 literal:literal
 
@@ -9274,6 +9274,6 @@ literal:literal
   IL_0024:  ret
 }
 ");
-       }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -412,22 +412,22 @@ F()
   // Code size       33 (0x21)
   .maxstack  4
   .locals init (IA V_0,
-                int V_1,
-                int V_2)
+  int V_1,
+  int V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  call       ""int[] B.F()""
   IL_0007:  ldc.i4.0
   IL_0008:  ldelem.i4
-  IL_0009:  stloc.1
+  IL_0009:  stloc.2
   IL_000a:  ldloc.0
-  IL_000b:  ldloc.1
-  IL_000c:  stloc.2
-  IL_000d:  ldloca.s   V_2
+  IL_000b:  ldloc.2
+  IL_000c:  stloc.1
+  IL_000d:  ldloca.s   V_1
   IL_000f:  ldloc.0
-  IL_0010:  ldloc.1
-  IL_0011:  stloc.2
-  IL_0012:  ldloca.s   V_2
+  IL_0010:  ldloc.2
+  IL_0011:  stloc.1
+  IL_0012:  ldloca.s   V_1
   IL_0014:  callvirt   ""int IA.P[ref int].get""
   IL_0019:  ldc.i4.1
   IL_001a:  add
@@ -461,22 +461,22 @@ F()
   // Code size       33 (0x21)
   .maxstack  4
   .locals init (int V_0,
-                int V_1,
-                int V_2)
+  int V_1,
+  int V_2)
   IL_0000:  ldarg.0
   IL_0001:  call       ""int[] B.F()""
   IL_0006:  ldc.i4.0
   IL_0007:  ldelem.i4
-  IL_0008:  stloc.0
+  IL_0008:  stloc.1
   IL_0009:  dup
-  IL_000a:  ldloc.0
-  IL_000b:  stloc.1
-  IL_000c:  ldloca.s   V_1
+  IL_000a:  ldloc.1
+  IL_000b:  stloc.0
+  IL_000c:  ldloca.s   V_0
   IL_000e:  callvirt   ""int IA.P[ref int].get""
   IL_0013:  stloc.2
-  IL_0014:  ldloc.0
-  IL_0015:  stloc.1
-  IL_0016:  ldloca.s   V_1
+  IL_0014:  ldloc.1
+  IL_0015:  stloc.0
+  IL_0016:  ldloca.s   V_0
   IL_0018:  ldloc.2
   IL_0019:  ldc.i4.1
   IL_001a:  add
@@ -733,27 +733,27 @@ F()
   // Code size       39 (0x27)
   .maxstack  5
   .locals init (int V_0,
-                int V_1,
-                int V_2,
-                int V_3)
+  int V_1,
+  int V_2,
+  int V_3)
   IL_0000:  ldarg.0
   IL_0001:  ldsfld     ""int C.x""
-  IL_0006:  stloc.0
+  IL_0006:  stloc.2
   IL_0007:  dup
-  IL_0008:  ldloc.0
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
+  IL_0008:  ldloc.2
+  IL_0009:  stloc.0
+  IL_000a:  ldloca.s   V_0
   IL_000c:  ldc.i4.0
-  IL_000d:  stloc.2
-  IL_000e:  ldloca.s   V_2
+  IL_000d:  stloc.1
+  IL_000e:  ldloca.s   V_1
   IL_0010:  callvirt   ""int IA.P[ref int, ref int].get""
   IL_0015:  stloc.3
-  IL_0016:  ldloc.0
-  IL_0017:  stloc.1
-  IL_0018:  ldloca.s   V_1
+  IL_0016:  ldloc.2
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
   IL_001a:  ldc.i4.0
-  IL_001b:  stloc.2
-  IL_001c:  ldloca.s   V_2
+  IL_001b:  stloc.1
+  IL_001c:  ldloca.s   V_1
   IL_001e:  ldloc.3
   IL_001f:  ldc.i4.1
   IL_0020:  add
@@ -765,30 +765,30 @@ F()
   // Code size       47 (0x2f)
   .maxstack  5
   .locals init (int V_0,
-                int V_1,
-                int V_2,
-                int V_3,
-                int V_4)
+  int V_1,
+  int V_2,
+  int V_3,
+  int V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldsfld     ""int C.x""
-  IL_0006:  stloc.0
+  IL_0006:  stloc.2
   IL_0007:  ldsfld     ""int C.y""
-  IL_000c:  stloc.1
+  IL_000c:  stloc.3
   IL_000d:  dup
-  IL_000e:  ldloc.0
-  IL_000f:  stloc.2
-  IL_0010:  ldloca.s   V_2
-  IL_0012:  ldloc.1
-  IL_0013:  stloc.3
-  IL_0014:  ldloca.s   V_3
+  IL_000e:  ldloc.2
+  IL_000f:  stloc.0
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  ldloc.3
+  IL_0013:  stloc.1
+  IL_0014:  ldloca.s   V_1
   IL_0016:  callvirt   ""int IA.P[ref int, ref int].get""
   IL_001b:  stloc.s    V_4
-  IL_001d:  ldloc.0
-  IL_001e:  stloc.2
-  IL_001f:  ldloca.s   V_2
-  IL_0021:  ldloc.1
-  IL_0022:  stloc.3
-  IL_0023:  ldloca.s   V_3
+  IL_001d:  ldloc.2
+  IL_001e:  stloc.0
+  IL_001f:  ldloca.s   V_0
+  IL_0021:  ldloc.3
+  IL_0022:  stloc.1
+  IL_0023:  ldloca.s   V_1
   IL_0025:  ldloc.s    V_4
   IL_0027:  ldc.i4.1
   IL_0028:  add

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -412,22 +412,22 @@ F()
   // Code size       33 (0x21)
   .maxstack  4
   .locals init (IA V_0,
-  int V_1,
-  int V_2)
+                int V_1,
+                int V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  call       ""int[] B.F()""
   IL_0007:  ldc.i4.0
   IL_0008:  ldelem.i4
-  IL_0009:  stloc.2
+  IL_0009:  stloc.1
   IL_000a:  ldloc.0
-  IL_000b:  ldloc.2
-  IL_000c:  stloc.1
-  IL_000d:  ldloca.s   V_1
+  IL_000b:  ldloc.1
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
   IL_000f:  ldloc.0
-  IL_0010:  ldloc.2
-  IL_0011:  stloc.1
-  IL_0012:  ldloca.s   V_1
+  IL_0010:  ldloc.1
+  IL_0011:  stloc.2
+  IL_0012:  ldloca.s   V_2
   IL_0014:  callvirt   ""int IA.P[ref int].get""
   IL_0019:  ldc.i4.1
   IL_001a:  add
@@ -461,22 +461,22 @@ F()
   // Code size       33 (0x21)
   .maxstack  4
   .locals init (int V_0,
-  int V_1,
-  int V_2)
+                int V_1,
+                int V_2)
   IL_0000:  ldarg.0
   IL_0001:  call       ""int[] B.F()""
   IL_0006:  ldc.i4.0
   IL_0007:  ldelem.i4
-  IL_0008:  stloc.1
+  IL_0008:  stloc.0
   IL_0009:  dup
-  IL_000a:  ldloc.1
-  IL_000b:  stloc.0
-  IL_000c:  ldloca.s   V_0
+  IL_000a:  ldloc.0
+  IL_000b:  stloc.1
+  IL_000c:  ldloca.s   V_1
   IL_000e:  callvirt   ""int IA.P[ref int].get""
   IL_0013:  stloc.2
-  IL_0014:  ldloc.1
-  IL_0015:  stloc.0
-  IL_0016:  ldloca.s   V_0
+  IL_0014:  ldloc.0
+  IL_0015:  stloc.1
+  IL_0016:  ldloca.s   V_1
   IL_0018:  ldloc.2
   IL_0019:  ldc.i4.1
   IL_001a:  add
@@ -733,27 +733,27 @@ F()
   // Code size       39 (0x27)
   .maxstack  5
   .locals init (int V_0,
-  int V_1,
-  int V_2,
-  int V_3)
+                int V_1,
+                int V_2,
+                int V_3)
   IL_0000:  ldarg.0
   IL_0001:  ldsfld     ""int C.x""
-  IL_0006:  stloc.2
+  IL_0006:  stloc.0
   IL_0007:  dup
-  IL_0008:  ldloc.2
-  IL_0009:  stloc.0
-  IL_000a:  ldloca.s   V_0
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.1
+  IL_000a:  ldloca.s   V_1
   IL_000c:  ldc.i4.0
-  IL_000d:  stloc.1
-  IL_000e:  ldloca.s   V_1
+  IL_000d:  stloc.2
+  IL_000e:  ldloca.s   V_2
   IL_0010:  callvirt   ""int IA.P[ref int, ref int].get""
   IL_0015:  stloc.3
-  IL_0016:  ldloc.2
-  IL_0017:  stloc.0
-  IL_0018:  ldloca.s   V_0
+  IL_0016:  ldloc.0
+  IL_0017:  stloc.1
+  IL_0018:  ldloca.s   V_1
   IL_001a:  ldc.i4.0
-  IL_001b:  stloc.1
-  IL_001c:  ldloca.s   V_1
+  IL_001b:  stloc.2
+  IL_001c:  ldloca.s   V_2
   IL_001e:  ldloc.3
   IL_001f:  ldc.i4.1
   IL_0020:  add
@@ -765,30 +765,30 @@ F()
   // Code size       47 (0x2f)
   .maxstack  5
   .locals init (int V_0,
-  int V_1,
-  int V_2,
-  int V_3,
-  int V_4)
+                int V_1,
+                int V_2,
+                int V_3,
+                int V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldsfld     ""int C.x""
-  IL_0006:  stloc.2
+  IL_0006:  stloc.0
   IL_0007:  ldsfld     ""int C.y""
-  IL_000c:  stloc.3
+  IL_000c:  stloc.1
   IL_000d:  dup
-  IL_000e:  ldloc.2
-  IL_000f:  stloc.0
-  IL_0010:  ldloca.s   V_0
-  IL_0012:  ldloc.3
-  IL_0013:  stloc.1
-  IL_0014:  ldloca.s   V_1
+  IL_000e:  ldloc.0
+  IL_000f:  stloc.2
+  IL_0010:  ldloca.s   V_2
+  IL_0012:  ldloc.1
+  IL_0013:  stloc.3
+  IL_0014:  ldloca.s   V_3
   IL_0016:  callvirt   ""int IA.P[ref int, ref int].get""
   IL_001b:  stloc.s    V_4
-  IL_001d:  ldloc.2
-  IL_001e:  stloc.0
-  IL_001f:  ldloca.s   V_0
-  IL_0021:  ldloc.3
-  IL_0022:  stloc.1
-  IL_0023:  ldloca.s   V_1
+  IL_001d:  ldloc.0
+  IL_001e:  stloc.2
+  IL_001f:  ldloca.s   V_2
+  IL_0021:  ldloc.1
+  IL_0022:  stloc.3
+  IL_0023:  ldloca.s   V_3
   IL_0025:  ldloc.s    V_4
   IL_0027:  ldc.i4.1
   IL_0028:  add

--- a/src/Compilers/Core/Portable/InternalUtilities/SpanUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpanUtilities.cs
@@ -22,6 +22,16 @@ namespace Microsoft.CodeAnalysis
         }
 
         public static bool All<TElement>(this ReadOnlySpan<TElement> span, Func<TElement, bool> predicate)
-            => span.All(predicate, static (item, predicate) => predicate(item));
+        {
+            foreach (var e in span)
+            {
+                if (!predicate(e))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/SpanUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpanUtilities.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -20,5 +20,8 @@ namespace Microsoft.CodeAnalysis
 
             return true;
         }
+
+        public static bool All<TElement>(this ReadOnlySpan<TElement> span, Func<TElement, bool> predicate)
+            => span.All(predicate, static (item, predicate) => predicate(item));
     }
 }

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -491,9 +491,27 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             _builder.AddRange(items._builder);
         }
 
+        public void AddRange<U>(ArrayBuilder<U> items, Func<U, T> selector)
+        {
+            foreach (var item in items)
+            {
+                _builder.Add(selector(item));
+            }
+        }
+
         public void AddRange<U>(ArrayBuilder<U> items) where U : T
         {
             _builder.AddRange(items._builder);
+        }
+
+        public void AddRange<U>(ArrayBuilder<U> items, int start, int length) where U : T
+        {
+            Debug.Assert(start >= 0 && length >= 0);
+            Debug.Assert(start + length <= items.Count);
+            for (int i = start, end = start + length; i < end; i++)
+            {
+                Add(items[i]);
+            }
         }
 
         public void AddRange(ImmutableArray<T> items)


### PR DESCRIPTION
This adds binding and lowering support for InterpolatedStringBuilderArgumentAttribute. For initial binding, we have an existing method that all argument binding goes through: CoerceArguments. However, lowering did not have a similar chokepoint, as every argument location started by calling `VisitList`, then `MakeArguments` at a later point. In order to ensure that the rewrite is handled correctly, I've done a refactor on `MakeArguments` to turn it into `VisitArguments` and update every place that handles arguments to instead use this new helper, which takes care of the rest of the argument rewrites (such as params) and will additionally update the receiver if needed.

Test plan: https://github.com/dotnet/roslyn/issues/51499