### PR TITLE
Do not expect that Framework dependencies will be non-null

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsReader.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsReader.cs
@@ -66,7 +66,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             }
 
             var autoReferences = projectAssets.Project?.Frameworks?.Values
-                .SelectMany(framework => framework.Dependencies?.Keys.Where(key => framework.Dependencies[key].AutoReferenced))
+                .Where(framework => framework.Dependencies != null)
+                .SelectMany(framework => framework.Dependencies!.Keys.Where(key => framework.Dependencies[key].AutoReferenced))
                 .Distinct()
                 .ToImmutableHashSet();
             autoReferences ??= ImmutableHashSet<string>.Empty;

--- a/src/VisualStudio/Core/Test/UnusedReferences/TestProjectAssetsFile.vb
+++ b/src/VisualStudio/Core/Test/UnusedReferences/TestProjectAssetsFile.vb
@@ -19,11 +19,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.UnusedReferences
 
             Dim libraries = BuildLibraries(allReferences)
             Dim targets = BuildTargets(targetFramework, allReferences)
+            Dim project = BuildProject(targetFramework)
 
             Dim projectAssets As ProjectAssetsFile = New ProjectAssetsFile With {
                 .Version = version,
                 .Targets = targets,
-                .Libraries = libraries
+                .Libraries = libraries,
+                .Project = project
             }
 
             Return projectAssets
@@ -87,6 +89,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.UnusedReferences
                 Function(reference)
                     Return String.Empty
                 End Function)
+        End Function
+
+        Private Function BuildProject(targetFramework As String) As ProjectAssetsProject
+            ' Frameworks won't always specify a set of dependencies.
+            ' This ensures the project asset reader does not error in these cases.
+            Return New ProjectAssetsProject With {
+                 .Frameworks = New Dictionary(Of String, ProjectAssetsProjectFramework) From {
+                    {targetFramework, New ProjectAssetsProjectFramework}
+                 }
+            }
         End Function
     End Module
 End Namespace


### PR DESCRIPTION
Fixes the "Object references not set to an instance of an object." reported in https://github.com/dotnet/roslyn/issues/53970

Remove Unused References will read the framework dependencies so that they won't be considered unused. Not all frameworks bring along dependencies and `.SelectMany()` fails when nulls are returned.