### PR TITLE
Correctly handle replacement as modified when possible

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1995,18 +1995,6 @@ class C { }
             Assert.Equal("path2.txt", additionalTextPaths[0]);
 
             Assert.Empty(additionalTextsContents);
-
-            // replace it with null, and check that we get back null
-            additionalTextPaths.Clear();
-            additionalTextsContents.Clear();
-            driver = driver.ReplaceAdditionalText(thirdText, null!);
-            driver = driver.RunGenerators(compilation);
-
-            Assert.Single(additionalTextPaths);
-            Assert.Null(additionalTextPaths[0]);
-            Assert.Single(additionalTextsContents);
-            Assert.Null(additionalTextsContents[0]);
-
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1928,5 +1928,85 @@ class C { }
             // replace it with null, and check that it throws
             Assert.Throws<ArgumentNullException>(() => driver.ReplaceAdditionalText(additionalText1, null!));
         }
+
+        [Fact]
+        public void Replaced_Input_Is_Treated_As_Modified()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+            Assert.Single(compilation.SyntaxTrees);
+
+            InMemoryAdditionalText additionalText = new InMemoryAdditionalText("path.txt", "abc");
+
+            List<string?> additionalTextPaths = new List<string?>();
+            List<string?> additionalTextsContents = new List<string?>();
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                var texts = ctx.AdditionalTextsProvider;
+                var paths = texts.Select((t, _) => t?.Path);
+                var contents = texts.Select((t, _) => t?.GetText()?.ToString());
+
+                ctx.RegisterSourceOutput(paths, (spc, p) => { additionalTextPaths.Add(p); });
+                ctx.RegisterSourceOutput(contents, (spc, p) => { additionalTextsContents.Add(p); });
+            }));
+
+            // run the generator once and check we saw the additional file
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions, additionalTexts: new[] { additionalText });
+            driver = driver.RunGenerators(compilation);
+            Assert.Equal(1, additionalTextPaths.Count);
+            Assert.Equal("path.txt", additionalTextPaths[0]);
+
+            Assert.Equal(1, additionalTextsContents.Count);
+            Assert.Equal("abc", additionalTextsContents[0]);
+
+            // re-run and check nothing else got added
+            driver = driver.RunGenerators(compilation);
+            Assert.Equal(1, additionalTextPaths.Count);
+            Assert.Equal(1, additionalTextsContents.Count);
+
+            // now, update the additional text, but keep the path the same
+            additionalTextPaths.Clear();
+            additionalTextsContents.Clear();
+            var secondText = new InMemoryAdditionalText("path.txt", "def");
+            driver = driver.ReplaceAdditionalText(additionalText, secondText);
+
+            // run, and check that only the contents got re-run
+            driver = driver.RunGenerators(compilation);
+            Assert.Empty(additionalTextPaths);
+
+            Assert.Equal(1, additionalTextsContents.Count);
+            Assert.Equal("def", additionalTextsContents[0]);
+
+            // now replace the text with a different path, but the same text
+            additionalTextPaths.Clear();
+            additionalTextsContents.Clear();
+            var thirdText = new InMemoryAdditionalText("path2.txt", "def");
+            driver = driver.ReplaceAdditionalText(secondText, thirdText);
+
+            // run, and check that only the paths got re-run
+            driver = driver.RunGenerators(compilation);
+
+            Assert.Equal(1, additionalTextPaths.Count);
+            Assert.Equal("path2.txt", additionalTextPaths[0]);
+
+            Assert.Empty(additionalTextsContents);
+
+            // replace it with null, and check that we get back null
+            additionalTextPaths.Clear();
+            additionalTextsContents.Clear();
+            driver = driver.ReplaceAdditionalText(thirdText, null!);
+            driver = driver.RunGenerators(compilation);
+
+            Assert.Single(additionalTextPaths);
+            Assert.Null(additionalTextPaths[0]);
+            Assert.Single(additionalTextsContents);
+            Assert.Null(additionalTextsContents[0]);
+
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -1199,6 +1199,116 @@ class F
         }
 
         [Fact]
