### PR TITLE
Update to Microsoft.CodeAnalysis.Testing 1.1.0-beta1.21322.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <!-- Versions used by several individual references below -->
     <RoslynDiagnosticsNugetPackageVersion>3.3.3-beta1.21105.3</RoslynDiagnosticsNugetPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-preview1.21054.10</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20623.3</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.0-beta1.21322.2</MicrosoftCodeAnalysisTestingVersion>
     <CodeStyleAnalyzerVersion>3.10.0</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>16.10.230</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>5.0.0-alpha1.19409.1</ILAsmPackageVersion>

--- a/src/CodeStyle/CSharp/Tests/FormattingAnalyzerTests.cs
+++ b/src/CodeStyle/CSharp/Tests/FormattingAnalyzerTests.cs
@@ -270,16 +270,15 @@ csharp_new_line_before_open_brace = methods
 
             await new CSharpCodeFixTest<CSharpFormattingAnalyzer, CSharpFormattingCodeFixProvider, XUnitVerifier>
             {
-                TestState = { Sources = { (Path.GetFullPath("Test0.cs"), testCode) } },
-                FixedState = { Sources = { (Path.GetFullPath("Test0.cs"), fixedCode) } },
-                SolutionTransforms =
+                TestState =
                 {
-                    (solution, projectId) =>
+                    Sources = { testCode },
+                    AnalyzerConfigFiles =
                     {
-                        var documentId = DocumentId.CreateNewId(projectId, ".editorconfig");
-                        return solution.AddAnalyzerConfigDocument(documentId, ".editorconfig", SourceText.From(editorConfig, Encoding.UTF8), filePath: Path.GetFullPath(".editorconfig"));
+                        ("/.editorconfig", editorConfig),
                     },
                 },
+                FixedState = { Sources = { fixedCode } },
             }.RunAsync();
         }
     }

--- a/src/CodeStyle/Core/Tests/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
+++ b/src/CodeStyle/Core/Tests/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
@@ -16,6 +16,7 @@
     <Compile Include="..\..\..\EditorFeatures\DiagnosticsTestUtilities\CodeActions\CSharpCodeRefactoringVerifier`1+Test.cs" Link="CSharpCodeRefactoringVerifier`1+Test.cs" />
     <Compile Include="..\..\..\EditorFeatures\DiagnosticsTestUtilities\CodeActions\CSharpCodeRefactoringVerifier`1.cs" Link="CSharpCodeRefactoringVerifier`1.cs" />
     <Compile Include="..\..\..\EditorFeatures\DiagnosticsTestUtilities\CodeActions\CSharpVerifierHelper.cs" Link="CSharpVerifierHelper.cs" />
+    <Compile Include="..\..\..\EditorFeatures\DiagnosticsTestUtilities\CodeActions\SharedVerifierState.cs" Link="SharedVerifierState.cs" />
     <Compile Include="..\..\..\EditorFeatures\DiagnosticsTestUtilities\CodeActions\VisualBasicCodeFixVerifier`2+Test.cs" Link="VisualBasicCodeFixVerifier`2+Test.cs" />
     <Compile Include="..\..\..\EditorFeatures\DiagnosticsTestUtilities\CodeActions\VisualBasicCodeFixVerifier`2.cs" Link="VisualBasicCodeFixVerifier`2.cs" />
     <Compile Include="..\..\..\EditorFeatures\DiagnosticsTestUtilities\CodeActions\VisualBasicCodeRefactoringVerifier`1+Test.cs" Link="VisualBasicCodeRefactoringVerifier`1+Test.cs" />

--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -48,7 +48,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
             if (index != 0)
                 Assert.NotNull(equivalenceKey);
 
-            var test = new VerifyCS.Test
+            options ??= new OptionsCollection(LanguageNames.CSharp);
+
+            await new VerifyCS.Test
             {
                 TestCode = text,
                 FixedCode = expected,
@@ -57,11 +59,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
                 CodeActionIndex = index,
                 CodeActionEquivalenceKey = equivalenceKey,
                 ExactActionSetOffered = actions,
-            };
-
-            if (options != null)
-                test.Options.AddRange(options);
-            await test.RunAsync();
+                Options = { options },
+            }.RunAsync();
         }
 
         #region update containing member tests
@@ -2278,7 +2277,8 @@ internal struct NewStruct
         return new NewStruct(value.a, value.a);
     }
 }";
