### PR TITLE
Create default option for lsp pull diagnostics to allow it to be switched on via feature flag

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -40,6 +40,7 @@ namespace Roslyn.Test.Utilities
         private static readonly TestComposition s_composition = EditorTestCompositions.LanguageServerProtocolWpf
             .AddParts(typeof(TestLspWorkspaceRegistrationService))
             .AddParts(typeof(TestDocumentTrackingService))
+            .AddParts(typeof(TestExperimentationService))
             .RemoveParts(typeof(MockWorkspaceEventListenerProvider));
 
         [Export(typeof(ILspWorkspaceRegistrationService)), PartNotDiscoverable]

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticModeServiceFactory.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticModeServiceFactory.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return isPullDiagnosticExperimentEnabled ? DiagnosticMode.Pull : DiagnosticMode.Push;
             }
 
-            private bool IsInCodeSpacesServer()
+            private static bool IsInCodeSpacesServer()
             {
                 // hack until there is an officially supported free-threaded synchronous platform API to ask this question.
                 return Environment.GetEnvironmentVariable("VisualStudioServerMode") == "1";

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticModeServiceFactory.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticModeServiceFactory.cs
@@ -5,32 +5,31 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
+namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    [ExportWorkspaceServiceFactory(typeof(IDiagnosticModeService), ServiceLayer.Host), Shared]
-    internal class VisualStudioDiagnosticModeServiceFactory : IWorkspaceServiceFactory
+    [ExportWorkspaceServiceFactory(typeof(IDiagnosticModeService), ServiceLayer.Default), Shared]
+    internal class DefaultDiagnosticModeServiceFactory : IWorkspaceServiceFactory
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualStudioDiagnosticModeServiceFactory()
+        public DefaultDiagnosticModeServiceFactory()
         {
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-            => new VisualStudioDiagnosticModeService(workspaceServices.Workspace);
+            => new DefaultDiagnosticModeService(workspaceServices.Workspace);
 
-        private class VisualStudioDiagnosticModeService : IDiagnosticModeService
+        private class DefaultDiagnosticModeService : IDiagnosticModeService
         {
             private readonly Workspace _workspace;
             private readonly Dictionary<Option2<DiagnosticMode>, Lazy<DiagnosticMode>> _optionToMode = new();
 
-            public VisualStudioDiagnosticModeService(Workspace workspace)
+            public DefaultDiagnosticModeService(Workspace workspace)
             {
                 _workspace = workspace;
             }
@@ -65,8 +64,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 if (inCodeSpacesServer)
                     return DiagnosticMode.Pull;
 
+                var diagnosticModeOption = _workspace.Options.GetOption(option);
+
+                // If the workspace diagnostic mode is set to Default, defer to the feature flag service.
+                if (diagnosticModeOption == DiagnosticMode.Default)
+                {
+                    return GetDiagnosticModeFromFeatureFlag();
+                }
+
                 // Otherwise, defer to the workspace+option to determine what mode we're in.
-                return _workspace.Options.GetOption(option);
+                return diagnosticModeOption;
+            }
+
+            private DiagnosticMode GetDiagnosticModeFromFeatureFlag()
+            {
+                var featureFlagService = _workspace.Services.GetRequiredService<IExperimentationService>();
+                var isPullDiagnosticExperimentEnabled = featureFlagService.IsExperimentEnabled(WellKnownExperimentNames.LspPullDiagnosticsFeatureFlag);
+                return isPullDiagnosticExperimentEnabled ? DiagnosticMode.Pull : DiagnosticMode.Push;
             }
 
             private bool IsInCodeSpacesServer()

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticModeService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticModeService.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Composition;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -17,30 +14,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal interface IDiagnosticModeService : IWorkspaceService
     {
         DiagnosticMode GetDiagnosticMode(Option2<DiagnosticMode> diagnosticMode);
-    }
-
-    [ExportWorkspaceServiceFactory(typeof(IDiagnosticModeService)), Shared]
-    internal class DefaultDiagnosticModeServiceFactory : IWorkspaceServiceFactory
-    {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultDiagnosticModeServiceFactory()
-        {
-        }
-
-        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-            => new DefaultDiagnosticModeService(workspaceServices.Workspace);
-
-        private class DefaultDiagnosticModeService : IDiagnosticModeService
-        {
-            private readonly Workspace _workspace;
-
-            public DefaultDiagnosticModeService(Workspace workspace)
-                => _workspace = workspace;
-
-            public DiagnosticMode GetDiagnosticMode(Option2<DiagnosticMode> diagnosticMode)
-                => _workspace.Options.GetOption(diagnosticMode);
-        }
     }
 
     internal static class DiagnosticModeExtensions

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -33,7 +33,9 @@
                     <CheckBox x:Name="Enable_pull_diagnostics_experimental_requires_restart"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_pull_diagnostics_experimental_requires_restart}" 
                               Checked="Enable_pull_diagnostics_experimental_requires_restart_Checked"
-                              Unchecked="Enable_pull_diagnostics_experimental_requires_restart_Unchecked"/>
+                              Unchecked="Enable_pull_diagnostics_experimental_requires_restart_Unchecked"
+                              Indeterminate="Enable_pull_diagnostics_experimental_requires_restart_Indeterminate"
+                              IsThreeState="True"/>
 
                     <CheckBox x:Name="Enable_Razor_pull_diagnostics_experimental_requires_restart"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_Razor_pull_diagnostics_experimental_requires_restart}" 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -152,8 +152,21 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         private void UpdatePullDiagnosticsOptions()
         {
-            Enable_pull_diagnostics_experimental_requires_restart.IsChecked = OptionStore.GetOption(InternalDiagnosticsOptions.NormalDiagnosticMode) == DiagnosticMode.Pull;
+            var normalPullDiagnosticsOption = OptionStore.GetOption(InternalDiagnosticsOptions.NormalDiagnosticMode);
+            Enable_pull_diagnostics_experimental_requires_restart.IsChecked = GetDiagnosticModeCheckboxValue(normalPullDiagnosticsOption);
+
             Enable_Razor_pull_diagnostics_experimental_requires_restart.IsChecked = OptionStore.GetOption(InternalDiagnosticsOptions.RazorDiagnosticMode) == DiagnosticMode.Pull;
+
+            static bool? GetDiagnosticModeCheckboxValue(DiagnosticMode mode)
+            {
+                return mode switch
+                {
+                    DiagnosticMode.Push => false,
+                    DiagnosticMode.Pull => true,
+                    DiagnosticMode.Default => null,
+                    _ => throw new System.ArgumentException("unknown diagnostic mode"),
+                };
+            }
         }
 
         private void Enable_pull_diagnostics_experimental_requires_restart_Checked(object sender, RoutedEventArgs e)
