### PR TITLE
Speed up progression searches by using the navigate-to index

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
@@ -53,15 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             }
 
             var sourceText = document.GetTextSynchronously(CancellationToken.None);
-            var item = _searchResult.NavigableItem;
-            var spanStart = item.SourceSpan.Start;
-            if (item.IsStale && spanStart > sourceText.Length)
-            {
-                // in the case of a stale item, the span may be out of bounds of the document. Cap
-                // us to the end of the document as that's where we're going to navigate the user
-                // to.
-                spanStart = sourceText.Length;
-            }
+            var span = NavigateToUtilities.GetBoundedSpan(_searchResult.NavigableItem, sourceText);
 
             var items = new List<DescriptionItem>
                     {
@@ -79,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                             new ReadOnlyCollection<DescriptionRun>(
                                 new[] { new DescriptionRun("Line:", bold: true) }),
                             new ReadOnlyCollection<DescriptionRun>(
-                                new[] { new DescriptionRun((sourceText.Lines.IndexOf(spanStart) + 1).ToString()) }))
+                                new[] { new DescriptionRun((sourceText.Lines.IndexOf(span.Start) + 1).ToString()) }))
                     };
 
             var summary = _searchResult.Summary;

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -41,22 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
         ISet<string> INavigateToItemProvider2.KindsProvided => KindsProvided;
 
         public ImmutableHashSet<string> KindsProvided
-        {
-            get
-            {
-                var result = ImmutableHashSet.Create<string>(StringComparer.Ordinal);
-                foreach (var project in _workspace.CurrentSolution.Projects)
-                {
-                    var navigateToSearchService = project.GetLanguageService<INavigateToSearchService>();
-                    if (navigateToSearchService != null)
-                    {
-                        result = result.Union(navigateToSearchService.KindsProvided);
-                    }
-                }
-
-                return result;
-            }
-        }
+            => NavigateToUtilities.GetKindsProvided(_workspace.CurrentSolution);
 
         public bool CanFilter
         {

--- a/src/Features/Core/Portable/Common/GlyphExtensions.cs
+++ b/src/Features/Core/Portable/Common/GlyphExtensions.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis
             return Glyph.None;
         }
 