+        public void IncrementalGenerator_With_Syntax_Filter_And_Changed_Tree_Order()
+        {
+            var source1 = @"
+#pragma warning disable CS0414
+class C 
+{
+    string fieldA = null; 
+}";
+            var source2 = @"
+#pragma warning disable CS0414
+class D 
+{
+    string fieldB = null; 
+}";
+            var source3 = @"
+#pragma warning disable CS0414
+class E 
+{
+    string fieldC = null; 
+}";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(new[] { source1, source2, source3 }, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            List<string> fieldsCalledFor = new List<string>();
+            List<string> syntaxFieldsCalledFor = new List<string>();
+
+            var testGenerator = new PipelineCallbackGenerator(context =>
+            {
+                var source = context.SyntaxProvider.CreateSyntaxProvider((c, _) =>
+                {
+                    if (c is FieldDeclarationSyntax fds)
+                    {
+                        syntaxFieldsCalledFor.Add(fds.Declaration.Variables[0].Identifier.ValueText);
+                        return true;
+                    }
+                    return false;
+                },
+                (c, _) => ((FieldDeclarationSyntax)c.Node).Declaration.Variables[0].Identifier.ValueText);
+
+                context.RegisterSourceOutput(source, (spc, fieldName) =>
+                {
+                    spc.AddSource(fieldName, "");
+                    fieldsCalledFor.Add(fieldName);
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { new IncrementalGeneratorWrapper(testGenerator) }, parseOptions: parseOptions);
+            driver = driver.RunGenerators(compilation);
+
+            var results = driver.GetRunResult();
+            Assert.Empty(results.Diagnostics);
+            Assert.Equal(3, results.GeneratedTrees.Length);
+            Assert.EndsWith("fieldA.cs", results.GeneratedTrees[0].FilePath);
+            Assert.EndsWith("fieldB.cs", results.GeneratedTrees[1].FilePath);
+            Assert.EndsWith("fieldC.cs", results.GeneratedTrees[2].FilePath);
+            Assert.Equal("fieldA", fieldsCalledFor[0]);
+            Assert.Equal("fieldB", fieldsCalledFor[1]);
+            Assert.Equal("fieldC", fieldsCalledFor[2]);
+            Assert.Equal("fieldA", syntaxFieldsCalledFor[0]);
+            Assert.Equal("fieldB", syntaxFieldsCalledFor[1]);
+            Assert.Equal("fieldC", syntaxFieldsCalledFor[2]);
+
+            //swap the order of the first and last trees
+            var firstTree = compilation.SyntaxTrees.First();
+            var lastTree = compilation.SyntaxTrees.Last();
+            var dummyTree = CSharpSyntaxTree.ParseText("", parseOptions);
+
+            compilation = compilation.ReplaceSyntaxTree(firstTree, dummyTree)
+                                     .ReplaceSyntaxTree(lastTree, firstTree)
+                                     .ReplaceSyntaxTree(dummyTree, lastTree);
+
+            // now re-run the drivers and confirm we didn't actually run
+            fieldsCalledFor.Clear();
+            syntaxFieldsCalledFor.Clear();
+            driver = driver.RunGenerators(compilation);
+            results = driver.GetRunResult();
+            Assert.Empty(results.Diagnostics);
+            Assert.Equal(3, results.GeneratedTrees.Length);
+            Assert.EndsWith("fieldA.cs", results.GeneratedTrees[0].FilePath);
+            Assert.EndsWith("fieldB.cs", results.GeneratedTrees[1].FilePath);
+            Assert.EndsWith("fieldC.cs", results.GeneratedTrees[2].FilePath);
+            Assert.Empty(fieldsCalledFor);
+            Assert.Empty(syntaxFieldsCalledFor);
+
+
+            // swap a tree for a tree with the same contents, but a new reference
+            var newLastTree = CSharpSyntaxTree.ParseText(lastTree.ToString(), parseOptions);
+
+            compilation = compilation.ReplaceSyntaxTree(firstTree, dummyTree)
+                                     .ReplaceSyntaxTree(lastTree, firstTree)
+                                     .ReplaceSyntaxTree(dummyTree, newLastTree);
+
+            // now re-run the drivers and confirm we only ran for the 'new' syntax tree
+            // but then stopped when we got the same value out
+            fieldsCalledFor.Clear();
+            syntaxFieldsCalledFor.Clear();
+            driver = driver.RunGenerators(compilation);
+            results = driver.GetRunResult();
+            Assert.Empty(results.Diagnostics);
+            Assert.Equal(3, results.GeneratedTrees.Length);
+            Assert.EndsWith("fieldA.cs", results.GeneratedTrees[0].FilePath);
+            Assert.EndsWith("fieldB.cs", results.GeneratedTrees[1].FilePath);
+            Assert.EndsWith("fieldC.cs", results.GeneratedTrees[2].FilePath);
+            Assert.Empty(fieldsCalledFor);
+            Assert.Single(syntaxFieldsCalledFor);
+            Assert.Equal("fieldC", syntaxFieldsCalledFor[0]);
+        }
+
+        [Fact]
         public void IncrementalGenerator_With_Syntax_Filter_Can_Have_Comparer()
         {
             var source1 = @"

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -1192,9 +1192,9 @@ class F
             Assert.Equal(3, results.GeneratedTrees.Length);
 
             // we produced the expected modified sources, but only called for the one different tree
-            Assert.EndsWith("fieldB.cs", results.GeneratedTrees[0].FilePath);
-            Assert.EndsWith("fieldC.cs", results.GeneratedTrees[1].FilePath);
-            Assert.EndsWith("fieldD.cs", results.GeneratedTrees[2].FilePath);
+            Assert.EndsWith("fieldD.cs", results.GeneratedTrees[0].FilePath);
+            Assert.EndsWith("fieldB.cs", results.GeneratedTrees[1].FilePath);
+            Assert.EndsWith("fieldC.cs", results.GeneratedTrees[2].FilePath);
             Assert.Single(fieldsCalledFor, "fieldD");
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -60,9 +60,9 @@ namespace Microsoft.CodeAnalysis
                 else if (inputItems.Length == previousTable.Count)
                 {
                     // When the number of items matches the previous iteration, we use a heuristic to mark the input as modified
-                    // This allows us to correctly 'replace' items even that aren't actually the same. In the case that the item 
-                    // really isn't modified, but a new item, we still function correctly as we mostly treat them the same, but
-                    // will perform an extra comparison that is ommitted in the pure 'added' case.
+                    // This allows us to correctly 'replace' items even when they aren't actually the same. In the case that the
+                    // item really isn't modified, but a new item, we still function correctly as we mostly treat them the same,
+                    // but will perform an extra comparison that is omitted in the pure 'added' case.
                     var modified = builder.TryModifyEntry(inputItems[itemIndex], _comparer);
                     Debug.Assert(modified);
                     itemsSet.Remove(inputItems[itemIndex]);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly Func<DriverStateTable.Builder, ImmutableArray<T>> _getInput;
         private readonly Action<IIncrementalGeneratorOutputNode> _registerOutput;
-        private readonly IEqualityComparer<T>? _comparer;
+        private readonly IEqualityComparer<T> _comparer;
 
         public InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput)
             : this(getInput, registerOutput: null, comparer: null)
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis
         private InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, Action<IIncrementalGeneratorOutputNode>? registerOutput, IEqualityComparer<T>? comparer = null)
         {
             _getInput = getInput;
-            _comparer = comparer;
+            _comparer = comparer ?? EqualityComparer<T>.Default;
             _registerOutput = registerOutput ?? (o => throw ExceptionUtilities.Unreachable);
         }
 
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis
             var builder = previousTable.ToBuilder();
 
             // for each item in the previous table, check if its still in the new items
+            int itemIndex = 0;
             foreach ((var oldItem, _) in previousTable)
             {
                 if (itemsSet.Remove(oldItem))
@@ -56,10 +57,21 @@ namespace Microsoft.CodeAnalysis
                     var usedCache = builder.TryUseCachedEntries();
                     Debug.Assert(usedCache);
                 }
+                else if (inputItems.Length == previousTable.Count)
+                {
+                    // When the number of items matches the previous iteration, we use a heuristic to mark the input as modified
+                    // This allows us to correctly 'replace' items even that aren't actually the same. In the case that the item 
+                    // really isn't modified, but a new item, we still function correctly as we mostly treat them the same, but
+                    // will perform an extra comparison that is ommitted in the pure 'added' case.
+                    var modified = builder.TryModifyEntry(inputItems[itemIndex], _comparer);
+                    Debug.Assert(modified);
+                    itemsSet.Remove(inputItems[itemIndex]);
+                }
                 else
                 {
                     builder.RemoveEntries();
                 }
+                itemIndex++;
             }
 
             // any remaining new items are added


### PR DESCRIPTION
Adds a hueristic that allows us to treat replaced inputs as modified when the number of items match.

This has no correctness impact, but improves the perf when replacing individual inputs.