### PR TITLE
Backport "Insertion depends on DARC publishing (#54420)"

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -291,7 +291,9 @@ stages:
         vmImage: vs2017-win2016
 
 - stage: insert
-  dependsOn: build
+  dependsOn:
+  - build
+  - publish_using_darc
   displayName: Insert to VS
 
   jobs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -332,6 +332,7 @@ stages:
           Write-Host "##vso[task.setvariable variable=Insertion.InsertToolset]$($branchData.insertToolset)"
         }
 
+        Write-Host "##vso[task.setvariable variable=Insertion.AutoComplete]$(-not $branchData.insertionCreateDraftPR)"
         Write-Host "##vso[task.setvariable variable=ComponentBranchName]$branchName"
         Write-Host "##vso[task.setvariable variable=VSBranchName]$($branchData.vsBranch)"
       displayName: Set Insertion Variables
@@ -339,7 +340,7 @@ stages:
     - powershell: |
         mv RoslynTools.VisualStudioInsertionTool.* RIT
         .\RIT\tools\OneOffInsertion.ps1 `
-          -autoComplete "false" `
+          -autoComplete "$(Insertion.AutoComplete)" `
           -buildQueueName "$(Build.DefinitionName)" `
           -cherryPick "(default)" `
           -clientId "$(ClientId)" `


### PR DESCRIPTION
I forgot that the change from #54420 also needs to be in the 16.11 branch to fix the same issue in 16.11 insertions.

I also included a change here to make AutoComplete always have the opposite value of CreateDraftPR. It feels like that's what tends to happen for the auto insertions in practice but would be happy to adjust it based on feedback.