-        private static Accessibility GetAccessibility(ImmutableArray<string> tags)
+        public static Accessibility GetAccessibility(ImmutableArray<string> tags)
         {
             foreach (var tag in tags)
             {

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -7,8 +7,6 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -7,6 +7,8 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {

--- a/src/Features/Core/Portable/NavigateTo/NavigateToUtilities.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToUtilities.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.NavigateTo
+{
+    internal static class NavigateToUtilities
+    {
+        public static ImmutableHashSet<string> GetKindsProvided(Solution solution)
+        {
+            var result = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+            foreach (var project in solution.Projects)
+            {
+                var navigateToSearchService = project.GetLanguageService<INavigateToSearchService>();
+                if (navigateToSearchService != null)
+                    result.UnionWith(navigateToSearchService.KindsProvided);
+            }
+
+            return result.ToImmutable();
+        }
+    }
+}

--- a/src/Features/Core/Portable/NavigateTo/NavigateToUtilities.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToUtilities.cs
@@ -5,7 +5,9 @@
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {
@@ -22,6 +24,22 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
 
             return result.ToImmutable();
+        }
+
+        public static TextSpan GetBoundedSpan(INavigableItem item, SourceText sourceText)
+        {
+            var spanStart = item.SourceSpan.Start;
+            var spanEnd = item.SourceSpan.End;
+            if (item.IsStale)
+            {
+                // in the case of a stale item, the span may be out of bounds of the document. Cap
+                // us to the end of the document as that's where we're going to navigate the user
+                // to.
+                spanStart = spanStart > sourceText.Length ? sourceText.Length : spanStart;
+                spanEnd = spanEnd > sourceText.Length ? sourceText.Length : spanEnd;
+            }
+
+            return TextSpan.FromBounds(spanStart, spanEnd);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
@@ -747,48 +747,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             this.AddLink(documentNode, GraphCommonSchema.Contains, symbolNode);
 
             return symbolNode;
-
-            //using (_gate.DisposableWait(cancellationToken))
-            //{
-            //    _createdNodes.Add(symbolNode);
-            //    _nodeToContextDocumentMap[symbolNode] = document;
-            //    _nodeToContextProjectMap[symbolNode] = project;
-            //}
         }
 
         private static string GetIconString(Glyph glyph)
         {
-            return glyph switch
+            var groupName = glyph switch
             {
-                Glyph.ClassPublic or Glyph.ClassProtected or Glyph.ClassPrivate or Glyph.ClassInternal => IconHelper.GetIconName("Class", GetAccessibility(glyph, Glyph.ClassPublic)),
-                Glyph.ConstantPublic or Glyph.ConstantProtected or Glyph.ConstantPrivate or Glyph.ConstantInternal => IconHelper.GetIconName("Field", GetAccessibility(glyph, Glyph.ConstantPublic)),
-                Glyph.DelegatePublic or Glyph.DelegateProtected or Glyph.DelegatePrivate or Glyph.DelegateInternal => IconHelper.GetIconName("Delegate", GetAccessibility(glyph, Glyph.DelegatePublic)),
-                Glyph.EnumPublic or Glyph.EnumProtected or Glyph.EnumPrivate or Glyph.EnumInternal => IconHelper.GetIconName("Enum", GetAccessibility(glyph, Glyph.EnumPublic)),
-                Glyph.EnumMemberPublic or Glyph.EnumMemberProtected or Glyph.EnumMemberPrivate or Glyph.EnumMemberInternal => IconHelper.GetIconName("EnumMember", GetAccessibility(glyph, Glyph.EnumMemberPublic)),
-                Glyph.ExtensionMethodPublic or Glyph.ExtensionMethodProtected or Glyph.ExtensionMethodPrivate or Glyph.ExtensionMethodInternal => IconHelper.GetIconName("Method", GetAccessibility(glyph, Glyph.ExtensionMethodPublic)),
-                Glyph.EventPublic or Glyph.EventProtected or Glyph.EventPrivate or Glyph.EventInternal => IconHelper.GetIconName("Event", GetAccessibility(glyph, Glyph.EventPublic)),
-                Glyph.FieldPublic or Glyph.FieldProtected or Glyph.FieldPrivate or Glyph.FieldInternal => IconHelper.GetIconName("Field", GetAccessibility(glyph, Glyph.FieldPublic)),
-                Glyph.InterfacePublic or Glyph.InterfaceProtected or Glyph.InterfacePrivate or Glyph.InterfaceInternal => IconHelper.GetIconName("Interface", GetAccessibility(glyph, Glyph.InterfacePublic)),
-                Glyph.MethodPublic or Glyph.MethodProtected or Glyph.MethodPrivate or Glyph.MethodInternal => IconHelper.GetIconName("Method", GetAccessibility(glyph, Glyph.MethodPublic)),
-                Glyph.ModulePublic or Glyph.ModuleProtected or Glyph.ModulePrivate or Glyph.ModuleInternal => IconHelper.GetIconName("Module", GetAccessibility(glyph, Glyph.ModulePublic)),
-                Glyph.PropertyPublic or Glyph.PropertyProtected or Glyph.PropertyPrivate or Glyph.PropertyInternal => IconHelper.GetIconName("Property", GetAccessibility(glyph, Glyph.PropertyPublic)),
-                Glyph.StructurePublic or Glyph.StructureProtected or Glyph.StructurePrivate or Glyph.StructureInternal => IconHelper.GetIconName("Structure", GetAccessibility(glyph, Glyph.StructurePublic)),
+                Glyph.ClassPublic or Glyph.ClassProtected or Glyph.ClassPrivate or Glyph.ClassInternal => "Class",
+                Glyph.ConstantPublic or Glyph.ConstantProtected or Glyph.ConstantPrivate or Glyph.ConstantInternal => "Field",
+                Glyph.DelegatePublic or Glyph.DelegateProtected or Glyph.DelegatePrivate or Glyph.DelegateInternal => "Delegate",
+                Glyph.EnumPublic or Glyph.EnumProtected or Glyph.EnumPrivate or Glyph.EnumInternal => "Enum",
+                Glyph.EnumMemberPublic or Glyph.EnumMemberProtected or Glyph.EnumMemberPrivate or Glyph.EnumMemberInternal => "EnumMember",
+                Glyph.ExtensionMethodPublic or Glyph.ExtensionMethodProtected or Glyph.ExtensionMethodPrivate or Glyph.ExtensionMethodInternal => "Method",
+                Glyph.EventPublic or Glyph.EventProtected or Glyph.EventPrivate or Glyph.EventInternal => "Event",
+                Glyph.FieldPublic or Glyph.FieldProtected or Glyph.FieldPrivate or Glyph.FieldInternal => "Field",
+                Glyph.InterfacePublic or Glyph.InterfaceProtected or Glyph.InterfacePrivate or Glyph.InterfaceInternal => "Interface",
+                Glyph.MethodPublic or Glyph.MethodProtected or Glyph.MethodPrivate or Glyph.MethodInternal => "Method",
+                Glyph.ModulePublic or Glyph.ModuleProtected or Glyph.ModulePrivate or Glyph.ModuleInternal => "Module",
+                Glyph.PropertyPublic or Glyph.PropertyProtected or Glyph.PropertyPrivate or Glyph.PropertyInternal => "Property",
+                Glyph.StructurePublic or Glyph.StructureProtected or Glyph.StructurePrivate or Glyph.StructureInternal => "Structure",
                 _ => null,
             };
-        }
 
-        private static Accessibility GetAccessibility(Glyph glyph, Glyph publicGlyph)
-        {
-            var diff = glyph - publicGlyph;
+            if (groupName == null)
+                return null;
 
-            return diff switch
-            {
-                0 => Accessibility.Public,
-                1 => Accessibility.Protected,
-                2 => Accessibility.Private,
-                3 => Accessibility.Internal,
-                _ => throw ExceptionUtilities.UnexpectedValue(glyph),
-            };
+            var accessibility = GlyphExtensions.GetAccessibility(GlyphTags.GetTags(glyph));
+            return IconHelper.GetIconName(groupName, accessibility);
         }
 
         public void ApplyToGraph(Graph graph)

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
@@ -819,16 +819,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 }
             }
         }
