### PR TITLE
EnC: Check member modifier updates in semantic analysis

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -1867,7 +1867,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1", FeaturesResources.const_field));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "a = 1", FeaturesResources.const_field));
         }
 
         [Fact]
@@ -1917,7 +1917,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1, b = 2", FeaturesResources.const_field));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "a = 1", FeaturesResources.const_field));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
@@ -33,6 +34,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             Iterator,
             ConstructorWithParameters
         }
+
+        public static string GetResource(string keyword)
+            => keyword switch
+            {
+                "class" => FeaturesResources.class_,
+                "struct" => CSharpFeaturesResources.struct_,
+                "interface" => FeaturesResources.interface_,
+                "record" => CSharpFeaturesResources.record_,
+                "record struct" => CSharpFeaturesResources.record_struct,
+                _ => throw ExceptionUtilities.UnexpectedValue(keyword)
+            };
 
         internal static SemanticEditDescription[] NoSemanticEdits = Array.Empty<SemanticEditDescription>();
 

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -24,11 +24,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
     internal abstract class EditAndContinueTestHelpers
     {
         public static readonly EditAndContinueCapabilities BaselineCapabilities = EditAndContinueCapabilities.Baseline;
-        public static readonly EditAndContinueCapabilities Net5RuntimeCapabilities = EditAndContinueCapabilities.Baseline |
-                                                                                     EditAndContinueCapabilities.AddInstanceFieldToExistingType |
-                                                                                     EditAndContinueCapabilities.AddStaticFieldToExistingType |
-                                                                                     EditAndContinueCapabilities.AddMethodToExistingType |
-                                                                                     EditAndContinueCapabilities.NewTypeDefinition;
+
+        public static readonly EditAndContinueCapabilities Net5RuntimeCapabilities =
+            EditAndContinueCapabilities.Baseline |
+            EditAndContinueCapabilities.AddInstanceFieldToExistingType |
+            EditAndContinueCapabilities.AddStaticFieldToExistingType |
+            EditAndContinueCapabilities.AddMethodToExistingType |
+            EditAndContinueCapabilities.NewTypeDefinition;
+
+        public static readonly EditAndContinueCapabilities Net6RuntimeCapabilities =
+            Net5RuntimeCapabilities |
+            EditAndContinueCapabilities.ChangeCustomAttributes;
 
         public abstract AbstractEditAndContinueAnalyzer Analyzer { get; }
         public abstract SyntaxNode FindNode(SyntaxNode root, TextSpan span);

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -1945,7 +1945,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1", FeaturesResources.const_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "a As Integer = 1", FeaturesResources.const_field))
         End Sub
 
         <Fact>
@@ -1990,7 +1990,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1, b As Integer = 2", FeaturesResources.const_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "a As Integer = 1", FeaturesResources.const_field))
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
@@ -29,6 +29,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Iterator
         End Enum
 
+        Public Shared Function GetResource(keyword As String) As String
+            Select Case keyword
+                Case "Class"
+                    Return FeaturesResources.class_
+                Case "Structure"
+                    Return VBFeaturesResources.structure_
+                Case "Module"
+                    Return VBFeaturesResources.module_
+                Case "Interface"
+                    Return FeaturesResources.interface_
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(keyword)
+            End Select
+        End Function
+
         Friend Shared NoSemanticEdits As SemanticEditDescription() = Array.Empty(Of SemanticEditDescription)
 
         Friend Overloads Shared Function Diagnostic(rudeEditKind As RudeEditKind, squiggle As String, ParamArray arguments As String()) As RudeEditDiagnosticDescription

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -4299,7 +4299,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingVisibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
+                Diagnostic(RudeEditKind.ChangingAccessibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
         End Sub
 
         <Fact>
@@ -4411,7 +4411,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingVisibility, visibility & " Sub New()", FeaturesResources.constructor))
+                Diagnostic(RudeEditKind.ChangingAccessibility, visibility & " Sub New()", FeaturesResources.constructor))
         End Sub
 
         <Fact>
@@ -6780,7 +6780,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingVisibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
+                Diagnostic(RudeEditKind.ChangingAccessibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
         End Sub
 
         <Fact>
@@ -6790,7 +6790,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangingVisibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
+                Diagnostic(RudeEditKind.ChangingAccessibility, "Class C", DeletedSymbolDisplay(FeaturesResources.constructor, "New()")))
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -282,51 +282,6 @@ Option Strict Off
 
 #Region "Attributes"
         <Fact>
-        Public Sub UpdateAttributes1()
-            Dim attribute = "Public Class A1Attribute : Inherits System.Attribute : End Class" & vbCrLf &
-                            "Public Class A2Attribute : Inherits System.Attribute : End Class" & vbCrLf
-
-            Dim src1 = attribute & "<A1>Class C : End Class"
-            Dim src2 = attribute & "<A2>Class C : End Class"
-
-            Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits(
-                "Update [<A1>Class C]@132 -> [<A2>Class C]@132")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "Class C", FeaturesResources.class_))
-        End Sub
-
-        <Fact>
-        Public Sub UpdateAttributes2()
-            Dim src1 = "<System.Obsolete(""1"")>Class C : End Class"
-            Dim src2 = "<System.Obsolete(""2"")>Class C : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [<System.Obsolete(""1"")>Class C]@0 -> [<System.Obsolete(""2"")>Class C]@0")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "Class C", FeaturesResources.class_))
-        End Sub
-
-        <Fact>
-        Public Sub UpdateAttributes3()
-            Dim attribute = "Public Class A1Attribute : Inherits System.Attribute : End Class" & vbCrLf &
-                            "Public Class A2Attribute : Inherits System.Attribute : End Class" & vbCrLf
-
-            Dim src1 = attribute & "<A1>Module C : End Module"
-            Dim src2 = attribute & "<A2>Module C : End Module"
-
-            Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits(
-                "Update [<A1>Module C]@132 -> [<A2>Module C]@132")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "Module C", VBFeaturesResources.module_))
-        End Sub
-
-        <Fact>
         Public Sub UpdateAttributes_TopLevel1()
             Dim src1 = "<Assembly: A(1)>"
             Dim src2 = "<Assembly: A(2)>"
@@ -472,7 +427,183 @@ Option Strict Off
 
 #End Region
 
