### PR TITLE
Be explicit about which code elements the reference counter supports

### DIFF
--- a/src/VisualStudio/CodeLens/ReferenceCodeLensProvider.cs
+++ b/src/VisualStudio/CodeLens/ReferenceCodeLensProvider.cs
@@ -63,12 +63,20 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         {
             if (descriptorContext != null && descriptorContext.ApplicableSpan.HasValue)
             {
-                // we allow all reference points. 
-                // engine will call this for all points our roslyn code lens (reference) tagger tagged.
-                return SpecializedTasks.True;
+                return IsSupportedCodeElementAsync(descriptor.Kind);
             }
 
             return SpecializedTasks.False;
+        }
+
+        private static Task<bool> IsSupportedCodeElementAsync(CodeElementKinds kinds)
+        {
+            // we currently allow reference points only on those code elements
+            return kinds switch
+            {
+                CodeElementKinds.Type or CodeElementKinds.Property or CodeElementKinds.Method => SpecializedTasks.True,
+                _ => SpecializedTasks.False,
+            };
         }
 
         public Task<IAsyncCodeLensDataPoint> CreateDataPointAsync(


### PR DESCRIPTION
The reference count CodeLens provider currently assumes that it supports all the nodes tagged by the C# CodeLens tagger. If the CodeLens tagger starts tagging more nodes, the reference count will break.

This PR makes the reference count CodeLens provider be explicit as to which kind of nodes it supports.