-
-        public IEnumerable<Tuple<GraphNode, GraphProperty, object>> DeferredPropertySets
-        {
-            get
-            {
-                using (_gate.DisposableWait())
-                {
-                    return _deferredPropertySets.ToArray();
-                }
-            }
-        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
@@ -691,12 +691,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
         }
 
-        public async Task AddNodeAsync(INavigateToSearchResult result, CancellationToken cancellationToken)
+        public async Task<GraphNode> CreateNodeAsync(INavigateToSearchResult result, CancellationToken cancellationToken)
         {
             var document = result.NavigableItem.Document;
             var project = document.Project;
             if (document.FilePath == null || project.FilePath == null)
-                return;
+                return null;
 
             var category = result.Kind switch
             {
@@ -716,7 +716,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             };
 
             if (category == null)
-                return;
+                return null;
 
             var documentNode = this.AddNodeForDocument(document);
 
@@ -739,12 +739,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             this.AddLink(documentNode, GraphCommonSchema.Contains, symbolNode);
 
-            using (_gate.DisposableWait(cancellationToken))
-            {
-                _createdNodes.Add(symbolNode);
-                _nodeToContextDocumentMap[symbolNode] = document;
-                _nodeToContextProjectMap[symbolNode] = project;
-            }
+            return symbolNode;
+
+            //using (_gate.DisposableWait(cancellationToken))
+            //{
+            //    _createdNodes.Add(symbolNode);
+            //    _nodeToContextDocumentMap[symbolNode] = document;
+            //    _nodeToContextProjectMap[symbolNode] = project;
+            //}
         }
 
         private static string GetIconString(Glyph glyph)

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
@@ -725,6 +725,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             var label = result.NavigableItem.DisplayTaggedParts.JoinText();
             var id = documentNode.Id.Add(GraphNodeId.GetLiteral(label));
+
+            // If we already have a node that matches this (say there are multiple identical sibling symbols in an error
+            // situation).  We just ignore the second match.
+            var existing = _graph.Nodes.Get(id);
+            if (existing != null)
+                return null;
+
             var symbolNode = _graph.Nodes.GetOrCreate(id);
 
             symbolNode.Label = label;

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.GraphModel;
+using Microsoft.VisualStudio.GraphModel.CodeSchema;
 using Microsoft.VisualStudio.GraphModel.Schemas;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Progression;
@@ -347,23 +348,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             if (graphObject is GraphNode graphNode)
             {
                 // If this is not a Roslyn node, bail out.
-                // TODO: The check here is to see if the SymbolId property exists on the node
-                // and if so, that's been created by us. However, eventually we'll want to extend
-                // this to other scenarios where C#\VB nodes that aren't created by us are passed in.
-                if (graphNode.GetValue<SymbolKey?>(RoslynGraphProperties.SymbolId) == null)
+                if (graphNode.GetValue(RoslynGraphProperties.ContextProjectId) == null)
+                    return null;
+
+                // Has to have at least a symbolid, or source location to navigate to.
+                if (graphNode.GetValue<SymbolKey?>(RoslynGraphProperties.SymbolId) == null &&
+                    graphNode.GetValue<SourceLocation>(CodeNodeProperties.SourceLocation).FileName == null)
                 {
                     return null;
                 }
 
                 if (typeof(T) == typeof(IGraphNavigateToItem))
-                {
                     return new GraphNavigatorExtension(_threadingContext, _workspace) as T;
-                }
 
                 if (typeof(T) == typeof(IGraphFormattedLabel))
-                {
                     return new GraphFormattedLabelExtension() as T;
-                }
             }
 
             return null;

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphProvider.cs
@@ -59,7 +59,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             _initialized = true;
         }
 
-        internal List<IGraphQuery> GetGraphQueries(IGraphContext context)
+        internal static List<IGraphQuery> GetGraphQueries(
+            IGraphContext context,
+            IThreadingContext threadingContext,
+            IAsynchronousOperationListener asyncListener)
         {
             var graphQueries = new List<IGraphQuery>();
 
@@ -137,7 +140,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                     // is a COM type. Therefore, it's probably best to grab the values we want now
                     // rather than get surprised by COM marshalling later.
                     graphQueries.Add(new SearchGraphQuery(
-                        _threadingContext, _asyncListener, searchParameters.SearchQuery.SearchString));
+                        searchParameters.SearchQuery.SearchString, threadingContext, asyncListener));
                 }
             }
 
