### PR TITLE
Revert "Query workspace for active document when we are not passed a project context in an LSP request"

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -88,30 +88,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return documents.FindDocumentInProjectContext(documentIdentifier);
         }
 
-        public static Document FindDocumentInProjectContext(this ImmutableArray<Document> documents, TextDocumentIdentifier documentIdentifier)
+        public static T FindDocumentInProjectContext<T>(this ImmutableArray<T> documents, TextDocumentIdentifier documentIdentifier) where T : TextDocument
         {
             if (documents.Length > 1)
             {
                 // We have more than one document; try to find the one that matches the right context
-                if (documentIdentifier is VSTextDocumentIdentifier vsDocumentIdentifier && vsDocumentIdentifier.ProjectContext != null)
+                if (documentIdentifier is VSTextDocumentIdentifier vsDocumentIdentifier)
                 {
-                    var projectId = ProtocolConversions.ProjectContextToProjectId(vsDocumentIdentifier.ProjectContext);
-                    var matchingDocument = documents.FirstOrDefault(d => d.Project.Id == projectId);
-
-                    if (matchingDocument != null)
+                    if (vsDocumentIdentifier.ProjectContext != null)
                     {
-                        return matchingDocument;
-                    }
-                }
-                else
-                {
-                    // We were not passed a project context.  This can happen when the LSP powered NavBar is not enabled.
-                    // This branch should be removed when we're using the LSP based navbar in all scenarios.
+                        var projectId = ProtocolConversions.ProjectContextToProjectId(vsDocumentIdentifier.ProjectContext);
+                        var matchingDocument = documents.FirstOrDefault(d => d.Project.Id == projectId);
 
-                    var solution = documents.First().Project.Solution;
-                    // Lookup which of the linked documents is currently active in the workspace.
-                    var documentIdInCurrentContext = solution.Workspace.GetDocumentIdInCurrentContext(documents.First().Id);
-                    return solution.GetRequiredDocument(documentIdInCurrentContext);
+                        if (matchingDocument != null)
+                        {
+                            return matchingDocument;
+                        }
+                    }
                 }
             }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -7,12 +7,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Test;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -37,7 +35,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
             var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
 
-            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
+            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document);
 
             Assert.Empty(results);
         }
@@ -57,7 +55,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             await OpenDocumentAsync(testLspServer, document);
 
             var results = await RunGetDocumentPullDiagnosticsAsync(
-                testLspServer, document.GetURI());
+                testLspServer, testLspServer.GetCurrentSolution().Projects.Single().Documents.Single());
 
             Assert.Equal("CS1513", results.Single().Diagnostics.Single().Code);
         }
@@ -76,7 +74,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
             await OpenDocumentAsync(testLspServer, document);
 
-            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
+            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document);
 
             Assert.Empty(results.Single().Diagnostics);
         }
@@ -141,7 +139,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             await WaitForDiagnosticsAsync(workspace);
             var results = await testLspServer.ExecuteRequestAsync<DocumentDiagnosticsParams, DiagnosticReport[]>(
                 MSLSPMethods.DocumentPullDiagnosticName,
-                CreateDocumentDiagnosticParams(document.GetURI()),
+                CreateDocumentDiagnosticParams(document),
                 new LSP.ClientCapabilities(),
                 clientName: null,
                 CancellationToken.None);
@@ -179,13 +177,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
             await OpenDocumentAsync(testLspServer, document);
 
-            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
+            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document);
 
             Assert.Equal("CS1513", results.Single().Diagnostics.Single().Code);
 
             var resultId = results.Single().ResultId;
             results = await RunGetDocumentPullDiagnosticsAsync(
-                testLspServer, document.GetURI(), previousResultId: resultId);
+                testLspServer, testLspServer.GetCurrentSolution().Projects.Single().Documents.Single(), previousResultId: resultId);
 
             Assert.Null(results.Single().Diagnostics);
             Assert.Equal(resultId, results.Single().ResultId);
@@ -205,13 +203,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
             await OpenDocumentAsync(testLspServer, document);
 
-            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
+            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document);
 
             Assert.Equal("CS1513", results[0].Diagnostics.Single().Code);
 
             await InsertTextAsync(testLspServer, document, buffer.CurrentSnapshot.Length, "}");
 
-            results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
+            results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, testLspServer.GetCurrentSolution().Projects.Single().Documents.Single());
 
             Assert.Empty(results[0].Diagnostics);
         }
@@ -229,7 +227,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
 
             await OpenDocumentAsync(testLspServer, document);
-            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
+            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document);
 
             Assert.Equal("CS1513", results[0].Diagnostics.Single().Code);
             Assert.Equal(new Position { Line = 0, Character = 9 }, results[0].Diagnostics.Single().Range.Start);
@@ -238,7 +236,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             await InsertTextAsync(testLspServer, document, position: 0, text: " ");
 
             results = await RunGetDocumentPullDiagnosticsAsync(
-                testLspServer, document.GetURI(),
+                testLspServer, testLspServer.GetCurrentSolution().Projects.Single().Documents.Single(),
                 previousResultId: results[0].ResultId);
 
             Assert.Equal("CS1513", results[0].Diagnostics.Single().Code);