-            var test = new VerifyCS.Test
+
+            await new VerifyCS.Test
             {
                 TestCode = text,
                 FixedCode = expected,
@@ -2349,11 +2349,9 @@ internal struct NewStruct
     // /0/Test0.cs(49,45): error CS0229: Ambiguity between '(int a, int a).a' and '(int a, int a).a'
     DiagnosticResult.CompilerError("CS0229").WithSpan(49, 45, 49, 46).WithArguments("(int a, int a).a", "(int a, int a).a"),
                     }
-                }
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                },
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
@@ -3352,7 +3350,7 @@ partial class Other
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestState =
                 {
@@ -3373,10 +3371,8 @@ partial class Other
                 CodeActionIndex = 1,
                 CodeActionEquivalenceKey = Scope.ContainingType.ToString(),
                 TestHost = host,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         #endregion update containing project tests
@@ -3511,7 +3507,7 @@ partial class Other
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 CodeActionIndex = 2,
                 CodeActionEquivalenceKey = Scope.ContainingProject.ToString(),
@@ -3524,10 +3520,8 @@ partial class Other
                 {
                     Sources = { expected1, expected2 },
                 },
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         #endregion
@@ -3638,7 +3632,7 @@ partial class Other
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 CodeActionIndex = 3,
                 CodeActionEquivalenceKey = Scope.DependentProjects.ToString(),
@@ -3667,10 +3661,8 @@ partial class Other
                         }
                     },
                 },
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
@@ -3777,7 +3769,7 @@ partial class Other
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 CodeActionIndex = 3,
                 CodeActionEquivalenceKey = Scope.DependentProjects.ToString(),
@@ -3798,10 +3790,8 @@ partial class Other
                         ["DependencyProject"] = { Sources = { expected2 } }
                     },
                 },
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -98,15 +98,13 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(39916, "https://github.com/dotnet/roslyn/issues/39916")]
@@ -135,15 +133,13 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferExplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferExplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -179,15 +175,13 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -229,15 +223,13 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -273,15 +265,13 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -309,15 +299,13 @@ class ReallyLongName
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -345,15 +333,13 @@ class ReallyLongLong
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -386,15 +372,13 @@ class ReallyLongName
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -426,15 +410,13 @@ class Program : Base
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -484,16 +466,14 @@ class Program : Base
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 0,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -551,15 +531,13 @@ class Program : Middle
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -795,15 +773,13 @@ class Program<T>
 }
 ";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = expected,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -860,16 +836,14 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -902,16 +876,14 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -955,16 +927,14 @@ class Program : Base
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1005,17 +975,15 @@ class Program : Base
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 MemberNames = ImmutableArray<string>.Empty,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1088,16 +1056,14 @@ class Program<T>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1130,16 +1096,14 @@ class Program<T>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1180,16 +1144,14 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1374,16 +1336,14 @@ class C
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 0,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1411,15 +1371,13 @@ class C
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1447,15 +1405,13 @@ class C
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1488,16 +1444,14 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1530,16 +1484,14 @@ class Program
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1580,16 +1532,14 @@ struct Bar
 {
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1632,16 +1582,14 @@ struct Bar
     public override int GetHashCode() => 0;
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1682,16 +1630,14 @@ struct Bar
 {
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1724,16 +1670,14 @@ class Foo<TBar> where TBar : struct
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1766,16 +1710,14 @@ class Foo<TBar> where TBar : struct
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1816,16 +1758,14 @@ enum Bar
 {
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1858,16 +1798,14 @@ class Foo
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1899,16 +1837,14 @@ class Program
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = ImmutableArray.Create("a", "b"),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1942,16 +1878,14 @@ class Program
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = ImmutableArray.Create("c", "b"),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -1983,16 +1917,14 @@ class Program
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = ImmutableArray<string>.Empty,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(17643, "https://github.com/dotnet/roslyn/issues/17643")]
@@ -2020,15 +1952,13 @@ class Program
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(25690, "https://github.com/dotnet/roslyn/issues/25690")]
@@ -2188,17 +2118,15 @@ class Program
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = default,
                 OptionsCallback = options => EnableOption(options, GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.GenerateOperatorsId),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -2278,17 +2206,15 @@ class Program
     public static bool operator {|CS0216:==|}(Program left, Program right) => true;
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = default,
                 OptionsCallback = options => Assert.Null(options.FirstOrDefault(i => i.Id == GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.GenerateOperatorsId)),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -2333,17 +2259,15 @@ struct Program
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = default,
                 OptionsCallback = options => EnableOption(options, GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.GenerateOperatorsId),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -2392,16 +2316,14 @@ enum Bar
 {
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 0,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -2466,16 +2388,14 @@ struct Bar : IEquatable<Bar>
     public static bool operator !=(Bar left, Bar right) => !(left == right);
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 0,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -2510,17 +2430,15 @@ struct Program : IEquatable<Program>
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = default,
                 OptionsCallback = options => EnableOption(options, GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.ImplementIEquatableId),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -2711,17 +2629,15 @@ class Program : IEquatable<Program>
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = default,
                 OptionsCallback = options => EnableOption(options, GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.ImplementIEquatableId),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -2844,17 +2760,15 @@ class Program : {|CS0535:System.IEquatable<Program>|}
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = default,
                 OptionsCallback = options => Assert.Null(options.FirstOrDefault(i => i.Id == GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.ImplementIEquatableId)),
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -3063,16 +2977,14 @@ struct S : IEquatable<S>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -3121,7 +3033,7 @@ struct S : IEquatable<S>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedState =
@@ -3135,10 +3047,8 @@ struct S : IEquatable<S>
                 },
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(37297, "https://github.com/dotnet/roslyn/issues/37297")]
@@ -3186,7 +3096,7 @@ struct S : IEquatable<S>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestState =
                 {
@@ -3211,10 +3121,8 @@ struct S : IEquatable<S>
                 },
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(37297, "https://github.com/dotnet/roslyn/issues/37297")]
@@ -3262,7 +3170,7 @@ struct S : IEquatable<S>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestState =
                 {
@@ -3279,10 +3187,8 @@ struct S : IEquatable<S>
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -3338,7 +3244,7 @@ struct S : IEquatable<S>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedState =
@@ -3352,10 +3258,8 @@ struct S : IEquatable<S>
                 },
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -3422,16 +3326,14 @@ struct S : IEquatable<S>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(39916, "https://github.com/dotnet/roslyn/issues/39916")]
@@ -3499,16 +3401,14 @@ struct S : IEquatable<S>
     }
 }";
 
