### PR TITLE
Mitigate circularity issue in checking IVT access

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/QuickAttributeChecker.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/QuickAttributeChecker.cs
@@ -48,6 +48,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var result = new QuickAttributeChecker();
             result.AddName(AttributeDescription.TypeIdentifierAttribute.Name, QuickAttributes.TypeIdentifier);
             result.AddName(AttributeDescription.TypeForwardedToAttribute.Name, QuickAttributes.TypeForwardedTo);
+            result.AddName(AttributeDescription.AssemblyKeyNameAttribute.Name, QuickAttributes.AssemblyKeyName);
+            result.AddName(AttributeDescription.AssemblyKeyFileAttribute.Name, QuickAttributes.AssemblyKeyFile);
+            result.AddName(AttributeDescription.AssemblySignatureKeyAttribute.Name, QuickAttributes.AssemblySignatureKey);
 
 #if DEBUG
             result._sealed = true;
@@ -138,6 +141,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         None = 0,
         TypeIdentifier = 1 << 0,
-        TypeForwardedTo = 2 << 0
+        TypeForwardedTo = 1 << 1,
+        AssemblyKeyName = 1 << 2,
+        AssemblyKeyFile = 1 << 3,
+        AssemblySignatureKey = 1 << 4,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                // We try to mitigate circularity problems by only actively loading attributes that pass a syntactic check
+                // We mitigate circularity problems by only actively loading attributes that pass a syntactic check
                 return GetWellKnownAttributeDataStringField(data => data.AssemblyKeyContainerAttributeSetting,
                     WellKnownAttributeData.StringMissingValue, QuickAttributes.AssemblyKeyName);
             }
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                // We try to mitigate circularity problems by only actively loading attributes that pass a syntactic check
+                // We mitigate circularity problems by only actively loading attributes that pass a syntactic check
                 return GetWellKnownAttributeDataStringField(data => data.AssemblyKeyFileAttributeSetting,
                     WellKnownAttributeData.StringMissingValue, QuickAttributes.AssemblyKeyFile);
             }
@@ -367,6 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                // We mitigate circularity problems by only actively loading attributes that pass a syntactic check
                 return GetWellKnownAttributeDataStringField(data => data.AssemblySignatureKeyAttributeSetting,
                     missingValue: null, QuickAttributes.AssemblySignatureKey);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -1433,17 +1433,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 }
                             }
 
-                        if (forwardedTypes.Add(forwarded))
-                        {
-                            if (forwarded.IsErrorType())
+                            if (forwardedTypes.Add(forwarded))
                             {
-                                if (!diagnostics.ReportUseSite(forwarded, NoLocation.Singleton))
+                                if (forwarded.IsErrorType())
                                 {
-                                    DiagnosticInfo info = ((ErrorTypeSymbol)forwarded).ErrorInfo;
-
-                                    if ((object)info != null)
+                                    if (!diagnostics.ReportUseSite(forwarded, NoLocation.Singleton))
                                     {
-                                        diagnostics.Add(info, NoLocation.Singleton);
+                                        DiagnosticInfo info = ((ErrorTypeSymbol)forwarded).ErrorInfo;
+
+                                        if ((object)info != null)
+                                        {
+                                            diagnostics.Add(info, NoLocation.Singleton);
+                                        }
                                     }
                                 }
                             }
@@ -1476,9 +1477,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 diagnostics.Free();
-            }
 
-            Debug.Assert(lazyNetModuleAttributesBag.IsSealed);
+                Debug.Assert(lazyNetModuleAttributesBag.IsSealed);
+            }
         }
 
         private CustomAttributesBag<CSharpAttributeData> GetNetModuleAttributesBag()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -1453,7 +1453,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            var diagnostics = BindingDiagnosticBag.GetInstance();
+            var discardedDiagnostics = BindingDiagnosticBag.Discarded;
 
             ImmutableArray<string> netModuleNames;
             ImmutableArray<CSharpAttributeData> attributesFromNetModules = GetNetModuleAttributes(out netModuleNames);