-#Region "Top-level Classes, Structs, Interfaces, Modules"
+#Region "Types"
+        <Theory>
+        <InlineData("Class", "Structure")>
+        <InlineData("Class", "Module")>
+        <InlineData("Class", "Interface")>
+        Public Sub Type_Kind_Update(oldKeyword As String, newKeyword As String)
+            Dim src1 = oldKeyword & " C : End " & oldKeyword
+            Dim src2 = newKeyword & " C : End " & newKeyword
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeKindUpdate, newKeyword & " C"))
+        End Sub
+
+        <Theory>
+        <InlineData("Public")>
+        Public Sub Type_Modifiers_Accessibility_Change(accessibility As String)
+
+            Dim src1 = accessibility + " Class C : End Class"
+            Dim src2 = "Class C : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [" + accessibility + " Class C]@0 -> [Class C]@0")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ChangingAccessibility, "Class C", FeaturesResources.class_))
+        End Sub
+
+        <Theory>
+        <InlineData("Public", "Public")>
+        <InlineData("Friend", "Friend")>
+        <InlineData("", "Friend")>
+        <InlineData("Friend", "")>
+        <InlineData("Protected", "Protected")>
+        <InlineData("Private", "Private")>
+        <InlineData("Private Protected", "Private Protected")>
+        <InlineData("Friend Protected", "Friend Protected")>
+        Public Sub Type_Modifiers_Accessibility_Partial(accessibilityA As String, accessibilityB As String)
+
+            Dim srcA1 = accessibilityA + " Partial Class C : End Class"
+            Dim srcB1 = "Partial Class C : End Class"
+            Dim srcA2 = "Partial Class C : End Class"
+            Dim srcB2 = accessibilityB + " Partial Class C : End Class"
+
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                })
+        End Sub
+
+        <Theory>
+        <InlineData("Class")>
+        <InlineData("Structure")>
+        <InlineData("Module")>
+        <InlineData("Interface")>
+        Public Sub Type_Modifiers_Friend_Remove(keyword As String)
+            Dim src1 = "Friend " & keyword & " C : End " & keyword
+            Dim src2 = keyword & " C : End " & keyword
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemantics()
+        End Sub
+
+        <Theory>
+        <InlineData("Class")>
+        <InlineData("Structure")>
+        <InlineData("Module")>
+        <InlineData("Interface")>
+        Public Sub Type_Modifiers_Friend_Add(keyword As String)
+            Dim src1 = keyword & " C : End " & keyword
+            Dim src2 = "Friend " & keyword & " C : End " & keyword
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemantics()
+        End Sub
+
+        <Theory>
+        <InlineData("Class")>
+        <InlineData("Structure")>
+        <InlineData("Interface")>
+        Public Sub Type_Modifiers_NestedPrivateInInterface_Remove(keyword As String)
+            Dim src1 = "Interface C : Private " & keyword & " S : End " & keyword & " : End Interface"
+            Dim src2 = "Interface C : " & keyword & " S : End " & keyword & " : End Interface"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ChangingAccessibility, keyword + " S", GetResource(keyword)))
+        End Sub
+
+        <Theory>
+        <InlineData("Class")>
+        <InlineData("Structure")>
+        <InlineData("Interface")>
+        Public Sub Type_Modifiers_NestedPublicInClass_Add(keyword As String)
+            Dim src1 = "Class C : " & keyword & " S : End " & keyword & " : End Class"
+            Dim src2 = "Class C : Public " & keyword & " S : End " & keyword & " : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemantics()
+        End Sub
+
+        <Theory>
+        <InlineData("Class")>
+        <InlineData("Structure")>
+        <InlineData("Interface")>
+        Public Sub Type_Modifiers_NestedPublicInInterface_Add(keyword As String)
+            Dim src1 = "Interface I : " + keyword + " S : End " & keyword & " : End Interface"
+            Dim src2 = "Interface I : Public " + keyword + " S : End " & keyword & " : End Interface"
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemantics()
+        End Sub
+
+        <Fact>
+        Public Sub Type_Attribute_Update_NotSupportedByRuntime1()
+            Dim attribute = "Public Class A1Attribute : Inherits System.Attribute : End Class" & vbCrLf &
+                            "Public Class A2Attribute : Inherits System.Attribute : End Class" & vbCrLf
+
+            Dim src1 = attribute & "<A1>Class C : End Class"
+            Dim src2 = attribute & "<A2>Class C : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyEdits(
+                "Update [<A1>Class C]@132 -> [<A2>Class C]@132")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "Class C", FeaturesResources.class_))
+        End Sub
+
+        <Theory>
+        <InlineData("Module")>
+        <InlineData("Class")>
+        <InlineData("Structure")>
+        <InlineData("Interface")>
+        Public Sub Type_Attribute_Update_NotSupportedByRuntime(keyword As String)
+            Dim src1 = "<System.Obsolete(""1"")>" & keyword & " C : End " & keyword
+            Dim src2 = "<System.Obsolete(""2"")>" & keyword & " C : End " & keyword
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [<System.Obsolete(""1"")>" & keyword & " C]@0 -> [<System.Obsolete(""2"")>" & keyword & " C]@0")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, keyword & " C", GetResource(keyword)))
+        End Sub
+
+        <Theory>
+        <InlineData("Module")>
+        <InlineData("Class")>
+        <InlineData("Structure")>
+        <InlineData("Interface")>
+        Public Sub Type_PartialModifier_Add(keyword As String)
+            Dim src1 = keyword & " C : End " & keyword
+            Dim src2 = "Partial " & keyword & " C : End " & keyword
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [" & keyword & " C]@0 -> [Partial " & keyword & " C]@0")
+
+            edits.VerifyRudeDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub Module_PartialModifier_Remove()
+            Dim src1 = "Partial Module C : End Module"
+            Dim src2 = "Module C : End Module"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [Partial Module C]@0 -> [Module C]@0")
+
+            edits.VerifyRudeDiagnostics()
+        End Sub
+
         <Fact>
         Public Sub ClassInsert()
             Dim src1 = ""
@@ -541,108 +672,6 @@ Option Strict Off
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Delete, Nothing, DeletedSymbolDisplay(VBFeaturesResources.module_, "C")))
-        End Sub
-
-        <Fact>
-        Public Sub TypeKindChange1()
-            Dim src1 = "Class C : End Class"
-            Dim src2 = "Structure C : End Structure"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Class C : End Class]@0 -> [Structure C : End Structure]@0",
-                "Update [Class C]@0 -> [Structure C]@0")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeKindUpdate, "Structure C", VBFeaturesResources.structure_))
-        End Sub
-
-        <Fact>
-        Public Sub TypeKindChange2()
-            Dim src1 = "Public Module C : End Module"
-            Dim src2 = "Public Class C : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Public Module C : End Module]@0 -> [Public Class C : End Class]@0",
-                "Update [Public Module C]@0 -> [Public Class C]@0")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeKindUpdate, "Public Class C", FeaturesResources.class_))
-        End Sub
-
-        <Fact>
-        Public Sub ModuleModifiersUpdate()
-            Dim src1 = "Module C : End Module"
-            Dim src2 = "Partial Module C : End Module"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Module C]@0 -> [Partial Module C]@0")
-
-            edits.VerifyRudeDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub ModuleModifiersUpdate2()
-            Dim src1 = "Partial Module C : End Module"
-            Dim src2 = "Module C : End Module"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Partial Module C]@0 -> [Module C]@0")
-
-            edits.VerifyRudeDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub InterfaceModifiersUpdate()
-            Dim src1 = "Public Interface C : End Interface"
-            Dim src2 = "Interface C : End Interface"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Public Interface C]@0 -> [Interface C]@0")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Interface C", FeaturesResources.interface_))
-        End Sub
-
-        <Fact>
-        Public Sub InterfaceModifiersUpdate2()
-            Dim src1 = "Public Interface C : Sub Goo() : End Interface"
-            Dim src2 = "Interface C : Sub Goo() : End Interface"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Public Interface C]@0 -> [Interface C]@0")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Interface C", FeaturesResources.interface_))
-        End Sub
-
-        <Fact>
-        Public Sub InterfaceModifiersUpdate3()
-            Dim src1 = "Interface C : Sub Goo() : End Interface"
-            Dim src2 = "Partial Interface C : Sub Goo() : End Interface"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Interface C]@0 -> [Partial Interface C]@0")
-
-            edits.VerifyRudeDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub StructModifiersUpdate()
-            Dim src1 = "Structure C : End Structure"
-            Dim src2 = "Public Structure C : End Structure"
-
-            Dim edits = GetTopEdits(src1, src2)
-            edits.VerifyEdits("Update [Structure C]@0 -> [Public Structure C]@0")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Public Structure C", VBFeaturesResources.structure_))
         End Sub
 
         <Fact>
@@ -872,7 +901,11 @@ End Interface
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
                 {
                     DocumentResults(),
-                    DocumentResults()
+                    DocumentResults(semanticEdits:=
+                    {
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("I.VirtualMethod")),
+                        SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("I.VirtualFunction"))
+                    })
                 })
         End Sub
 
@@ -1102,7 +1135,8 @@ Delegate Sub D()
                         {
                             SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("F")),
                             SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("M").GetMember("F")),
-                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("S").GetMember("F"))
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("S").GetMember("F")),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("I").GetMember("F"))
                         })
                 })
         End Sub
@@ -1177,9 +1211,11 @@ End Interface
                     DocumentResults(
                         semanticEdits:=
                         {
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("AbstractMethod")),
                             SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("VirtualMethod")),
                             SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("ToString")),
-                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("IG"))
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("IG")),
+                            SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("I").GetMember("G"))
                         })
                 })
         End Sub
@@ -1313,7 +1349,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub Enum_Modifiers_Update()
+        Public Sub Enum_Accessibility_Change()
             Dim src1 = "Public Enum Color : Red = 1 : Blue = 2 : End Enum"
             Dim src2 = "Enum Color : Red = 1 : Blue = 2 : End Enum"
             Dim edits = GetTopEdits(src1, src2)
@@ -1322,7 +1358,19 @@ End Class
                 "Update [Public Enum Color]@0 -> [Enum Color]@0")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Enum Color", FeaturesResources.enum_))
+                Diagnostic(RudeEditKind.ChangingAccessibility, "Enum Color", FeaturesResources.enum_))
+        End Sub
+
+        <Fact>
+        Public Sub Enum_Accessibility_NoChange()
+            Dim src1 = "Friend Enum Color : Red = 1 : Blue = 2 : End Enum"
+            Dim src2 = "Enum Color : Red = 1 : Blue = 2 : End Enum"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [Friend Enum Color]@0 -> [Enum Color]@0")
+
+            edits.VerifySemantics()
         End Sub
 
         <Fact>
@@ -1581,7 +1629,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub Delegates_Update_Modifiers()
+        Public Sub Delegates_Accessibility_Update()
             Dim src1 = "Public Delegate Sub D()"
             Dim src2 = "Private Delegate Sub D()"
             Dim edits = GetTopEdits(src1, src2)
@@ -1590,7 +1638,7 @@ End Class
                 "Update [Public Delegate Sub D()]@0 -> [Private Delegate Sub D()]@0")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Delegate Sub D()", FeaturesResources.delegate_))
+                Diagnostic(RudeEditKind.ChangingAccessibility, "Private Delegate Sub D()", FeaturesResources.delegate_))
         End Sub
 
         <Fact>
@@ -2969,6 +3017,98 @@ End Class"
 #End Region
 
 #Region "Methods"
