### PR TITLE
Do not trim off the end of NuGet package names

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.DataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.DataSource.cs
@@ -123,9 +123,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
                             content = ReferenceUpdate.ReferenceInfo.ReferenceType;
                             break;
                         case UnusedReferencesTableKeyNames.ReferenceName:
-                            // It is unnecessary to display the full path to project and assembly files.
-                            content = ReferenceUpdate.ReferenceInfo.ReferenceType == ReferenceType.Project
-                                ? Path.GetFileNameWithoutExtension(ReferenceUpdate.ReferenceInfo.ItemSpecification)
+                            // For Project and Assembly references, use the file name instead of overwhelming the user with the full path.
+                            content = ReferenceUpdate.ReferenceInfo.ReferenceType != ReferenceType.Package
+                                ? Path.GetFileName(ReferenceUpdate.ReferenceInfo.ItemSpecification)
                                 : ReferenceUpdate.ReferenceInfo.ItemSpecification;
                             break;
                         case UnusedReferencesTableKeyNames.UpdateAction:

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.DataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/Dialog/UnusedReferencesTableProvider.DataSource.cs
@@ -124,7 +124,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
                             break;
                         case UnusedReferencesTableKeyNames.ReferenceName:
                             // It is unnecessary to display the full path to project and assembly files.
-                            content = Path.GetFileNameWithoutExtension(ReferenceUpdate.ReferenceInfo.ItemSpecification);
+                            content = ReferenceUpdate.ReferenceInfo.ReferenceType == ReferenceType.Project
+                                ? Path.GetFileNameWithoutExtension(ReferenceUpdate.ReferenceInfo.ItemSpecification)
+                                : ReferenceUpdate.ReferenceInfo.ItemSpecification;
                             break;
                         case UnusedReferencesTableKeyNames.UpdateAction:
                             content = ReferenceUpdate.Action;


### PR DESCRIPTION
Package names are being trimmed at the last `.` in the Remove Unused References dialog.

![image](https://user-images.githubusercontent.com/611219/122844551-c707f380-d2b6-11eb-8fb6-6393658ff943.png)