@@ -148,7 +151,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
         {
             EnsureInitialized();
 
-            var graphQueries = GetGraphQueries(context);
+            var graphQueries = GetGraphQueries(context, _threadingContext, _asyncListener);
 
             if (graphQueries.Count > 0)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
@@ -30,15 +30,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
 
             public void ReportProgress(int current, int maximum)
-            {
-                _context.ReportProgress(current, maximum, null);
-            }
+                => _context.ReportProgress(current, maximum, null);
 
             public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
             {
                 var node = await _graphBuilder.CreateNodeAsync(result, cancellationToken).ConfigureAwait(false);
                 if (node != null)
                 {
+                    // _context.OutputNodes is not threadsafe.  So ensure only one navto callback can mutate it at a time.
                     lock (this)
                         _context.OutputNodes.Add(node);
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.GraphModel;
+using Microsoft.CodeAnalysis.NavigateTo;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
+{
+    internal sealed partial class SearchGraphQuery
+    {
+        private class ProgressionNavigateToSearchCallback : INavigateToSearchCallback
+        {
+            private readonly IGraphContext _context;
+            private readonly GraphBuilder _graphBuilder;
+
+            public ProgressionNavigateToSearchCallback(IGraphContext context, GraphBuilder graphBuilder)
+            {
+                _context = context;
+                _graphBuilder = graphBuilder;
+            }
+
+            public void Done(bool isFullyLoaded)
+            {
+                // Do nothing here.  Even though the navigate to search completed, we still haven't passed any
+                // information along to progression.  That will happen in GraphQueryManager.PopulateContextGraphAsync
+            }
+
+            public void ReportProgress(int current, int maximum)
+            {
+                _context.ReportProgress(current, maximum, null);
+            }
+
+            public Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
+            {
+                return _graphBuilder.AddNodeAsync(result, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
@@ -34,9 +34,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 _context.ReportProgress(current, maximum, null);
             }
 
-            public Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
+            public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
             {
-                return _graphBuilder.AddNodeAsync(result, cancellationToken);
+                var node = await _graphBuilder.CreateNodeAsync(result, cancellationToken).ConfigureAwait(false);
+                if (node != null)
+                {
+                    lock (this)
+                        _context.OutputNodes.Add(node);
+                }
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
@@ -69,7 +69,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             public void Done(bool isFullyLoaded)
             {
-                _context.OnCompleted();
+                // Do nothing here.  Even though the navigate to search completed, we still haven't passed any
+                // information along to progression.  That will happen in GraphQueryManager.PopulateContextGraphAsync
             }
 
             public void ReportProgress(int current, int maximum)
@@ -79,20 +80,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             public Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
             {
-                var symbolNode = GetSymbolNode(result);
-                var documentNode = _graphBuilder.AddNodeForDocument(result.NavigableItem.Document);
-                _graphBuilder.AddLink(documentNode, GraphCommonSchema.Contains, symbolNode);
-                return Task.CompletedTask;
-            }
-
-            private GraphNode GetSymbolNode(INavigateToSearchResult result)
-            {
-                throw new System.NotImplementedException();
+                return _graphBuilder.AddNodeAsync(result, cancellationToken);
             }
         }
 
-#if false
-        public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
+        public async Task<GraphBuilder> GetGraphAsync1(Solution solution, IGraphContext context, CancellationToken cancellationToken)
         {
             var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
 
@@ -253,6 +245,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             return results.ToImmutable();
         }
-#endif
     }
-    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphQueries/SearchGraphQuery.cs
@@ -36,7 +36,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             _searchPattern = searchPattern;
         }
 
-        public async Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
+        public Task<GraphBuilder> GetGraphAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
+        {
+            var option = solution.Options.GetOption(ProgressionOptions.SearchUsingNavigateToEngine);
+            return option
+                ? SearchUsingNavigateToEngineAsync(solution, context, cancellationToken)
+                : SearchUsingSymbolsAsync(solution, context, cancellationToken);
+        }
+
+        private async Task<GraphBuilder> SearchUsingNavigateToEngineAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
         {
             var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
             var callback = new ProgressionNavigateToSearchCallback(context, graphBuilder);
@@ -54,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             return graphBuilder;
         }
 
-        public async Task<GraphBuilder> GetGraphAsync1(Solution solution, IGraphContext context, CancellationToken cancellationToken)
+        private async Task<GraphBuilder> SearchUsingSymbolsAsync(Solution solution, IGraphContext context, CancellationToken cancellationToken)
         {
             var graphBuilder = await GraphBuilder.CreateForInputNodesAsync(solution, context.InputNodes, cancellationToken).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptions.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
+{
+    internal static class ProgressionOptions
+    {
+        public static readonly Option2<bool> SearchUsingNavigateToEngine = new(
+            nameof(ProgressionOptions), nameof(SearchUsingNavigateToEngine), defaultValue: false,
+            storageLocations: new RoamingProfileStorageLocation($"TextEditor.Specific.ProgressionOptions.SearchUsingNavigateToEngine"));
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptions.cs
@@ -10,8 +10,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 {
     internal static class ProgressionOptions
     {
+        private const string LocalRegistryPath = @"Roslyn\Internal\OnOff\Components\Progression\";
+
         public static readonly Option2<bool> SearchUsingNavigateToEngine = new(
             nameof(ProgressionOptions), nameof(SearchUsingNavigateToEngine), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.Specific.ProgressionOptions.SearchUsingNavigateToEngine"));
+            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "SearchUsingNavigateToEngine"));
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptionsProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptionsProvider.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Options.Providers;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
+{
+    [ExportOptionProvider, Shared]
+    internal class ProgressionOptionsProvider : IOptionProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public ProgressionOptionsProvider()
+        {
+        }
+
+        public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
+            ProgressionOptions.SearchUsingNavigateToEngine);
+    }
+}

--- a/src/VisualStudio/Core/Test/Progression/GraphProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/GraphProviderTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
         <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
         Public Sub TestGetContainsGraphQueries()
             Dim context = CreateGraphContext(GraphContextDirection.Contains, Array.Empty(Of GraphCategory)())
-            Dim queries = AbstractGraphProvider.GetGraphQueries(context)
+            Dim queries = AbstractGraphProvider.GetGraphQueries(context, threadingContext:=Nothing, asyncListener:=Nothing)
             Assert.Equal(queries.Single().GetType(), GetType(ContainsGraphQuery))
         End Sub
 
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
         <Fact, Trait(Traits.Feature, Traits.Features.Progression)>
         Public Sub TestGetContainsGraphQueriesWithTarget()
             Dim context = CreateGraphContext(GraphContextDirection.Target, {CodeLinkCategories.Contains})
-            Dim queries = AbstractGraphProvider.GetGraphQueries(context)
+            Dim queries = AbstractGraphProvider.GetGraphQueries(context, threadingContext:=Nothing, asyncListener:=Nothing)
             Assert.Equal(queries.Single().GetType(), GetType(ContainsGraphQuery))
         End Sub
 

--- a/src/VisualStudio/Core/Test/Progression/MockGraphContext.vb
+++ b/src/VisualStudio/Core/Test/Progression/MockGraphContext.vb
@@ -12,6 +12,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
         Private ReadOnly _direction As GraphContextDirection
         Private ReadOnly _graph As Graph
         Private ReadOnly _inputNodes As ISet(Of GraphNode)
+        Private ReadOnly _outputNodes As New HashSet(Of GraphNode)
 
         Public Sub New(direction As GraphContextDirection, graph As Graph, inputNodes As IEnumerable(Of GraphNode))
             _direction = direction
@@ -89,7 +90,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
 
         Public ReadOnly Property OutputNodes As ISet(Of GraphNode) Implements IGraphContext.OutputNodes
             Get
-                Throw New NotImplementedException()
+                Return _outputNodes
             End Get
         End Property
 

--- a/src/VisualStudio/Core/Test/Progression/ProgressionTestState.vb
+++ b/src/VisualStudio/Core/Test/Progression/ProgressionTestState.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.FindSymbols
@@ -14,10 +13,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
     Friend Class ProgressionTestState
         Implements IDisposable
 
-        Private ReadOnly _workspace As TestWorkspace
+        Public ReadOnly Workspace As TestWorkspace
 
         Public Sub New(workspace As TestWorkspace)
-            _workspace = workspace
+            Me.Workspace = workspace
         End Sub
 
         Public Shared Function Create(workspaceXml As XElement) As ProgressionTestState
@@ -27,29 +26,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
         End Function
 
         Public Function GetGraphWithDocumentNode(filePath As String) As Graph
-            Dim graphBuilder As New GraphBuilder(_workspace.CurrentSolution, CancellationToken.None)
-            Dim documentId = _workspace.Documents.Single(Function(d) d.FilePath = filePath).Id
-            graphBuilder.AddNodeForDocument(_workspace.CurrentSolution.GetDocument(documentId))
+            Dim graphBuilder As New GraphBuilder(Workspace.CurrentSolution, CancellationToken.None)
+            Dim documentId = Workspace.Documents.Single(Function(d) d.FilePath = filePath).Id
+            graphBuilder.AddNodeForDocument(Workspace.CurrentSolution.GetDocument(documentId))
             Return graphBuilder.Graph
         End Function
 
         Public Async Function GetGraphWithMarkedSymbolNodeAsync(Optional symbolTransform As Func(Of ISymbol, ISymbol) = Nothing) As Task(Of Graph)
-            Dim hostDocument As TestHostDocument = _workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
-            Dim document = _workspace.CurrentSolution.GetDocument(hostDocument.Id)
+            Dim hostDocument As TestHostDocument = Workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
+            Dim document = Workspace.CurrentSolution.GetDocument(hostDocument.Id)
             Dim symbol = Await GetMarkedSymbolAsync()
 
             If symbolTransform IsNot Nothing Then
                 symbol = symbolTransform(symbol)
             End If
 
-            Dim graphBuilder As New GraphBuilder(_workspace.CurrentSolution, CancellationToken.None)
+            Dim graphBuilder As New GraphBuilder(Workspace.CurrentSolution, CancellationToken.None)
             graphBuilder.AddNodeAsync(symbol, document.Project, document).Wait(CancellationToken.None)
             Return graphBuilder.Graph
         End Function
 
         Public Async Function GetGraphContextAfterQuery(graph As Graph, graphQuery As IGraphQuery, direction As GraphContextDirection) As Task(Of IGraphContext)
             Dim graphContext As New MockGraphContext(direction, graph.Copy(), graph.Nodes)
-            Dim graphBuilder = Await graphQuery.GetGraphAsync(_workspace.CurrentSolution, graphContext, CancellationToken.None)
+            Dim graphBuilder = Await graphQuery.GetGraphAsync(Workspace.CurrentSolution, graphContext, CancellationToken.None)
             graphBuilder.ApplyToGraph(graphContext.Graph)
 
             Return graphContext
@@ -64,7 +63,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
         End Function
 
         Private Sub Dispose() Implements IDisposable.Dispose
-            _workspace.Dispose()
+            Workspace.Dispose()
         End Sub
 
         Public Async Function AssertMarkedSymbolLabelIsAsync(graphCommandId As String, label As String, description As String) As Task
@@ -76,13 +75,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
         End Function
 
         Public Function GetMarkedSymbolAsync() As Task(Of ISymbol)
-            Dim hostDocument As TestHostDocument = _workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
-            Dim document = _workspace.CurrentSolution.GetDocument(hostDocument.Id)
+            Dim hostDocument As TestHostDocument = Workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
+            Dim document = Workspace.CurrentSolution.GetDocument(hostDocument.Id)
             Return SymbolFinder.FindSymbolAtPositionAsync(document, hostDocument.CursorPosition.Value)
         End Function
 
         Public Function GetSolution() As Solution
-            Return _workspace.CurrentSolution
+            Return Workspace.CurrentSolution
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
@@ -3,7 +3,9 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.GraphModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Progression
@@ -19,11 +21,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class C { }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="C"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("C", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -51,11 +55,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class C { class F { } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="F"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("F", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -85,11 +91,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class C { void M(); }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="M"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("M", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -124,7 +132,7 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                             <Document FilePath="Z:\Project2.vb">
 Namespace N
     Partial Class C
@@ -132,11 +140,13 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="C"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("C", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -172,7 +182,7 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                             <Document FilePath="Z:\Project2.vb">
 Namespace N
     Partial Class C
@@ -180,11 +190,13 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="Goo"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("Goo", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -219,7 +231,7 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                             <Document FilePath="Z:\Project2.vb">
 Namespace N
     Partial Class C
@@ -227,11 +239,13 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="Z"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("Z", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -266,11 +280,13 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class Dog { void Bark() { } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="D.B"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -300,11 +316,13 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class Dog { void Bark() { } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="C.B"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("C.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -322,11 +340,13 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="D.B"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -356,11 +376,13 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="A.D.B"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("A.D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -394,7 +416,9 @@ End Namespace
                         </Project>
                     </Workspace>)
 
-                Dim outputContext = Await testState.GetGraphContextAfterQuery(New Graph(), New SearchGraphQuery(searchPattern:="A.D.B"), GraphContextDirection.Custom)
+                Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
+                Dim outputContext = Await testState.GetGraphContextAfterQuery(
+                    New Graph(), New SearchGraphQuery("A.D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 ' When searching, don't descend into projects with a null FilePath because they are artifacts and not
                 ' representable in the Solution Explorer, e.g., Venus projects create sub-projects with a null file

--- a/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests.vb
@@ -33,16 +33,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 C)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=C)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 C)" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -67,18 +66,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 F)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Private" Label="F"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=(Name=F ParentType=C))" Category="CodeSchema_Class" CodeSchemaProperty_IsPrivate="True" CommonLabel="F" Icon="Microsoft.VisualStudio.Class.Private" Label="F"/>
-                            <Node Id="(@3 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=C)" Category="Contains"/>
-                            <Link Source="(@3 Type=C)" Target="(@3 Type=(Name=F ParentType=C))" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 F)" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -103,18 +99,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 M())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="M()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=C Member=M)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="M" Icon="Microsoft.VisualStudio.Method.Private" Label="M"/>
-                            <Node Id="(@3 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=C)" Category="Contains"/>
-                            <Link Source="(@3 Type=C)" Target="(@3 Type=C Member=M)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 M())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -152,19 +145,19 @@ End Namespace
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 C)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project2.vb"/>
+                            <Node Id="(@1 @3 C)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                             <Node Id="(@1 @3)" Category="CodeSchema_ProjectItem" Label="Project.vb"/>
-                            <Node Id="(@4 Namespace=N Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@1 @3)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 C)" Category="Contains"/>
+                            <Link Source="(@1 @3)" Target="(@1 @3 C)" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.vbproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project2.vb"/>
                             <Alias n="3" Uri="File=file:///Z:/Project.vb"/>
-                            <Alias n="4" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -202,18 +195,15 @@ End Namespace
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Goo())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Public" Label="Goo()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.vb"/>
-                            <Node Id="(@3 Namespace=N Type=C Member=Goo)" Category="CodeSchema_Method" CodeSchemaProperty_IsHideBySignature="True" CodeSchemaProperty_IsPublic="True" CommonLabel="Goo" Icon="Microsoft.VisualStudio.Method.Public" Label="Goo"/>
-                            <Node Id="(@3 Namespace=N Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@3 Namespace=N Type=C)" Target="(@3 Namespace=N Type=C Member=Goo)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Goo())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.vbproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.vb"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -251,23 +241,19 @@ End Namespace
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 ZBar())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Public" Label="ZBar()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project2.vb"/>
+                            <Node Id="(@1 @3 ZGoo())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Public" Label="ZGoo()"/>
                             <Node Id="(@1 @3)" Category="CodeSchema_ProjectItem" Label="Project.vb"/>
-                            <Node Id="(@4 Namespace=N Type=C Member=ZBar)" Category="CodeSchema_Method" CodeSchemaProperty_IsHideBySignature="True" CodeSchemaProperty_IsPublic="True" CommonLabel="ZBar" Icon="Microsoft.VisualStudio.Method.Public" Label="ZBar"/>
-                            <Node Id="(@4 Namespace=N Type=C Member=ZGoo)" Category="CodeSchema_Method" CodeSchemaProperty_IsHideBySignature="True" CodeSchemaProperty_IsPublic="True" CommonLabel="ZGoo" Icon="Microsoft.VisualStudio.Method.Public" Label="ZGoo"/>
-                            <Node Id="(@4 Namespace=N Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@1 @3)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@4 Namespace=N Type=C)" Target="(@4 Namespace=N Type=C Member=ZBar)" Category="Contains"/>
-                            <Link Source="(@4 Namespace=N Type=C)" Target="(@4 Namespace=N Type=C Member=ZGoo)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 ZBar())" Category="Contains"/>
+                            <Link Source="(@1 @3)" Target="(@1 @3 ZGoo())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.vbproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project2.vb"/>
                             <Alias n="3" Uri="File=file:///Z:/Project.vb"/>
-                            <Alias n="4" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -292,18 +278,15 @@ End Namespace
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Bark())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=Dog Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
-                            <Node Id="(@3 Type=Dog)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=Dog)" Category="Contains"/>
-                            <Link Source="(@3 Type=Dog)" Target="(@3 Type=Dog Member=Bark)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Bark())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -352,18 +335,15 @@ End Namespace
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Bark())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog&lt;X&gt;" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog&lt;X&gt;"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="Contains"/>
-                            <Link Source="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Bark())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -388,18 +368,15 @@ End Namespace
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Bark())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog&lt;X&gt;" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog&lt;X&gt;"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="Contains"/>
-                            <Link Source="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Bark())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using

--- a/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests_NavigateTo.vb
+++ b/src/VisualStudio/Core/Test/Progression/SearchGraphQueryTests_NavigateTo.vb
@@ -13,7 +13,7 @@ Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
     <UseExportProvider, Trait(Traits.Feature, Traits.Features.Progression)>
-    Public Class SearchGraphQueryTests
+    Public Class SearchGraphQueryTests_NavigateTo
         <WpfFact>
         Public Async Function SearchForType() As Task
             Using testState = ProgressionTestState.Create(
@@ -21,28 +21,28 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class C { }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="C", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("C", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 C)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=C)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 C)" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -55,30 +55,28 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class C { class F { } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="F", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("F", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 F)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Private" Label="F"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=(Name=F ParentType=C))" Category="CodeSchema_Class" CodeSchemaProperty_IsPrivate="True" CommonLabel="F" Icon="Microsoft.VisualStudio.Class.Private" Label="F"/>
-                            <Node Id="(@3 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=C)" Category="Contains"/>
-                            <Link Source="(@3 Type=C)" Target="(@3 Type=(Name=F ParentType=C))" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 F)" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -91,30 +89,28 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class C { void M(); }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="M", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("M", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 M())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="M()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=C Member=M)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="M" Icon="Microsoft.VisualStudio.Method.Private" Label="M"/>
-                            <Node Id="(@3 Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=C)" Category="Contains"/>
-                            <Link Source="(@3 Type=C)" Target="(@3 Type=C Member=M)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 M())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -132,7 +128,7 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                             <Document FilePath="Z:\Project2.vb">
 Namespace N
     Partial Class C
@@ -140,31 +136,32 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="C", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("C", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 C)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project2.vb"/>
+                            <Node Id="(@1 @3 C)" Category="CodeSchema_Class" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                             <Node Id="(@1 @3)" Category="CodeSchema_ProjectItem" Label="Project.vb"/>
-                            <Node Id="(@4 Namespace=N Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@1 @3)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 C)" Category="Contains"/>
+                            <Link Source="(@1 @3)" Target="(@1 @3 C)" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.vbproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project2.vb"/>
                             <Alias n="3" Uri="File=file:///Z:/Project.vb"/>
-                            <Alias n="4" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -182,7 +179,7 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                             <Document FilePath="Z:\Project2.vb">
 Namespace N
     Partial Class C
@@ -190,30 +187,28 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="Goo", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("Goo", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Goo())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Public" Label="Goo()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.vb"/>
-                            <Node Id="(@3 Namespace=N Type=C Member=Goo)" Category="CodeSchema_Method" CodeSchemaProperty_IsHideBySignature="True" CodeSchemaProperty_IsPublic="True" CommonLabel="Goo" Icon="Microsoft.VisualStudio.Method.Public" Label="Goo"/>
-                            <Node Id="(@3 Namespace=N Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@3 Namespace=N Type=C)" Target="(@3 Namespace=N Type=C Member=Goo)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Goo())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.vbproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.vb"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -231,7 +226,7 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                             <Document FilePath="Z:\Project2.vb">
 Namespace N
     Partial Class C
@@ -239,35 +234,32 @@ Namespace N
         End Sub
     End Class
 End Namespace
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="Z", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("Z", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 ZBar())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Public" Label="ZBar()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project2.vb"/>
+                            <Node Id="(@1 @3 ZGoo())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Public" Label="ZGoo()"/>
                             <Node Id="(@1 @3)" Category="CodeSchema_ProjectItem" Label="Project.vb"/>
-                            <Node Id="(@4 Namespace=N Type=C Member=ZBar)" Category="CodeSchema_Method" CodeSchemaProperty_IsHideBySignature="True" CodeSchemaProperty_IsPublic="True" CommonLabel="ZBar" Icon="Microsoft.VisualStudio.Method.Public" Label="ZBar"/>
-                            <Node Id="(@4 Namespace=N Type=C Member=ZGoo)" Category="CodeSchema_Method" CodeSchemaProperty_IsHideBySignature="True" CodeSchemaProperty_IsPublic="True" CommonLabel="ZGoo" Icon="Microsoft.VisualStudio.Method.Public" Label="ZGoo"/>
-                            <Node Id="(@4 Namespace=N Type=C)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="C" Icon="Microsoft.VisualStudio.Class.Internal" Label="C"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@1 @3)" Target="(@4 Namespace=N Type=C)" Category="Contains"/>
-                            <Link Source="(@4 Namespace=N Type=C)" Target="(@4 Namespace=N Type=C Member=ZBar)" Category="Contains"/>
-                            <Link Source="(@4 Namespace=N Type=C)" Target="(@4 Namespace=N Type=C Member=ZGoo)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 ZBar())" Category="Contains"/>
+                            <Link Source="(@1 @3)" Target="(@1 @3 ZGoo())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.vbproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project2.vb"/>
                             <Alias n="3" Uri="File=file:///Z:/Project.vb"/>
-                            <Alias n="4" Uri="Assembly=file:///Z:/VisualBasicAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -280,30 +272,28 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class Dog { void Bark() { } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Bark())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Type=Dog Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
-                            <Node Id="(@3 Type=Dog)" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Type=Dog)" Category="Contains"/>
-                            <Link Source="(@3 Type=Dog)" Target="(@3 Type=Dog Member=Bark)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Bark())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -316,13 +306,14 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 class Dog { void Bark() { } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="C.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("C.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
@@ -340,30 +331,28 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Bark())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog&lt;X&gt;" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog&lt;X&gt;"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="Contains"/>
-                            <Link Source="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Bark())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -376,30 +365,28 @@ End Namespace
                         <Project Language="C#" CommonReferences="true" FilePath="Z:\Project.csproj">
                             <Document FilePath="Z:\Project.cs">
                                 namespace Animal { class Dog&lt;X&gt; { void Bark() { } } }
-                         </Document>
+                            </Document>
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="A.D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("A.D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,
                     <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
                         <Nodes>
+                            <Node Id="(@1 @2 Bark())" Category="CodeSchema_Method" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark()"/>
                             <Node Id="(@1 @2)" Category="CodeSchema_ProjectItem" Label="Project.cs"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="CodeSchema_Method" CodeSchemaProperty_IsPrivate="True" CommonLabel="Bark" Icon="Microsoft.VisualStudio.Method.Private" Label="Bark"/>
-                            <Node Id="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="CodeSchema_Class" CodeSchemaProperty_IsInternal="True" CommonLabel="Dog&lt;X&gt;" Icon="Microsoft.VisualStudio.Class.Internal" Label="Dog&lt;X&gt;"/>
                         </Nodes>
                         <Links>
-                            <Link Source="(@1 @2)" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Category="Contains"/>
-                            <Link Source="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1))" Target="(@3 Namespace=Animal Type=(Name=Dog GenericParameterCount=1) Member=Bark)" Category="Contains"/>
+                            <Link Source="(@1 @2)" Target="(@1 @2 Bark())" Category="Contains"/>
                         </Links>
                         <IdentifierAliases>
                             <Alias n="1" Uri="Assembly=file:///Z:/Project.csproj"/>
                             <Alias n="2" Uri="File=file:///Z:/Project.cs"/>
-                            <Alias n="3" Uri="Assembly=file:///Z:/CSharpAssembly1.dll"/>
                         </IdentifierAliases>
                     </DirectedGraph>)
             End Using
