### PR TITLE
Visit target-typed `new()` args after conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -138,6 +138,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     hasErrors);
             }
 
+            if (conversion.Kind == ConversionKind.ObjectCreation)
+            {
+                var convertedObjectCreation = ConvertObjectCreationExpression(syntax, (BoundUnconvertedObjectCreationExpression)source, isCast, destination, diagnostics);
+                return new BoundConversion(
+                    syntax,
+                    convertedObjectCreation,
+                    conversion,
+                    CheckOverflowAtRuntime,
+                    explicitCastInCode: isCast && !wasCompilerGenerated,
+                    conversionGroupOpt,
+                    convertedObjectCreation.ConstantValue,
+                    destination,
+                    hasErrors);
+            }
+
             if (conversion.Kind == ConversionKind.InterpolatedString)
             {
                 var unconvertedSource = (BoundUnconvertedInterpolatedString)source;
@@ -164,11 +179,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return source;
                 }
-            }
-
-            if (conversion.IsObjectCreation)
-            {
-                return ConvertObjectCreationExpression(syntax, (BoundUnconvertedObjectCreationExpression)source, isCast, destination, diagnostics);
             }
 
             if (source.Kind == BoundKind.UnconvertedConditionalOperator)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -551,17 +551,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Returns true if the conversion is an implicit object creation expression conversion.
-        /// </summary>
-        internal bool IsObjectCreation
-        {
-            get
-            {
-                return Kind == ConversionKind.ObjectCreation;
-            }
-        }
-
-        /// <summary>
         /// Returns true if the conversion is an implicit switch expression conversion.
         /// </summary>
         public bool IsSwitchExpression

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7361,7 +7361,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return resultState;
                         }
 
-                    case BoundObjectCreationExpression { WasTargetTyped: true }:
+                    case BoundObjectCreationExpression { WasTargetTyped: true } objectCreation:
+                        {
+                            VisitArguments(
+                                objectCreation,
+                                objectCreation.Arguments,
+                                objectCreation.ArgumentRefKindsOpt,
+                                (MethodSymbol)AsMemberOfType(targetTypeWithNullability.Type, objectCreation.Constructor),
+                                objectCreation.ArgsToParamsOpt,
+                                objectCreation.DefaultArguments,
+                                objectCreation.Expanded,
+                                invokedAsExtensionMethod: false);
+                            return NullableFlowState.NotNull;
+                        }
+
                     case BoundUnconvertedObjectCreationExpression:
                         return NullableFlowState.NotNull;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -21,10 +21,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return RewriteInterpolatedStringConversion(node);
             }
 
-            if (node.ConversionKind is ConversionKind.SwitchExpression or ConversionKind.ConditionalExpression)
+            if (node.ConversionKind is
+                ConversionKind.SwitchExpression or
+                ConversionKind.ConditionalExpression or
+                ConversionKind.ObjectCreation)
             {
-                // Skip through target-typed conditionals and switches
-                Debug.Assert(node.Operand is BoundConditionalOperator { WasTargetTyped: true } or BoundConvertedSwitchExpression { WasTargetTyped: true });
+                // Skip through target-typed expressions.
+                Debug.Assert(node.Operand is
+                    BoundConditionalOperator { WasTargetTyped: true } or
+                    BoundConvertedSwitchExpression { WasTargetTyped: true } or
+                    BoundObjectCreationExpression { WasTargetTyped: true });
                 return Visit(node.Operand)!;
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/49736