@@ -276,54 +274,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             await OpenDocumentAsync(testLspServer, document);
 
             var progress = BufferedProgress.Create<DiagnosticReport>(null);
-            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI(), progress: progress);
+            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, testLspServer.GetCurrentSolution().Projects.Single().Documents.Single(), progress: progress);
 
             Assert.Null(results);
             Assert.Equal("CS1513", progress.GetValues()!.Single().Diagnostics.Single().Code);
-        }
-
-        [Fact]
-        public async Task TestDocumentDiagnosticsForOpenFilesUsesActiveContext()
-        {
-            var documentText =
-@"#if ONE
-class A {
-#endif
-class B {";
-            var workspaceXml =
-@$"<Workspace>
-    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"" PreprocessorSymbols=""ONE"">
-        <Document FilePath=""C:\C.cs"">{documentText}</Document>
-    </Project>
-    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj2"">
-        <Document IsLinkFile=""true"" LinkFilePath=""C:\C.cs"" LinkAssemblyName=""CSProj1"">{documentText}</Document>
-    </Project>
-</Workspace>";
-
-            using var testLspServer = CreateTestWorkspaceFromXml(workspaceXml, BackgroundAnalysisScope.OpenFilesAndProjects);
-
-            var csproj1Document = testLspServer.GetCurrentSolution().Projects.Where(p => p.Name == "CSProj1").Single().Documents.First();
-            var csproj2Document = testLspServer.GetCurrentSolution().Projects.Where(p => p.Name == "CSProj2").Single().Documents.First();
-
-            // Open either of the documents via LSP, we're tracking the URI and text.
-            await OpenDocumentAsync(testLspServer, csproj1Document);
-
-            // This opens all documents in the workspace and ensures buffers are created.
-            testLspServer.TestWorkspace.GetTestDocument(csproj1Document.Id).GetTextBuffer();
-
-            // Set CSProj2 as the active context and get diagnostics.
-            testLspServer.TestWorkspace.SetDocumentContext(csproj2Document.Id);
-            var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, csproj2Document.GetURI());
-            Assert.Equal("CS1513", results.Single().Diagnostics.Single().Code);
-            var vsDiagnostic = (LSP.VSDiagnostic)results.Single().Diagnostics.Single();
-            Assert.Equal("CSProj2", vsDiagnostic.Projects.Single().ProjectName);
-
-            // Set CSProj1 as the active context and get diagnostics.
-            testLspServer.TestWorkspace.SetDocumentContext(csproj1Document.Id);
-            results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, csproj1Document.GetURI());
-            Assert.Equal(2, results.Single().Diagnostics!.Length);
-            Assert.All(results.Single().Diagnostics, d => Assert.Equal("CS1513", d.Code));
-            Assert.All(results.Single().Diagnostics, d => Assert.Equal("CSProj1", ((VSDiagnostic)d).Projects.Single().ProjectName));
         }
 
         #endregion
@@ -526,7 +480,7 @@ class B {";
 
         private static async Task<DiagnosticReport[]> RunGetDocumentPullDiagnosticsAsync(
             TestLspServer testLspServer,
-            Uri uri,
+            Document document,
             string? previousResultId = null,
             IProgress<DiagnosticReport[]>? progress = null)
         {
@@ -534,7 +488,7 @@ class B {";
 
             var result = await testLspServer.ExecuteRequestAsync<DocumentDiagnosticsParams, DiagnosticReport[]>(
                 MSLSPMethods.DocumentPullDiagnosticName,
-                CreateDocumentDiagnosticParams(uri, previousResultId, progress),
+                CreateDocumentDiagnosticParams(document, previousResultId, progress),
                 new LSP.ClientCapabilities(),
                 clientName: null,
                 CancellationToken.None);
@@ -569,13 +523,13 @@ class B {";
         }
 
         private static DocumentDiagnosticsParams CreateDocumentDiagnosticParams(
-            Uri uri,
+            Document document,
             string? previousResultId = null,
             IProgress<DiagnosticReport[]>? progress = null)
         {
             return new DocumentDiagnosticsParams
             {
-                TextDocument = new LSP.TextDocumentIdentifier { Uri = uri },
+                TextDocument = ProtocolConversions.DocumentToTextDocumentIdentifier(document),
                 PreviousResultId = previousResultId,
                 PartialResultToken = progress,
             };
@@ -599,13 +553,6 @@ class B {";
         {
             var testLspServer = CreateTestLspServer(markup, out _);
             InitializeDiagnostics(scope, testLspServer.TestWorkspace, mode);
-            return testLspServer;
-        }
-
-        private TestLspServer CreateTestWorkspaceFromXml(string xmlMarkup, BackgroundAnalysisScope scope, bool pullDiagnostics = true)
-        {
-            var testLspServer = CreateXmlTestLspServer(xmlMarkup, out _);
-            InitializeDiagnostics(scope, testLspServer.TestWorkspace, pullDiagnostics);
             return testLspServer;
         }
 


### PR DESCRIPTION
Reverts dotnet/roslyn#54397

This is a possible option for unblocking the broken build in the main branch.