### PR TITLE
Bugfix: GetAwaitExpressionInfo ignores BoundConversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -899,19 +899,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentException("node.Kind==" + node.Kind());
             }
 
-            //usually the GetUpperBoundNode is sufficient, but we need to handle
-            //for example BoundExpressionStatement or BoundConversion here, too.
-            BoundAwaitExpression boundAwait = null;
-            foreach (var boundNode in GetBoundNodes(node))
-            {
-                if (boundNode is BoundAwaitExpression ba)
-                {
-                    Debug.Assert(boundNode.Syntax == node);
-                    boundAwait = ba;
-                    break;
-                }
-            }
-            var awaitableInfo = boundAwait?.AwaitableInfo;
+            BoundAwaitExpression boundAwait = (BoundAwaitExpression)GetLowerBoundNode(node);
+            Debug.Assert(boundAwait.Syntax == node);
+
+            var awaitableInfo = boundAwait.AwaitableInfo;
             if (awaitableInfo == null)
             {
                 return default(AwaitExpressionInfo);

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -899,10 +899,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentException("node.Kind==" + node.Kind());
             }
 
-            BoundAwaitExpression boundAwait = (BoundAwaitExpression)GetLowerBoundNode(node);
-            Debug.Assert(boundAwait.Syntax == node);
-
-            var awaitableInfo = boundAwait.AwaitableInfo;
+            var bound = GetLowerBoundNode(node);
+            BoundAwaitableInfo awaitableInfo = (((bound as BoundExpressionStatement)?.Expression ?? bound) as BoundAwaitExpression)?.AwaitableInfo;
             if (awaitableInfo == null)
             {
                 return default(AwaitExpressionInfo);
@@ -912,8 +910,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 getAwaiter: (IMethodSymbol)awaitableInfo.GetAwaiter?.ExpressionSymbol.GetPublicSymbol(),
                 isCompleted: awaitableInfo.IsCompleted.GetPublicSymbol(),
                 getResult: awaitableInfo.GetResult.GetPublicSymbol(),
-                isDynamic: awaitableInfo.IsDynamic
-            );
+                isDynamic: awaitableInfo.IsDynamic);
         }
 
         public override ForEachStatementInfo GetForEachStatementInfo(ForEachStatementSyntax node)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -157,8 +157,7 @@ public class C {
             compilation = comp;
             var syntaxNode = (AwaitExpressionSyntax)tree.FindNodeOrTokenByKind(SyntaxKind.AwaitExpression).AsNode();
             var treeModel = comp.GetSemanticModel(tree);
-            var awaitExpr = treeModel.GetAwaitExpressionInfo(syntaxNode);
-            return awaitExpr;
+            return treeModel.GetAwaitExpressionInfo(syntaxNode);
         }
 
         private AwaitExpressionInfo GetAwaitExpressionInfo(string text, params DiagnosticDescription[] diagnostics)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -21,6 +21,97 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class AwaitExpressionTests : CompilingTestBase
     {
         [Fact]
+        public void TestAwaitInfoExtensionMethod()
+        {
+            var text =
+@"using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+static class App{
+    public static async Task Main(){
+        MyAwaitable Get()
+        {
+            return new MyAwaitable();
+        }
+
+        var x = Get();
+        x.SetValue(42);
+
+        Console.WriteLine(await x + ""!"");
+    }
+}
+
+struct MyAwaitable
+{
+    private ValueTask<int> task;
+    private TaskCompletionSource<int> source;
+
+    private TaskCompletionSource<int> Source
+    {
+        get
+        {
+            if (source == null)
+            {
+                source = new TaskCompletionSource<int>();
+                task = new ValueTask<int>(source.Task);
+            }
+            return source;
+        }
+    }
+    internal ValueTask<int> Task
+    {
+        get
+        {
+            _ = Source;
+            return task;
+        }
+    }
+
+    public void SetValue(int i)
+    {
+        Source.SetResult(i);
+    }
+}
+
+static class MyAwaitableExtension
+{
+    public static System.Runtime.CompilerServices.ValueTaskAwaiter<int> GetAwaiter(this MyAwaitable a)
+    {
+        return a.Task.GetAwaiter();
+    }
+}";
+            var refApis = System.AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).Select(
+                a => MetadataReference.CreateFromFile(a.Location)
+            );
+            var tree = SyntaxFactory.SyntaxTree(SyntaxFactory.ParseCompilationUnit(text));
+            var csCompilation = CSharpCompilation.Create("something",
+                   new[] { tree },
+                   refApis,
+                   new CSharpCompilationOptions(OutputKind.ConsoleApplication)
+            );
+
+            var model = csCompilation.GetSemanticModel(tree);
+            var awaitExpression = tree.GetRoot().DescendantNodes().OfType<AwaitExpressionSyntax>().First();
+
+            var op = model.GetOperation(awaitExpression);
+            var info = model.GetAwaitExpressionInfo(awaitExpression);
+
+            Assert.Equal(
+                "System.Runtime.CompilerServices.ValueTaskAwaiter<System.Int32> MyAwaitableExtension.GetAwaiter(this MyAwaitable a)",
+                info.GetAwaiterMethod.ToTestDisplayString()
+            );
+            Assert.Equal(
+                "System.Int32 System.Runtime.CompilerServices.ValueTaskAwaiter<System.Int32>.GetResult()",
+                info.GetResultMethod.ToTestDisplayString()
+            );
+            Assert.Equal(
+                "System.Boolean System.Runtime.CompilerServices.ValueTaskAwaiter<System.Int32>.IsCompleted { get; }",
+                info.IsCompletedProperty.ToTestDisplayString()
+            );
+        }
+
+        [Fact]
         [WorkItem(711413, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/711413")]
         public void TestAwaitInfo()
         {
@@ -70,7 +161,8 @@ public class C {
             Assert.Equal(0, info.GetHashCode());
         }
 
-        private AwaitExpressionInfo GetAwaitExpressionInfo(string text, out CSharpCompilation compilation, params DiagnosticDescription[] diagnostics)
+        private AwaitExpressionInfo GetAwaitExpressionInfo(string text,
+            out CSharpCompilation compilation, params DiagnosticDescription[] diagnostics)
         {
             var tree = Parse(text, options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
             var comp = CreateCompilationWithMscorlib45(new SyntaxTree[] { tree }, new MetadataReference[] { SystemRef });
@@ -78,7 +170,8 @@ public class C {
             compilation = comp;
             var syntaxNode = (AwaitExpressionSyntax)tree.FindNodeOrTokenByKind(SyntaxKind.AwaitExpression).AsNode();
             var treeModel = comp.GetSemanticModel(tree);
-            return treeModel.GetAwaitExpressionInfo(syntaxNode);
+            var awaitExpr = treeModel.GetAwaitExpressionInfo(syntaxNode);
+            return awaitExpr;
         }
 
         private AwaitExpressionInfo GetAwaitExpressionInfo(string text, params DiagnosticDescription[] diagnostics)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -77,7 +77,7 @@ static class MyAwaitableExtension
     }
 }";
 
-            var csCompilation = CreateCompilation(text, targetFramework: TargetFramework.StandardLatest);
+            var csCompilation = CreateCompilation(text, targetFramework: TargetFramework.NetCoreAppAndCSharp);
             var tree = csCompilation.SyntaxTrees.Single();
 
             var model = csCompilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -82,7 +82,7 @@ static class MyAwaitableExtension
 
             var model = csCompilation.GetSemanticModel(tree);
             var awaitExpression = tree.GetRoot().DescendantNodes().OfType<AwaitExpressionSyntax>().First();
-            Assert.Equal("[234..241)", awaitExpression.Location.SourceSpan.ToString());
+            Assert.Equal("await x", awaitExpression.ToString());
 
             var info = model.GetAwaitExpressionInfo(awaitExpression);
             Assert.Equal(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -76,8 +76,8 @@ static class MyAwaitableExtension
         return a.Task.GetAwaiter();
     }
 }";
-           
-            var csCompilation = CreateCompilationWithCSharp(text);
+
+            var csCompilation = CreateCompilation(text, targetFramework: TargetFramework.StandardLatest);
             var tree = csCompilation.SyntaxTrees.Single();
 
             var model = csCompilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AwaitExpressionTests.cs
@@ -82,9 +82,9 @@ static class MyAwaitableExtension
 
             var model = csCompilation.GetSemanticModel(tree);
             var awaitExpression = tree.GetRoot().DescendantNodes().OfType<AwaitExpressionSyntax>().First();
+            Assert.Equal("[234..241)", awaitExpression.Location.SourceSpan.ToString());
 
             var info = model.GetAwaitExpressionInfo(awaitExpression);
-
             Assert.Equal(
                 "System.Runtime.CompilerServices.ValueTaskAwaiter<System.Int32> MyAwaitableExtension.GetAwaiter(this MyAwaitable a)",
                 info.GetAwaiterMethod.ToTestDisplayString()


### PR DESCRIPTION
fixes #54298
Bugfix to handle "BoundConversion"