-            var test = new VerifyCS.Test
+            await new VerifyCS.Test
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 CodeActionIndex = 1,
                 LanguageVersion = LanguageVersion.CSharp6,
-            };
-
-            test.Options.AddRange(PreferExplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferExplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -3693,7 +3593,7 @@ namespace N
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedState =
@@ -3710,10 +3610,8 @@ namespace N
                 MemberNames = default,
                 OptionsCallback = options => EnableOption(options, GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.GenerateOperatorsId),
                 LanguageVersion = LanguageVersion.Default,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(40053, "https://github.com/dotnet/roslyn/issues/40053")]
@@ -3761,17 +3659,15 @@ namespace N
     }
 }";
 
-            var test = new TestWithDialog
+            await new TestWithDialog
             {
                 TestCode = code,
                 FixedCode = fixedCode,
                 MemberNames = default,
                 OptionsCallback = options => EnableOption(options, GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.GenerateOperatorsId),
                 LanguageVersion = LanguageVersion.Default,
-            };
-
-            test.Options.AddRange(PreferImplicitTypeWithInfo());
-            await test.RunAsync();
+                Options = { PreferImplicitTypeWithInfo() },
+            }.RunAsync();
         }
 
         [WorkItem(42574, "https://github.com/dotnet/roslyn/issues/42574")]

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateEqualsAndGetHas
             public ImmutableArray<string> MemberNames;
             public Action<ImmutableArray<PickMembersOption>> OptionsCallback;
 
