### PR TITLE
Insert after DARC publishing

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -291,7 +291,9 @@ stages:
         vmImage: vs2017-win2016
 
 - stage: insert
-  dependsOn: build
+  dependsOn:
+  - build
+  - publish_using_darc
   displayName: Insert to VS
 
   jobs:


### PR DESCRIPTION
Example run (internal only): https://dev.azure.com/dnceng/internal/_build/results?buildId=1207982&view=results

The insertion tool is too fast currently, so we have to slow it down to keep other infrastructure from having issues 😅

If we insert to VS as soon as the `build` stage is complete, most things just work, but the Insertion Symbol Check usually fails because the symbols aren't actually available yet on the symbol server. This change makes it so we delay inserting until all other publishing and validation is done, This slows down the insertion by maybe 30 minutes, but makes it so the developer doesn't need to manually re-run the Insertion Symbol Check.

If we were to figure out a way to kick off the insertion after just the `build` stage is complete, then delay running the Insertion Symbol Check until the symbols are ready, we could save a significant chunk of time in the loop from merging on GitHub to inserting into VS. Also, in the past, there have been issues where symbols were slow to become available, and even the mitigation in this PR wouldn't have been sufficient, so it could provide additional resiliency in the future. dotnet/roslyn-tools#1017

@JoeRobich @dotnet/roslyn-infrastructure for review