### PR TITLE
Move to a simpler event source system for nav bars

### DIFF
--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -123,8 +123,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
             void ConnectToNewWorkspace()
             {
-                // For the first time you open the file, we'll start immediately
-                StartModelUpdateAndSelectedItemUpdateTasks(modelUpdateDelay: 0);
+                // For the first time you open the file, kick off the work to determine the nav bars.
+                StartModelUpdateAndSelectedItemUpdateTasks();
             }
         }
 
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
                     if (currentContextDocumentId != null && currentContextDocumentId.ProjectId == args.ProjectId)
                     {
-                        StartModelUpdateAndSelectedItemUpdateTasks(modelUpdateDelay: 0);
+                        StartModelUpdateAndSelectedItemUpdateTasks();
                     }
                 }
             }
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                 if (currentContextDocumentId != null && currentContextDocumentId == args.DocumentId)
                 {
                     // The context has changed, so update everything.
-                    StartModelUpdateAndSelectedItemUpdateTasks(modelUpdateDelay: 0);
+                    StartModelUpdateAndSelectedItemUpdateTasks();
                 }
             }
         }
@@ -208,14 +208,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                 args.OldActiveContextDocumentId == currentContextDocumentId)
             {
                 // if the active context changed, recompute the types/member as they may be changed as well.
-                StartModelUpdateAndSelectedItemUpdateTasks(modelUpdateDelay: 0);
+                StartModelUpdateAndSelectedItemUpdateTasks();
             }
         }
 
         private void OnSubjectBufferPostChanged(object? sender, EventArgs e)
         {
             AssertIsForeground();
-            StartModelUpdateAndSelectedItemUpdateTasks(modelUpdateDelay: TaggerConstants.MediumDelay);
+            StartModelUpdateAndSelectedItemUpdateTasks();
         }
 
         private void OnCaretMoved(object? sender, EventArgs e)
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             // Now that the edit has been done, refresh to make sure everything is up-to-date.
             // Have to make sure we come back to the main thread for this.
             AssertIsForeground();
-            StartModelUpdateAndSelectedItemUpdateTasks(modelUpdateDelay: 0);
+            StartModelUpdateAndSelectedItemUpdateTasks();
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -221,13 +221,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         private void OnCaretMoved(object? sender, EventArgs e)
         {
             AssertIsForeground();
-            StartSelectedItemUpdateTask(delay: TaggerConstants.NearImmediateDelay);
+            StartSelectedItemUpdateTask();
         }
 
         private void OnViewFocused(object? sender, EventArgs e)
         {
             AssertIsForeground();
-            StartSelectedItemUpdateTask(delay: TaggerConstants.ShortDelay);
+            StartSelectedItemUpdateTask();
         }
 
         private void OnDropDownFocused(object? sender, EventArgs e)

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -74,10 +74,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             presenter.ItemSelected += OnItemSelected;
 
             // Initialize the tasks to be an empty model so we never have to deal with a null case.
-            _latestModelAndSelectedInfo_OnlyAccessOnUIThread.model = new(
-                ImmutableArray<NavigationBarItem>.Empty,
-                semanticVersionStamp: default,
-                itemService: null!);
+            _latestModelAndSelectedInfo_OnlyAccessOnUIThread.model = new(ImmutableArray<NavigationBarItem>.Empty, itemService: null!);
             _latestModelAndSelectedInfo_OnlyAccessOnUIThread.selectedInfo = new(typeItem: null, memberItem: null);
 
             _modelTask = Task.FromResult(_latestModelAndSelectedInfo_OnlyAccessOnUIThread.model);

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         /// <summary>
         /// Starts a new task to compute the model based on the current text.
         /// </summary>
-        private void StartModelUpdateAndSelectedItemUpdateTasks()
+        private void StartModelUpdateAndSelectedItemUpdateTasksOnUIThread()
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             _modelTask = ComputeModelAfterDelayAsync(_modelTask, textSnapshot, modelUpdateDelay, cancellationToken);
             _modelTask.CompletesAsyncOperation(asyncToken);
 
