### PR TITLE
Query workspace for active document when we are not passed a project context in an LSP request

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return documents.FindDocumentInProjectContext(documentIdentifier);
         }
 
-        public static T FindDocumentInProjectContext<T>(this ImmutableArray<T> documents, TextDocumentIdentifier documentIdentifier) where T : TextDocument
+        public static Document FindDocumentInProjectContext(this ImmutableArray<Document> documents, TextDocumentIdentifier documentIdentifier)
         {
             if (documents.Length > 1)
             {
@@ -108,16 +108,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                     // We were not passed a project context.  This can happen when the LSP powered NavBar is not enabled.
                     // This branch should be removed when we're using the LSP based navbar in all scenarios.
 
-                    // Lookup the active document and determine if any of the documents from the request URI match.
                     var solution = documents.First().Project.Solution;
-                    var service = solution.Workspace.Services.GetRequiredService<IDocumentTrackingService>();
-
-                    var activeDocument = service.GetActiveDocument(solution);
-                    var matchingDocument = documents.FirstOrDefault(d => d.Id == activeDocument?.Id);
-                    if (matchingDocument != null)
-                    {
-                        return matchingDocument;
-                    }
+                    // Lookup which of the linked documents is currently active in the workspace.
+                    var documentIdInCurrentContext = solution.Workspace.GetDocumentIdInCurrentContext(documents.First().Id);
+                    return solution.GetRequiredDocument(documentIdInCurrentContext);
                 }
             }
 

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -93,17 +93,30 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             if (documents.Length > 1)
             {
                 // We have more than one document; try to find the one that matches the right context
-                if (documentIdentifier is VSTextDocumentIdentifier vsDocumentIdentifier)
+                if (documentIdentifier is VSTextDocumentIdentifier vsDocumentIdentifier && vsDocumentIdentifier.ProjectContext != null)
                 {
-                    if (vsDocumentIdentifier.ProjectContext != null)
-                    {
-                        var projectId = ProtocolConversions.ProjectContextToProjectId(vsDocumentIdentifier.ProjectContext);
-                        var matchingDocument = documents.FirstOrDefault(d => d.Project.Id == projectId);
+                    var projectId = ProtocolConversions.ProjectContextToProjectId(vsDocumentIdentifier.ProjectContext);
+                    var matchingDocument = documents.FirstOrDefault(d => d.Project.Id == projectId);
 
-                        if (matchingDocument != null)
-                        {
-                            return matchingDocument;
-                        }
+                    if (matchingDocument != null)
+                    {
+                        return matchingDocument;
+                    }
+                }
+                else
+                {
+                    // We were not passed a project context.  This can happen when the LSP powered NavBar is not enabled.
+                    // This branch should be removed when we're using the LSP based navbar in all scenarios.
+
+                    // Lookup the active document and determine if any of the documents from the request URI match.
+                    var solution = documents.First().Project.Solution;
+                    var service = solution.Workspace.Services.GetRequiredService<IDocumentTrackingService>();
+
+                    var activeDocument = service.GetActiveDocument(solution);
+                    var matchingDocument = documents.FirstOrDefault(d => d.Id == activeDocument?.Id);
+                    if (matchingDocument != null)
+                    {
+                        return matchingDocument;
                     }
                 }
             }


### PR DESCRIPTION
In only-LSP scenarios, LSP determines the project context when the LSP navbar is active.  LSP is able to handle dropdownbar events, query the server for all project contexts, and then handle selection events when the user switches the context.

However, we are not able to enable the LSP NavBar in classic scenarios due to missing features (code generation, multiple ranges, missing icons, etc).   So for LSP pull diagnostics in classic, the LSP client does not know which project context is active as Roslyn is handling all NavBar integration (outside of LSP).   Per conversations with the editor, the lsp client is not easily able to query for the active dropdown and convert that result into the project context needed to pass with LSP pull diagnostics requests.

The result of this issue is that LSP pull diagnostics currently does not return errors for the correct context.  It arbitrarily picks the first project context ( can result in incorrect squiggles).  To temporarily solve this issue, we can query the workspace for the document in the current context.

I am also in favor of blocking enabling additional LSP features in classic scenarios on full LSP navbar support.  This should only be used for the diagnostics experiment.