+        <Theory>
+        <InlineData("Shared")>
+        <InlineData("Overridable")>
+        <InlineData("Overrides")>
+        <InlineData("NotOverridable Overrides", "Overrides")>
+        Public Sub Method_Modifiers_Update(oldModifiers As String, Optional newModifiers As String = "")
+            If oldModifiers <> "" Then
+                oldModifiers &= " "
+            End If
+
+            If newModifiers <> "" Then
+                newModifiers &= " "
+            End If
+
+            Dim src1 = "Class C" & vbCrLf & oldModifiers & "Sub F() : End Sub : End Class"
+            Dim src2 = "Class C" & vbCrLf & newModifiers & "Sub F() : End Sub : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [" & oldModifiers & "Sub F() : End Sub]@9 -> [" & newModifiers & "Sub F() : End Sub]@9",
+                "Update [" & oldModifiers & "Sub F()]@9 -> [" & newModifiers & "Sub F()]@9")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "Sub F()", FeaturesResources.method))
+        End Sub
+
+        <Fact>
+        Public Sub Method_MustOverrideModifier_Update()
+            Dim src1 = "Class C" & vbCrLf & "MustOverride Sub F() : End Class"
+            Dim src2 = "Class C" & vbCrLf & "Sub F() : End Sub : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Sub F()", FeaturesResources.method))
+        End Sub
+
+        <Theory>
+        <InlineData("Shadows")>
+        <InlineData("Overloads")>
+        Public Sub Method_Modifiers_Update_NoImpact(oldModifiers As String, Optional newModifiers As String = "")
+            If oldModifiers <> "" Then
+                oldModifiers &= " "
+            End If
+
+            If newModifiers <> "" Then
+                newModifiers &= " "
+            End If
+
+            Dim src1 = "Class C " & vbLf & oldModifiers & "Sub F() : End Sub : End Class"
+            Dim src2 = "Class C " & vbLf & newModifiers & "Sub F() : End Sub : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [" & oldModifiers & "Sub F() : End Sub]@9 -> [" & newModifiers & "Sub F() : End Sub]@9",
+                "Update [" & oldModifiers & "Sub F()]@9 -> [" & newModifiers & "Sub F()]@9")
+
+            ' Currently, an edit is produced eventhough there is no metadata/IL change. Consider improving.
+            edits.VerifySemantics(
+                semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember(Of MethodSymbol)("F"))})
+        End Sub
+
+        <Fact>
+        Public Sub Method_AsyncModifier_Add()
+            Dim src1 = "Class C : " & vbLf & "Function F() As Task(Of String) : End Function : End Class"
+            Dim src2 = "Class C : " & vbLf & "Async Function F() As Task(Of String) : End Function : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [Function F() As Task(Of String) : End Function]@11 -> [Async Function F() As Task(Of String) : End Function]@11",
+                "Update [Function F() As Task(Of String)]@11 -> [Async Function F() As Task(Of String)]@11")
+
+            edits.VerifyRudeDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub Method_AsyncModifier_Remove()
+            Dim src1 = "Class C : " & vbLf & "Async Function F() As Task(Of String) : End Function : End Class"
+            Dim src2 = "Class C : " & vbLf & "Function F() As Task(Of String) : End Function : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [Async Function F() As Task(Of String) : End Function]@11 -> [Function F() As Task(Of String) : End Function]@11",
+                "Update [Async Function F() As Task(Of String)]@11 -> [Function F() As Task(Of String)]@11")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "Function F()", FeaturesResources.method))
+        End Sub
 
         <Fact>
         Public Sub MethodUpdate1()
@@ -3314,35 +3454,6 @@ Imports System.Runtime.InteropServices
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Renamed, "Sub Bar", FeaturesResources.method))
-        End Sub
-
-        <Fact>
-        Public Sub MethodUpdate_AsyncModifier1()
-            Dim src1 = "Class C : " & vbLf & "Function F() As Task(Of String) : End Function : End Class"
-            Dim src2 = "Class C : " & vbLf & "Async Function F() As Task(Of String) : End Function : End Class"
-
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Function F() As Task(Of String) : End Function]@11 -> [Async Function F() As Task(Of String) : End Function]@11",
-                "Update [Function F() As Task(Of String)]@11 -> [Async Function F() As Task(Of String)]@11")
-
-            edits.VerifyRudeDiagnostics()
-        End Sub
-
-        <Fact>
-        Public Sub MethodUpdate_AsyncModifier2()
-            Dim src1 = "Class C : " & vbLf & "Async Function F() As Task(Of String) : End Function : End Class"
-            Dim src2 = "Class C : " & vbLf & "Function F() As Task(Of String) : End Function : End Class"
-
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Async Function F() As Task(Of String) : End Function]@11 -> [Function F() As Task(Of String) : End Function]@11",
-                "Update [Async Function F() As Task(Of String)]@11 -> [Function F() As Task(Of String)]@11")
-
-            edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "Function F()", FeaturesResources.method))
         End Sub
 
         <Fact>
@@ -3943,19 +4054,14 @@ End Class
             Dim srcA2 = "Partial Class C" + vbCrLf + "Private Sub F() : End Sub : End Class"
             Dim srcB2 = "Partial Class C" + vbCrLf + "Partial Private Sub F() : End Sub : End Class"
 
-            ' TODO: current
-            GetTopEdits(srcA1, srcA2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.ModifiersUpdate, "Private Sub F()", FeaturesResources.method))
-            GetTopEdits(srcB1, srcB2).VerifyRudeDiagnostics(Diagnostic(RudeEditKind.ModifiersUpdate, "Partial Private Sub F()", FeaturesResources.method))
-
-            ' TODO: correct 
-            ' EditAndContinueValidation.VerifySemantics(
-            '      { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
-            '     
-            '     {
-            '         DocumentResults(),
-            '         DocumentResults(
-            '             semanticEdits:= { SemanticEdit(SemanticEditKind.Update, c => c.GetMember(Of NamedTypeSymbol)("C").GetMember("F")) }),
-            '     });
+            ' TODO: should be an update edit since the location of the implementation changed
+            ' semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("F"))}
+            EditAndContinueValidation.VerifySemantics(
+                {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
+                {
+                    DocumentResults(),
+                    DocumentResults()
+                })
         End Sub
 
         <Fact>
@@ -4034,6 +4140,21 @@ End Class
 #End Region
 
 #Region "Operators"
+
+        <Theory>
+        <InlineData("Narrowing", "Widening")>
+        <InlineData("Widening", "Narrowing")>
+        Public Sub Operator_Modifiers_Update(oldModifiers As String, newModifiers As String)
+            Dim src1 = "Class C" & vbCrLf & "Public Shared " & oldModifiers & " Operator CType(d As C) As Integer : End Operator : End Class"
+            Dim src2 = "Class C" & vbCrLf & "Public Shared " & newModifiers & " Operator CType(d As C) As Integer : End Operator : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits("Update [Public Shared " + oldModifiers + " Operator CType(d As C) As Integer]@9 -> [Public Shared " + newModifiers + " Operator CType(d As C) As Integer]@9")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Public Shared " & newModifiers & " Operator CType(d As C)", FeaturesResources.operator_))
+        End Sub
 
         <Fact>
         Public Sub OperatorInsert()
@@ -4535,7 +4656,7 @@ End Class
                 {
                     DocumentResults(),
                     DocumentResults(
-                        diagnostics:={Diagnostic(RudeEditKind.ModifiersUpdate, "Public Sub New()", FeaturesResources.constructor)})
+                        diagnostics:={Diagnostic(RudeEditKind.ChangingAccessibility, "Public Sub New()", FeaturesResources.constructor)})
                 })
         End Sub
 
@@ -4656,7 +4777,7 @@ End Class
         <InlineData("")>
         <InlineData("Friend")>
         <InlineData("Public")>
-        Public Sub InstanceCtor_Partial_VisibilityUpdate(visibility As String)
+        Public Sub InstanceCtor_Partial_AccessibilityUpdate(visibility As String)
             If visibility.Length > 0 Then
                 visibility &= " "
             End If
@@ -4672,7 +4793,7 @@ End Class
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
                 {
                     DocumentResults(
-                        diagnostics:={Diagnostic(RudeEditKind.ModifiersUpdate, visibility & "Sub New()", FeaturesResources.constructor)}),
+                        diagnostics:={Diagnostic(RudeEditKind.ChangingAccessibility, visibility & "Sub New()", FeaturesResources.constructor)}),
                     DocumentResults()
                 })
         End Sub
@@ -5318,12 +5439,35 @@ End Class
                 {GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2)},
                 {
                     DocumentResults(),
-                    DocumentResults()
+                    DocumentResults(semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("M.ExternSub"))})
                 })
         End Sub
 #End Region
 
 #Region "Fields"
