### PR TITLE
Fix incorrect unit test code sample in source generator docs

### DIFF
--- a/docs/features/source-generators.cookbook.md
+++ b/docs/features/source-generators.cookbook.md
@@ -693,10 +693,10 @@ await new VerifyCS.Test
     TestState = 
     {
         Sources = { code },
-    },
-    GeneratedSources =
-    {
-        (typeof(YourGenerator), "GeneratedFileName", SourceText.From(generated, Encoding.UTF8, SourceHashAlgorithm.Sha256)),
+        GeneratedSources =
+        {
+            (typeof(YourGenerator), "GeneratedFileName", SourceText.From(generated, Encoding.UTF8, SourceHashAlgorithm.Sha256))
+        }
     },
 }.RunAsync();
 ```

--- a/docs/features/source-generators.cookbook.md
+++ b/docs/features/source-generators.cookbook.md
@@ -695,8 +695,8 @@ await new VerifyCS.Test
         Sources = { code },
         GeneratedSources =
         {
-            (typeof(YourGenerator), "GeneratedFileName", SourceText.From(generated, Encoding.UTF8, SourceHashAlgorithm.Sha256))
-        }
+            (typeof(YourGenerator), "GeneratedFileName", SourceText.From(generated, Encoding.UTF8, SourceHashAlgorithm.Sha256)),
+        },
     },
 }.RunAsync();
 ```


### PR DESCRIPTION
The [`GeneratedSources` property](https://github.com/dotnet/roslyn-sdk/blob/db69a5baaba95118f13d60a36d8828c31d78412e/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ProjectState.cs#L68) is defined on the `Microsoft.CodeAnalysis.Testing.ProjectState` class, not the `Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest` class. So the sample code provided in source generator cookbook was incorrect and did not compile. Fixed by moving it to the correct place.