### PR TITLE
Draft.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -404,6 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (p.RefKind != RefKind.None)
                     {
                         var synthesizedParam = new SourceClonedParameterSymbol(originalParam: p, newOwner: this, newOrdinal: ordinal++, suppressOptional: true);
+                        Debug.Assert(!synthesizedParam.IsOptional);
                         parameters.Add(synthesizedParam);
                     }
                 }


### PR DESCRIPTION
Calling IsOptional here causes an assertion in `AssertMemberExposure` to fail:

https://github.com/dotnet/roslyn/blob/55b6ebe89b9418b0a0a2e33b64f8e52da9195cc4/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs#L1521

This is blocking me from addressing https://github.com/dotnet/roslyn/pull/54355/files#r658950078. I'm unable to figure out what's happening here :(

It may or may not be related to https://github.com/dotnet/roslyn/pull/53044

cc @AlekseyTs @333fred 