+        <Theory>
+        <InlineData("Shared")>
+        <InlineData("Const")>
+        Public Sub Field_Modifiers_Update(oldModifiers As String, Optional newModifiers As String = "")
+            If oldModifiers <> "" Then
+                oldModifiers &= " "
+            End If
+
+            If newModifiers <> "" Then
+                newModifiers &= " "
+            End If
+
+            Dim src1 = "Class C : " & oldModifiers & "Dim F As Integer = 0 : End Class"
+            Dim src2 = "Class C : " & newModifiers & "Dim F As Integer = 0 : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits("Update [" & oldModifiers & "Dim F As Integer = 0]@10 -> [" & newModifiers & "Dim F As Integer = 0]@10")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "F As Integer = 0", FeaturesResources.field))
+        End Sub
+
         <Fact>
         Public Sub FieldUpdate_Rename1()
             Dim src1 = "Class C : Dim a As Integer = 0 : End Class"
@@ -5633,7 +5777,7 @@ End Class
                 "Update [Dim a As WE]@10 -> [WithEvents a As WE]@10")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "WithEvents a As WE", VBFeaturesResources.WithEvents_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "a As WE", VBFeaturesResources.WithEvents_field))
         End Sub
 
         <Fact>
@@ -5646,7 +5790,7 @@ End Class
                 "Update [WithEvents a As WE]@10 -> [Dim a As WE]@10")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Dim a As WE", FeaturesResources.field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "a As WE", FeaturesResources.field))
         End Sub
 
         <Fact>
@@ -6120,6 +6264,42 @@ End Class
 #End Region
 
 #Region "Properties"
+        <Theory>
+        <InlineData("Shared")>
+        <InlineData("Overridable")>
+        <InlineData("Overrides")>
+        <InlineData("NotOverridable Overrides", "Overrides")>
+        Public Sub Property_Modifiers_Update(oldModifiers As String, Optional newModifiers As String = "")
+            If oldModifiers <> "" Then
+                oldModifiers &= " "
+            End If
+
+            If newModifiers <> "" Then
+                newModifiers &= " "
+            End If
+
+            Dim src1 = "Class C" & vbLf & oldModifiers & "ReadOnly Property F As Integer" & vbLf & "Get" & vbLf & "Return 1 : End Get : End Property : End Class"
+            Dim src2 = "Class C" & vbLf & newModifiers & "ReadOnly Property F As Integer" & vbLf & "Get" & vbLf & "Return 1 : End Get : End Property : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits("Update [" & oldModifiers & "ReadOnly Property F As Integer]@8 -> [" & newModifiers & "ReadOnly Property F As Integer]@8")
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "ReadOnly Property F", FeaturesResources.property_))
+        End Sub
+
+        <Fact>
+        Public Sub Property_MustOverrideModifier_Update()
+            Dim src1 = "Class C" & vbLf & "ReadOnly MustOverride Property F As Integer" & vbLf & "End Class"
+            Dim src2 = "Class C" & vbLf & "ReadOnly Property F As Integer" & vbLf & "Get" & vbLf & "Return 1 : End Get : End Property : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ReadOnly Property F", FeaturesResources.property_))
+        End Sub
+
         <Fact>
         Public Sub PropertyReorder1()
             Dim src1 = "Class C : ReadOnly Property P" & vbLf & "Get" & vbLf & "Return 1 : End Get : End Property : " &
@@ -7563,7 +7743,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Dim x = 0", FeaturesResources.field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "x = 0", FeaturesResources.field))
         End Sub
 
         <Fact>
@@ -7573,7 +7753,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Const x = 0", FeaturesResources.const_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "x = 0", FeaturesResources.const_field))
         End Sub
 
         <Fact>
@@ -8316,6 +8496,47 @@ End Class
 #End Region
 
 #Region "Events"
+
+        <Theory>
+        <InlineData("Shared")>
+        Public Sub Event_Modifiers_Update(oldModifiers As String, Optional newModifiers As String = "")
+            If oldModifiers <> "" Then
+                oldModifiers &= " "
+            End If
+
+            If newModifiers <> "" Then
+                newModifiers &= " "
+            End If
+
+            Dim src1 = "
+Class C
+   " & oldModifiers & " Custom Event E As Action
+    AddHandler(value As Action)
+    End AddHandler
+    RemoveHandler(value As Action)
+    End RemoveHandler
+    RaiseEvent()
+    End RaiseEvent
+  End Event
+End Class"
+
+            Dim src2 = "
+Class C
+   " & newModifiers & " Custom Event E As Action
+    AddHandler(value As Action)
+    End AddHandler
+    RemoveHandler(value As Action)
+    End RemoveHandler
+    RaiseEvent()
+    End RaiseEvent
+  End Event
+End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "Event E", FeaturesResources.event_))
+        End Sub
 
         <Fact>
         Public Sub EventAccessorReorder1()

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1181,7 +1181,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     Contract.ThrowIfNull(oldNode);
                     Contract.ThrowIfNull(newNode);
 
-                    // Either old or new property/indexer has an expression body (or both do).
+                    // Certain updates of a property/indexer node affects its accessors.
+                    // Return all affected symbols for these updates.
+
+                    // 1) Old or new property/indexer has an expression body:
                     //   int this[...] => expr;
                     //   int this[...] { get => expr; }
                     //   int P => expr;
@@ -1197,6 +1200,36 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                         return OneOrMany.Create(ImmutableArray.Create((oldSymbol, newSymbol), (oldGetterSymbol, newGetterSymbol)));
                     }
+
+                    // 2) Property/indexer declarations differ in readonly keyword.
+                    if (oldNode is PropertyDeclarationSyntax oldProperty && newNode is PropertyDeclarationSyntax newProperty && DiffersInReadOnlyModifier(oldProperty.Modifiers, newProperty.Modifiers) ||
+                        oldNode is IndexerDeclarationSyntax oldIndexer && newNode is IndexerDeclarationSyntax newIndexer && DiffersInReadOnlyModifier(oldIndexer.Modifiers, newIndexer.Modifiers))
+                    {
+                        Debug.Assert(oldSymbol is IPropertySymbol);
+                        Debug.Assert(newSymbol is IPropertySymbol);
+
+                        var oldPropertySymbol = (IPropertySymbol)oldSymbol;
+                        var newPropertySymbol = (IPropertySymbol)newSymbol;
+
+                        using var _ = ArrayBuilder<(ISymbol?, ISymbol?)>.GetInstance(out var builder);
+
+                        builder.Add((oldPropertySymbol, newPropertySymbol));
+
+                        if (oldPropertySymbol.GetMethod != null && newPropertySymbol.GetMethod != null && oldPropertySymbol.GetMethod.IsReadOnly != newPropertySymbol.GetMethod.IsReadOnly)
+                        {
+                            builder.Add((oldPropertySymbol.GetMethod, newPropertySymbol.GetMethod));
+                        }
+
+                        if (oldPropertySymbol.SetMethod != null && newPropertySymbol.SetMethod != null && oldPropertySymbol.SetMethod.IsReadOnly != newPropertySymbol.SetMethod.IsReadOnly)
+                        {
+                            builder.Add((oldPropertySymbol.SetMethod, newPropertySymbol.SetMethod));
+                        }
+
+                        return OneOrMany.Create(builder.ToImmutable());
+                    }
+
+                    static bool DiffersInReadOnlyModifier(SyntaxTokenList oldModifiers, SyntaxTokenList newModifiers)
+                        => (oldModifiers.IndexOf(SyntaxKind.ReadOnlyKeyword) >= 0) != (newModifiers.IndexOf(SyntaxKind.ReadOnlyKeyword) >= 0);
 
                     break;
 
@@ -2603,13 +2636,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                // Allow partial keyword to be added or removed.
-                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.PartialKeyword, ignore2: SyntaxKind.UnsafeKeyword))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier))
                 {
                     ReportError(RudeEditKind.Renamed);
@@ -2630,12 +2656,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                if (!SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.BaseList, newNode.BaseList))
                 {
                     ReportError(RudeEditKind.EnumUnderlyingTypeUpdate);
@@ -2648,12 +2668,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(DelegateDeclarationSyntax oldNode, DelegateDeclarationSyntax newNode)
             {
-                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.UnsafeKeyword))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.ReturnType, newNode.ReturnType))
                 {
                     ReportError(RudeEditKind.TypeUpdate);
@@ -2671,12 +2685,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 if (oldNode.Kind() != newNode.Kind())
                 {
                     ReportError(RudeEditKind.FieldKindUpdate);
-                    return;
-                }
-
-                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.UnsafeKeyword))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
                     return;
                 }
             }
