### PR TITLE
🐇 Use ImmutableSegmentedDictionary to optimize storage and lookup

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -7,17 +7,18 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {
     internal sealed class DriverStateTable
     {
-        private readonly ImmutableDictionary<object, IStateTable> _tables;
+        private readonly ImmutableSegmentedDictionary<object, IStateTable> _tables;
 
-        internal static DriverStateTable Empty { get; } = new DriverStateTable(ImmutableDictionary<object, IStateTable>.Empty);
+        internal static DriverStateTable Empty { get; } = new DriverStateTable(ImmutableSegmentedDictionary<object, IStateTable>.Empty);
 
-        private DriverStateTable(ImmutableDictionary<object, IStateTable> tables)
+        private DriverStateTable(ImmutableSegmentedDictionary<object, IStateTable> tables)
         {
             _tables = tables;
         }
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis
 
         public sealed class Builder
         {
-            private readonly ImmutableDictionary<object, IStateTable>.Builder _tableBuilder = ImmutableDictionary.CreateBuilder<object, IStateTable>();
+            private readonly ImmutableSegmentedDictionary<object, IStateTable>.Builder _tableBuilder = ImmutableSegmentedDictionary.CreateBuilder<object, IStateTable>();
             private readonly ImmutableArray<ISyntaxInputNode> _syntaxInputNodes;
             private readonly ImmutableDictionary<ISyntaxInputNode, Exception>.Builder _syntaxExceptions = ImmutableDictionary.CreateBuilder<ISyntaxInputNode, Exception>();
             private readonly DriverStateTable _previousTable;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/ISyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/ISyntaxInputNode.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -18,6 +18,6 @@ namespace Microsoft.CodeAnalysis
 
         void VisitTree(SyntaxNode root, EntryState state, SemanticModel? model, CancellationToken cancellationToken);
 
-        void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables);
+        void SaveStateAndFree(ImmutableSegmentedDictionary<object, IStateTable>.Builder tables);
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -54,7 +55,7 @@ namespace Microsoft.CodeAnalysis
 
             public ISyntaxInputNode SyntaxInputNode { get => _owner; }
 
-            public void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables)
+            public void SaveStateAndFree(ImmutableSegmentedDictionary<object, IStateTable>.Builder tables)
             {
                 tables[_owner._filterKey] = _filterTable.ToImmutableAndFree();
                 tables[_owner] = _transformTable.ToImmutableAndFree();

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -4,9 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis
 
             public ISyntaxInputNode SyntaxInputNode { get => _owner; }
 
-            public void SaveStateAndFree(ImmutableDictionary<object, IStateTable>.Builder tables)
+            public void SaveStateAndFree(ImmutableSegmentedDictionary<object, IStateTable>.Builder tables)
             {
                 _nodeStateTable.AddEntry(_receiver, EntryState.Modified);
                 tables[_owner] = _nodeStateTable.ToImmutableAndFree();


### PR DESCRIPTION
I noticed that these collections are constructed once via a builder, and then not mutated after `ToImmutable()` is called. `ImmutableSegmentedDictionary<TKey, TValue>` is a more efficient collection for this purpose.