-            StartSelectedItemUpdateTask(delay: 0);
+            StartSelectedItemUpdateTask();
         }
 
         private static async Task<NavigationBarModel> ComputeModelAfterDelayAsync(
@@ -128,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         /// <summary>
         /// Starts a new task to compute what item should be selected.
         /// </summary>
-        private void StartSelectedItemUpdateTask(int delay)
+        private void StartSelectedItemUpdateTask()
         {
             AssertIsForeground();
 
@@ -143,19 +144,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             var cancellationToken = _selectedItemInfoTaskCancellationSource.Token;
 
             var asyncToken = _asyncListener.BeginAsyncOperation(GetType().Name + ".StartSelectedItemUpdateTask");
-            var selectedItemInfoTask = DetermineSelectedItemInfoAsync(_modelTask, delay, subjectBufferCaretPosition.Value, cancellationToken);
+            var selectedItemInfoTask = DetermineSelectedItemInfoAsync(_modelTask, subjectBufferCaretPosition.Value, cancellationToken);
             selectedItemInfoTask.CompletesAsyncOperation(asyncToken);
         }
 
         private async Task DetermineSelectedItemInfoAsync(
             Task<NavigationBarModel> lastModelTask,
-            int delay,
             SnapshotPoint caretPosition,
             CancellationToken cancellationToken)
         {
             // First wait the delay before doing any other work.  That way if we get canceled due to other events (like
             // the user moving around), we don't end up doing anything, and the next task can take over.
-            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(TaggerConstants.NearImmediateDelay, cancellationToken).ConfigureAwait(false);
 
             var lastModel = await lastModelTask.ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested)

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         /// <summary>
         /// Starts a new task to compute the model based on the current text.
         /// </summary>
-        private void StartModelUpdateAndSelectedItemUpdateTasks(int modelUpdateDelay)
+        private void StartModelUpdateAndSelectedItemUpdateTasks()
         {
             AssertIsForeground();
 
@@ -49,21 +49,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
             // Enqueue a new computation for the model
             var asyncToken = _asyncListener.BeginAsyncOperation(GetType().Name + ".StartModelUpdateTask");
-            _modelTask = ComputeModelAfterDelayAsync(_modelTask, textSnapshot, modelUpdateDelay, cancellationToken);
+            _modelTask = ComputeModelAfterDelayAsync(_modelTask, textSnapshot, cancellationToken);
             _modelTask.CompletesAsyncOperation(asyncToken);
 
             StartSelectedItemUpdateTask();
         }
 
         private static async Task<NavigationBarModel> ComputeModelAfterDelayAsync(
-            Task<NavigationBarModel> modelTask, ITextSnapshot textSnapshot, int modelUpdateDelay, CancellationToken cancellationToken)
+            Task<NavigationBarModel> modelTask, ITextSnapshot textSnapshot, CancellationToken cancellationToken)
         {
             var previousModel = await modelTask.ConfigureAwait(false);
             if (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    await Task.Delay(modelUpdateDelay, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(TaggerConstants.ShortDelay, cancellationToken).ConfigureAwait(false);
                     return await ComputeModelAsync(previousModel, textSnapshot, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarModel.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarModel.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 {
@@ -11,19 +10,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
     {
         public ImmutableArray<NavigationBarItem> Types { get; }
 
-        /// <summary>
-        /// The VersionStamp of the project when this model was computed.
-        /// </summary>
-        public VersionStamp SemanticVersionStamp { get; }
-
         public INavigationBarItemService ItemService { get; }
 
-        public NavigationBarModel(ImmutableArray<NavigationBarItem> types, VersionStamp semanticVersionStamp, INavigationBarItemService itemService)
+        public NavigationBarModel(ImmutableArray<NavigationBarItem> types, INavigationBarItemService itemService)
         {
-            Contract.ThrowIfNull(types);
-
             this.Types = types;
-            this.SemanticVersionStamp = semanticVersionStamp;
             this.ItemService = itemService;
         }
     }

--- a/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim items = Await service.GetItemsAsync(document, snapshot, Nothing)
 
                 Dim hostDocument = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
-                Dim model As New NavigationBarModel(items.ToImmutableArray(), VersionStamp.Create(), service)
+                Dim model As New NavigationBarModel(items.ToImmutableArray(), service)
                 Dim selectedItems = NavigationBarController.ComputeSelectedTypeAndMember(model, New SnapshotPoint(hostDocument.GetTextBuffer().CurrentSnapshot, hostDocument.CursorPosition.Value), Nothing)
 
                 Dim isCaseSensitive = document.GetLanguageService(Of ISyntaxFactsService)().IsCaseSensitive


### PR DESCRIPTION
Nav bars manually connects up to multiple events, and also has to replicate a lot of the logic for handling those events that the tagging system already has.  This moves us a much more similar system (and a followup PR will take us even close in terms of how events are processed).   Can be reviewed one commit at a time.  Explanations inlined.

Note tehre is a followup PR to this coming.  However, i wanted to break the overall change into two pieces.