-            public override AdhocWorkspace CreateWorkspace()
+            protected override Workspace CreateWorkspaceImpl()
             {
                 // If we're a dialog test, then mixin our mock and initialize its values to the ones the test asked for.
                 var workspace = new AdhocWorkspace(s_composition.GetHostServices());

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
 using System.Threading;
@@ -28,6 +27,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
     {
         public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, XUnitVerifier>
         {
+            /// <summary>
+            /// The index in <see cref="Testing.ProjectState.AnalyzerConfigFiles"/> of the generated
+            /// <strong>.editorconfig</strong> file for <see cref="Options"/>, or <see langword="null"/> if no such
+            /// file has been generated yet.
+            /// </summary>
+            private int? _analyzerConfigIndex;
+
             static Test()
             {
                 // If we have outdated defaults from the host unit test application targeting an older .NET Framework, use more
@@ -53,18 +59,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                     compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
                     solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
 
-                    var (analyzerConfigSource, remainingOptions) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
-                    if (analyzerConfigSource is object)
-                    {
-                        foreach (var id in solution.ProjectIds)
-                        {
-                            var documentId = DocumentId.CreateNewId(id, ".editorconfig");
-                            solution = solution.AddAnalyzerConfigDocument(documentId, ".editorconfig", analyzerConfigSource, filePath: "/.editorconfig");
-                        }
-                    }
-
 #if !CODE_STYLE
                     var options = solution.Options;
+                    var (_, remainingOptions) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
                     foreach (var (key, value) in remainingOptions)
                     {
                         options = options.WithChangedOption(key, value);
@@ -97,6 +94,30 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             /// </summary>
             public string[]? ExactActionSetOffered { get; set; }
 
+            protected override async Task RunImplAsync(CancellationToken cancellationToken)
+            {
+                var (analyzerConfigSource, _) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
+                if (analyzerConfigSource is object)
+                {
+                    if (_analyzerConfigIndex is null)
+                    {
+                        _analyzerConfigIndex = TestState.AnalyzerConfigFiles.Count;
+                        TestState.AnalyzerConfigFiles.Add(("/.editorconfig", analyzerConfigSource));
+                    }
+                    else
+                    {
+                        TestState.AnalyzerConfigFiles[_analyzerConfigIndex.Value] = ("/.editorconfig", analyzerConfigSource);
+                    }
+                }
+                else if (_analyzerConfigIndex is { } index)
+                {
+                    _analyzerConfigIndex = null;
+                    TestState.AnalyzerConfigFiles.RemoveAt(index);
+                }
+
+                await base.RunImplAsync(cancellationToken);
+            }
+
             protected override ImmutableArray<CodeAction> FilterCodeActions(ImmutableArray<CodeAction> actions)
             {
                 var result = base.FilterCodeActions(actions);
@@ -110,8 +131,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             }
 
 #if !CODE_STYLE
-            private readonly List<AdhocWorkspace> _workspaces = new();
-
             protected override AnalyzerOptions GetAnalyzerOptions(Project project)
                 => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), project.Solution);
 
@@ -122,37 +141,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             private static readonly TestComposition s_editorFeaturesOOPComposition = EditorTestCompositions.EditorFeatures.WithTestHostParts(TestHost.OutOfProcess);
 
-            public override AdhocWorkspace CreateWorkspace()
+            protected override Workspace CreateWorkspaceImpl()
             {
                 if (TestHost == TestHost.InProcess)
-                    return base.CreateWorkspace();
+                    return base.CreateWorkspaceImpl();
 
                 var hostServices = s_editorFeaturesOOPComposition.GetHostServices();
                 var workspace = new AdhocWorkspace(hostServices);
-                lock (_workspaces)
-                    _workspaces.Add(workspace);
-
                 return workspace;
-            }
-
-            public override async Task RunAsync(CancellationToken cancellationToken = default)
-            {
-                try
-                {
-                    await base.RunAsync(cancellationToken).ConfigureAwait(false);
-                }
-                finally
-                {
-                    var workspaces = new List<AdhocWorkspace>();
-                    lock (_workspaces)
-                    {
-                        workspaces.AddRange(_workspaces);
-                        _workspaces.Clear();
-                    }
-
-                    foreach (var workspace in workspaces)
-                        workspace.Dispose();
-                }
             }
 #endif
         }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -27,12 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
     {
         public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, XUnitVerifier>
         {
-            /// <summary>
-            /// The index in <see cref="Testing.ProjectState.AnalyzerConfigFiles"/> of the generated
-            /// <strong>.editorconfig</strong> file for <see cref="Options"/>, or <see langword="null"/> if no such
-            /// file has been generated yet.
-            /// </summary>
-            private int? _analyzerConfigIndex;
+            private readonly SharedVerifierState _sharedState;
 
             static Test()
             {
@@ -50,6 +45,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             public Test()
             {
+                _sharedState = new SharedVerifierState(this, DefaultFileExt);
+
                 SolutionTransforms.Add((solution, projectId) =>
                 {
                     var parseOptions = (CSharpParseOptions)solution.GetProject(projectId)!.ParseOptions!;
@@ -58,17 +55,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                     var compilationOptions = solution.GetProject(projectId)!.CompilationOptions!;
                     compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
                     solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
-
-#if !CODE_STYLE
-                    var options = solution.Options;
-                    var (_, remainingOptions) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
-                    foreach (var (key, value) in remainingOptions)
-                    {
-                        options = options.WithChangedOption(key, value);
-                    }
-
-                    solution = solution.WithOptions(options);
-#endif
 
                     return solution;
                 });
@@ -80,13 +66,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             /// </summary>
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp8;
 
-            /// <summary>
-            /// Gets a collection of options to apply to <see cref="Solution.Options"/> for testing. Values may be added
-            /// using a collection initializer.
-            /// </summary>
-            internal OptionsCollection Options { get; } = new OptionsCollection(LanguageNames.CSharp);
+            /// <inheritdoc cref="SharedVerifierState.Options"/>
+            internal OptionsCollection Options => _sharedState.Options;
 
-            public string? EditorConfig { get; set; }
+            /// <inheritdoc cref="SharedVerifierState.EditorConfig"/>
+            public string? EditorConfig
+            {
+                get => _sharedState.EditorConfig;
+                set => _sharedState.EditorConfig = value;
+            }
 
             /// <summary>
             /// The set of code action <see cref="CodeAction.Title"/>s offered the user in this exact order.
@@ -96,25 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             protected override async Task RunImplAsync(CancellationToken cancellationToken)
             {
-                var (analyzerConfigSource, _) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
-                if (analyzerConfigSource is object)
-                {
-                    if (_analyzerConfigIndex is null)
-                    {
-                        _analyzerConfigIndex = TestState.AnalyzerConfigFiles.Count;
-                        TestState.AnalyzerConfigFiles.Add(("/.editorconfig", analyzerConfigSource));
-                    }
-                    else
-                    {
-                        TestState.AnalyzerConfigFiles[_analyzerConfigIndex.Value] = ("/.editorconfig", analyzerConfigSource);
-                    }
-                }
-                else if (_analyzerConfigIndex is { } index)
-                {
-                    _analyzerConfigIndex = null;
-                    TestState.AnalyzerConfigFiles.RemoveAt(index);
-                }
-
+                _sharedState.Apply();
                 await base.RunImplAsync(cancellationToken);
             }
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/SharedVerifierState.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/SharedVerifierState.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+#if !CODE_STYLE
+using Roslyn.Utilities;
+#endif
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
+{
+    internal sealed class SharedVerifierState
+    {
+        private readonly AnalyzerTest<XUnitVerifier> _test;
+        private readonly string _defaultFileExt;
+
+        /// <summary>
+        /// The index in <see cref="Testing.ProjectState.AnalyzerConfigFiles"/> of the generated
+        /// <strong>.editorconfig</strong> file for <see cref="Options"/>, or <see langword="null"/> if no such
+        /// file has been generated yet.
+        /// </summary>
+        private int? _analyzerConfigIndex;
+
+        /// <summary>
+        /// The index in <see cref="AnalyzerTest{TVerifier}.SolutionTransforms"/> of the options transformation for
+        /// remaining <see cref="Options"/>, or <see langword="null"/> if no such transfor has been generated yet.
+        /// </summary>
+        private Func<Solution, ProjectId, Solution>? _remainingOptionsSolutionTransform;
+
+        public SharedVerifierState(AnalyzerTest<XUnitVerifier> test, string defaultFileExt)
+        {
+            _test = test;
+            _defaultFileExt = defaultFileExt;
+            Options = new OptionsCollection(test.Language);
+        }
+
+        public string? EditorConfig { get; set; }
+
+        /// <summary>
+        /// Gets a collection of options to apply to <see cref="Solution.Options"/> for testing. Values may be added
+        /// using a collection initializer.
+        /// </summary>
+        internal OptionsCollection Options { get; }
+
+        internal void Apply()
+        {
+            var (analyzerConfigSource, remainingOptions) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(_defaultFileExt, EditorConfig, Options);
+            if (analyzerConfigSource is not null)
+            {
+                if (_analyzerConfigIndex is null)
+                {
+                    _analyzerConfigIndex = _test.TestState.AnalyzerConfigFiles.Count;
+                    _test.TestState.AnalyzerConfigFiles.Add(("/.editorconfig", analyzerConfigSource));
+                }
+                else
+                {
+                    _test.TestState.AnalyzerConfigFiles[_analyzerConfigIndex.Value] = ("/.editorconfig", analyzerConfigSource);
+                }
+            }
+            else if (_analyzerConfigIndex is { } index)
+            {
+                _analyzerConfigIndex = null;
+                _test.TestState.AnalyzerConfigFiles.RemoveAt(index);
+            }
+
+            var solutionTransformIndex = _remainingOptionsSolutionTransform is not null ? _test.SolutionTransforms.IndexOf(_remainingOptionsSolutionTransform) : -1;
+            if (remainingOptions is not null)
+            {
+                // Generate a new solution transform
+                _remainingOptionsSolutionTransform = (solution, projectId) =>
+                {
+#if !CODE_STYLE
+                    var options = solution.Options;
+                    foreach (var (key, value) in remainingOptions)
+                    {
+                        options = options.WithChangedOption(key, value);
+                    }
+
+                    solution = solution.WithOptions(options);
+#endif
+
+                    return solution;
+                };
+
+                if (solutionTransformIndex < 0)
+                {
+                    _test.SolutionTransforms.Add(_remainingOptionsSolutionTransform);
+                }
+                else
+                {
+                    _test.SolutionTransforms[solutionTransformIndex] = _remainingOptionsSolutionTransform;
+                }
+            }
+            else if (_remainingOptionsSolutionTransform is not null)
+            {
+                _test.SolutionTransforms.Remove(_remainingOptionsSolutionTransform);
+                _remainingOptionsSolutionTransform = null;
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
@@ -26,12 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
     {
         public class Test : VisualBasicCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
         {
-            /// <summary>
-            /// The index in <see cref="Testing.ProjectState.AnalyzerConfigFiles"/> of the generated
-            /// <strong>.editorconfig</strong> file for <see cref="Options"/>, or <see langword="null"/> if no such
-            /// file has been generated yet.
-            /// </summary>
-            private int? _analyzerConfigIndex;
+            private readonly SharedVerifierState _sharedState;
 
             static Test()
             {
@@ -49,23 +44,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             public Test()
             {
+                _sharedState = new SharedVerifierState(this, DefaultFileExt);
+
                 MarkupOptions = Testing.MarkupOptions.UseFirstDescriptor;
 
                 SolutionTransforms.Add((solution, projectId) =>
                 {
                     var parseOptions = (VisualBasicParseOptions)solution.GetProject(projectId)!.ParseOptions!;
                     solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion));
-
-#if !CODE_STYLE
-                    var options = solution.Options;
-                    var (_, remainingOptions) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
-                    foreach (var (key, value) in remainingOptions)
-                    {
-                        options = options.WithChangedOption(key, value);
-                    }
-
-                    solution = solution.WithOptions(options);
-#endif
 
                     return solution;
                 });
@@ -77,13 +63,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             /// </summary>
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.VisualBasic16;
 
-            /// <summary>
-            /// Gets a collection of options to apply to <see cref="Solution.Options"/> for testing. Values may be added
-            /// using a collection initializer.
-            /// </summary>
-            internal OptionsCollection Options { get; } = new OptionsCollection(LanguageNames.VisualBasic);
+            /// <inheritdoc cref="SharedVerifierState.Options"/>
+            internal OptionsCollection Options => _sharedState.Options;
 
-            public string? EditorConfig { get; set; }
+            /// <inheritdoc cref="SharedVerifierState.EditorConfig"/>
+            public string? EditorConfig
+            {
+                get => _sharedState.EditorConfig;
+                set => _sharedState.EditorConfig = value;
+            }
 
             public Func<ImmutableArray<Diagnostic>, Diagnostic?>? DiagnosticSelector { get; set; }
 
@@ -94,25 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                     Assert.True(CodeFixTestBehaviors.HasFlag(Testing.CodeFixTestBehaviors.FixOne), $"'{nameof(DiagnosticSelector)}' can only be used with '{nameof(Testing.CodeFixTestBehaviors)}.{nameof(Testing.CodeFixTestBehaviors.FixOne)}'");
                 }
 
-                var (analyzerConfigSource, _) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
-                if (analyzerConfigSource is object)
-                {
-                    if (_analyzerConfigIndex is null)
-                    {
-                        _analyzerConfigIndex = TestState.AnalyzerConfigFiles.Count;
-                        TestState.AnalyzerConfigFiles.Add(("/.editorconfig", analyzerConfigSource));
-                    }
-                    else
-                    {
-                        TestState.AnalyzerConfigFiles[_analyzerConfigIndex.Value] = ("/.editorconfig", analyzerConfigSource);
-                    }
-                }
-                else if (_analyzerConfigIndex is { } index)
-                {
-                    _analyzerConfigIndex = null;
-                    TestState.AnalyzerConfigFiles.RemoveAt(index);
-                }
-
+                _sharedState.Apply();
                 await base.RunImplAsync(cancellationToken);
             }
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
@@ -26,6 +26,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
     {
         public class Test : VisualBasicCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
         {
+            /// <summary>
+            /// The index in <see cref="Testing.ProjectState.AnalyzerConfigFiles"/> of the generated
+            /// <strong>.editorconfig</strong> file for <see cref="Options"/>, or <see langword="null"/> if no such
+            /// file has been generated yet.
+            /// </summary>
+            private int? _analyzerConfigIndex;
+
             static Test()
             {
                 // If we have outdated defaults from the host unit test application targeting an older .NET Framework, use more
@@ -49,18 +56,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                     var parseOptions = (VisualBasicParseOptions)solution.GetProject(projectId)!.ParseOptions!;
                     solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion));
 
-                    var (analyzerConfigSource, remainingOptions) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
-                    if (analyzerConfigSource is object)
-                    {
-                        foreach (var id in solution.ProjectIds)
-                        {
-                            var documentId = DocumentId.CreateNewId(id, ".editorconfig");
-                            solution = solution.AddAnalyzerConfigDocument(documentId, ".editorconfig", analyzerConfigSource, filePath: "/.editorconfig");
-                        }
-                    }
-
 #if !CODE_STYLE
                     var options = solution.Options;
+                    var (_, remainingOptions) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
                     foreach (var (key, value) in remainingOptions)
                     {
                         options = options.WithChangedOption(key, value);
@@ -89,14 +87,33 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             public Func<ImmutableArray<Diagnostic>, Diagnostic?>? DiagnosticSelector { get; set; }
 
-            public override async Task RunAsync(CancellationToken cancellationToken = default)
+            protected override async Task RunImplAsync(CancellationToken cancellationToken = default)
             {
                 if (DiagnosticSelector is object)
                 {
                     Assert.True(CodeFixTestBehaviors.HasFlag(Testing.CodeFixTestBehaviors.FixOne), $"'{nameof(DiagnosticSelector)}' can only be used with '{nameof(Testing.CodeFixTestBehaviors)}.{nameof(Testing.CodeFixTestBehaviors.FixOne)}'");
                 }
 
-                await base.RunAsync(cancellationToken);
+                var (analyzerConfigSource, _) = CodeFixVerifierHelper.ConvertOptionsToAnalyzerConfig(DefaultFileExt, EditorConfig, Options);
+                if (analyzerConfigSource is object)
+                {
+                    if (_analyzerConfigIndex is null)
+                    {
+                        _analyzerConfigIndex = TestState.AnalyzerConfigFiles.Count;
+                        TestState.AnalyzerConfigFiles.Add(("/.editorconfig", analyzerConfigSource));
+                    }
+                    else
+                    {
+                        TestState.AnalyzerConfigFiles[_analyzerConfigIndex.Value] = ("/.editorconfig", analyzerConfigSource);
+                    }
+                }
+                else if (_analyzerConfigIndex is { } index)
+                {
+                    _analyzerConfigIndex = null;
+                    TestState.AnalyzerConfigFiles.RemoveAt(index);
+                }
+
+                await base.RunImplAsync(cancellationToken);
             }
 
 #if !CODE_STYLE

--- a/src/Workspaces/CoreTestUtilities/OptionsCollection.cs
+++ b/src/Workspaces/CoreTestUtilities/OptionsCollection.cs
@@ -49,6 +49,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         public void Add<T>(PerLanguageOption2<CodeStyleOption2<T>> option, T value, NotificationOption2 notification)
             => _options.Add(new OptionKey2(option, _languageName), new CodeStyleOption2<T>(value, notification));
 
+        // 📝 This can be removed if/when collection initializers support AddRange.
+        public void Add(OptionsCollection options)
+            => AddRange(options);
+
         public void AddRange(OptionsCollection options)
         {
             foreach (var (key, value) in options)


### PR DESCRIPTION
Review commit-by-commit recommended.

* Update to Microsoft.CodeAnalysis.Testing and account for small API changes
* Add `OptionsCollection.Add(OptionsCollection)` since `AddRange` cannot be used in a collection initializer