@@ -165,6 +178,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         private void Enable_pull_diagnostics_experimental_requires_restart_Unchecked(object sender, RoutedEventArgs e)
         {
             this.OptionStore.SetOption(InternalDiagnosticsOptions.NormalDiagnosticMode, DiagnosticMode.Push);
+            UpdatePullDiagnosticsOptions();
+        }
+
+        private void Enable_pull_diagnostics_experimental_requires_restart_Indeterminate(object sender, RoutedEventArgs e)
+        {
+            this.OptionStore.SetOption(InternalDiagnosticsOptions.NormalDiagnosticMode, DiagnosticMode.Default);
             UpdatePullDiagnosticsOptions();
         }
 

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticMode.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticMode.cs
@@ -16,5 +16,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// responding to LSP pull requests for them.
         /// </summary>
         Pull,
+
+        /// <summary>
+        /// Default mode - when the option is set to default we use a feature flag to determine if we're
+        /// is in <see cref="Push"/> or <see cref="Pull"/>
+        /// </summary>
+        Default,
     }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/InternalDiagnosticsOptions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/InternalDiagnosticsOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public static readonly Option2<bool> ProcessHiddenDiagnostics = new(nameof(InternalDiagnosticsOptions), nameof(ProcessHiddenDiagnostics), defaultValue: false,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Process Hidden Diagnostics"));
 
-        public static readonly Option2<DiagnosticMode> NormalDiagnosticMode = new(nameof(InternalDiagnosticsOptions), nameof(NormalDiagnosticMode), defaultValue: DiagnosticMode.Push,
+        public static readonly Option2<DiagnosticMode> NormalDiagnosticMode = new(nameof(InternalDiagnosticsOptions), nameof(NormalDiagnosticMode), defaultValue: DiagnosticMode.Default,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "NormalDiagnosticMode"));
 
         public static readonly Option2<DiagnosticMode> RazorDiagnosticMode = new(nameof(InternalDiagnosticsOptions), nameof(RazorDiagnosticMode), defaultValue: DiagnosticMode.Pull,

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -41,5 +41,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string CloudCache = "Roslyn.CloudCache";
         public const string UnnamedSymbolCompletionDisabled = "Roslyn.UnnamedSymbolCompletionDisabled";
         public const string RazorLspEditorFeatureFlag = "Razor.LSP.Editor";
+        public const string LspPullDiagnosticsFeatureFlag = "Lsp.PullDiagnostics";
     }
 }


### PR DESCRIPTION
Creating a default option so that we can turn on the option via a feature flag, but still allow users to specifically opt-out (and not override that setting if they do).