@@ -2737,13 +2745,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                // Ignore async keyword when matching modifiers. Async checks are done in ComputeBodyMatch.
-                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.AsyncKeyword, ignore2: SyntaxKind.UnsafeKeyword))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.ReturnType, newNode.ReturnType))
                 {
                     ReportError(RudeEditKind.TypeUpdate);
@@ -2765,12 +2766,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(ConversionOperatorDeclarationSyntax oldNode, ConversionOperatorDeclarationSyntax newNode)
             {
-                if (!SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.ImplicitOrExplicitKeyword, newNode.ImplicitOrExplicitKeyword))
                 {
                     ReportError(RudeEditKind.Renamed);
@@ -2792,12 +2787,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(OperatorDeclarationSyntax oldNode, OperatorDeclarationSyntax newNode)
             {
-                if (!SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.OperatorToken, newNode.OperatorToken))
                 {
                     ReportError(RudeEditKind.Renamed);
@@ -2819,12 +2808,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(AccessorDeclarationSyntax oldNode, AccessorDeclarationSyntax newNode)
             {
-                if (!SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (oldNode.Kind() != newNode.Kind())
                 {
                     ReportError(RudeEditKind.AccessorKindUpdate);
@@ -2860,12 +2843,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(ConstructorDeclarationSyntax oldNode, ConstructorDeclarationSyntax newNode)
             {
-                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.UnsafeKeyword))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 ClassifyMethodBodyRudeUpdate(
                     (SyntaxNode?)oldNode.Body ?? oldNode.ExpressionBody?.Expression,
                     (SyntaxNode?)newNode.Body ?? newNode.ExpressionBody?.Expression,
@@ -2884,12 +2861,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(PropertyDeclarationSyntax oldNode, PropertyDeclarationSyntax newNode)
             {
-                if (!AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore: SyntaxKind.UnsafeKeyword))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.Type, newNode.Type))
                 {
                     ReportError(RudeEditKind.TypeUpdate);
@@ -2944,12 +2915,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(IndexerDeclarationSyntax oldNode, IndexerDeclarationSyntax newNode)
             {
-                if (!SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers))
-                {
-                    ReportError(RudeEditKind.ModifiersUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.Type, newNode.Type))
                 {
                     ReportError(RudeEditKind.TypeUpdate);
@@ -2962,16 +2927,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return;
                 }
 
-                Debug.Assert(!SyntaxFactory.AreEquivalent(oldNode.ExpressionBody, newNode.ExpressionBody));
+                if (SyntaxFactory.AreEquivalent(oldNode.ExpressionBody, newNode.ExpressionBody))
+                {
+                    var oldBody = SyntaxUtilities.TryGetEffectiveGetterBody(oldNode.ExpressionBody, oldNode.AccessorList);
+                    var newBody = SyntaxUtilities.TryGetEffectiveGetterBody(newNode.ExpressionBody, newNode.AccessorList);
 
-                var oldBody = SyntaxUtilities.TryGetEffectiveGetterBody(oldNode.ExpressionBody, oldNode.AccessorList);
-                var newBody = SyntaxUtilities.TryGetEffectiveGetterBody(newNode.ExpressionBody, newNode.AccessorList);
-
-                ClassifyMethodBodyRudeUpdate(
-                    oldBody,
-                    newBody,
-                    containingMethod: null,
-                    containingType: (TypeDeclarationSyntax?)newNode.Parent);
+                    ClassifyMethodBodyRudeUpdate(
+                        oldBody,
+                        newBody,
+                        containingMethod: null,
+                        containingType: (TypeDeclarationSyntax?)newNode.Parent);
+                }
             }
 
             private void ClassifyUpdate(TypeParameterSyntax oldNode, TypeParameterSyntax newNode)

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -2630,12 +2630,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             private void ClassifyUpdate(TypeDeclarationSyntax oldNode, TypeDeclarationSyntax newNode)
             {
-                if (oldNode.Kind() != newNode.Kind())
-                {
-                    ReportError(RudeEditKind.TypeKindUpdate);
-                    return;
-                }
-
                 if (!SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier))
                 {
                     ReportError(RudeEditKind.Renamed);
@@ -2768,7 +2762,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             {
                 if (!SyntaxFactory.AreEquivalent(oldNode.ImplicitOrExplicitKeyword, newNode.ImplicitOrExplicitKeyword))
                 {
-                    ReportError(RudeEditKind.Renamed);
+                    ReportError(RudeEditKind.ModifiersUpdate);
                     return;
                 }
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2485,7 +2485,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                             // their accessors below.
                                             continue;
                                         }
-                                        else if (IsPropertyAccessorDeclarationMatchingPrimaryConstructorParameter(oldDeclaration, newSymbol.ContainingType, out var isFirst))
+
+                                        if (IsPropertyAccessorDeclarationMatchingPrimaryConstructorParameter(oldDeclaration, newSymbol.ContainingType, out var isFirst))
                                         {
                                             // Defer a constructor edit to cover the property initializer changing
                                             DeferConstructorEdit(oldSymbol.ContainingType, newSymbol.ContainingType, newDeclaration: null, syntaxMap, oldSymbol.IsStatic, ref instanceConstructorEdits, ref staticConstructorEdits);
@@ -2505,10 +2506,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                             }
                                         }
 
-                                        // can't change visibility:
+                                        // The new symbol is implicitly declared and thus has implied accessibility that needs to be the same
+                                        // as the accessibility of the deleted explicit symbol.
                                         if (newSymbol.DeclaredAccessibility != oldSymbol.DeclaredAccessibility)
                                         {
-                                            ReportDeletedMemberRudeEdit(diagnostics, editScript, oldDeclaration, oldSymbol, RudeEditKind.ChangingVisibility);
+                                            ReportDeletedMemberRudeEdit(diagnostics, editScript, oldDeclaration, oldSymbol, RudeEditKind.ChangingAccessibility);
                                             continue;
                                         }
 
@@ -2594,16 +2596,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                                         if (oldSymbol.IsImplicitlyDeclared)
                                         {
-                                            // Replace implicit declaration with an explicit one with a different visibility is a rude edit.
-                                            if (oldSymbol.DeclaredAccessibility != newSymbol.DeclaredAccessibility)
-                                            {
-                                                diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.ChangingVisibility,
-                                                    GetDiagnosticSpan(newDeclaration, edit.Kind),
-                                                    arguments: new[] { GetDisplayName(newDeclaration, edit.Kind) }));
-
-                                                continue;
-                                            }
-
                                             // If a user explicitly implements a member of a record then we want to issue an update, not an insert.
                                             if (oldSymbol.DeclaringSyntaxReferences.Length == 1)
                                             {
@@ -2711,14 +2703,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                             // If a constructor changes from including initializers to not including initializers
                                             // we don't need to aggregate syntax map from all initializers for the constructor update semantic edit.
                                             var isNewConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(newDeclaration);
-                                            if (isNewConstructorWithMemberInitializers ||
-                                                IsDeclarationWithInitializer(oldDeclaration) ||
-                                                IsDeclarationWithInitializer(newDeclaration) ||
-                                                isRecordPrimaryConstructorParameter)
+                                            var isDeclarationWithInitializer = IsDeclarationWithInitializer(oldDeclaration) || IsDeclarationWithInitializer(newDeclaration);
+
+                                            if (isNewConstructorWithMemberInitializers || isDeclarationWithInitializer || isRecordPrimaryConstructorParameter)
                                             {
                                                 if (isNewConstructorWithMemberInitializers)
                                                 {
                                                     processedSymbols.Remove(newSymbol);
+                                                }
+
+                                                if (isDeclarationWithInitializer)
+                                                {
+                                                    AnalyzeSymbolUpdate(oldSymbol, newSymbol, newDeclaration, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
                                                 }
 
                                                 DeferConstructorEdit(oldSymbol.ContainingType, newSymbol.ContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic, ref instanceConstructorEdits, ref staticConstructorEdits);
@@ -2888,18 +2884,19 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                     // If a constructor changes from including initializers to not including initializers
                                     // we don't need to aggregate syntax map from all initializers for the constructor update semantic edit.
                                     var isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(newDeclaration);
+                                    var isDeclarationWithInitializer = IsDeclarationWithInitializer(oldDeclaration) || IsDeclarationWithInitializer(newDeclaration);
 
-                                    if (isConstructorWithMemberInitializers ||
-                                        IsDeclarationWithInitializer(oldDeclaration) ||
-                                        IsDeclarationWithInitializer(newDeclaration))
+                                    if (isConstructorWithMemberInitializers || isDeclarationWithInitializer)
                                     {
                                         if (isConstructorWithMemberInitializers)
                                         {
                                             processedSymbols.Remove(newSymbol);
                                         }
 
-                                        // Need to check for attribute rude edits for fields and properties
-                                        AnalyzeCustomAttributes(oldSymbol, newSymbol, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
+                                        if (isDeclarationWithInitializer)
+                                        {
+                                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, newDeclaration, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
+                                        }
 
                                         DeferConstructorEdit(oldSymbol.ContainingType, newSymbol.ContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic, ref instanceConstructorEdits, ref staticConstructorEdits);
 
@@ -2919,7 +2916,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                         if (editKind == SemanticEditKind.Update)
                         {
-                            AnalyzeCustomAttributes(oldSymbol, newSymbol, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
+                            Contract.ThrowIfNull(oldSymbol);
+
+                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, newDeclaration, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
 
                             // The only update to the type itself that's supported is an addition or removal of the partial modifier,
                             // which does not have impact on the emitted type metadata.
@@ -2928,9 +2927,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 continue;
                             }
 
-                            // The field/property itself is being updated. Currently we do not allow any modifiers to be updated. Attribute
-                            // updates will have been handled already
-                            if (newSymbol is IFieldSymbol or IPropertySymbol)
+                            // The field/property/event itself is being updated. Currently we do not allow any modifiers to be updated.
+                            // Attribute updates will have been handled already.
+                            if (newSymbol is IFieldSymbol or IPropertySymbol or IEventSymbol)
                             {
                                 continue;
                             }
@@ -2988,7 +2987,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         Contract.ThrowIfFalse(IsDeclarationWithInitializer(oldDeclaration) == IsDeclarationWithInitializer(newDeclaration));
 
                         var isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(newDeclaration);
-                        if (isConstructorWithMemberInitializers || IsDeclarationWithInitializer(newDeclaration))
+                        var isDeclarationWithInitializer = IsDeclarationWithInitializer(newDeclaration);
+
+                        if (isConstructorWithMemberInitializers || isDeclarationWithInitializer)
                         {
                             // TODO: only create syntax map if any field initializers are active/contain lambdas or this is a partial type
                             syntaxMap ??= CreateSyntaxMapForEquivalentNodes(oldDeclaration, newDeclaration);
@@ -3020,6 +3021,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         oldModel,
                         oldCompilation,
                         processedSymbols,
+                        capabilities,
                         isStatic: false,
                         semanticEdits,
                         diagnostics,
@@ -3034,6 +3036,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         oldModel,
                         oldCompilation,
                         processedSymbols,
+                        capabilities,
                         isStatic: true,
                         semanticEdits,
                         diagnostics,
@@ -3062,7 +3065,85 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private void AnalyzeCustomAttributes(ISymbol? oldSymbol, ISymbol newSymbol, EditAndContinueCapabilities capabilities, ArrayBuilder<RudeEditDiagnostic> diagnostics, ArrayBuilder<SemanticEditInfo>? semanticEdits, Func<SyntaxNode, SyntaxNode?>? syntaxMap, CancellationToken cancellationToken)
+        private void ReportUpdatedSymbolDeclarationRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol oldSymbol, ISymbol newSymbol, SyntaxNode newDeclaration)
+        {
+            var rudeEdit = RudeEditKind.None;
+
+            if (oldSymbol.DeclaredAccessibility != newSymbol.DeclaredAccessibility)
+            {
+                rudeEdit = RudeEditKind.ChangingAccessibility;
+            }
+
+            if (oldSymbol.IsStatic != newSymbol.IsStatic)
+            {
+                rudeEdit = RudeEditKind.ModifiersUpdate;
+            }
+
+            if (oldSymbol is IFieldSymbol oldField && newSymbol is IFieldSymbol newField)
+            {
+                if (oldField.IsConst != newField.IsConst ||
+                    oldField.IsReadOnly != newField.IsReadOnly ||
+                    oldField.IsVolatile != newField.IsVolatile)
+                {
+                    rudeEdit = RudeEditKind.ModifiersUpdate;
+                }
+            }
+            else if (oldSymbol is IMethodSymbol oldMethod && newSymbol is IMethodSymbol newMethod)
+            {
+                if (oldMethod.IsReadOnly != newMethod.IsReadOnly)
+                {
+                    rudeEdit = RudeEditKind.ModifiersUpdate;
+                }
+            }
+            else if (oldSymbol is INamedTypeSymbol oldType && newSymbol is INamedTypeSymbol newType)
+            {
+                if (oldType.IsRefLikeType != newType.IsRefLikeType ||
+                    oldType.IsReadOnly != newType.IsReadOnly)
+                {
+                    rudeEdit = RudeEditKind.ModifiersUpdate;
+                }
+            }
+            else if (oldSymbol is IEventSymbol { AddMethod: not null, RemoveMethod: not null } oldEvent &&
+                     newSymbol is IEventSymbol { AddMethod: not null, RemoveMethod: not null } newEvent)
+            {
+                // "readonly" modifier can only be applied on the event itself, not on its accessors.
+                if (oldEvent.AddMethod.IsReadOnly != newEvent.AddMethod.IsReadOnly ||
+                    oldEvent.RemoveMethod.IsReadOnly != newEvent.RemoveMethod.IsReadOnly)
+                {
+                    rudeEdit = RudeEditKind.ModifiersUpdate;
+                }
+            }
+
+            if (rudeEdit != RudeEditKind.None)
+            {
+                diagnostics.Add(new RudeEditDiagnostic(rudeEdit,
+                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
+                    arguments: new[] { GetDisplayName(newDeclaration, EditKind.Update) }));
+            }
+        }
+
+        private void AnalyzeSymbolUpdate(
+            ISymbol oldSymbol,
+            ISymbol newSymbol,
+            SyntaxNode? newDeclaration,
+            EditAndContinueCapabilities capabilities,
+            ArrayBuilder<RudeEditDiagnostic> diagnostics,
+            ArrayBuilder<SemanticEditInfo>? semanticEdits,
+            Func<SyntaxNode, SyntaxNode?>? syntaxMap,
+            CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfFalse(newSymbol.IsImplicitlyDeclared == newDeclaration is null);
+
+            AnalyzeCustomAttributes(oldSymbol, newSymbol, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
+
+            // We might be updating an explicit old declaration to an implicit new declaration.
+            if (newDeclaration != null)
+            {
+                ReportUpdatedSymbolDeclarationRudeEdits(diagnostics, oldSymbol, newSymbol, newDeclaration);
+            }
+        }
+
+        private void AnalyzeCustomAttributes(ISymbol oldSymbol, ISymbol newSymbol, EditAndContinueCapabilities capabilities, ArrayBuilder<RudeEditDiagnostic> diagnostics, ArrayBuilder<SemanticEditInfo>? semanticEdits, Func<SyntaxNode, SyntaxNode?>? syntaxMap, CancellationToken cancellationToken)
         {
             var needsEdit = false;
 
@@ -3077,26 +3158,30 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
             else if (newSymbol is INamedTypeSymbol { DelegateInvokeMethod: not null } newType)
             {
-                var oldType = oldSymbol as INamedTypeSymbol;
+                if (oldSymbol is not INamedTypeSymbol { DelegateInvokeMethod: not null } oldType)
+                {
+                    return;
+                }
+
                 // If this is a delegate with attributes on its return type for example, they are found on the DelegateInvokeMethod
-                AnalyzeCustomAttributes(oldType?.DelegateInvokeMethod, newType.DelegateInvokeMethod, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
+                AnalyzeCustomAttributes(oldType.DelegateInvokeMethod, newType.DelegateInvokeMethod, capabilities, diagnostics, semanticEdits, syntaxMap, cancellationToken);
             }
 
             foreach (var parameter in newSymbol.GetParameters())
             {
-                var oldParameter = oldSymbol?.GetParameters().FirstOrDefault(p => p.Name.Equals(parameter.Name));
+                var oldParameter = oldSymbol.GetParameters().FirstOrDefault(p => p.Name.Equals(parameter.Name));
                 needsEdit |= HasCustomAttributeChanges(oldParameter?.GetAttributes(), parameter.GetAttributes(), parameter, capabilities, diagnostics);
             }
 
             foreach (var typeParam in newSymbol.GetTypeParameters())
             {
-                var oldParameter = oldSymbol?.GetTypeParameters().FirstOrDefault(p => p.Name.Equals(typeParam.Name));
+                var oldParameter = oldSymbol.GetTypeParameters().FirstOrDefault(p => p.Name.Equals(typeParam.Name));
                 needsEdit |= HasCustomAttributeChanges(oldParameter?.GetAttributes(), typeParam.GetAttributes(), typeParam, capabilities, diagnostics);
             }
 
             // This is the only case we care about whether to issue an edit or not, because this is the only case where types have their attributes checked
             // and types are the only things that would otherwise not have edits reported.
-            needsEdit |= HasCustomAttributeChanges(oldSymbol?.GetAttributes(), newSymbol.GetAttributes(), newSymbol, capabilities, diagnostics);
+            needsEdit |= HasCustomAttributeChanges(oldSymbol.GetAttributes(), newSymbol.GetAttributes(), newSymbol, capabilities, diagnostics);
 
             // If we don't need to add an edit, then we're done
             if (!needsEdit || semanticEdits is null)
@@ -3105,7 +3190,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             // Most symbol types will automatically have an edit added, so we just need to handle a few
-            if (newSymbol is INamedTypeSymbol or IFieldSymbol or IPropertySymbol)
+            if (newSymbol is INamedTypeSymbol or IFieldSymbol or IPropertySymbol or IEventSymbol)
             {
                 var symbolKey = SymbolKey.Create(newSymbol, cancellationToken);
                 semanticEdits.Add(new SemanticEditInfo(SemanticEditKind.Update, symbolKey, syntaxMap, syntaxMapTree: null, partialType: null));
@@ -3534,6 +3619,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             SemanticModel? oldModel,
             Compilation oldCompilation,
             IReadOnlySet<ISymbol> processedSymbols,
+            EditAndContinueCapabilities capabilities,
             bool isStatic,
             [Out] ArrayBuilder<SemanticEditInfo> semanticEdits,
             [Out] ArrayBuilder<RudeEditDiagnostic> diagnostics,
@@ -3582,49 +3668,45 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     var syntaxMapToUse = aggregateSyntaxMap;
 
+                    SyntaxNode? newDeclaration = null;
                     ISymbol? oldCtor;
                     if (!newCtor.IsImplicitlyDeclared)
                     {
                         // Constructors have to have a single declaration syntax, they can't be partial
-                        var newDeclaration = GetSymbolDeclarationSyntax(newCtor.DeclaringSyntaxReferences.Single(), cancellationToken);
+                        newDeclaration = GetSymbolDeclarationSyntax(newCtor.DeclaringSyntaxReferences.Single(), cancellationToken);
 
-                        // Compiler generated constructors of records are not implicitly declared, since they
-                        // points to the actual record declaration. We want to skip these checks because we can't
-                        // reason about initializers for them.
-                        if (!IsRecordDeclaration(newDeclaration))
+                        // Implicit record constructors are represented by the record declaration itself.
+                        // https://github.com/dotnet/roslyn/issues/54403
+                        var isPrimaryRecordConstructor = IsRecordDeclaration(newDeclaration);
+
+                        // Constructor that doesn't contain initializers had a corresponding semantic edit produced previously 
+                        // or was not edited. In either case we should not produce a semantic edit for it.
+                        if (!isPrimaryRecordConstructor && !IsConstructorWithMemberInitializers(newDeclaration))
                         {
-                            // Constructor that doesn't contain initializers had a corresponding semantic edit produced previously 
-                            // or was not edited. In either case we should not produce a semantic edit for it.
-                            if (!IsConstructorWithMemberInitializers(newDeclaration))
-                            {
-                                continue;
-                            }
+                            continue;
+                        }
 
-                            // If no initializer updates were made in the type we only need to produce semantic edits for constructors
-                            // whose body has been updated, otherwise we need to produce edits for all constructors that include initializers.
-                            // If changes were made to initializers or constructors of a partial type in another document they will be merged
-                            // when aggregating semantic edits from all changed documents. Rude edits resulting from those changes, if any, will
-                            // be reported in the document they were made in.
-                            if (!anyInitializerUpdatesInCurrentDocument && !updatesInCurrentDocument.ChangedDeclarations.ContainsKey(newDeclaration))
-                            {
-                                continue;
-                            }
+                        // If no initializer updates were made in the type we only need to produce semantic edits for constructors
+                        // whose body has been updated, otherwise we need to produce edits for all constructors that include initializers.
+                        // If changes were made to initializers or constructors of a partial type in another document they will be merged
+                        // when aggregating semantic edits from all changed documents. Rude edits resulting from those changes, if any, will
+                        // be reported in the document they were made in.
+                        if (!isPrimaryRecordConstructor && !anyInitializerUpdatesInCurrentDocument && !updatesInCurrentDocument.ChangedDeclarations.ContainsKey(newDeclaration))
+                        {
+                            continue;
                         }
 
                         // To avoid costly SymbolKey resolution we first try to match the constructor in the current document
                         // and special case parameter-less constructor.
 
-                        // In the case of records, newDeclaration will point to the record declaration, and hence this
-                        // actually finds the old record declaration, but that is actually sufficient for our needs, as all
-                        // we're using it for is detecting an update, and any changes to the standard record constructors must
-                        // be an update by definition.
-                        if (topMatch.TryGetOldNode(newDeclaration, out var oldDeclaration))
+                        // In the case of records, newDeclaration will point to the record declaration, take the slow path.
+                        if (!isPrimaryRecordConstructor && topMatch.TryGetOldNode(newDeclaration, out var oldDeclaration))
                         {
                             Contract.ThrowIfNull(oldModel);
                             oldCtor = oldModel.GetDeclaredSymbol(oldDeclaration, cancellationToken);
-                            Contract.ThrowIfNull(oldCtor);
+                            Contract.ThrowIfFalse(oldCtor is IMethodSymbol { MethodKind: MethodKind.Constructor or MethodKind.StaticConstructor });
                         }
-                        else if (newCtor.Parameters.Length == 0)
+                        else if (!isPrimaryRecordConstructor && newCtor.Parameters.Length == 0)
                         {
                             oldCtor = TryGetParameterlessConstructor(oldType, isStatic);
                         }
@@ -3662,7 +3744,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         // When explicitly implementing the copy constructor of a record the parameter name must match for symbol matching to work
                         // TODO: Remove this requirement with https://github.com/dotnet/roslyn/issues/52563
                         if (oldCtor != null &&
-                            !IsRecordDeclaration(newDeclaration) &&
+                            !isPrimaryRecordConstructor &&
                             oldCtor.DeclaringSyntaxReferences.Length == 0 &&
                             newCtor.Parameters.Length == 1 &&
                             newType.IsRecord &&
@@ -3719,6 +3801,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (oldCtor != null)
                     {
+                        AnalyzeSymbolUpdate(oldCtor, newCtor, newDeclaration, capabilities, diagnostics, semanticEdits: null, syntaxMap: null, cancellationToken);
+
                         semanticEdits.Add(new SemanticEditInfo(
                             SemanticEditKind.Update,
                             newCtorKey,

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.StackAllocUpdate, nameof(FeaturesResources.Modifying_0_which_contains_the_stackalloc_operator_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.ExperimentalFeaturesEnabled, nameof(FeaturesResources.Modifying_source_with_experimental_language_features_enabled_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.AwaitStatementUpdate, nameof(FeaturesResources.Updating_a_complex_statement_containing_an_await_expression_will_prevent_the_debug_session_from_continuing));
-            AddRudeEdit(RudeEditKind.ChangingVisibility, nameof(FeaturesResources.Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing));
+            AddRudeEdit(RudeEditKind.ChangingAccessibility, nameof(FeaturesResources.Changing_visibility_of_0_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.CapturingVariable, nameof(FeaturesResources.Capturing_variable_0_that_hasn_t_been_captured_before_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.NotCapturingVariable, nameof(FeaturesResources.Ceasing_to_capture_variable_0_will_prevent_the_debug_session_from_continuing));
             AddRudeEdit(RudeEditKind.DeletingCapturedVariable, nameof(FeaturesResources.Deleting_captured_variable_0_will_prevent_the_debug_session_from_continuing));

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ExperimentalFeaturesEnabled = 45,
 
         AwaitStatementUpdate = 46,
-        ChangingVisibility = 47,
+        ChangingAccessibility = 47,
 
         CapturingVariable = 48,
         NotCapturingVariable = 49,

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -1280,16 +1280,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         node = node.Parent             ' for attributes on return types of functions
                     End If
 
-                Case SyntaxKind.EventStatement
-                    If node.Parent.IsKind(SyntaxKind.EventBlock) Then
-                        Return False
-                    End If
-
-                Case SyntaxKind.PropertyStatement  ' autoprop or interface property
-                    If node.Parent.IsKind(SyntaxKind.PropertyBlock) Then
-                        Return False
-                    End If
-
                 Case SyntaxKind.Parameter
                     If editKind = EditKind.Update Then
                         ' for delegate invoke methods we need to go one step higher, to the delegate itself
@@ -2462,7 +2452,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case SyntaxKind.FieldDeclaration
-                        ClassifyUpdate(DirectCast(oldNode, FieldDeclarationSyntax), DirectCast(newNode, FieldDeclarationSyntax))
                         Return
 
                     Case SyntaxKind.VariableDeclarator
@@ -2505,7 +2494,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case SyntaxKind.SubNewStatement
-                        ClassifyUpdate(DirectCast(oldNode, SubNewStatementSyntax), DirectCast(newNode, SubNewStatementSyntax))
                         Return
 
                     Case SyntaxKind.PropertyBlock
@@ -2593,16 +2581,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As TypeStatementSyntax, newNode As TypeStatementSyntax)
-                If oldNode.RawKind <> newNode.RawKind Then
-                    ReportError(RudeEditKind.TypeKindUpdate)
-                    Return
-                End If
-
-                If Not AreModifiersEquivalent(oldNode.Modifiers, newNode.Modifiers, ignore:=SyntaxKind.PartialKeyword) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                    Return
-                End If
-
                 If Not SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier) Then
                     ReportError(RudeEditKind.Renamed)
                 End If
@@ -2623,11 +2601,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return
                 End If
 
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                    Return
-                End If
-
                 If Not SyntaxFactory.AreEquivalent(oldNode.UnderlyingType, newNode.UnderlyingType) Then
                     ReportError(RudeEditKind.EnumUnderlyingTypeUpdate)
                     Return
@@ -2635,11 +2608,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As DelegateStatementSyntax, newNode As DelegateStatementSyntax)
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                    Return
-                End If
-
                 ' Function changed to Sub or vice versa. Note that Function doesn't need to have AsClause.
                 If oldNode.RawKind <> newNode.RawKind Then
                     ReportError(RudeEditKind.TypeUpdate)
@@ -2655,14 +2623,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     ReportError(RudeEditKind.Renamed)
                     Return
                 End If
-            End Sub
-
-            Private Sub ClassifyUpdate(oldNode As FieldDeclarationSyntax, newNode As FieldDeclarationSyntax)
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                End If
-
-                ' VariableDeclarator separators were modified
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As ModifiedIdentifierSyntax, newNode As ModifiedIdentifierSyntax)
@@ -2716,12 +2676,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As PropertyStatementSyntax, newNode As PropertyStatementSyntax)
-                If Not IncludesSignificantPropertyModifiers(oldNode.Modifiers, newNode.Modifiers) OrElse
-                   Not IncludesSignificantPropertyModifiers(newNode.Modifiers, oldNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                    Return
-                End If
-
                 If Not SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier) Then
                     ReportError(RudeEditKind.Renamed)
                     Return
@@ -2741,23 +2695,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
                 End If
             End Sub
-
-            Private Shared Function IncludesSignificantPropertyModifiers(subset As SyntaxTokenList, superset As SyntaxTokenList) As Boolean
-                For Each modifier In subset
-                    ' ReadOnly and WriteOnly keywords are redundant, it would be a semantic error if they Then didn't match the present accessors. 
-                    ' We want to allow adding an accessor to a property, which requires change in the RO/WO modifiers.
-                    If modifier.IsKind(SyntaxKind.ReadOnlyKeyword) OrElse
-                       modifier.IsKind(SyntaxKind.WriteOnlyKeyword) Then
-                        Continue For
-                    End If
-
-                    If Not superset.Any(modifier.Kind) Then
-                        Return False
-                    End If
-                Next
-
-                Return True
-            End Function
 
             ' Returns true if the initializer has changed.
             Private Function ClassifyTypeAndInitializerUpdates(oldEqualsValue As EqualsValueSyntax,
@@ -2780,10 +2717,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 ' A custom event can't be matched with a field event and vice versa:
                 Debug.Assert(SyntaxFactory.AreEquivalent(oldNode.CustomKeyword, newNode.CustomKeyword))
 
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                End If
-
                 If Not SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier) Then
                     ReportError(RudeEditKind.Renamed)
                     Return
@@ -2797,8 +2730,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Dim oldHasGeneratedType = oldNode.ParameterList IsNot Nothing
                 Dim newHasGeneratedType = newNode.ParameterList IsNot Nothing
 
-                Debug.Assert(oldHasGeneratedType <> newHasGeneratedType)
-                ReportError(RudeEditKind.TypeUpdate)
+                If oldHasGeneratedType <> newHasGeneratedType Then
+                    ReportError(RudeEditKind.TypeUpdate)
+                End If
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As MethodBlockSyntax, newNode As MethodBlockSyntax)
@@ -2819,11 +2753,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return
                 End If
 
-                If Not ClassifyMethodModifierUpdate(oldNode.Modifiers, newNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                    Return
-                End If
-
                 ' TODO (tomat): We can support this
                 If Not SyntaxFactory.AreEquivalent(oldNode.HandlesClause, newNode.HandlesClause) Then
                     ReportError(RudeEditKind.HandlesClauseUpdate)
@@ -2835,35 +2764,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return
                 End If
             End Sub
-
-            Private Shared Function ClassifyMethodModifierUpdate(oldModifiers As SyntaxTokenList, newModifiers As SyntaxTokenList) As Boolean
-                ' Ignore Async and Iterator keywords when matching modifiers.
-                ' State machine checks are done in ComputeBodyMatch.
-
-                Dim oldAsyncIndex = oldModifiers.IndexOf(SyntaxKind.AsyncKeyword)
-                Dim newAsyncIndex = newModifiers.IndexOf(SyntaxKind.AsyncKeyword)
-
-                If oldAsyncIndex >= 0 Then
-                    oldModifiers = oldModifiers.RemoveAt(oldAsyncIndex)
-                End If
-
-                If newAsyncIndex >= 0 Then
-                    newModifiers = newModifiers.RemoveAt(newAsyncIndex)
-                End If
-
-                Dim oldIteratorIndex = oldModifiers.IndexOf(SyntaxKind.IteratorKeyword)
-                Dim newIteratorIndex = newModifiers.IndexOf(SyntaxKind.IteratorKeyword)
-
-                If oldIteratorIndex >= 0 Then
-                    oldModifiers = oldModifiers.RemoveAt(oldIteratorIndex)
-                End If
-
-                If newIteratorIndex >= 0 Then
-                    newModifiers = newModifiers.RemoveAt(newIteratorIndex)
-                End If
-
-                Return SyntaxFactory.AreEquivalent(oldModifiers, newModifiers)
-            End Function
 
             Private Sub ClassifyUpdate(oldNode As DeclareStatementSyntax, newNode As DeclareStatementSyntax)
                 If Not SyntaxFactory.AreEquivalent(oldNode.Identifier, newNode.Identifier) Then
@@ -2898,13 +2798,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As OperatorStatementSyntax, newNode As OperatorStatementSyntax)
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
+                Dim oldWidening = oldNode.Modifiers.IndexOf(SyntaxKind.WideningKeyword) >= 0
+                Dim oldNarrowing = oldNode.Modifiers.IndexOf(SyntaxKind.NarrowingKeyword) >= 0
+                Dim newWidening = newNode.Modifiers.IndexOf(SyntaxKind.WideningKeyword) >= 0
+                Dim newNarrowing = newNode.Modifiers.IndexOf(SyntaxKind.NarrowingKeyword) >= 0
+
+                If newWidening <> oldWidening OrElse newNarrowing <> oldNarrowing Then
                     ReportError(RudeEditKind.ModifiersUpdate)
                     Return
                 End If
-
-                Debug.Assert(Not SyntaxFactory.AreEquivalent(oldNode.OperatorToken, newNode.OperatorToken))
-                ReportError(RudeEditKind.Renamed)
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As AccessorBlockSyntax, newNode As AccessorBlockSyntax)
@@ -2934,13 +2836,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                                              newNode,
                                              containingMethod:=Nothing,
                                              containingType:=DirectCast(newNode.Parent, TypeBlockSyntax))
-            End Sub
-
-            Private Sub ClassifyUpdate(oldNode As SubNewStatementSyntax, newNode As SubNewStatementSyntax)
-                If Not SyntaxFactory.AreEquivalent(oldNode.Modifiers, newNode.Modifiers) Then
-                    ReportError(RudeEditKind.ModifiersUpdate)
-                    Return
-                End If
             End Sub
 
             Private Sub ClassifyUpdate(oldNode As SimpleAsClauseSyntax, newNode As SimpleAsClauseSyntax)
@@ -2983,21 +2878,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                 ClassifyUpdate(oldNode.Identifier, newNode.Identifier)
             End Sub
-
-            Private Shared Function AreModifiersEquivalent(oldModifiers As SyntaxTokenList, newModifiers As SyntaxTokenList, ignore As SyntaxKind) As Boolean
-                Dim oldIgnoredModifierIndex = oldModifiers.IndexOf(ignore)
-                Dim newIgnoredModifierIndex = newModifiers.IndexOf(ignore)
-
-                If oldIgnoredModifierIndex >= 0 Then
-                    oldModifiers = oldModifiers.RemoveAt(oldIgnoredModifierIndex)
-                End If
-
-                If newIgnoredModifierIndex >= 0 Then
-                    newModifiers = newModifiers.RemoveAt(newIgnoredModifierIndex)
-                End If
-
-                Return SyntaxFactory.AreEquivalent(oldModifiers, newModifiers)
-            End Function
 
             Private Sub ClassifyMethodBodyRudeUpdate(oldBody As MethodBlockBaseSyntax,
                                                      newBody As MethodBlockBaseSyntax,


### PR DESCRIPTION
Analyzing modifier changes in semantic analysis has multiple advantages: 
1) We can detect the actual impact of change on the generated code. In cases when changing a modifier does not affect the generated code we don't need to issue a rude edit.
2) When analyzing syntax of a type or its member without semantic information we do not know whether to report a rude edit or not - the type may be reloadable, in which case most rude edits are not applicable.

The PR also fixes a few issues uncovered by the changes in the analyzer.