@@ -416,9 +403,10 @@ End Namespace
                         </Project>
                     </Workspace>)
 
+                testState.Workspace.SetOptions(testState.Workspace.Options.WithChangedOption(ProgressionOptions.SearchUsingNavigateToEngine, True))
                 Dim threadingContext = testState.Workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim outputContext = Await testState.GetGraphContextAfterQuery(
-                    New Graph(), New SearchGraphQuery(searchPattern:="A.D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
+                    New Graph(), New SearchGraphQuery("A.D.B", threadingContext, AsynchronousOperationListenerProvider.NullListener), GraphContextDirection.Custom)
 
                 ' When searching, don't descend into projects with a null FilePath because they are artifacts and not
                 ' representable in the Solution Explorer, e.g., Venus projects create sub-projects with a null file


### PR DESCRIPTION
The current progression search system works by literally walking the entire solution, producing compilations for all projects and symbols for every symbol therein.  This is pretty terrible as it's enormously costly and uses a ton of ram.  On my machine it takes a full 2 minutes to search Roslyn.sln and uses at least a GB of ram.

This PR introduces a new implementation of progression search that sits on top of the NavigateTo search index instead.  This  brings search time down <4 seconds, and  uses around 900mb less memory.  This also benefits from: 

1. NavigateTo running OutOfProc
2. all the work we did to dedupe results in navto
3. the work to allow navto to return results before the solution (or oop) has fully loaded

However, this change is not a pure win.  The way progression search works today is that all entries are backed by real symbols.  This means that the presented nodes can expose commands (like 'find all callers').  These continue to work for normal progression items.  However, this is not supported for tehse new search results (as they're not backed by a real symbol anymore).

The progression team is going to investigate though how often (if ever) these advanced commands are used *on search results*.  We hypothesize that very few people will be affected by this, but we would like data to be sure.  So, in the meantime, this will be off by default.