@@ -1462,17 +1462,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (attributesFromNetModules.Any())
             {
-                wellKnownData = limitedDecodeWellKnownAttributes(attributesFromNetModules, netModuleNames, diagnostics);
+                wellKnownData = limitedDecodeWellKnownAttributes(attributesFromNetModules, netModuleNames, discardedDiagnostics);
             }
 
-            diagnostics.Free();
+            discardedDiagnostics.Free();
 
             return (CommonAssemblyWellKnownAttributeData)wellKnownData;
 
             // Similar to ValidateAttributeUsageAndDecodeWellKnownAttributes, but doesn't load assembly-level attributes from source
             // and only decodes 3 specific attributes.
             WellKnownAttributeData limitedDecodeWellKnownAttributes(ImmutableArray<CSharpAttributeData> attributesFromNetModules,
-                ImmutableArray<string> netModuleNames, BindingDiagnosticBag diagnostics)
+                ImmutableArray<string> netModuleNames, BindingDiagnosticBag discardedDiagnostics)
             {
                 Debug.Assert(attributesFromNetModules.Any());
                 Debug.Assert(netModuleNames.Any());
@@ -1488,7 +1488,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 for (int i = netModuleAttributesCount - 1; i >= 0; i--)
                 {
                     CSharpAttributeData attribute = attributesFromNetModules[i];
-                    if (!attribute.HasErrors && ValidateAttributeUsageForNetModuleAttribute(attribute, netModuleNames[i], diagnostics, ref uniqueAttributes))
+                    if (!attribute.HasErrors && ValidateAttributeUsageForNetModuleAttribute(attribute, netModuleNames[i], discardedDiagnostics, ref uniqueAttributes))
                     {
                         limitedDecodeWellKnownAttribute(attribute, ref result);
                     }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1779,6 +1779,30 @@ public class C
 
         [Theory]
         [MemberData(nameof(AllProviderParseOptions))]
+        public void AssemblySignatureKeyOnNetModule(CSharpParseOptions parseOptions)
+        {
+            var other = CreateCompilation(@"
+[assembly: System.Reflection.AssemblySignatureKeyAttribute(
+    ""00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"",
+    ""bc6402e37ad723580b576953f40475ceae4b784d3661b90c3c6f5a1f7283388a7880683e0821610bee977f70506bb75584080e01b2ec97483c4d601ce1c981752a07276b420d78594d0ef28f8ec016d0a5b6d56cfc22e9f25a2ed9545942ccbf2d6295b9528641d98776e06a3273ab233271a3c9f53099b4d4e029582a6d5819"")]
+
+public class C
+{
+    static void Goo() {}
+}",
+                options: TestOptions.SigningReleaseModule, parseOptions: parseOptions);
+
+            var comp = CreateCompilation("",
+                references: new[] { other.EmitToImageReference() },
+                options: TestOptions.SigningReleaseDll,
+                parseOptions: parseOptions);
+
+            comp.VerifyDiagnostics();
+            Assert.StartsWith("0024000004", ((SourceAssemblySymbol)comp.Assembly.Modules[1].ContainingAssembly).SignatureKey);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllProviderParseOptions))]
         public void DelaySignItWithOnlyPublicKey(CSharpParseOptions parseOptions)
         {
             var other = CreateCompilation(

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -2309,4 +2309,47 @@ BC37254: Public sign was specified and requires a public key, but no public key 
 </errors>)
     End Sub
 
+    <Theory>
+    <MemberData(NameOf(AllProviderParseOptions))>
+    <WorkItem(1341051, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1341051")>
+    Public Sub IVT_Circularity(parseOptions As VisualBasicParseOptions)
+        Dim other As VisualBasicCompilation = CreateCompilation(
+<compilation name="HasIVTToCompilation">
+    <file name="a.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("WantsIVTAccess")>
+Public MustInherit Class TestBaseClass
+    Friend Overridable ReadOnly Property SupportSvgImages
+        Get
+        End Get
+    End Property
+End Class
+]]>
+    </file>
+</compilation>, options:=TestOptions.SigningReleaseDll, parseOptions:=parseOptions)
+
+        other.VerifyDiagnostics()
+
+        Dim c2 As VisualBasicCompilation = CreateCompilation(
+<compilation name="WantsIVTAccess">
+    <file name="a.vb"><![CDATA[
+Public Class Class1
+    Inherits TestBaseClass
+
+    Friend Overrides ReadOnly Property SupportSvgImages As Object
+        Get
+            Return True
+        End Get
+    End Property
+End Class
+]]>
+    </file>
+    <file name="b.vb"><![CDATA[
+<assembly: Class1>
+]]>
+    </file>
+</compilation>, {New VisualBasicCompilationReference(other)}, options:=TestOptions.SigningReleaseDll, parseOptions:=parseOptions)
+
+        c2.VerifyDiagnostics()
+    End Sub
+
 End Class

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -2318,8 +2318,9 @@ BC37254: Public sign was specified and requires a public key, but no public key 
     <file name="a.vb"><![CDATA[
 <Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("WantsIVTAccess")>
 Public MustInherit Class TestBaseClass
-    Friend Overridable ReadOnly Property SupportSvgImages
+    Friend Overridable ReadOnly Property SupportSvgImages As Object
         Get
+            Return True
         End Get
     End Property
 End Class
@@ -2349,7 +2350,64 @@ End Class
     </file>
 </compilation>, {New VisualBasicCompilationReference(other)}, options:=TestOptions.SigningReleaseDll, parseOptions:=parseOptions)
 
-        c2.VerifyDiagnostics()
+        c2.AssertTheseDiagnostics(<error><![CDATA[
+BC31504: 'Class1' cannot be used as an attribute because it does not inherit from 'System.Attribute'.
+<assembly: Class1>
+           ~~~~~~
+]]></error>)
+    End Sub
+
+    <Theory>
+    <MemberData(NameOf(AllProviderParseOptions))>
+    <WorkItem(1341051, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1341051")>
+    Public Sub IVT_Circularity_AttributeReferencesProperty(parseOptions As VisualBasicParseOptions)
+        Dim other As VisualBasicCompilation = CreateCompilation(
+<compilation name="HasIVTToCompilation">
+    <file name="a.vb"><![CDATA[
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("WantsIVTAccess")>
+Public MustInherit Class TestBaseClass
+    Friend Overridable ReadOnly Property SupportSvgImages As Object
+        Get
+            Return True
+        End Get
+    End Property
+End Class
+
+Public Class MyAttribute
+    Inherits System.Attribute
+
+    Public Sub New(s As String)
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>, options:=TestOptions.SigningReleaseDll, parseOptions:=parseOptions)
+
+        other.VerifyDiagnostics()
+
+        Dim c2 As VisualBasicCompilation = CreateCompilation(
+<compilation name="WantsIVTAccess">
+    <file name="a.vb"><![CDATA[
+Public Class Class1
+    Inherits TestBaseClass
+
+    Friend Const Constant As String = "text"
+
+    Friend Overrides ReadOnly Property SupportSvgImages As Object
+        Get
+            Return True
+        End Get
+    End Property
+End Class
+]]>
+    </file>
+    <file name="b.vb"><![CDATA[
+<assembly: MyAttribute(Class1.Constant)>
+]]>
+    </file>
+</compilation>, {New VisualBasicCompilationReference(other)}, options:=TestOptions.SigningReleaseDll, parseOptions:=parseOptions)
+
+        c2.AssertNoDiagnostics()
     End Sub
 
 End Class


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1341051

This is a similar mitigation we used for type forwards: PR https://github.com/dotnet/roslyn/pull/23647

Issue for QB approval: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1347877